### PR TITLE
fix: Sass @import → @use 마이그레이션

### DIFF
--- a/assets/css/cert-page.scss
+++ b/assets/css/cert-page.scss
@@ -2,4 +2,4 @@
 # Certification page styles (loaded only on certification pages)
 ---
 
-@import "certification";
+@use "certification";

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,11 +4,10 @@
 ---
 
 // Import partials from `_sass`
-// Note: @import is deprecated in Dart Sass 3.0 but required for Jekyll compatibility
-@import "variables";
-@import "base";
-@import "layout";
-@import "components";
-@import "chat-widget";
+@use "variables";
+@use "base";
+@use "layout";
+@use "components";
+@use "chat-widget";
 // post, lightbox, syntax → assets/css/post.scss (loaded on post pages only)
 // certification → assets/css/certification.scss (loaded on certification pages only)

--- a/assets/css/post-page.scss
+++ b/assets/css/post-page.scss
@@ -2,6 +2,6 @@
 # Post-specific styles (loaded only on post pages)
 ---
 
-@import "post";
-@import "lightbox";
-@import "syntax";
+@use "post";
+@use "lightbox";
+@use "syntax";


### PR DESCRIPTION
## Summary
- `assets/css/main.scss`, `post-page.scss`, `cert-page.scss`의 `@import` → `@use` 변경
- Dart Sass 3.0 deprecation 경고 완전 제거
- Jekyll 빌드 테스트 통과 (4.1초, 에러/경고 0)

## Test plan
- [x] Docker ARM64 Ruby 3.2 Jekyll 빌드 성공 확인
- [x] Sass deprecation 경고 0건 확인