### PR TITLE
fix: 검색 UI 및 Mermaid 다크모드 CSS 변수 수정

### DIFF
--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -49,7 +49,7 @@
   height: 32px;
   border: none;
   background: rgba(0, 0, 0, 0.06);
-  color: var(--text-color, #333);
+  color: var(--color-text-primary, #333);
   border-radius: 6px;
   cursor: pointer;
   display: flex;

--- a/assets/js/main-search.js
+++ b/assets/js/main-search.js
@@ -26,10 +26,10 @@
       const style = document.createElement('style');
       style.id = 'search-enhanced-styles';
       style.textContent = `
-        .search-source-badge{font-size:.7rem;color:var(--text-secondary,#888);padding:4px 8px;text-align:right;opacity:.7}
-        .search-category{background:var(--accent-color,#4a9eff);color:#fff;font-size:.7rem;padding:1px 6px;border-radius:3px;margin-right:4px}
-        .search-tag{background:var(--bg-secondary,#f0f0f0);color:var(--text-secondary,#666);font-size:.65rem;padding:1px 5px;border-radius:3px;margin-right:3px}
-        .search-result-item.active{background:var(--bg-secondary,#f5f5f5)}
+        .search-source-badge{font-size:.7rem;color:var(--color-text-secondary,#888);padding:4px 8px;text-align:right;opacity:.7}
+        .search-category{background:var(--color-primary,#4a9eff);color:#fff;font-size:.7rem;padding:1px 6px;border-radius:3px;margin-right:4px}
+        .search-tag{background:var(--color-bg-secondary,#f0f0f0);color:var(--color-text-secondary,#666);font-size:.65rem;padding:1px 5px;border-radius:3px;margin-right:3px}
+        .search-result-item.active{background:var(--color-bg-secondary,#f5f5f5)}
         .search-result-item mark{background:rgba(255,200,0,.3);color:inherit;padding:0 1px;border-radius:2px}
       `;
       document.head.appendChild(style);


### PR DESCRIPTION
## Summary
- **main-search.js**: 6개 broken CSS 변수를 design system 표준으로 수정
  - `--text-secondary` → `--color-text-secondary`
  - `--accent-color` → `--color-primary`
  - `--bg-secondary` → `--color-bg-secondary`
- **mermaid.html**: `--text-color` → `--color-text-primary`로 수정
- 다크모드에서 검색 결과 UI와 Mermaid 툴바 버튼 색상이 정상 반영됨

## Test plan
- [ ] 다크모드에서 검색 결과 카테고리 배지, 태그, 활성 항목 색상 확인
- [ ] 다크모드에서 Mermaid 다이어그램 툴바 버튼 텍스트 색상 확인
- [ ] 라이트모드에서 기존 동작 유지 확인