### PR TITLE
fix: google-protobuf 보안 취약점 패치 (CVE DoS)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
-# 로컬: Ruby 2.6+ (Bundler 2.4.4). Vercel/CI: 2.7+ 권장
-ruby ">= 2.6.0"
+# CI/Vercel: Ruby 2.7+ 필수 (google-protobuf >= 3.25.5 보안 패치)
+ruby ">= 2.7.0"
 
 gem "jekyll", "~> 4.3.4"
 
@@ -13,3 +13,6 @@ end
 
 # Performance
 gem "webrick", "~> 1.8"
+
+# Security: CVE fix for protobuf DoS (Dependabot alert #8)
+gem "google-protobuf", ">= 3.25.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,12 +11,12 @@ GEM
     eventmachine (1.2.7)
     ffi (1.17.3)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.4)
-    google-protobuf (3.23.4-aarch64-linux)
-    google-protobuf (3.23.4-arm64-darwin)
-    google-protobuf (3.23.4-x86-linux)
-    google-protobuf (3.23.4-x86_64-darwin)
-    google-protobuf (3.23.4-x86_64-linux)
+    google-protobuf (3.25.5)
+    google-protobuf (3.25.5-aarch64-linux)
+    google-protobuf (3.25.5-arm64-darwin)
+    google-protobuf (3.25.5-x86-linux)
+    google-protobuf (3.25.5-x86_64-darwin)
+    google-protobuf (3.25.5-x86_64-linux)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -96,6 +96,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  google-protobuf (>= 3.25.5)
   jekyll (~> 4.3.4)
   jekyll-feed (~> 0.15)
   jekyll-seo-tag (~> 2.8)


### PR DESCRIPTION
## Summary

- **google-protobuf** 3.23.4 → 3.25.5 업데이트 (Dependabot alert #8 해결)
- protobuf-java DoS 취약점 패치 (severity: **high**)
- Ruby 최소 버전 2.6 → 2.7 상향 (protobuf 3.25.5 요구사항)

## 변경 내용

| 파일 | 변경 |
|------|------|
| `Gemfile` | `ruby ">= 2.7.0"`, `gem "google-protobuf", ">= 3.25.5"` 추가 |
| `Gemfile.lock` | 모든 플랫폼 google-protobuf 3.23.4 → 3.25.5 |

## 영향 범위

- **CI/Vercel**: Ruby 3.x 사용 → 정상 동작
- **로컬 개발**: Ruby 2.7+ 필요 (2.6 사용 시 `bundle install` 실패 가능)

## Test plan

- [x] Gemfile/Gemfile.lock 구문 검증
- [ ] CI에서 `bundle install` + Jekyll 빌드 성공 확인
- [ ] Dependabot alert #8 자동 해소 확인