### PR TITLE
fix: light mode UI/UX 색감 개선

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -102,6 +102,23 @@
   --color-primary-light: rgba(96, 165, 250, 0.2);
 }
 
+/* CSS-only dark mode fallback (no-JS) */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --color-bg-primary: #0f172a;
+    --color-bg-secondary: #1e293b;
+    --color-bg-tertiary: #334155;
+    --color-text-primary: #f1f5f9;
+    --color-text-secondary: #cbd5e1;
+    --color-text-tertiary: #94a3b8;
+    --color-border: #334155;
+    --color-border-light: #1e293b;
+    --color-primary: #60a5fa;
+    --color-primary-hover: #93c5fd;
+    --color-primary-light: rgba(96, 165, 250, 0.2);
+  }
+}
+
 /* Reduced Motion */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -393,10 +393,10 @@
 
 .lang-ai-badge {
   font-size: 0.625rem;
-  color: var(--text-tertiary, #8b949e);
+  color: var(--color-text-tertiary);
   text-align: center;
   padding: 0.25rem 0.5rem;
-  border-bottom: 1px solid var(--border-color, #30363d);
+  border-bottom: 1px solid var(--color-border);
   letter-spacing: 0.02em;
   white-space: nowrap;
 }

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -19,7 +19,7 @@
   margin-top: 2.4rem;
   margin-bottom: 1rem;
   padding-bottom: 0.45rem;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .post-article .post-content h3 {

--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -62,6 +62,18 @@
   background: rgba(99, 102, 241, 0.5);
 }
 
+[data-theme="light"] .highlight pre::-webkit-scrollbar-track {
+  background: var(--color-bg-tertiary);
+}
+
+[data-theme="light"] .highlight pre::-webkit-scrollbar-thumb {
+  background: rgba(99, 102, 241, 0.25);
+}
+
+[data-theme="light"] .highlight pre::-webkit-scrollbar-thumb:hover {
+  background: rgba(99, 102, 241, 0.4);
+}
+
 /* Rouge syntax highlighting tokens */
 .highlight .c,
 .highlight .c1,

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,66 +1,11 @@
-// Colors - Light Mode
-$light-bg: #ffffff;
-$light-bg-secondary: #f8f9fa;
-$light-bg-tertiary: #e9ecef;
-$light-text: #212529;
-$light-text-secondary: #6c757d;
-$light-border: #dee2e6;
+// Legacy SCSS variables — not used at runtime.
+// All theming is done via CSS custom properties in _base.scss.
+// This file is kept for reference only.
+//
+// See _base.scss :root { } for light mode defaults
+// See _base.scss [data-theme="dark"] { } for dark mode overrides
 
-// Colors - Dark Mode
-$dark-bg: #0d1117;
-$dark-bg-secondary: #161b22;
-$dark-bg-tertiary: #21262d;
-$dark-text: #c9d1d9;
-$dark-text-secondary: #8b949e;
-$dark-border: #30363d;
-
-// Accent Colors
-$primary: #2563eb;
-$primary-hover: #1d4ed8;
-$secondary: #10b981;
-$danger: #ef4444;
-$warning: #f59e0b;
-$info: #06b6d4;
-
-// Category Colors
-$color-security: #dc2626;
-$color-devsecops: #7c3aed;
-$color-cloud: #0891b2;
-$color-kubernetes: #326ce5;
-$color-finops: #16a34a;
-$color-incident: #ea580c;
-
-// Typography
-$font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Noto Sans KR', sans-serif;
-$font-mono: 'JetBrains Mono', 'Fira Code', Consolas, monospace;
-$font-size-base: 16px;
-$line-height-base: 1.7;
-
-// Spacing
-$spacing-xs: 0.25rem;
-$spacing-sm: 0.5rem;
-$spacing-md: 1rem;
-$spacing-lg: 1.5rem;
-$spacing-xl: 2rem;
-$spacing-2xl: 3rem;
-
-// Border Radius
-$radius-sm: 4px;
-$radius-md: 8px;
-$radius-lg: 12px;
-$radius-full: 9999px;
-
-// Shadows
-$shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-$shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
-$shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
-
-// Transitions
-$transition-fast: 150ms ease;
-$transition-base: 200ms ease;
-$transition-slow: 300ms ease;
-
-// Breakpoints
+// Breakpoints (still used by some SCSS @media queries)
 $breakpoint-sm: 640px;
 $breakpoint-md: 768px;
 $breakpoint-lg: 1024px;


### PR DESCRIPTION
## Summary
Light mode에서 UI 요소가 제대로 표시되지 않는 문제들을 수정합니다.

## Changes

### CSS 변수 수정
- **post h2 하단 보더 안 보임**: `var(--border-color)` → `var(--color-border)` (미정의 변수 참조)
- **AI 번역 배지 색상 오류**: `var(--text-tertiary)` → `var(--color-text-tertiary)`, `var(--border-color, #30363d)` → `var(--color-border)` (다크 모드 fallback 색상 제거)

### Light mode 코드 블록 스크롤바
- `rgba(255,255,255,0.05)` 트랙 → `var(--color-bg-tertiary)` (light 배경에서 보이도록)
- 스크롤바 thumb 색상 light mode 전용 추가

### No-JS 다크모드 대응
- `@media (prefers-color-scheme: dark)` CSS-only fallback 추가
- `:root:not([data-theme])` 선택자로 JS 미실행 시에도 OS 다크모드 반영

### 코드 정리
- `_variables.scss` 미사용 SCSS 변수 제거 (breakpoint/container만 유지)

## Test plan
- [ ] Light mode에서 포스트 h2 하단 보더 표시 확인
- [ ] Light mode 코드 블록 스크롤바 가시성 확인
- [ ] 언어 드롭다운 AI 배지 색상 정상 확인
- [ ] Jekyll build 정상 확인