### PR TITLE
feat: AI 번역 시스템 개선 - Google Gemini AI 통합

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,6 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="google" content="notranslate">
 
   <!-- Console Filter Module (deferred to reduce FID impact) -->
   <script src="{{ "/assets/js/console-filter.js" | relative_url }}" defer></script>
@@ -75,8 +74,12 @@
   <meta name="google-site-verification" content="4f3Fngt0n2PDMUdFumJYQEwXKluVehXzwPV_TqxTauU" />
   <link rel="canonical" href="{{ canonical_url }}">
   
-  <!-- International SEO - hreflang -->
+  <!-- International SEO - hreflang (client-side translation available) -->
   <link rel="alternate" hreflang="ko" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="en" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="ja" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="zh-Hans" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="zh-Hant" href="{{ canonical_url }}">
   <link rel="alternate" hreflang="x-default" href="{{ canonical_url }}">
   
   <!-- AI Discoverability Meta Tags -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -31,6 +31,7 @@
           </button>
           <div class="lang-dropdown-overlay" id="lang-dropdown-overlay" aria-hidden="true"></div>
           <div class="lang-dropdown notranslate" id="lang-dropdown" translate="no" role="menu" aria-label="언어 선택">
+            <div class="lang-ai-badge" aria-hidden="true">Gemini AI Translation</div>
             <button class="lang-option" data-lang="ko" title="한국어" role="menuitem">
               <span class="lang-flag">🇰🇷</span>
               <span class="lang-name">한국어</span>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -391,6 +391,16 @@
   text-overflow: ellipsis;
 }
 
+.lang-ai-badge {
+  font-size: 0.625rem;
+  color: var(--text-tertiary, #8b949e);
+  text-align: center;
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--border-color, #30363d);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
 /* Dark theme */
 [data-theme="dark"] .lang-dropdown {
   background: var(--color-bg-secondary);

--- a/assets/js/main-search.js
+++ b/assets/js/main-search.js
@@ -1062,8 +1062,10 @@
     }
 
     // Language option click handler
+    // Translation is delegated to google-translate.js (Gemini AI-powered)
+    // This handler only updates UI state - no MyMemory API calls
     langOptions.forEach(option => {
-      option.addEventListener('click', async function() {
+      option.addEventListener('click', function() {
         const targetLang = this.dataset.lang;
 
         if (targetLang === currentLang) {
@@ -1087,21 +1089,8 @@
         // Close dropdown
         closeDropdown();
 
-        // Show loading
-        showToast('번역 중...', 'loading');
-
-        try {
-          if (targetLang === 'ko') {
-            restoreOriginal();
-            showToast('원본으로 복원되었습니다', 'success');
-          } else {
-            await translatePage(targetLang);
-            showToast(`${getLanguageName(targetLang)}로 번역되었습니다`, 'success');
-          }
-          currentLang = targetLang;
-        } catch (error) {
-          showToast('번역 실패. 다시 시도해주세요.', 'error');
-        }
+        currentLang = targetLang;
+        // Actual translation handled by google-translate.js (Google Gemini AI)
       });
     });
 


### PR DESCRIPTION
## Summary
- Google Translate가 2025.12부터 Gemini AI 기반으로 업그레이드됨에 따라, 블로그 번역 시스템을 최적화
- MyMemory API(저품질)와 Google Translate(Gemini AI) 두 엔진이 동시 작동하는 충돌 버그 해결
- 국제 SEO 및 번역 UX 개선

## Changes
- **번역 엔진 통합**: `main-search.js`의 MyMemory API 번역 비활성화, Google Translate(Gemini AI) 단일 엔진으로 통합
- **hreflang 태그 보완**: `ko`, `x-default`만 있던 것에 `en`, `ja`, `zh-Hans`, `zh-Hant` 추가
- **notranslate 메타 태그 제거**: Google 검색에서 국제 사용자에게 번역 제안 허용
- **AI 번역 배지**: 언어 드롭다운에 "Gemini AI Translation" 표시 추가

## Background
Google Translate의 "Understand"/"Ask" 버튼은 현재 앱 전용(iOS/Android)이며 웹 API로는 미제공.
다만 핵심 번역 엔진은 이미 Gemini 모델로 업그레이드되어 Google Translate Widget도 혜택을 받음.

## Test plan
- [ ] 언어 선택 드롭다운에서 영어/일본어/중국어 전환 확인
- [ ] 번역 시 페이지 정상 번역 (Google Translate 기반)
- [ ] "Gemini AI Translation" 배지 표시 확인
- [ ] Jekyll build 정상 확인