### PR TITLE
fix: Lightbox 커서 개선 및 Mermaid 이미지 클릭 활성화

### DIFF
--- a/_sass/_lightbox.scss
+++ b/_sass/_lightbox.scss
@@ -68,14 +68,14 @@
   object-fit: contain;
   border-radius: 12px;
   box-shadow: 0 25px 80px rgba(0, 0, 0, 0.6), 0 10px 30px rgba(0, 0, 0, 0.4);
-  cursor: grab;
+  cursor: zoom-in;
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
   transform-origin: center center;
   user-select: none;
   -webkit-user-drag: none;
 
   &.zoomed {
-    cursor: move;
+    cursor: grab;
     max-width: none;
     max-height: none;
   }

--- a/assets/js/post-page.js
+++ b/assets/js/post-page.js
@@ -488,8 +488,6 @@
     var images = document.querySelectorAll('.clickable-image, .post-content img, .post-image img');
     images.forEach(function(img) {
       if (img.dataset.lightboxAttached === 'true') return;
-      // Skip mermaid diagram SVGs (already full-width, no zoom needed)
-      if (img.src && img.src.indexOf('/mermaid/') !== -1) return;
 
       img.style.cursor = 'zoom-in';
       img.dataset.lightboxAttached = 'true';


### PR DESCRIPTION
## Summary
- Mermaid SVG 이미지도 클릭하여 lightbox로 확대 가능하도록 변경
- 기본 lightbox 커서를 `grab`에서 `zoom-in`으로 변경 (손바닥 모양 제거)
- 확대(zoom) 시에만 `grab`/`grabbing` 커서 표시

## Test plan
- [ ] Mermaid 이미지 클릭 시 lightbox 열림 확인
- [ ] lightbox에서 기본 커서가 zoom-in인지 확인
- [ ] 확대 후에만 grab 커서 표시되는지 확인