### PR TITLE
fix(agents): seo-optimizer에 memory: project 추가

### DIFF
--- a/.claude/agents/seo-optimizer.md
+++ b/.claude/agents/seo-optimizer.md
@@ -6,6 +6,7 @@ disallowedTools: Write, Edit
 model: haiku
 permissionMode: plan
 maxTurns: 8
+memory: project
 ---
 
 You are an SEO specialist for a Korean tech blog.


### PR DESCRIPTION
## Summary
- seo-optimizer 에이전트에 `memory: project` 추가
- SEO 키워드 전략, 패턴을 세션 간 기억하도록 개선

## Test plan
- [ ] 에이전트 로드 시 memory 정상 동작 확인