### PR TITLE
fix: Mermaid SVG 이미지 lightbox 비활성화

### DIFF
--- a/assets/js/post-page.js
+++ b/assets/js/post-page.js
@@ -488,6 +488,8 @@
     var images = document.querySelectorAll('.clickable-image, .post-content img, .post-image img');
     images.forEach(function(img) {
       if (img.dataset.lightboxAttached === 'true') return;
+      // Skip mermaid diagram SVGs (already full-width, no zoom needed)
+      if (img.src && img.src.indexOf('/mermaid/') !== -1) return;
 
       img.style.cursor = 'zoom-in';
       img.dataset.lightboxAttached = 'true';


### PR DESCRIPTION
## Summary
- Mermaid SVG 이미지(`/mermaid/` 경로)를 lightbox 핸들러에서 제외
- 이미 `width: 100%`로 표시되는 다이어그램에 확대/드래그가 불필요
- 손바닥(grab) 커서가 계속 표시되어 다음 이미지 선택이 어려운 문제 해결

## Test plan
- [ ] Mermaid 이미지 클릭 시 lightbox 열리지 않음 확인
- [ ] 일반 이미지는 기존대로 lightbox 작동 확인
- [ ] Mermaid 이미지에 zoom-in 커서 표시 안 됨 확인