### PR TITLE
fix: 다이어그램 SVG 다크모드 지원

### DIFF
--- a/_includes/mermaid.html
+++ b/_includes/mermaid.html
@@ -20,11 +20,19 @@ img[src*="/mermaid/"] {
   filter: invert(1) hue-rotate(180deg);
 }
 
+/* Dark mode for diagram SVGs (light background, non-mermaid) */
+[data-theme="dark"] .post-content img[src*="/diagrams/"] {
+  filter: invert(1) hue-rotate(180deg);
+}
+
 /* prefers-color-scheme fallback for Safari/system dark mode */
 @media (prefers-color-scheme: dark) {
   html:not([data-theme="light"]) img[src*="/mermaid/"] {
     background: transparent;
     border-color: rgba(255, 255, 255, 0.15);
+    filter: invert(1) hue-rotate(180deg);
+  }
+  html:not([data-theme="light"]) .post-content img[src*="/diagrams/"] {
     filter: invert(1) hue-rotate(180deg);
   }
 }


### PR DESCRIPTION
## Summary
- `/assets/images/diagrams/` 경로의 24개 라이트 배경 SVG에 다크모드 filter 적용
- `data-theme="dark"` 및 `prefers-color-scheme` Safari fallback 지원
- 이미 어두운 배경의 SVG (section banners, 포스트 헤더 이미지 등)는 영향 없음

## Test plan
- [ ] 다크모드에서 diagram SVG 이미지 색상 반전 확인
- [ ] 라이트모드에서 기존과 동일하게 표시되는지 확인
- [ ] section-*.svg 배너 이미지가 영향받지 않는지 확인