### PR TITLE
feat: 번역 언어 변경 - zh-TW 제거, 스페인어 추가

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -79,7 +79,7 @@
   <link rel="alternate" hreflang="en" href="{{ canonical_url }}">
   <link rel="alternate" hreflang="ja" href="{{ canonical_url }}">
   <link rel="alternate" hreflang="zh-Hans" href="{{ canonical_url }}">
-  <link rel="alternate" hreflang="zh-Hant" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="es" href="{{ canonical_url }}">
   <link rel="alternate" hreflang="x-default" href="{{ canonical_url }}">
   
   <!-- AI Discoverability Meta Tags -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -48,9 +48,9 @@
               <span class="lang-flag">🇨🇳</span>
               <span class="lang-name">简体中文</span>
             </button>
-            <button class="lang-option" data-lang="zh-TW" title="繁體中文" role="menuitem">
-              <span class="lang-flag">🇹🇼</span>
-              <span class="lang-name">繁體中文</span>
+            <button class="lang-option" data-lang="es" title="Español" role="menuitem">
+              <span class="lang-flag">🇪🇸</span>
+              <span class="lang-name">Español</span>
             </button>
           </div>
           <!-- Hidden Google Translate Element -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
     </div>
     {% endif %}
 
-    <h1 class="post-title" itemprop="name headline">{{ page.title | escape }}</h1>
+    <h1 class="post-title" itemprop="name headline" lang="ko">{{ page.title | escape }}</h1>
 
     <div class="post-meta">
       <span class="meta-item">
@@ -102,7 +102,7 @@ layout: default
   {% include adsense.html type="in-article" %}
   {% endif %}
 
-  <div class="post-content" itemprop="articleBody">
+  <div class="post-content" itemprop="articleBody" lang="ko">
     {{ content }}
   </div>
 

--- a/assets/js/google-translate.js
+++ b/assets/js/google-translate.js
@@ -29,7 +29,7 @@ function googleTranslateElementInit() {
 
     new google.translate.TranslateElement({
       pageLanguage: 'ko',
-      includedLanguages: 'en,ja,zh-CN,zh-TW',
+      includedLanguages: 'en,ja,zh-CN,es',
       layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
       autoDisplay: false
     }, 'google_translate_element');
@@ -50,7 +50,7 @@ function googleTranslateElementInit() {
     'en': 'EN',
     'ja': 'JA',
     'zh-CN': 'CN',
-    'zh-TW': 'TW',
+    'es': 'ES',
     'zh': 'CN'
   };
 
@@ -60,10 +60,10 @@ function googleTranslateElementInit() {
     'en': { flag: '\uD83C\uDDFA\uD83C\uDDF8', name: 'English' },
     'ja': { flag: '\uD83C\uDDEF\uD83C\uDDF5', name: '日本語' },
     'zh-CN': { flag: '\uD83C\uDDE8\uD83C\uDDF3', name: '简体中文' },
-    'zh-TW': { flag: '\uD83C\uDDF9\uD83C\uDDFC', name: '繁體中文' }
+    'es': { flag: '\uD83C\uDDEA\uD83C\uDDF8', name: 'Espa\u00f1ol' }
   };
 
-  var SUPPORTED_LANGS = ['ko', 'en', 'ja', 'zh-CN', 'zh-TW'];
+  var SUPPORTED_LANGS = ['ko', 'en', 'ja', 'zh-CN', 'es'];
   var translateScriptLoaded = false;
   var scriptLoadRetries = 0;
   var maxRetries = 3;
@@ -210,9 +210,9 @@ function googleTranslateElementInit() {
 
     if (lang.startsWith('ko')) return 'ko';
     if (lang.startsWith('ja')) return 'ja';
-    if (lang.startsWith('zh-tw') || lang.startsWith('zh-hant')) return 'zh-TW';
     if (lang.startsWith('zh')) return 'zh-CN';
     if (lang.startsWith('en')) return 'en';
+    if (lang.startsWith('es')) return 'es';
 
     return 'ko';
   }
@@ -391,7 +391,7 @@ function googleTranslateElementInit() {
           else if (text.includes('English') || text.includes('🇺🇸')) lang = 'en';
           else if (text.includes('日本語') || text.includes('🇯🇵')) lang = 'ja';
           else if (text.includes('简体中文') || text.includes('🇨🇳')) lang = 'zh-CN';
-          else if (text.includes('繁體中文') || text.includes('🇹🇼')) lang = 'zh-TW';
+          else if (text.includes('Español') || text.includes('🇪🇸')) lang = 'es';
         }
 
         if (lang) {


### PR DESCRIPTION
## Summary
- 대만 중국어(zh-TW/繁體中文) 제거, 중국어 간체(zh-CN)만 유지
- 스페인어(es/Español) 추가
- 포스트 본문 번역 정확도 향상을 위한 lang 속성 추가

## Changes
- **header.html**: 언어 드롭다운에서 zh-TW 제거, es(Español) 추가
- **google-translate.js**: LANG_MAP, LANG_LABELS, SUPPORTED_LANGS, 시스템 언어 감지 업데이트
- **head.html**: hreflang zh-Hant → es 변경
- **post.html**: 제목/본문에 `lang="ko"` 추가 (Google Translate 번역 정확도 향상)

## Supported Languages (5)
| Code | Language | Flag |
|------|----------|------|
| ko | 한국어 | KR |
| en | English | US |
| ja | 日本語 | JP |
| zh-CN | 简体中文 | CN |
| es | Español | ES |

## Test plan
- [ ] 언어 드롭다운에서 스페인어 선택 시 정상 번역
- [ ] 대만 중국어 옵션 제거 확인
- [ ] Jekyll build 정상 확인