### PR TITLE
fix: Mermaid SVG 이미지 사이즈 확대

### DIFF
--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -4,16 +4,12 @@
 img[src*="/mermaid/"] {
   display: block;
   margin: 1.5rem auto;
-  max-width: 100%;
-  min-width: 280px;
-  max-height: 800px;
-  width: auto;
+  width: 100%;
   height: auto;
   padding: 1.5rem;
   border-radius: 12px;
   background: #f8f9fa;
   border: 1px solid #e2e8f0;
-  object-fit: contain;
 }
 
 [data-theme="dark"] img[src*="/mermaid/"] {
@@ -24,9 +20,6 @@ img[src*="/mermaid/"] {
 @media (max-width: 768px) {
   img[src*="/mermaid/"] {
     padding: 0.75rem;
-    min-width: 200px;
-    max-height: 600px;
-    overflow-x: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- SVG 이미지가 너무 작게 표시되는 문제 수정
- `width: auto` → `width: 100%`로 변경하여 콘텐츠 영역을 가득 채움

## Test plan
- [ ] 데스크톱에서 적절한 크기로 표시 확인
- [ ] 모바일에서 반응형 표시 확인
- [ ] 다크모드에서 정상 표시 확인