### PR TITLE
fix: Safari Mermaid 렌더링 호환성 개선

### DIFF
--- a/assets/js/mermaid-init.js
+++ b/assets/js/mermaid-init.js
@@ -7,6 +7,9 @@
   var hasMermaid = document.querySelector('.language-mermaid, pre code.mermaid');
   if (!hasMermaid) return;
 
+  // Detect Safari (foreignObject rendering issues)
+  var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
   // Load mermaid.js on demand
   var script = document.createElement('script');
   script.src = 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js';
@@ -17,10 +20,10 @@
       mermaid.initialize({
         startOnLoad: false,
         theme: isDark ? 'dark' : 'default',
-        securityLevel: 'loose',
+        securityLevel: 'strict',
         flowchart: {
           useMaxWidth: true,
-          htmlLabels: true,
+          htmlLabels: !isSafari,
           curve: 'basis',
           padding: 15
         },
@@ -104,8 +107,8 @@
         var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
         mermaid.initialize({
           theme: isDark ? 'dark' : 'default',
-          securityLevel: 'loose',
-          flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
+          securityLevel: 'strict',
+          flowchart: { useMaxWidth: true, htmlLabels: !isSafari, curve: 'basis' },
           sequence: { useMaxWidth: true, wrap: true },
           logLevel: 'error'
         });


### PR DESCRIPTION
## Summary
- Safari에서 Mermaid 다이어그램이 깨지는 문제 수정
- Safari의 SVG foreignObject 렌더링 버그 우회: `htmlLabels: false` 적용
- `securityLevel: 'strict'`로 변경하여 안정적 SVG 텍스트 렌더링
- 다크모드 전환 시 재렌더링에도 동일 설정 적용

## Root Cause
Safari는 SVG 내 `foreignObject` 요소 렌더링에 문제가 있어, `htmlLabels: true` 설정 시 노드 텍스트가 보이지 않거나 레이아웃이 깨짐

## Test plan
- [ ] Safari에서 Mermaid flowchart 정상 렌더링 확인
- [ ] Chrome/Firefox에서 기존 렌더링 유지 확인
- [ ] 다크모드 전환 시 정상 재렌더링 확인