### PR TITLE
fix: Mermaid SVG 다크모드 배경 투명 + 색상 반전

### DIFF
--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -9,14 +9,15 @@ img[src*="/mermaid/"] {
   min-height: 120px;
   padding: 1.5rem;
   border-radius: 12px;
-  background: #f8f9fa;
+  background: transparent;
   border: 1px solid #e2e8f0;
   object-fit: contain;
 }
 
 [data-theme="dark"] img[src*="/mermaid/"] {
-  background: #ffffff;
-  border-color: #d0d7de;
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.15);
+  filter: invert(1) hue-rotate(180deg);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- 라이트/다크 모드 모두 SVG 이미지 배경을 투명으로 변경
- 다크모드에서 `filter: invert(1) hue-rotate(180deg)` 적용
  - 어두운 텍스트 → 밝은 텍스트
  - 밝은 노드 배경 → 어두운 노드 배경
  - hue-rotate로 원래 색상 의미 유지 (빨강/초록 경고색 등)

## Test plan
- [ ] 라이트모드: 배경 투명, 기존 색상 유지
- [ ] 다크모드: 배경 투명, 텍스트/노드 색상 자연스러운 반전
- [ ] 커스텀 색상 노드 (빨강/초록 경고) 다크모드 가독성