### PR TITLE
fix: sass-embedded Ruby 3.3+ 호환성 수정

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,6 @@ gem "webrick", "~> 1.8"
 
 # Security: CVE fix for protobuf DoS (Dependabot alert #8)
 gem "google-protobuf", ">= 3.25.5"
+
+# Fix: sass-embedded 1.58.3 breaks on Ruby 3.3+ (FileUtils::URI error)
+gem "sass-embedded", "~> 1.85"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,9 +67,7 @@ GEM
     rexml (3.4.4)
     rouge (3.30.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.58.3)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
+    sass-embedded (1.85.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
@@ -101,6 +99,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.15)
   jekyll-seo-tag (~> 2.8)
   jekyll-sitemap (~> 1.4)
+  sass-embedded (~> 1.85)
   webrick (~> 1.8)
 
 RUBY VERSION


### PR DESCRIPTION
## Summary

- **sass-embedded** 1.58.3 → 1.85.0 업데이트
- Ruby 3.3.10에서 `NameError: uninitialized constant FileUtils::URI` 에러 해결
- Jekyll CI (`jekyll.yml`) 및 Security Audit (`security-audit.yml`) 빌드 실패 수정

## 원인

sass-embedded 1.58.3의 rake 빌드 스크립트가 Ruby 3.3에서 제거된 `FileUtils::URI` 상수를 참조하여 네이티브 확장 빌드 실패

## 변경

| 파일 | 변경 |
|------|------|
| `Gemfile` | `gem "sass-embedded", "~> 1.85"` 추가 |
| `Gemfile.lock` | sass-embedded 1.58.3 → 1.85.0, protobuf 의존성 제거 |

## Test plan

- [ ] Jekyll CI 빌드 성공 확인 (Ruby 3.3)
- [ ] Security Audit bundle-audit 통과 확인
- [ ] Vercel 배포 정상 확인