### PR TITLE
feat: 03-07 기술·보안 주간 다이제스트 - Android 제로데이, DevSecOps 보안 부채

### DIFF
--- a/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
+++ b/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
@@ -1,0 +1,478 @@
+---
+layout: post
+title: "기술·보안 주간 다이제스트: Android 129개 취약점, DevSecOps 보안 부채, K8s 공격 급증"
+date: 2026-03-07 12:00:00 +0900
+categories: [security, devsecops]
+tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Android, Zero-Day, Kubernetes, Supply-Chain]
+excerpt: "Google Android 129개 취약점 패치(Qualcomm 제로데이 CVE-2026-21385 활성 공격), VMware Aria Operations CVE-2026-22719 KEV 등재, Datadog DevSecOps 보고서(87% 조직 취약), VoidLink AI 기반 K8s 악성코드 등 20건의 DevSecOps 실무 위협 분석."
+description: "Google Android 129개 취약점 패치(Qualcomm 제로데이 CVE-2026-21385 활성 공격), VMware Aria Operations CVE-2026-22719 KEV 등재, Datadog DevSecOps 보고서(87% 조직 취약), VoidLink AI 기반 K8s 악성코드 등 20건의 DevSecOps 실무 위협 분석."
+keywords: [Security-Weekly, DevSecOps, Android, Zero-Day, Kubernetes, Supply-Chain, Weekly-Digest, 2026]
+author: Twodragon
+comments: true
+image: /assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
+image_alt: "Tech Security Weekly Digest March 07 2026 Android Zero Day DevSecOps"
+toc: true
+---
+
+{% include ai-summary-card.html
+  title='기술·보안 주간 다이제스트 (2026년 03월 07일)'
+  categories_html='<span class="category-tag security">보안</span> <span class="category-tag devsecops">DevSecOps</span>'
+  tags_html='<span class="tag">Security-Weekly</span>
+      <span class="tag">Android-Zero-Day</span>
+      <span class="tag">DevSecOps-Report</span>
+      <span class="tag">Kubernetes</span>
+      <span class="tag">Supply-Chain</span>
+      <span class="tag">2026</span>'
+  highlights_html='<li><strong>Android 129개 취약점 패치</strong>: Qualcomm 제로데이 CVE-2026-21385 활성 공격 확인, 234개 칩셋 영향</li>
+      <li><strong>VMware Aria Operations 활성 공격</strong>: CVE-2026-22719 CISA KEV 등재, 인증 없이 임의 명령 실행</li>
+      <li><strong>Datadog DevSecOps 보고서</strong>: 87% 조직이 운영 환경에 공격 가능한 취약점 보유, 의존성 평균 278일 지연</li>
+      <li><strong>VoidLink K8s 악성코드</strong>: AI로 제작된 클라우드 네이티브 컨테이너 인식형 악성코드 프레임워크 확산</li>'
+  period='2026년 03월 07일 (24시간)'
+  audience='보안 담당자, DevSecOps 엔지니어, SRE, 클라우드 아키텍트'
+%}
+
+---
+
+## 서론
+
+안녕하세요, **Twodragon**입니다.
+
+2026년 03월 07일 기준, 지난 24시간 동안 발표된 주요 기술 및 보안 뉴스를 심층 분석하여 정리했습니다.
+
+> **관련 다이제스트**: Cisco SD-WAN CVE-2026-20122, Tycoon 2FA 해체, GPT-5.4 출시 등은 [3월 6일 다이제스트](/2026/03/06/Tech_Security_Weekly_Digest_Security_Threat_AI_AWS/)에서 다루었습니다.
+
+**수집 통계:**
+- **총 뉴스 수**: 20개 (큐레이션)
+- **보안 뉴스**: 8개
+- **DevSecOps 뉴스**: 3개
+- **AI/ML 뉴스**: 3개
+- **클라우드/K8s 뉴스**: 3개
+- **블록체인 뉴스**: 3개
+
+---
+
+## 빠른 참조
+
+### 이번 주 하이라이트
+
+| 분야 | 소스 | 핵심 내용 | 영향도 |
+|------|------|----------|--------|
+| **보안** | Google/CISA | Android 129개 취약점 패치, Qualcomm 제로데이 CVE-2026-21385 활성 공격 | Critical |
+| **보안** | CISA | VMware Aria Operations CVE-2026-22719 KEV 등재, 인증 없이 명령 실행 | Critical |
+| **보안** | CISA/Tenable | Cisco SD-WAN CVE-2026-20127 인증 우회, Volt Typhoon 연계 의심 | Critical |
+| **보안** | The Hacker News | APT28 MSHTML 제로데이 CVE-2026-21513, 우크라이나 표적 공격 | High |
+| **보안** | Google TAG | 중국 사이버 첩보 GridTide 캠페인 차단, 42개국 53개 조직 표적 | High |
+| **보안** | Microsoft | OAuth 스캠으로 정부 기관 표적, 악성 리디렉트 URL 활용 | High |
+| **DevSecOps** | Datadog | DevSecOps 2026 보고서: 87% 조직 운영 환경에 공격 가능 취약점 보유 | High |
+| **DevSecOps** | Help Net Security | CI/CD 파이프라인 자동 공격 캠페인, GitHub 토큰 유출 | High |
+| **AI/ML** | SecurityWeek | AI 기반 공격 89% 증가, 에이전틱 AI 랜섬웨어 100배 빠른 유출 | High |
+| **클라우드** | Cisco/Check Point | VoidLink: AI 제작 K8s 인식형 악성코드 프레임워크 | High |
+
+---
+
+![Security News Section Banner](/assets/images/section-security.svg)
+
+## 1. 보안 뉴스
+
+### 1.1 Google Android 3월 보안 업데이트: 129개 취약점 패치
+
+> **심각도**: Critical | **CVE**: CVE-2026-21385, CVE-2026-0006
+
+Google이 **Android 역사상 최대 규모의 보안 업데이트**를 배포했습니다. 총 **129개 취약점**이 수정되었으며, 이 중 **10개는 Critical** 등급입니다. 2018년 4월 이후 단일 월 기준 가장 많은 패치입니다.
+
+핵심은 **CVE-2026-21385**(CVSS 7.8)로, Qualcomm 오픈소스 디스플레이 드라이버의 메모리 손상 취약점입니다. Google은 "제한적이고 표적화된 공격에 활용되고 있다"고 확인했으며, **234개 Qualcomm 칩셋**이 영향을 받습니다. 보안 전문가들은 상업용 스파이웨어 업체가 언론인, 활동가, 정부 관료를 표적으로 이 취약점을 악용하고 있다고 분석합니다.
+
+또한 **CVE-2026-0006**은 System 컴포넌트의 원격 코드 실행(RCE) 취약점으로, 추가 권한 없이 원격에서 악성 코드를 실행할 수 있습니다.
+
+**실무 대응:**
+- Android 보안 패치 레벨 `2026-03-05` 이상으로 즉시 업데이트
+- MDM 정책으로 조직 내 Android 디바이스 패치 상태 모니터링
+- Qualcomm 칩셋 기반 IoT/임베디드 장비도 펌웨어 업데이트 확인
+
+#### 위협 분석
+
+| 항목 | 내용 |
+|------|------|
+| **CVE ID** | CVE-2026-21385 |
+| **CVSS** | 7.8 |
+| **공격 벡터** | 로컬 (표적 공격) |
+| **영향** | 메모리 손상, 권한 상승 |
+| **대상** | 234개 Qualcomm 칩셋 |
+| **심각도** | Critical |
+| **대응 우선순위** | P0 - 즉시 업데이트 |
+
+#### MITRE ATT&CK 매핑
+
+- **T1203** (Exploitation for Client Execution) -- 디스플레이 드라이버 취약점 악용
+- **T1068** (Exploitation for Privilege Escalation) -- 커널 레벨 권한 상승
+- **T1082** (System Information Discovery) -- 칩셋 정보 기반 표적 선별
+
+> **출처**: [The Hacker News](https://thehackernews.com/2026/03/google-confirms-cve-2026-21385-in.html), [CyberScoop](https://cyberscoop.com/android-security-update-march-2026/)
+
+---
+
+### 1.2 VMware Aria Operations 명령 주입 취약점 활성 공격
+
+> **심각도**: Critical | **CVE**: CVE-2026-22719
+
+CISA가 **VMware Aria Operations**의 명령 주입 취약점 CVE-2026-22719(CVSS 8.1)를 **KEV(Known Exploited Vulnerabilities) 카탈로그**에 등재했습니다. 이 취약점은 인증되지 않은 공격자가 임의의 운영 체제 명령을 실행할 수 있게 합니다.
+
+Aria Operations는 VMware 가상화 인프라의 성능 및 용량 관리 핵심 도구이므로, 침해 시 전체 vSphere 환경의 가시성과 제어권이 위험에 노출됩니다.
+
+**실무 대응:**
+- FCEB 기관: 2026년 3월 24일까지 패치 의무 적용
+- VMware Aria Operations 긴급 업데이트 적용
+- Aria Operations 인스턴스의 네트워크 접근 제한 (관리 네트워크로 격리)
+
+#### MITRE ATT&CK 매핑
+
+- **T1059** (Command and Scripting Interpreter) -- 임의 명령 실행
+- **T1190** (Exploit Public-Facing Application) -- 인증 없이 외부 노출 서비스 공격
+
+> **출처**: [The Hacker News](https://thehackernews.com/2026/03/cisa-adds-actively-exploited-vmware.html)
+
+---
+
+### 1.3 Cisco SD-WAN 인증 우회 제로데이 (CVE-2026-20127)
+
+> **심각도**: Critical | **CVE**: CVE-2026-20127
+
+Cisco Catalyst SD-WAN Controller/Manager에서 **인증 우회** 취약점이 발견되어 실제 공격에 활용되고 있습니다. 원격의 인증되지 않은 공격자가 조작된 요청을 보내 **고권한 사용자로 로그인**할 수 있습니다.
+
+CISA는 **긴급 지시문 ED 26-03**을 발령하여 Cisco SD-WAN 시스템의 즉각적인 조치를 명령했습니다. **Volt Typhoon** 그룹이 과거 Cisco 장비를 악용한 이력이 있어, 이번 취약점과의 연관성에 주의가 필요합니다.
+
+**실무 대응:**
+- CISA ED 26-03에 따른 즉시 패치 적용
+- SD-WAN Controller/Manager 접근 로그 긴급 검토
+- 비인가 관리자 계정 생성 여부 확인
+
+#### 위협 분석
+
+| 항목 | 내용 |
+|------|------|
+| **CVE ID** | CVE-2026-20127 |
+| **공격 벡터** | 네트워크 (인증 불필요) |
+| **영향** | 고권한 인증 우회 |
+| **연관 위협** | Volt Typhoon (중국 APT) |
+| **CISA 지시** | ED 26-03 긴급 지시문 |
+| **대응 우선순위** | P0 - 즉시 대응 |
+
+> **출처**: [Tenable](https://www.tenable.com/blog/cve-2026-20127-cisco-catalyst-sd-wan-controllermanager-zero-day-authentication-bypass), [CISA](https://www.cisa.gov/news-events/alerts/2026/03/05/cisa-adds-five-known-exploited-vulnerabilities-catalog)
+
+---
+
+### 1.4 APT28 MSHTML 제로데이 악용 확인 (CVE-2026-21513)
+
+> **심각도**: High | **CVE**: CVE-2026-21513
+
+러시아 연계 APT28(Fancy Bear)이 Microsoft MSHTML 프레임워크의 보안 기능 우회 취약점 **CVE-2026-21513**(CVSS 8.8)을 **2월 패치 전부터 제로데이로 악용**한 것이 확인되었습니다.
+
+이 취약점은 Microsoft의 2026년 2월 Patch Tuesday에서 수정되었지만, 패치 전 우크라이나를 표적으로 한 실제 공격에 사용되었습니다.
+
+**실무 대응:**
+- 2026년 2월 Windows 보안 업데이트 미적용 시 즉시 패치
+- MSHTML 관련 탐지 규칙 추가 (특히 Mark-of-the-Web 우회 시도)
+- 우크라이나 관련 조직은 APT28 IoC 긴급 점검
+
+> **출처**: [The Hacker News](https://thehackernews.com/2026/03/apt28-tied-to-cve-2026-21513-mshtml-0.html)
+
+---
+
+### 1.5 Google, 중국 사이버 첩보 캠페인 GridTide 차단
+
+> **심각도**: High
+
+Google이 **42개국 53개 조직**을 표적으로 한 대규모 중국 사이버 첩보 캠페인을 차단했습니다. **GridTide** 악성코드를 사용한 이 캠페인은 정부, 국방, 기술 분야를 주로 공격했습니다.
+
+**실무 대응:**
+- Google TAG가 공개한 GridTide IoC 기반 네트워크 스캔
+- 외부 노출 서비스의 비정상 트래픽 패턴 점검
+- APT 수준의 위협에 대비한 EDR/NDR 탐지 규칙 업데이트
+
+> **출처**: [Cybersecurity News](https://www.cybersecurity-review.com/news-march-2026/)
+
+---
+
+### 1.6 악성 PHP 패키지: 크로스 플랫폼 RAT 배포
+
+> **심각도**: High
+
+Packagist PHP 패키지 레지스트리에서 Laravel 유틸리티로 위장한 **악성 패키지**가 발견되었습니다. Windows, macOS, Linux 모두에서 작동하는 **크로스 플랫폼 RAT(원격 접근 트로이목마)**를 배포하며, 발견 시점에도 여전히 다운로드 가능했습니다.
+
+**실무 대응:**
+- 프로젝트의 Composer 의존성 감사 (`composer audit`)
+- 최근 추가된 Laravel 관련 패키지의 출처와 다운로드 수 확인
+- CI/CD 파이프라인에 패키지 출처 검증 단계 추가
+
+> **출처**: [The Hacker News](https://thehackernews.com/)
+
+---
+
+### 1.7 Microsoft OAuth 스캠: 정부 기관 표적 공격
+
+> **심각도**: High
+
+Microsoft가 **OAuth 남용 스캠**에 대해 경고했습니다. 피싱 이메일과 URL 리디렉트를 활용하여 피해자의 시스템에 악성코드를 설치하며, 주로 **정부 및 공공 부문 조직**을 표적으로 합니다.
+
+**실무 대응:**
+- Azure AD/Entra ID의 OAuth 앱 동의 정책 강화
+- 관리자 동의 워크플로우 활성화
+- 비정상 OAuth 앱 등록/권한 부여 모니터링
+
+> **출처**: [Microsoft Security](https://www.microsoft.com/en-us/security/blog/)
+
+---
+
+### 1.8 보복성 핵티비스트 공격 급증: Epic Fury 이후
+
+> **심각도**: Medium
+
+미국-이스라엘 합동 군사 작전(Epic Fury/Roaring Lion) 이후 **보복성 핵티비스트 활동이 급증**했습니다. Radware에 따르면, **Keymous+**와 **DieNet** 두 그룹이 2월 28일-3월 2일 사이 전체 공격의 약 70%를 수행했습니다.
+
+**실무 대응:**
+- DDoS 완화 서비스 확인 및 임계값 조정
+- 중동 관련 서비스 운영 조직은 WAF 규칙 강화
+- 핵티비스트 그룹 IoC 모니터링
+
+> **출처**: [The Hacker News](https://thehackernews.com/)
+
+---
+
+![DevSecOps Section Banner](/assets/images/section-devsecops.svg)
+
+## 2. DevSecOps 뉴스
+
+### 2.1 Datadog DevSecOps 2026 보고서: 87% 조직이 공격 가능 취약점 보유
+
+> **심각도**: High
+
+Datadog의 **State of DevSecOps 2026** 보고서가 발표되었습니다. 조사 대상 조직의 **87%가 운영 환경에서 하나 이상의 공격 가능한 취약점**을 실행하고 있으며, 서비스의 40%가 영향을 받습니다.
+
+핵심 수치:
+- **Java 서비스의 59%**에 공격 가능한 취약점 존재 (.NET 47%, Rust 40%)
+- 의존성은 최신 버전 대비 **평균 278일 지연** (작년 215일에서 악화)
+- Java는 **492일** 지연으로 가장 심각
+- EOL(지원 종료) 런타임 사용: 서비스의 10% (Go 23%, PHP 13%)
+- **월 1회 미만 배포 조직**은 매일 배포 조직보다 **70% 더 많은 오래된 라이브러리** 보유
+
+**실무 대응:**
+- SCA(Software Composition Analysis) 도구로 운영 환경 의존성 감사
+- 배포 빈도 증가가 보안 부채 감소에 직접적 연관 -- CI/CD 자동화 강화
+- EOL 런타임 사용 현황 파악 및 업그레이드 계획 수립
+
+> **출처**: [Help Net Security](https://www.helpnetsecurity.com/2026/03/02/devsecops-supply-chain-risk-security-debt/), [StepSecurity](https://www.stepsecurity.io/blog/datadogs-devsecops-2026-report-validates-what-weve-been-building)
+
+---
+
+### 2.2 CI/CD 파이프라인 자동 공격 캠페인
+
+> **심각도**: High
+
+주요 오픈소스 리포지토리를 대상으로 한 **1주일간의 자동화된 CI/CD 파이프라인 공격**이 보고되었습니다. **hackerbot-claw**라는 자율 봇이 5가지 익스플로잇 기법을 사용하여 GitHub에서 가장 인기 있는 리포지토리 중 하나에서 **쓰기 권한이 있는 GitHub 토큰을 유출**하는 데 성공했습니다.
+
+**실무 대응:**
+- GitHub Actions 워크플로우에서 `permissions` 블록으로 최소 권한 적용
+- `GITHUB_TOKEN` 권한을 `read-only`로 기본 설정
+- 서드파티 Actions의 커밋 SHA 고정 (태그 대신)
+- 워크플로우 실행 로그에서 비정상 토큰 사용 모니터링
+
+> **출처**: [Help Net Security](https://www.helpnetsecurity.com/2026/03/02/devsecops-supply-chain-risk-security-debt/)
+
+---
+
+### 2.3 코드 서명 인증서 유효기간 460일로 제한
+
+> **심각도**: Medium
+
+2026년 3월 1일부터 CA/B Forum 규정에 따라 **코드 서명 인증서의 최대 유효기간이 460일**로 제한됩니다. 공급망 공격이 증가하고 AI 기반 위협이 확대되면서, DevSecOps 팀은 CI/CD 보안을 강화하고 인증서 갱신 자동화가 필수가 되었습니다.
+
+**실무 대응:**
+- 코드 서명 인증서 만료일 확인 및 자동 갱신 파이프라인 구축
+- cert-manager 또는 HashiCorp Vault PKI로 자동화
+- 인증서 만료 30일 전 알림 설정
+
+> **출처**: [DevOps.com](https://devops.com/three-encryption-resolutions-for-devsecops-in-2026/)
+
+---
+
+![AI Section Banner](/assets/images/section-ai.svg)
+
+## 3. AI/ML 뉴스
+
+### 3.1 AI 기반 사이버 공격 89% 증가
+
+> **심각도**: High
+
+2026년 3월 기준, **AI 기반 사이버 공격이 89% 증가**했습니다. 피싱, 딥페이크 캠페인, 자격 증명 탈취에 AI가 적극적으로 활용되고 있으며, 아이덴티티 위협(API 자격 증명 남용, 내부자 위협)이 대부분의 데이터 유출 원인을 차지합니다.
+
+특히 위험한 것은 **에이전틱 AI**의 등장입니다. 기존 도구와 달리, 에이전틱 AI는 네트워크 방어에 적응하고, 공격 중 페이로드를 변경하며, 탐지 응답으로부터 학습할 수 있습니다. 통제된 테스트에서 **AI 기반 랜섬웨어가 인간 공격자보다 100배 빠른 데이터 유출**을 달성했습니다.
+
+**실무 대응:**
+- AI 기반 피싱 탐지 도구 도입 (기존 패턴 매칭만으로 부족)
+- 딥페이크 기반 소셜 엔지니어링에 대비한 다단계 인증 절차 강화
+- 아이덴티티 및 횡적 이동 가시성 확보가 핵심 방어선
+
+> **출처**: [SecurityWeek](https://www.securityweek.com/cyber-insights-2026-malware-and-cyberattacks-in-the-age-of-ai/), [ThreatDown](https://www.threatdown.com/blog/machine-scale-cybercrime-the-2026-state-of-malware-report/)
+
+---
+
+### 3.2 AI가 DevSecOps를 재편: PR 병합 98% 증가
+
+> **심각도**: Medium
+
+AI를 활용하는 개발자는 **98% 더 많은 PR을 병합**하고 있습니다. 보안 팀에게 이 속도는 복합적인 문제를 만듭니다. 코드가 더 많고, 더 빠르게 생산되며, 리뷰할 시간은 줄어듭니다.
+
+JFrog은 **AI 모델을 소프트웨어 아티팩트와 동일한 수준으로 관리**하는 플랫폼 확장을 발표하여, DevSecOps, MLOps, 거버넌스를 하나의 플랫폼으로 통합합니다.
+
+**실무 대응:**
+- AI 생성 코드에 대한 자동 보안 스캔 파이프라인 필수
+- SAST/SCA 도구를 PR 수준에서 게이트로 설정
+- AI 모델 아티팩트도 SBOM에 포함
+
+> **출처**: [Computer Weekly](https://www.computerweekly.com/news/366639364/How-AI-code-generation-is-pushing-DevSecOps-to-machine-speed)
+
+---
+
+### 3.3 랜섬웨어 생태계의 구조적 변화
+
+> **심각도**: High
+
+랜섬웨어 공격은 2025년 7,200건으로 전년 대비 **47% 증가**했지만, 수익은 감소했습니다. **LockBit과 RansomHub**가 사라진 후 **Akira(16%), Qilin(16%), DragonForce(5%)**가 부상했습니다.
+
+Recorded Future는 **2026년을 러시아 외 지역 랜섬웨어 조직이 러시아 내 조직 수를 처음으로 초과하는 해**로 예측합니다. 전술도 변화하여, 암호화 대신 데이터 탈취와 AI 딥페이크를 결합한 **"심리적 랜섬웨어"** 방식이 확산되고 있습니다.
+
+**실무 대응:**
+- 암호화보다 데이터 유출 방지(DLP)에 초점
+- 백업만으로 부족 -- 데이터 유출 탐지 및 차단 역량 강화
+- 공격자의 표준화된 플레이북을 역이용하여 허니팟/디코이 배치
+
+> **출처**: [Recorded Future](https://www.recordedfuture.com/blog/ransomware-tactics-2026), [BlackFog](https://www.blackfog.com/the-state-of-ransomware-2026/)
+
+---
+
+![Cloud Section Banner](/assets/images/section-cloud.svg)
+
+## 4. 클라우드/K8s 뉴스
+
+### 4.1 VoidLink: AI로 제작된 K8s 인식형 악성코드
+
+> **심각도**: High
+
+Check Point Research가 공개한 **VoidLink**는 클라우드 네이티브 환경에 특화된 악성코드 프레임워크입니다. AWS, GCP, Azure, Alibaba, Tencent 환경을 탐지하고, Docker 컨테이너와 Kubernetes 포드 내부에서 동작하는지 판별하여 **행위를 자동으로 조정**합니다.
+
+이는 공격자가 **클라우드 네이티브, 컨테이너 인식형, AI 가속 공격 프레임워크**를 구축하는 새로운 단계에 진입했음을 의미합니다.
+
+**실무 대응:**
+- 런타임 컨테이너 보안 도구 배포 (Falco, Sysdig Secure)
+- Pod Security Standards 적용 (`restricted` 프로필)
+- K8s RBAC 최소 권한 원칙 검토 및 서비스 어카운트 감사
+
+#### MITRE ATT&CK 매핑 (Containers)
+
+- **T1610** (Deploy Container) -- 악성 컨테이너 배포
+- **T1613** (Container and Resource Discovery) -- 클라우드/K8s 환경 탐지
+- **T1611** (Escape to Host) -- 컨테이너 탈출 시도
+
+> **출처**: [Cisco Security Blog](https://blogs.cisco.com/security/voidlink-ai-built-malware-and-the-future-of-workload-security)
+
+---
+
+### 4.2 Kubernetes 공격 도구 급증
+
+> **심각도**: High
+
+CSO Online은 2026년 3월 **Kubernetes 전용 공격 도구의 급격한 증가**를 보고했습니다. 노출된 API 서버를 통한 권한 상승, 탈취된 Pod를 이용한 크립토마이너 배포 등 점점 정교한 공격이 이루어지고 있습니다.
+
+Kubernetes는 전 세계 컨테이너화된 워크로드의 **60% 이상**을 관리하며, API 서버, etcd, kubelet, 서비스 어카운트, 컨테이너 런타임 모두가 공격 표면입니다.
+
+**실무 대응:**
+- K8s API 서버 외부 노출 차단 (VPN/Bastion 경유)
+- etcd 암호화 및 접근 제어 강화
+- Network Policy로 Pod 간 통신 최소화
+- `kube-bench`로 CIS Kubernetes 벤치마크 준수 점검
+
+> **출처**: [DEV Community](https://dev.to/deepseax/kubernetes-cluster-attacks-surge-in-2026-how-to-harden-your-k8s-foo)
+
+---
+
+### 4.3 서비스 메시 복귀: 제로 트러스트 보안 강화
+
+> **심각도**: Medium
+
+2026년 서비스 메시가 **제로 트러스트 보안의 핵심 인프라**로 재부상하고 있습니다. 기존 사이드카 기반 메시의 채택은 50%에서 42%로 감소했지만, **Ambient Mode(사이드카리스)** 아키텍처가 새로운 관심을 끌고 있습니다.
+
+AI 기반 워크로드의 증가로 보안 연결, 워크로드 아이덴티티, 관측성 문제가 더욱 시급해졌습니다.
+
+**실무 대응:**
+- Istio Ambient Mode 또는 Cilium Service Mesh 평가
+- mTLS 기반 서비스 간 통신 암호화 적용
+- 서비스 메시 기반 트래픽 관측 및 이상 탐지
+
+> **출처**: [Cloud Native Now](https://cloudnativenow.com/contributed-content/why-service-mesh-is-poised-for-a-dramatic-comeback-in-2026/)
+
+---
+
+![Blockchain Section Banner](/assets/images/section-blockchain.svg)
+
+## 5. 블록체인 뉴스
+
+### 5.1 GENIUS Act: 미국 스테이블코인 규제 프레임워크 구체화
+
+> **심각도**: Medium
+
+2025년 7월 초당적으로 통과된 **GENIUS Act**의 구현 타임라인이 구체화되고 있습니다. 감독 기관은 **2026년 7월 18일까지** 미국 달러 기반 스테이블코인 발행사에 대한 시행 규칙을 발표해야 하며, 규정은 **2027년 1월 18일까지** 발효됩니다.
+
+SEC와 CFTC도 **Project Crypto** 공동 프로젝트를 발표하며 디지털 자산 규제 협력을 강화하고 있습니다.
+
+**실무 대응:**
+- 스테이블코인 관련 서비스 운영 조직은 GENIUS Act 준수 타임라인 확인
+- AML/KYC 체계를 새 규정에 맞게 업데이트 계획 수립
+
+> **출처**: [Cleary Gottlieb](https://www.clearygottlieb.com/news-and-insights/publication-listing/2026-digital-assets-regulatory-update-a-landmark-2025-but-more-developments-on-the-horizon)
+
+---
+
+### 5.2 일본 암호화폐 세율 55%에서 20%로 인하 예정
+
+> **심각도**: Medium
+
+일본이 **2026년 암호화폐 세율을 55%에서 20%로 인하**할 예정입니다. 기존 잡소득으로 분류되던 암호화폐 수익을 전통적인 자본 이득세율과 동일하게 적용하여, 암호화폐 투자 환경을 크게 개선합니다.
+
+> **출처**: [Sumsub](https://sumsub.com/blog/global-crypto-regulations/)
+
+---
+
+### 5.3 EU MiCA 전면 시행: 세계 최초 포괄적 암호화폐 규제
+
+> **심각도**: Medium
+
+EU의 **MiCA(Markets in Crypto-Assets Regulation)**가 **전면 시행**에 들어갔습니다. 세계 최초의 포괄적 암호화폐 규제 프레임워크로, 엄격한 요구사항으로 인해 일부 시장 참여자에게는 상당한 혼란이 발생하고 있습니다.
+
+> **출처**: [Elliptic](https://www.elliptic.co/blog/regulatory-and-policy-crypto-trends-to-except-in-2026)
+
+---
+
+## 마무리
+
+### 이번 주 핵심 Action Items
+
+| 우선순위 | 조치 항목 | 관련 뉴스 |
+|---------|----------|----------|
+| P0 | Android 보안 패치 `2026-03-05` 즉시 적용 | 1.1 Android 129개 취약점 |
+| P0 | VMware Aria Operations 긴급 패치 | 1.2 CVE-2026-22719 |
+| P0 | Cisco SD-WAN Controller CISA ED 26-03 대응 | 1.3 CVE-2026-20127 |
+| P1 | Windows 2월 보안 업데이트 미적용 시 즉시 패치 | 1.4 APT28 MSHTML |
+| P1 | 운영 환경 SCA 감사 및 EOL 런타임 교체 | 2.1 Datadog 보고서 |
+| P1 | GitHub Actions 토큰 권한 최소화 | 2.2 CI/CD 공격 |
+| P1 | K8s API 서버 외부 노출 차단 및 RBAC 감사 | 4.1-4.2 K8s 위협 |
+| P2 | AI 생성 코드 자동 보안 스캔 게이트 설정 | 3.2 AI DevSecOps |
+| P2 | DLP 역량 강화 (랜섬웨어 전술 변화 대비) | 3.3 랜섬웨어 생태계 |
+
+---
+
+> **다음 다이제스트**는 2026년 3월 8일에 업데이트됩니다.
+> 질문이나 추가 분석이 필요한 항목이 있으면 댓글로 남겨주세요.
+
+---
+
+*이 포스트가 유용했다면, [tech.2twodragon.com](https://tech.2twodragon.com)을 방문하여 더 많은 DevSecOps 인사이트를 확인하세요.*

--- a/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
+++ b/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
@@ -1,0 +1,185 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="50%" stop-color="#080f1a"/>
+      <stop offset="100%" stop-color="#0f172a"/>
+    </linearGradient>
+    <linearGradient id="accentRed" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#b91c1c"/>
+    </linearGradient>
+    <linearGradient id="accentGreen" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#15803d"/>
+    </linearGradient>
+    <linearGradient id="shieldGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#dc2626"/>
+      <stop offset="100%" stop-color="#7f1d1d"/>
+    </linearGradient>
+    <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.3"/>
+      <stop offset="100%" stop-color="#ef4444" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowGreen" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Glow -->
+  <ellipse cx="130" cy="270" rx="175" ry="175" fill="url(#glowRed)"/>
+  <ellipse cx="1060" cy="250" rx="215" ry="200" fill="url(#glowGreen)"/>
+
+  <!-- Grid pattern -->
+  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
+    <line x1="0" y1="100" x2="1200" y2="100"/>
+    <line x1="0" y1="200" x2="1200" y2="200"/>
+    <line x1="0" y1="300" x2="1200" y2="300"/>
+    <line x1="0" y1="400" x2="1200" y2="400"/>
+    <line x1="0" y1="500" x2="1200" y2="500"/>
+    <line x1="200" y1="0" x2="200" y2="630"/>
+    <line x1="400" y1="0" x2="400" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/>
+    <line x1="800" y1="0" x2="800" y2="630"/>
+    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  </g>
+
+  <!-- Primary icon: Android Shield with vulnerability -->
+  <g transform="translate(44, 145)">
+    <!-- Shield shape -->
+    <path d="M62 10 L110 30 L110 75 C110 105 90 130 62 145 C34 130 14 105 14 75 L14 30 Z" fill="url(#shieldGrad)" opacity="0.9"/>
+    <path d="M62 25 L98 40 L98 72 C98 95 82 115 62 126 C42 115 26 95 26 72 L26 40 Z" fill="#7f1d1d" opacity="0.5"/>
+    <!-- Android robot head -->
+    <rect x="42" y="50" width="40" height="30" rx="4" fill="#22c55e" opacity="0.8"/>
+    <rect x="42" y="44" width="40" height="20" rx="10" fill="#22c55e" opacity="0.8"/>
+    <!-- Eyes -->
+    <circle cx="52" cy="52" r="3" fill="#0f172a"/>
+    <circle cx="72" cy="52" r="3" fill="#0f172a"/>
+    <!-- Antennae -->
+    <line x1="50" y1="35" x2="45" y2="26" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+    <line x1="74" y1="35" x2="79" y2="26" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+    <!-- Warning triangle overlay -->
+    <polygon points="62,62 52,80 72,80" fill="#ef4444" stroke="#fca5a5" stroke-width="1.5"/>
+    <text x="62" y="77" text-anchor="middle" fill="white" font-family="Arial" font-size="10" font-weight="bold">!</text>
+    <!-- CVE label -->
+    <rect x="14" y="128" width="96" height="22" rx="6" fill="#7f1d1d" opacity="0.8"/>
+    <text x="62" y="143" text-anchor="middle" fill="#fca5a5" font-family="monospace" font-size="11" font-weight="bold" letter-spacing="2">129 CVEs</text>
+  </g>
+
+  <!-- Secondary icon: DevSecOps Pipeline -->
+  <g transform="translate(44, 355)">
+    <!-- Pipeline stages -->
+    <rect x="10" y="30" width="35" height="28" rx="4" fill="#03131c" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="27" y="48" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="8" font-weight="bold">DEV</text>
+    <line x1="45" y1="44" x2="55" y2="44" stroke="#22c55e" stroke-width="1.5"/>
+    <polygon points="53,40 60,44 53,48" fill="#22c55e"/>
+    <rect x="60" y="30" width="35" height="28" rx="4" fill="#03131c" stroke="#eab308" stroke-width="1.5"/>
+    <text x="77" y="48" text-anchor="middle" fill="#facc15" font-family="monospace" font-size="8" font-weight="bold">SEC</text>
+    <line x1="95" y1="44" x2="105" y2="44" stroke="#eab308" stroke-width="1.5"/>
+    <polygon points="103,40 110,44 103,48" fill="#eab308"/>
+    <rect x="110" y="30" width="35" height="28" rx="4" fill="#03131c" stroke="#06b6d4" stroke-width="1.5"/>
+    <text x="127" y="48" text-anchor="middle" fill="#22d3ee" font-family="monospace" font-size="8" font-weight="bold">OPS</text>
+    <!-- Stats -->
+    <text x="10" y="85" fill="#ef4444" font-family="monospace" font-size="10" font-weight="bold">87%</text>
+    <text x="10" y="98" fill="#94a3b8" font-family="monospace" font-size="8">orgs exposed</text>
+    <text x="75" y="85" fill="#eab308" font-family="monospace" font-size="10" font-weight="bold">278d</text>
+    <text x="75" y="98" fill="#94a3b8" font-family="monospace" font-size="8">dep lag</text>
+    <!-- Label -->
+    <text x="62" y="125" text-anchor="middle" fill="#22c55e" font-family="monospace" font-size="10" font-weight="bold" letter-spacing="2">DEVSECOPS</text>
+  </g>
+
+  <!-- Main title area -->
+  <g transform="translate(210, 95)">
+    <text x="0" y="0" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" letter-spacing="5">TECH SECURITY WEEKLY DIGEST</text>
+    <text x="0" y="55" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="bold">Tech Security Weekly</text>
+    <text x="0" y="103" fill="#67e8f9" font-family="Arial, sans-serif" font-size="30" font-weight="300">Android Zero-Day DevSecOps K8s</text>
+  </g>
+
+  <!-- Date badge -->
+  <rect x="210" y="230" width="188" height="36" rx="18" fill="url(#accentRed)" opacity="0.9"/>
+  <text x="304" y="254" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="15" font-weight="bold">March 07, 2026</text>
+
+  <!-- Stats cards -->
+  <g transform="translate(210, 298)">
+    <!-- Card 1: Security -->
+    <rect x="0" y="0" width="195" height="95" rx="10" fill="#180a0a" stroke="#dc2626" stroke-width="1.5"/>
+    <text x="16" y="28" fill="#ef4444" font-family="Arial, sans-serif" font-size="11" font-weight="bold" letter-spacing="1">SECURITY</text>
+    <text x="16" y="68" fill="#f8fafc" font-family="Arial, sans-serif" font-size="40" font-weight="bold">8</text>
+    <text x="60" y="68" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">articles</text>
+    <text x="16" y="85" fill="#64748b" font-family="Arial, sans-serif" font-size="12">Android CVE, VMware, APT28</text>
+    <!-- Card 2: DevSecOps -->
+    <rect x="215" y="0" width="195" height="95" rx="10" fill="#0d1520" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="231" y="28" fill="#4ade80" font-family="Arial, sans-serif" font-size="11" font-weight="bold" letter-spacing="1">DEVSECOPS</text>
+    <text x="231" y="68" fill="#f8fafc" font-family="Arial, sans-serif" font-size="40" font-weight="bold">6</text>
+    <text x="275" y="68" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">articles</text>
+    <text x="231" y="85" fill="#64748b" font-family="Arial, sans-serif" font-size="12">Datadog, CI/CD, AI Agent</text>
+    <!-- Card 3: Cloud -->
+    <rect x="430" y="0" width="195" height="95" rx="10" fill="#03131c" stroke="#0ea5e9" stroke-width="1.5"/>
+    <text x="446" y="28" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="bold" letter-spacing="1">CLOUD / K8S</text>
+    <text x="446" y="68" fill="#f8fafc" font-family="Arial, sans-serif" font-size="40" font-weight="bold">6</text>
+    <text x="490" y="68" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">articles</text>
+    <text x="446" y="85" fill="#64748b" font-family="Arial, sans-serif" font-size="12">VoidLink, K8s Attacks</text>
+  </g>
+
+  <!-- Key topic tags -->
+  <g transform="translate(210, 430)">
+    <rect x="0" y="0" width="110" height="32" rx="16" fill="#7f1d1d" opacity="0.85"/>
+    <text x="55" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="bold">Android 129</text>
+    <rect x="124" y="0" width="82" height="32" rx="16" fill="#14532d" opacity="0.85"/>
+    <text x="165" y="21" text-anchor="middle" fill="#4ade80" font-family="Arial, sans-serif" font-size="13" font-weight="bold">DevSec</text>
+    <rect x="220" y="0" width="82" height="32" rx="16" fill="#062535" opacity="0.85"/>
+    <text x="261" y="21" text-anchor="middle" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13" font-weight="bold">VoidLink</text>
+    <rect x="316" y="0" width="72" height="32" rx="16" fill="#1e293b" opacity="0.85"/>
+    <text x="352" y="21" text-anchor="middle" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="13" font-weight="bold">APT28</text>
+  </g>
+
+  <!-- Right visualization -->
+  <g transform="translate(858, 138)" opacity="0.55">
+    <!-- Android CVE severity -->
+    <rect x="60" y="8" width="190" height="28" rx="6" fill="#180a0a" stroke="#ef4444" stroke-width="1.5"/>
+    <text x="155" y="27" text-anchor="middle" fill="#fca5a5" font-family="monospace" font-size="11" font-weight="bold">ANDROID CVE-2026-21385</text>
+    <!-- Severity bar -->
+    <rect x="60" y="44" width="190" height="12" rx="6" fill="#1e293b"/>
+    <rect x="60" y="44" width="148" height="12" rx="6" fill="#ef4444" opacity="0.85"/>
+    <text x="245" y="55" text-anchor="end" fill="#fca5a5" font-family="monospace" font-size="9">7.8/10</text>
+    <!-- Attack chain -->
+    <rect x="60" y="70" width="80" height="28" rx="5" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
+    <text x="100" y="88" text-anchor="middle" fill="#fca5a5" font-family="monospace" font-size="9">Qualcomm 0day</text>
+    <line x1="140" y1="84" x2="160" y2="84" stroke="#ef4444" stroke-width="1.5"/>
+    <polygon points="158,79 168,84 158,89" fill="#ef4444"/>
+    <rect x="168" y="70" width="82" height="28" rx="5" fill="#1e293b" stroke="#dc2626" stroke-width="1"/>
+    <text x="209" y="88" text-anchor="middle" fill="#fca5a5" font-family="monospace" font-size="9">234 Chipsets</text>
+    <!-- DevSecOps section -->
+    <line x1="155" y1="108" x2="155" y2="128" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="4,3"/>
+    <text x="155" y="148" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="11" font-weight="bold">DEVSECOPS 2026</text>
+    <!-- Stats boxes -->
+    <rect x="60" y="158" width="82" height="26" rx="4" fill="#03131c" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="101" y="175" text-anchor="middle" fill="#4ade80" font-family="monospace" font-size="9" font-weight="bold">87% EXPOSED</text>
+    <rect x="168" y="158" width="82" height="26" rx="4" fill="#03131c" stroke="#eab308" stroke-width="1.5"/>
+    <text x="209" y="175" text-anchor="middle" fill="#facc15" font-family="monospace" font-size="9" font-weight="bold">278d LAG</text>
+    <!-- K8s section -->
+    <line x1="155" y1="194" x2="155" y2="214" stroke="#38bdf8" stroke-width="1.5" stroke-dasharray="4,3"/>
+    <rect x="68" y="214" width="174" height="50" rx="6" fill="#03131c" stroke="#0ea5e9" stroke-width="1.5"/>
+    <text x="155" y="234" text-anchor="middle" fill="#38bdf8" font-family="monospace" font-size="9" font-weight="bold">K8S THREAT LANDSCAPE</text>
+    <text x="155" y="250" text-anchor="middle" fill="#94a3b8" font-family="monospace" font-size="9">VoidLink / GridTide / CI-CD</text>
+    <text x="155" y="263" text-anchor="middle" fill="#64748b" font-family="monospace" font-size="9">Agentic AI / Supply Chain</text>
+  </g>
+
+  <!-- Bottom bar -->
+  <rect x="0" y="510" width="1200" height="120" fill="#080e1a" opacity="0.9"/>
+  <rect x="0" y="510" width="1200" height="2" fill="url(#accentRed)" opacity="0.6"/>
+  <rect x="0" y="512" width="1200" height="1" fill="url(#accentGreen)" opacity="0.3"/>
+
+  <!-- Bottom text -->
+  <text x="80" y="558" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16" font-weight="bold">tech.2twodragon.com</text>
+  <text x="80" y="584" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
+
+  <!-- Bottom right -->
+  <text x="1130" y="552" text-anchor="end" fill="#ef4444" font-family="Arial, sans-serif" font-size="22" font-weight="bold">20</text>
+  <text x="1130" y="570" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">curated articles</text>
+  <text x="1130" y="588" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="12">Android 0day | DevSecOps | VoidLink | APT28</text>
+</svg>


### PR DESCRIPTION
## Summary
- 2026-03-07 기술·보안 주간 다이제스트 포스트 생성
- 전용 SVG OG 이미지 생성

## 주요 뉴스 (20건)
- **보안 8건**: Android 129 CVE (Qualcomm 0day), VMware Aria CVE-2026-22719, Cisco SD-WAN CVE-2026-20127, APT28 MSHTML 0day, GridTide 중국 첩보, PHP RAT, MS OAuth 스캠, 핵티비스트 급증
- **DevSecOps 3건**: Datadog 보고서 (87% 취약), CI/CD 자동 공격, 코드서명 460일 제한
- **AI/ML 3건**: AI 공격 89% 증가, AI DevSecOps PR 98% 증가, 랜섬웨어 생태계 변화
- **클라우드/K8s 3건**: VoidLink K8s 악성코드, K8s 공격 도구 급증, 서비스 메시 복귀
- **블록체인 3건**: GENIUS Act, 일본 세율 인하, EU MiCA 시행

## Validation
- [x] Front matter 12개 항목 PASS
- [x] SVG 한국어 없음 확인
- [x] FAQ 섹션 없음
- [x] 기존 포스트 구조/패턴 준수