### PR TITLE
improve: 9개 포스트 SVG 이미지 품질 개선 (batch5)

### DIFF
--- a/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
+++ b/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
@@ -1,19 +1,209 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#050d1a"/>
+      <stop offset="50%" stop-color="#0a1e35"/>
+      <stop offset="100%" stop-color="#0d2540"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#818cf8"/>
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e2a4a"/>
+      <stop offset="100%" stop-color="#0a1f38"/>
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a2840"/>
+      <stop offset="100%" stop-color="#081c30"/>
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c2645"/>
+      <stop offset="100%" stop-color="#091e35"/>
+    </linearGradient>
+    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#38bdf8"/>
+      <stop offset="100%" stop-color="#0ea5e9"/>
+    </linearGradient>
+    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#818cf8"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow" x="-5%" y="-5%" width="110%" height="120%">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.5"/>
+    </filter>
+    <filter id="titleGlow">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e3a5f" stroke-width="0.5" opacity="0.4"/>
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Kandji macOS Complete Master</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">SetupFrom Security Regula...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">May 2, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Outer glow border -->
+  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#38bdf8" stroke-width="1" opacity="0.2"/>
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
+
+  <!-- Decorative circles background -->
+  <circle cx="1050" cy="120" r="180" fill="#38bdf8" opacity="0.03"/>
+  <circle cx="1050" cy="120" r="120" fill="#38bdf8" opacity="0.04"/>
+  <circle cx="150" cy="500" r="120" fill="#818cf8" opacity="0.03"/>
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="220" height="34" rx="17" fill="#0e2a4a" stroke="#38bdf8" stroke-width="1.5"/>
+  <text x="170" y="61" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">macOS MANAGEMENT</text>
+
+  <!-- Date badge -->
+  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0e2a4a" stroke="#818cf8" stroke-width="1.5"/>
+  <text x="1100" y="61" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">May 2, 2025</text>
+
+  <!-- Main title -->
+  <text x="60" y="145" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Kandji macOS Complete</text>
+  <text x="60" y="198" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Master Guide</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="238" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1">Security  |  Compliance  |  All-in-One Platform</text>
+
+  <!-- Divider line -->
+  <line x1="60" y1="258" x2="640" y2="258" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- CARD 1: Device Security -->
+  <rect x="60" y="278" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#38bdf8" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="60" y="278" width="340" height="5" rx="3" fill="#38bdf8"/>
+
+  <!-- Card 1 icon: shield -->
+  <circle cx="110" cy="335" r="28" fill="#0a1f38" stroke="#38bdf8" stroke-width="1.5"/>
+  <path d="M110 313 L110 313 C110 313 124 318 124 330 L124 342 C124 350 110 357 110 357 C110 357 96 350 96 342 L96 330 C96 318 110 313 110 313Z" fill="none" stroke="#38bdf8" stroke-width="2" filter="url(#glow)"/>
+  <path d="M104 335 L108 340 L117 330" stroke="#38bdf8" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="148" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Device Security</text>
+  <text x="148" y="348" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13">Endpoint Protection</text>
+
+  <line x1="85" y1="375" x2="375" y2="375" stroke="#1e3a5f" stroke-width="1"/>
+
+  <text x="85" y="402" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">MDM Enrollment</text>
+  <rect x="330" y="390" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
+  <text x="357" y="404" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Active</text>
+
+  <text x="85" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">FileVault Encryption</text>
+  <rect x="330" y="420" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
+  <text x="357" y="434" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">ON</text>
+
+  <text x="85" y="462" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Gatekeeper Control</text>
+  <rect x="330" y="450" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
+  <text x="357" y="464" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">ON</text>
+
+  <text x="85" y="492" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">XProtect Updates</text>
+  <rect x="330" y="480" width="55" height="20" rx="10" fill="#083020" stroke="#34d399" stroke-width="1"/>
+  <text x="357" y="494" fill="#34d399" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Auto</text>
+
+  <text x="85" y="522" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SIP Enforcement</text>
+  <rect x="330" y="510" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
+  <text x="357" y="524" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Lock</text>
+
+  <!-- CARD 2: Compliance -->
+  <rect x="430" y="278" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="430" y="278" width="340" height="5" rx="3" fill="#818cf8"/>
+
+  <!-- Card 2 icon: checklist -->
+  <circle cx="480" cy="335" r="28" fill="#0a1429" stroke="#818cf8" stroke-width="1.5"/>
+  <rect x="468" y="320" width="24" height="28" rx="3" fill="none" stroke="#818cf8" stroke-width="1.8"/>
+  <line x1="472" y1="328" x2="488" y2="328" stroke="#818cf8" stroke-width="1.5"/>
+  <line x1="472" y1="334" x2="488" y2="334" stroke="#818cf8" stroke-width="1.5"/>
+  <line x1="472" y1="340" x2="483" y2="340" stroke="#818cf8" stroke-width="1.5"/>
+  <path d="M484 338 L487 342 L492 334" stroke="#818cf8" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="518" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Compliance</text>
+  <text x="518" y="348" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Policy Enforcement</text>
+
+  <line x1="455" y1="375" x2="745" y2="375" stroke="#1e3a5f" stroke-width="1"/>
+
+  <!-- Compliance progress bars -->
+  <text x="455" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">SOC 2 Type II</text>
+  <rect x="455" y="406" width="290" height="8" rx="4" fill="#0d1f33"/>
+  <rect x="455" y="406" width="261" height="8" rx="4" fill="#818cf8"/>
+  <text x="745" y="415" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">90%</text>
+
+  <text x="455" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">CIS Benchmark</text>
+  <rect x="455" y="438" width="290" height="8" rx="4" fill="#0d1f33"/>
+  <rect x="455" y="438" width="275" height="8" rx="4" fill="#818cf8"/>
+  <text x="745" y="447" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">95%</text>
+
+  <text x="455" y="464" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">NIST CSF</text>
+  <rect x="455" y="470" width="290" height="8" rx="4" fill="#0d1f33"/>
+  <rect x="455" y="470" width="246" height="8" rx="4" fill="#6366f1"/>
+  <text x="745" y="479" fill="#6366f1" font-family="Arial, sans-serif" font-size="11" text-anchor="end">85%</text>
+
+  <text x="455" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">HIPAA Controls</text>
+  <rect x="455" y="502" width="290" height="8" rx="4" fill="#0d1f33"/>
+  <rect x="455" y="502" width="232" height="8" rx="4" fill="#6366f1"/>
+  <text x="745" y="511" fill="#6366f1" font-family="Arial, sans-serif" font-size="11" text-anchor="end">80%</text>
+
+  <text x="455" y="528" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">PCI-DSS</text>
+  <rect x="455" y="534" width="290" height="8" rx="4" fill="#0d1f33"/>
+  <rect x="455" y="534" width="218" height="8" rx="4" fill="#818cf8"/>
+  <text x="745" y="543" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">75%</text>
+
+  <!-- CARD 3: Deployment -->
+  <rect x="800" y="278" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#34d399" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="800" y="278" width="340" height="5" rx="3" fill="#34d399"/>
+
+  <!-- Card 3 icon: rocket/deploy -->
+  <circle cx="850" cy="335" r="28" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M850 315 C850 315 858 320 860 330 L862 344 L855 340 L850 348 L845 340 L838 344 L840 330 C842 320 850 315 850 315Z" fill="none" stroke="#34d399" stroke-width="2" filter="url(#glow)"/>
+  <circle cx="850" cy="330" r="3" fill="#34d399"/>
+
+  <text x="888" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Deployment</text>
+  <text x="888" y="348" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Fleet Management</text>
+
+  <line x1="825" y1="375" x2="1115" y2="375" stroke="#1e3a5f" stroke-width="1"/>
+
+  <!-- Deployment stats -->
+  <text x="825" y="405" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Zero-Touch Enrollment</text>
+  <circle cx="1100" cy="400" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M1095 400 L1098 404 L1105 396" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="825" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Auto App Deployment</text>
+  <circle cx="1100" cy="427" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M1095 427 L1098 431 L1105 423" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="825" y="459" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">OS Update Policy</text>
+  <circle cx="1100" cy="454" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M1095 454 L1098 458 L1105 450" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="825" y="486" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Blueprint Config</text>
+  <circle cx="1100" cy="481" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M1095 481 L1098 485 L1105 477" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="825" y="513" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Remote Wipe Support</text>
+  <circle cx="1100" cy="508" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
+  <path d="M1095 508 L1098 512 L1105 504" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <text x="825" y="535" fill="#34d399" font-family="Arial, sans-serif" font-size="12" font-weight="600">Kandji Library: 150+ One-Click Apps</text>
+
+  <!-- Footer -->
+  <rect x="0" y="596" width="1200" height="34" fill="#050d1a" opacity="0.8"/>
+  <line x1="0" y1="596" x2="1200" y2="596" stroke="#1e3a5f" stroke-width="1"/>
+  <text x="60" y="618" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="600">MDM</text>
+  <text x="115" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Kandji</text>
+  <text x="190" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">macOS Security</text>
+  <text x="320" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Apple Fleet</text>
+  <text x="430" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero-Touch</text>
+  <text x="540" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Compliance</text>
+  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
+++ b/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
@@ -1,19 +1,172 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0a00"/>
+      <stop offset="50%" stop-color="#1a1200"/>
+      <stop offset="100%" stop-color="#0d1a2e"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f6821f"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
     </linearGradient>
+    <linearGradient id="accentGrad2" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#fb923c"/>
+    </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a1500"/>
+      <stop offset="100%" stop-color="#1a0d00"/>
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c1e3a"/>
+      <stop offset="100%" stop-color="#071428"/>
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a0d00"/>
+      <stop offset="100%" stop-color="#0f0800"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a1a00" stroke-width="0.5" opacity="0.5"/>
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Cloud Security Course 7Batch</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">6Week Cloudflare and gith...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">May 23, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Decorative glows -->
+  <circle cx="1080" cy="100" r="200" fill="#f6821f" opacity="0.04"/>
+  <circle cx="1080" cy="100" r="120" fill="#f6821f" opacity="0.05"/>
+  <circle cx="100" cy="520" r="150" fill="#3b82f6" opacity="0.04"/>
+
+  <!-- Outer border -->
+  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#f6821f" stroke-width="1" opacity="0.15"/>
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="250" height="34" rx="17" fill="#2a1500" stroke="#f6821f" stroke-width="1.5"/>
+  <text x="185" y="61" fill="#f6821f" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">CLOUD SECURITY COURSE</text>
+
+  <!-- Date badge -->
+  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0c1e3a" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="1100" y="61" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">May 23, 2025</text>
+
+  <!-- Main title -->
+  <text x="60" y="145" fill="#fff7ed" font-family="Arial, sans-serif" font-size="44" font-weight="800" filter="url(#glow)">Cloudflare and GitHub Security</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="188" fill="#fdba74" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">Batch 7  |  Week 6  |  Practical Guide</text>
+
+  <!-- Divider -->
+  <line x1="60" y1="208" x2="760" y2="208" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- CARD 1: Cloudflare WAF -->
+  <rect x="60" y="228" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#f6821f" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="60" y="228" width="340" height="5" rx="3" fill="#f6821f"/>
+
+  <!-- WAF icon: cloud shape -->
+  <circle cx="110" cy="290" r="28" fill="#1a0d00" stroke="#f6821f" stroke-width="1.5"/>
+  <path d="M98 294 C98 287 103 282 109 282 C110 278 115 275 121 277 C124 274 129 274 131 278 C135 279 137 284 135 288 L134 294 Z" fill="none" stroke="#f6821f" stroke-width="2" filter="url(#glow)"/>
+  <path d="M101 294 L119 294" stroke="#f6821f" stroke-width="1.5"/>
+  <path d="M104 297 L116 297" stroke="#f6821f" stroke-width="1"/>
+
+  <text x="148" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">Cloudflare WAF</text>
+  <text x="148" y="303" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Web Application Firewall</text>
+
+  <line x1="85" y1="325" x2="375" y2="325" stroke="#3a1a00" stroke-width="1"/>
+
+  <text x="85" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Rule Management</text>
+  <text x="85" y="374" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Block SQLi, XSS, RCE attacks</text>
+
+  <text x="85" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Rate Limiting</text>
+  <text x="85" y="422" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Threshold-based IP blocking</text>
+
+  <text x="85" y="448" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Bot Management</text>
+  <text x="85" y="470" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">CAPTCHA and JS challenge</text>
+
+  <text x="85" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Page Shield CSP</text>
+  <text x="85" y="518" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Script integrity monitoring</text>
+
+  <!-- CARD 2: GitHub Security -->
+  <rect x="430" y="228" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="430" y="228" width="340" height="5" rx="3" fill="#3b82f6"/>
+
+  <!-- GitHub icon: cat/octocat shape simplified -->
+  <circle cx="480" cy="290" r="28" fill="#071428" stroke="#3b82f6" stroke-width="1.5"/>
+  <circle cx="480" cy="287" r="11" fill="none" stroke="#3b82f6" stroke-width="2"/>
+  <path d="M469 295 C469 302 475 306 480 306 C485 306 491 302 491 295" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+  <circle cx="476" cy="285" r="1.5" fill="#3b82f6"/>
+  <circle cx="484" cy="285" r="1.5" fill="#3b82f6"/>
+
+  <text x="518" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">GitHub Security</text>
+  <text x="518" y="303" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13">Source Code Protection</text>
+
+  <line x1="455" y1="325" x2="745" y2="325" stroke="#0c1e3a" stroke-width="1"/>
+
+  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Secret Scanning</text>
+  <text x="455" y="374" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Auto-detect API keys and tokens</text>
+
+  <text x="455" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Dependabot Alerts</text>
+  <text x="455" y="422" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">CVE patch automation PRs</text>
+
+  <text x="455" y="448" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Code Scanning (CodeQL)</text>
+  <text x="455" y="470" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Static analysis in CI pipeline</text>
+
+  <text x="455" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Branch Protection Rules</text>
+  <text x="455" y="518" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Required reviews and status checks</text>
+
+  <!-- CARD 3: DDoS Protection -->
+  <rect x="800" y="228" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#fb923c" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="800" y="228" width="340" height="5" rx="3" fill="#fb923c"/>
+
+  <!-- DDoS icon: shield with lightning -->
+  <circle cx="850" cy="290" r="28" fill="#1a0d00" stroke="#fb923c" stroke-width="1.5"/>
+  <path d="M850 268 C850 268 864 274 864 284 L864 298 C864 308 850 316 850 316 C850 316 836 308 836 298 L836 284 C836 274 850 268 850 268Z" fill="none" stroke="#fb923c" stroke-width="2" filter="url(#glow)"/>
+  <path d="M855 278 L847 290 L852 290 L845 304 L857 288 L851 288 Z" fill="#fb923c"/>
+
+  <text x="888" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">DDoS Protection</text>
+  <text x="888" y="303" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Attack Mitigation</text>
+
+  <line x1="825" y1="325" x2="1115" y2="325" stroke="#3a1a00" stroke-width="1"/>
+
+  <!-- Traffic visualization bars -->
+  <text x="825" y="350" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Traffic Filtering Capacity</text>
+  <text x="825" y="368" fill="#fb923c" font-family="Arial, sans-serif" font-size="20" font-weight="700">100 Tbps</text>
+  <text x="930" y="368" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Network Edge</text>
+
+  <text x="825" y="394" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">L3/L4 Volume Attacks</text>
+  <rect x="825" y="400" width="270" height="10" rx="5" fill="#1a0d00"/>
+  <rect x="825" y="400" width="230" height="10" rx="5" fill="#f6821f"/>
+  <text x="1098" y="411" fill="#f6821f" font-family="Arial, sans-serif" font-size="12" text-anchor="end">Blocked</text>
+
+  <text x="825" y="428" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">L7 HTTP Flood</text>
+  <rect x="825" y="434" width="270" height="10" rx="5" fill="#1a0d00"/>
+  <rect x="825" y="434" width="210" height="10" rx="5" fill="#fb923c"/>
+  <text x="1098" y="445" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" text-anchor="end">Filtered</text>
+
+  <text x="825" y="462" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Anycast Routing</text>
+  <text x="825" y="482" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">300+ PoPs worldwide edge nodes</text>
+
+  <text x="825" y="508" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Zero-Day Response</text>
+  <text x="825" y="528" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Emergency rule deploy in minutes</text>
+
+  <!-- Footer -->
+  <rect x="0" y="596" width="1200" height="34" fill="#0f0a00" opacity="0.9"/>
+  <line x1="0" y1="596" x2="1200" y2="596" stroke="#3a1a00" stroke-width="1"/>
+  <text x="60" y="618" fill="#f6821f" font-family="Arial, sans-serif" font-size="13" font-weight="600">Cloudflare</text>
+  <text x="145" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">WAF</text>
+  <text x="195" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">GitHub Actions</text>
+  <text x="315" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">DDoS Mitigation</text>
+  <text x="450" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero Trust</text>
+  <text x="555" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Supply Chain Security</text>
+  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
@@ -1,19 +1,207 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#04091a"/>
+      <stop offset="50%" stop-color="#080f26"/>
+      <stop offset="100%" stop-color="#050e1e"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#6366f1"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e1040"/>
+      <stop offset="100%" stop-color="#080b2e"/>
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#041a28"/>
+      <stop offset="100%" stop-color="#02111c"/>
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1035"/>
+      <stop offset="100%" stop-color="#060b25"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0e1540" stroke-width="0.5" opacity="0.6"/>
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Cloud Security Course 7Batch</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">8Week CICDand Kubernetes ...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Jun 6, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Glow accents -->
+  <circle cx="1100" cy="80" r="220" fill="#6366f1" opacity="0.04"/>
+  <circle cx="1100" cy="80" r="130" fill="#22d3ee" opacity="0.04"/>
+  <circle cx="80" cy="540" r="160" fill="#6366f1" opacity="0.03"/>
+
+  <!-- Outer border -->
+  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#6366f1" stroke-width="1" opacity="0.2"/>
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="250" height="34" rx="17" fill="#0e1040" stroke="#6366f1" stroke-width="1.5"/>
+  <text x="185" y="61" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">CLOUD SECURITY COURSE</text>
+
+  <!-- Date badge -->
+  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#041a28" stroke="#22d3ee" stroke-width="1.5"/>
+  <text x="1100" y="61" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Jun 6, 2025</text>
+
+  <!-- Main title -->
+  <text x="60" y="145" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="44" font-weight="800" filter="url(#glow)">CI/CD and Kubernetes Security</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="188" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">Batch 7  |  Week 8  |  Practical Guide</text>
+
+  <!-- Divider -->
+  <line x1="60" y1="208" x2="720" y2="208" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- CARD 1: CI/CD Pipeline -->
+  <rect x="60" y="228" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#6366f1" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="60" y="228" width="340" height="5" rx="3" fill="#6366f1"/>
+
+  <!-- CI/CD icon: pipeline flow -->
+  <circle cx="110" cy="290" r="28" fill="#080b2e" stroke="#6366f1" stroke-width="1.5"/>
+  <circle cx="98" cy="290" r="5" fill="#6366f1"/>
+  <line x1="103" y1="290" x2="117" y2="290" stroke="#6366f1" stroke-width="2"/>
+  <circle cx="122" cy="290" r="5" fill="#818cf8"/>
+  <!-- arrow -->
+  <path d="M108 285 L115 290 L108 295" fill="#6366f1"/>
+
+  <text x="148" y="283" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">CI/CD Pipeline</text>
+  <text x="148" y="303" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Pipeline Security</text>
+
+  <line x1="85" y1="325" x2="375" y2="325" stroke="#0e1040" stroke-width="1"/>
+
+  <!-- Pipeline steps visualization -->
+  <text x="85" y="348" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600">PIPELINE STAGES</text>
+
+  <!-- Stage blocks -->
+  <rect x="85" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
+  <text x="116" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Build</text>
+
+  <path d="M147 372 L155 372" stroke="#6366f1" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="152" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
+
+  <rect x="159" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
+  <text x="190" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Scan</text>
+
+  <text x="224" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
+
+  <rect x="233" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
+  <text x="264" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Sign</text>
+
+  <text x="298" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
+
+  <rect x="307" y="358" width="62" height="28" rx="6" fill="#0a3a20" stroke="#22c55e" stroke-width="1"/>
+  <text x="338" y="377" fill="#86efac" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Deploy</text>
+
+  <text x="85" y="414" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SAST / DAST Scanning</text>
+  <text x="85" y="434" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">SonarQube and OWASP ZAP integration</text>
+
+  <text x="85" y="458" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Secret Detection</text>
+  <text x="85" y="478" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">Gitleaks and truffleHog pre-commit</text>
+
+  <text x="85" y="502" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Artifact Signing</text>
+  <text x="85" y="522" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">Sigstore Cosign keyless signing</text>
+
+  <!-- CARD 2: K8s Runtime -->
+  <rect x="430" y="228" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#22d3ee" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="430" y="228" width="340" height="5" rx="3" fill="#22d3ee"/>
+
+  <!-- K8s icon: hexagon wheel -->
+  <circle cx="480" cy="290" r="28" fill="#02111c" stroke="#22d3ee" stroke-width="1.5"/>
+  <polygon points="480,268 494,276 494,292 480,300 466,292 466,276" fill="none" stroke="#22d3ee" stroke-width="2" filter="url(#glow)"/>
+  <circle cx="480" cy="284" r="4" fill="#22d3ee"/>
+  <line x1="480" y1="268" x2="480" y2="272" stroke="#22d3ee" stroke-width="1.5"/>
+  <line x1="494" y1="276" x2="491" y2="278" stroke="#22d3ee" stroke-width="1.5"/>
+  <line x1="494" y1="292" x2="491" y2="290" stroke="#22d3ee" stroke-width="1.5"/>
+  <line x1="480" y1="300" x2="480" y2="296" stroke="#22d3ee" stroke-width="1.5"/>
+  <line x1="466" y1="292" x2="469" y2="290" stroke="#22d3ee" stroke-width="1.5"/>
+  <line x1="466" y1="276" x2="469" y2="278" stroke="#22d3ee" stroke-width="1.5"/>
+
+  <text x="518" y="283" fill="#e0f7fa" font-family="Arial, sans-serif" font-size="18" font-weight="700">K8s Runtime</text>
+  <text x="518" y="303" fill="#67e8f9" font-family="Arial, sans-serif" font-size="13">Runtime Security</text>
+
+  <line x1="455" y1="325" x2="745" y2="325" stroke="#041a28" stroke-width="1"/>
+
+  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Falco Runtime Detection</text>
+  <text x="455" y="372" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Syscall anomaly alerting</text>
+
+  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">OPA / Kyverno Policy</text>
+  <text x="455" y="418" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Admission controller enforcement</text>
+
+  <text x="455" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Network Policy</text>
+  <text x="455" y="464" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Calico zero-trust microsegmentation</text>
+
+  <text x="455" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">RBAC Hardening</text>
+  <text x="455" y="510" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Least-privilege service accounts</text>
+
+  <text x="455" y="536" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Audit logging to SIEM</text>
+
+  <!-- CARD 3: Image Scanning -->
+  <rect x="800" y="228" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="800" y="228" width="340" height="5" rx="3" fill="#818cf8"/>
+
+  <!-- Scan icon: magnifier over layers -->
+  <circle cx="850" cy="290" r="28" fill="#060b25" stroke="#818cf8" stroke-width="1.5"/>
+  <rect x="838" y="280" width="18" height="16" rx="2" fill="none" stroke="#818cf8" stroke-width="1.5"/>
+  <line x1="838" y1="284" x2="856" y2="284" stroke="#818cf8" stroke-width="1"/>
+  <line x1="838" y1="288" x2="856" y2="288" stroke="#818cf8" stroke-width="1"/>
+  <circle cx="858" cy="298" r="6" fill="none" stroke="#818cf8" stroke-width="2" filter="url(#glow)"/>
+  <line x1="862" y1="302" x2="866" y2="306" stroke="#818cf8" stroke-width="2.5" stroke-linecap="round"/>
+
+  <text x="888" y="283" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">Image Scanning</text>
+  <text x="888" y="303" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Container Security</text>
+
+  <line x1="825" y1="325" x2="1115" y2="325" stroke="#0a1035" stroke-width="1"/>
+
+  <!-- CVE severity breakdown -->
+  <text x="825" y="350" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600">CVE SEVERITY BREAKDOWN</text>
+
+  <text x="825" y="376" fill="#f87171" font-family="Arial, sans-serif" font-size="13">Critical</text>
+  <rect x="885" y="365" width="190" height="14" rx="7" fill="#1a0a0a"/>
+  <rect x="885" y="365" width="38" height="14" rx="7" fill="#ef4444"/>
+  <text x="1080" y="378" fill="#f87171" font-family="Arial, sans-serif" font-size="12" text-anchor="end">2</text>
+
+  <text x="825" y="402" fill="#fb923c" font-family="Arial, sans-serif" font-size="13">High</text>
+  <rect x="885" y="391" width="190" height="14" rx="7" fill="#1a0a0a"/>
+  <rect x="885" y="391" width="76" height="14" rx="7" fill="#f97316"/>
+  <text x="1080" y="404" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" text-anchor="end">8</text>
+
+  <text x="825" y="428" fill="#fbbf24" font-family="Arial, sans-serif" font-size="13">Medium</text>
+  <rect x="885" y="417" width="190" height="14" rx="7" fill="#1a0a0a"/>
+  <rect x="885" y="417" width="114" height="14" rx="7" fill="#f59e0b"/>
+  <text x="1080" y="430" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12" text-anchor="end">12</text>
+
+  <text x="825" y="454" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Low</text>
+  <rect x="885" y="443" width="190" height="14" rx="7" fill="#0a1035"/>
+  <rect x="885" y="443" width="152" height="14" rx="7" fill="#4b5563"/>
+  <text x="1080" y="456" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12" text-anchor="end">16</text>
+
+  <text x="825" y="480" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Trivy / Grype Scanning</text>
+  <text x="825" y="500" fill="#818cf8" font-family="Arial, sans-serif" font-size="12">Gate build on Critical and High CVEs</text>
+
+  <text x="825" y="524" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Distroless Base Images</text>
+  <text x="825" y="544" fill="#818cf8" font-family="Arial, sans-serif" font-size="12">Reduce attack surface by 80%</text>
+
+  <!-- Footer -->
+  <rect x="0" y="596" width="1200" height="34" fill="#04091a" opacity="0.9"/>
+  <line x1="0" y1="596" x2="1200" y2="596" stroke="#0e1540" stroke-width="1"/>
+  <text x="60" y="618" fill="#6366f1" font-family="Arial, sans-serif" font-size="13" font-weight="600">Kubernetes</text>
+  <text x="155" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">CI/CD Security</text>
+  <text x="275" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">OPA Policy</text>
+  <text x="375" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Falco</text>
+  <text x="430" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Trivy</text>
+  <text x="490" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
+  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
+++ b/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
@@ -1,19 +1,208 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#130000"/>
+      <stop offset="50%" stop-color="#1a0505"/>
+      <stop offset="100%" stop-color="#0f0000"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#f97316"/>
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a0a0a"/>
+      <stop offset="100%" stop-color="#1a0505"/>
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a1200"/>
+      <stop offset="100%" stop-color="#1a0c00"/>
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1a0a"/>
+      <stop offset="100%" stop-color="#051205"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="redGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.7"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a0a0a" stroke-width="0.5" opacity="0.6"/>
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">npm Large scale Security 20</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600"></text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Sep 10, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Danger glow accents -->
+  <circle cx="600" cy="300" r="400" fill="#ef4444" opacity="0.02"/>
+  <circle cx="1100" cy="80" r="200" fill="#ef4444" opacity="0.04"/>
+  <circle cx="1100" cy="80" r="100" fill="#ef4444" opacity="0.05"/>
+
+  <!-- Outer border - alert red -->
+  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.3"/>
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
+
+  <!-- Alert badge -->
+  <rect x="60" y="38" width="240" height="34" rx="17" fill="#2a0a0a" stroke="#ef4444" stroke-width="1.5"/>
+  <!-- Warning triangle icon -->
+  <path d="M80 55 L88 41 L96 55 Z" fill="none" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="88" y="55" fill="#ef4444" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="700">!</text>
+  <text x="175" y="61" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">SUPPLY CHAIN ATTACK</text>
+
+  <!-- Date badge -->
+  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#2a0a0a" stroke="#f97316" stroke-width="1.5"/>
+  <text x="1100" y="61" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Sep 10, 2025</text>
+
+  <!-- Main title -->
+  <text x="60" y="145" fill="#fecaca" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#redGlow)">npm Large-Scale Security Breach</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="188" fill="#fca5a5" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">20+ Packages  |  Malware Infection  |  Supply Chain</text>
+
+  <!-- Alert count indicator -->
+  <rect x="730" y="155" width="160" height="50" rx="10" fill="#2a0a0a" stroke="#ef4444" stroke-width="2"/>
+  <text x="810" y="177" fill="#ef4444" font-family="Arial, sans-serif" font-size="28" font-weight="800" text-anchor="middle" filter="url(#glow)">20+</text>
+  <text x="810" y="196" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Infected Packages</text>
+
+  <!-- Divider -->
+  <line x1="60" y1="210" x2="900" y2="210" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.5"/>
+
+  <!-- CARD 1: Attack Vector -->
+  <rect x="60" y="230" width="340" height="310" rx="16" fill="url(#card1Grad)" stroke="#ef4444" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="60" y="230" width="340" height="5" rx="3" fill="#ef4444"/>
+
+  <!-- Attack icon: crosshair -->
+  <circle cx="110" cy="293" r="28" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
+  <circle cx="110" cy="293" r="14" fill="none" stroke="#ef4444" stroke-width="1.5" filter="url(#glow)"/>
+  <circle cx="110" cy="293" r="5" fill="#ef4444"/>
+  <line x1="110" y1="275" x2="110" y2="285" stroke="#ef4444" stroke-width="1.5"/>
+  <line x1="110" y1="301" x2="110" y2="311" stroke="#ef4444" stroke-width="1.5"/>
+  <line x1="92" y1="293" x2="102" y2="293" stroke="#ef4444" stroke-width="1.5"/>
+  <line x1="118" y1="293" x2="128" y2="293" stroke="#ef4444" stroke-width="1.5"/>
+
+  <text x="148" y="286" fill="#fecaca" font-family="Arial, sans-serif" font-size="18" font-weight="700">Attack Vector</text>
+  <text x="148" y="306" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Infection Chain</text>
+
+  <line x1="85" y1="328" x2="375" y2="328" stroke="#3a0a0a" stroke-width="1"/>
+
+  <!-- Attack chain diagram -->
+  <rect x="85" y="340" width="100" height="24" rx="5" fill="#3a0a0a" stroke="#ef4444" stroke-width="1"/>
+  <text x="135" y="357" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Typosquat</text>
+
+  <text x="188" y="356" fill="#ef4444" font-family="Arial, sans-serif" font-size="16">></text>
+
+  <rect x="198" y="340" width="100" height="24" rx="5" fill="#3a0a0a" stroke="#f97316" stroke-width="1"/>
+  <text x="248" y="357" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Postinstall</text>
+
+  <text x="301" y="356" fill="#ef4444" font-family="Arial, sans-serif" font-size="16">></text>
+
+  <rect x="311" y="340" width="50" height="24" rx="5" fill="#3a1000" stroke="#f97316" stroke-width="1"/>
+  <text x="336" y="357" fill="#fb923c" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">RCE</text>
+
+  <text x="85" y="392" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Package Name Spoofing</text>
+  <text x="85" y="412" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">lodash vs 1odash (typo hijack)</text>
+
+  <text x="85" y="436" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Malicious postinstall Hook</text>
+  <text x="85" y="456" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">Executes on npm install command</text>
+
+  <text x="85" y="480" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Data Exfiltration</text>
+  <text x="85" y="500" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">ENV vars, SSH keys, secrets stolen</text>
+
+  <text x="85" y="524" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Lateral Movement</text>
+  <text x="85" y="544" fill="#f97316" font-family="Arial, sans-serif" font-size="12">CI/CD pipeline compromise</text>
+
+  <!-- CARD 2: Affected Packages -->
+  <rect x="430" y="230" width="340" height="310" rx="16" fill="url(#card2Grad)" stroke="#f97316" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="430" y="230" width="340" height="5" rx="3" fill="#f97316"/>
+
+  <!-- Package icon: box -->
+  <circle cx="480" cy="293" r="28" fill="#1a0c00" stroke="#f97316" stroke-width="1.5"/>
+  <rect x="467" y="280" width="26" height="24" rx="2" fill="none" stroke="#f97316" stroke-width="1.8"/>
+  <line x1="467" y1="288" x2="493" y2="288" stroke="#f97316" stroke-width="1.5"/>
+  <line x1="480" y1="280" x2="480" y2="288" stroke="#f97316" stroke-width="1.5"/>
+
+  <text x="518" y="286" fill="#fef3c7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Affected Packages</text>
+  <text x="518" y="306" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Compromised Libraries</text>
+
+  <line x1="455" y1="328" x2="745" y2="328" stroke="#3a1200" stroke-width="1"/>
+
+  <!-- Package list with threat level -->
+  <text x="455" y="352" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="600">PACKAGE NAME</text>
+  <text x="680" y="352" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="600">SEVERITY</text>
+
+  <text x="455" y="374" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">node-fetch-extra</text>
+  <rect x="680" y="362" width="58" height="18" rx="9" fill="#3a0a0a"/>
+  <text x="709" y="375" fill="#ef4444" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">CRITICAL</text>
+
+  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">axios-utils-plus</text>
+  <rect x="680" y="386" width="58" height="18" rx="9" fill="#3a1000"/>
+  <text x="709" y="399" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
+
+  <text x="455" y="422" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">crypto-utils-node</text>
+  <rect x="680" y="410" width="58" height="18" rx="9" fill="#3a0a0a"/>
+  <text x="709" y="423" fill="#ef4444" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">CRITICAL</text>
+
+  <text x="455" y="446" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">express-session-ext</text>
+  <rect x="680" y="434" width="58" height="18" rx="9" fill="#3a1000"/>
+  <text x="709" y="447" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
+
+  <text x="455" y="470" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">webpack-loader-x</text>
+  <rect x="680" y="458" width="58" height="18" rx="9" fill="#3a1000"/>
+  <text x="709" y="471" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
+
+  <text x="455" y="498" fill="#64748b" font-family="Arial, sans-serif" font-size="12">... and 15 more packages</text>
+  <text x="455" y="518" fill="#f97316" font-family="Arial, sans-serif" font-size="14" font-weight="600">Total Downloads Before Takedown:</text>
+  <text x="455" y="538" fill="#fbbf24" font-family="Arial, sans-serif" font-size="20" font-weight="800">2.3M+</text>
+
+  <!-- CARD 3: Defense -->
+  <rect x="800" y="230" width="340" height="310" rx="16" fill="url(#card3Grad)" stroke="#22c55e" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="800" y="230" width="340" height="5" rx="3" fill="#22c55e"/>
+
+  <!-- Defense icon: lock -->
+  <circle cx="850" cy="293" r="28" fill="#051205" stroke="#22c55e" stroke-width="1.5"/>
+  <rect x="840" y="287" width="20" height="16" rx="3" fill="none" stroke="#22c55e" stroke-width="2"/>
+  <path d="M843 287 C843 280 857 280 857 287" fill="none" stroke="#22c55e" stroke-width="2" filter="url(#glow)"/>
+  <circle cx="850" cy="295" r="2.5" fill="#22c55e"/>
+  <line x1="850" y1="297" x2="850" y2="301" stroke="#22c55e" stroke-width="2"/>
+
+  <text x="888" y="286" fill="#dcfce7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Defense</text>
+  <text x="888" y="306" fill="#86efac" font-family="Arial, sans-serif" font-size="13">Mitigation Strategies</text>
+
+  <line x1="825" y1="328" x2="1115" y2="328" stroke="#0a1a0a" stroke-width="1"/>
+
+  <text x="825" y="354" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Dependency Audit</text>
+  <text x="825" y="374" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Run npm audit and fix regularly</text>
+
+  <text x="825" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Package Lock Files</text>
+  <text x="825" y="418" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Commit package-lock.json always</text>
+
+  <text x="825" y="442" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Private Registry Mirror</text>
+  <text x="825" y="462" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Verdaccio or Artifactory proxy</text>
+
+  <text x="825" y="486" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SCA Tools</text>
+  <text x="825" y="506" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Snyk, Socket.dev monitoring</text>
+
+  <text x="825" y="530" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">npm 2FA Enforcement</text>
+  <text x="825" y="550" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Require 2FA for all publishers</text>
+
+  <!-- Footer -->
+  <rect x="0" y="596" width="1200" height="34" fill="#130000" opacity="0.9"/>
+  <line x1="0" y1="596" x2="1200" y2="596" stroke="#3a0a0a" stroke-width="1"/>
+  <text x="60" y="618" fill="#ef4444" font-family="Arial, sans-serif" font-size="13" font-weight="600">Supply Chain</text>
+  <text x="165" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">npm Security</text>
+  <text x="280" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Malware</text>
+  <text x="360" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Typosquatting</text>
+  <text x="480" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">SCA</text>
+  <text x="530" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Dependency Risk</text>
+  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
@@ -1,19 +1,195 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a0800"/>
+      <stop offset="50%" stop-color="#161000"/>
+      <stop offset="100%" stop-color="#0a0e1a"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#3b82f6"/>
     </linearGradient>
+    <linearGradient id="awsOrange" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f59e0b"/>
+      <stop offset="100%" stop-color="#fb923c"/>
+    </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1e1200"/>
+      <stop offset="100%" stop-color="#120c00"/>
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e1a2e"/>
+      <stop offset="100%" stop-color="#08101e"/>
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1e14"/>
+      <stop offset="100%" stop-color="#04120c"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="awsGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e1200" stroke-width="0.5" opacity="0.6"/>
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">AWS reInforce 2025 Cloud</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">Security and Future</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Sep 16, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- Glow accents -->
+  <circle cx="1100" cy="90" r="220" fill="#f59e0b" opacity="0.04"/>
+  <circle cx="1100" cy="90" r="130" fill="#f59e0b" opacity="0.05"/>
+  <circle cx="80" cy="540" r="180" fill="#3b82f6" opacity="0.04"/>
+
+  <!-- AWS smile arc decorative -->
+  <path d="M 900 50 Q 1050 110 900 170" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.15"/>
+
+  <!-- Outer border -->
+  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#f59e0b" stroke-width="1" opacity="0.2"/>
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
+
+  <!-- AWS Badge -->
+  <rect x="60" y="38" width="240" height="34" rx="17" fill="#1e1200" stroke="#f59e0b" stroke-width="1.5"/>
+  <!-- AWS cloud icon simplified -->
+  <path d="M76 58 C76 53 79 50 83 50 C84 47 87 45 91 46 C93 44 96 44 97 47 C100 48 101 51 99 54 L98 58 Z" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="165" y="61" fill="#f59e0b" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">AWS re:Inforce 2025</text>
+
+  <!-- Date badge -->
+  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0e1a2e" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="1100" y="61" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Sep 16, 2025</text>
+
+  <!-- AWS logo area top right -->
+  <text x="1080" y="150" fill="#f59e0b" font-family="Arial, sans-serif" font-size="36" font-weight="900" text-anchor="middle" opacity="0.15" filter="url(#awsGlow)">AWS</text>
+
+  <!-- Main title -->
+  <text x="60" y="140" fill="#fef3c7" font-family="Arial, sans-serif" font-size="52" font-weight="800" filter="url(#awsGlow)">AWS re:Inforce 2025</text>
+
+  <!-- Subtitle -->
+  <text x="60" y="185" fill="#fbbf24" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1">Cloud Security  |  Current and Future</text>
+
+  <!-- Divider -->
+  <line x1="60" y1="206" x2="800" y2="206" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
+
+  <!-- CARD 1: Identity Security -->
+  <rect x="60" y="226" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#f59e0b" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="60" y="226" width="340" height="5" rx="3" fill="#f59e0b"/>
+
+  <!-- Identity icon: person + key -->
+  <circle cx="110" cy="291" r="28" fill="#120c00" stroke="#f59e0b" stroke-width="1.5"/>
+  <circle cx="110" cy="283" r="7" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <path d="M99 300 C99 294 104 291 110 291 C116 291 121 294 121 300" fill="none" stroke="#f59e0b" stroke-width="1.8" filter="url(#glow)"/>
+  <!-- key -->
+  <circle cx="107" cy="305" r="4" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+  <line x1="111" y1="305" x2="118" y2="305" stroke="#f59e0b" stroke-width="1.5"/>
+  <line x1="116" y1="302" x2="116" y2="308" stroke="#f59e0b" stroke-width="1.5"/>
+
+  <text x="148" y="284" fill="#fef3c7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Identity Security</text>
+  <text x="148" y="304" fill="#fbbf24" font-family="Arial, sans-serif" font-size="13">IAM and Zero Trust</text>
+
+  <line x1="85" y1="326" x2="375" y2="326" stroke="#2e1a00" stroke-width="1"/>
+
+  <text x="85" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">IAM Identity Center</text>
+  <text x="85" y="372" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Centralized SSO for AWS orgs</text>
+
+  <text x="85" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Permission Boundaries</text>
+  <text x="85" y="418" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Guardrails for delegated admins</text>
+
+  <text x="85" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS Verified Access</text>
+  <text x="85" y="464" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Zero-trust app access, no VPN</text>
+
+  <text x="85" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Access Analyzer</text>
+  <text x="85" y="510" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">External resource exposure checks</text>
+
+  <text x="85" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Cedar Policy Language</text>
+  <text x="85" y="554" fill="#f59e0b" font-family="Arial, sans-serif" font-size="12">Fine-grained authorization logic</text>
+
+  <!-- CARD 2: Threat Detection -->
+  <rect x="430" y="226" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="430" y="226" width="340" height="5" rx="3" fill="#3b82f6"/>
+
+  <!-- Radar/detection icon -->
+  <circle cx="480" cy="291" r="28" fill="#08101e" stroke="#3b82f6" stroke-width="1.5"/>
+  <circle cx="480" cy="291" r="18" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.5"/>
+  <circle cx="480" cy="291" r="10" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.7"/>
+  <circle cx="480" cy="291" r="3" fill="#3b82f6"/>
+  <!-- Radar sweep line -->
+  <line x1="480" y1="291" x2="494" y2="278" stroke="#3b82f6" stroke-width="2" filter="url(#glow)" opacity="0.8"/>
+  <circle cx="492" cy="280" r="2" fill="#60a5fa"/>
+
+  <text x="518" y="284" fill="#eff6ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">Threat Detection</text>
+  <text x="518" y="304" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13">AI-Powered Security</text>
+
+  <line x1="455" y1="326" x2="745" y2="326" stroke="#0e1a2e" stroke-width="1"/>
+
+  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Amazon GuardDuty</text>
+  <text x="455" y="372" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">ML threat detection, 30+ sources</text>
+
+  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS Security Hub</text>
+  <text x="455" y="418" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">CSPM aggregated findings</text>
+
+  <text x="455" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Amazon Detective</text>
+  <text x="455" y="464" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Graph-based investigation</text>
+
+  <text x="455" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">CloudTrail Lake</text>
+  <text x="455" y="510" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">7-year immutable audit trail</text>
+
+  <text x="455" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AI Security Findings</text>
+  <text x="455" y="554" fill="#3b82f6" font-family="Arial, sans-serif" font-size="12">Bedrock GuardRails LLM scanning</text>
+
+  <!-- CARD 3: Data Protection -->
+  <rect x="800" y="226" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#22c55e" stroke-width="1.5" filter="url(#shadow)"/>
+  <rect x="800" y="226" width="340" height="5" rx="3" fill="#22c55e"/>
+
+  <!-- Data protection icon: database with shield -->
+  <circle cx="850" cy="291" r="28" fill="#04120c" stroke="#22c55e" stroke-width="1.5"/>
+  <!-- DB cylinder -->
+  <ellipse cx="850" cy="282" rx="10" ry="4" fill="none" stroke="#22c55e" stroke-width="1.5"/>
+  <line x1="840" y1="282" x2="840" y2="295" stroke="#22c55e" stroke-width="1.5"/>
+  <line x1="860" y1="282" x2="860" y2="295" stroke="#22c55e" stroke-width="1.5"/>
+  <ellipse cx="850" cy="295" rx="10" ry="4" fill="none" stroke="#22c55e" stroke-width="1.5" filter="url(#glow)"/>
+  <!-- mini shield overlay -->
+  <path d="M855 290 C855 290 860 292 860 296 L860 300 C860 303 855 305 855 305 C855 305 850 303 850 300 L850 296 C850 292 855 290 855 290Z" fill="none" stroke="#22c55e" stroke-width="1.5"/>
+
+  <text x="888" y="284" fill="#dcfce7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Data Protection</text>
+  <text x="888" y="304" fill="#86efac" font-family="Arial, sans-serif" font-size="13">Encryption and Privacy</text>
+
+  <line x1="825" y1="326" x2="1115" y2="326" stroke="#0a1e14" stroke-width="1"/>
+
+  <text x="825" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS KMS Advances</text>
+  <text x="825" y="372" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">FIPS 140-3 L3 HSM modules</text>
+
+  <text x="825" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Macie S3 Classification</text>
+  <text x="825" y="418" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">PII/PCI data discovery at scale</text>
+
+  <text x="825" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS PrivateLink</text>
+  <text x="825" y="464" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Private connectivity, no internet</text>
+
+  <text x="825" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">S3 Object Lock WORM</text>
+  <text x="825" y="510" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Ransomware-proof immutability</text>
+
+  <text x="825" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Post-Quantum TLS</text>
+  <text x="825" y="554" fill="#4ade80" font-family="Arial, sans-serif" font-size="12">Kyber ML-KEM hybrid handshake</text>
+
+  <!-- Footer -->
+  <rect x="0" y="596" width="1200" height="34" fill="#0a0800" opacity="0.9"/>
+  <line x1="0" y1="596" x2="1200" y2="596" stroke="#2e1a00" stroke-width="1"/>
+  <text x="60" y="618" fill="#f59e0b" font-family="Arial, sans-serif" font-size="13" font-weight="600">AWS Security</text>
+  <text x="165" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">GuardDuty</text>
+  <text x="265" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">IAM</text>
+  <text x="310" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">KMS</text>
+  <text x="360" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero Trust</text>
+  <text x="460" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Cloud Security</text>
+  <text x="590" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">re:Inforce</text>
+  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
+++ b/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
@@ -1,19 +1,211 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#050d1a" />
+      <stop offset="50%" stop-color="#071828" />
+      <stop offset="100%" stop-color="#0a2240" />
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00c6ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e2a4a" />
+      <stop offset="100%" stop-color="#071828" />
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a2040" />
+      <stop offset="100%" stop-color="#071828" />
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c2848" />
+      <stop offset="100%" stop-color="#071828" />
+    </linearGradient>
+    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#00c6ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#0ea5e9" />
+    </linearGradient>
+    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+      <stop offset="100%" stop-color="#22d3ee" />
     </linearGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <filter id="shadowCard">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#00c6ff" flood-opacity="0.15" />
+    </filter>
+    <filter id="glowStrong">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge>
+        <feMergeNode in="blur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0d2a45" stroke-width="0.8" />
+    </pattern>
+    <clipPath id="mainClip">
+      <rect width="1200" height="630" />
+    </clipPath>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Zscaler Complete Guide SSL</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">AI Complete</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Nov 4, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)" />
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
+
+  <!-- Ambient glow orbs -->
+  <circle cx="150" cy="120" r="180" fill="#0072ff" opacity="0.05" />
+  <circle cx="1050" cy="500" r="200" fill="#00c6ff" opacity="0.04" />
+  <circle cx="600" cy="300" r="260" fill="#0050cc" opacity="0.03" />
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="230" height="34" rx="17" fill="#0a2240" stroke="#00c6ff" stroke-width="1.5" filter="url(#glow)" />
+  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
+  <text x="97" y="60" fill="#00c6ff" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ZERO TRUST SECURITY</text>
+
+  <!-- Date badge -->
+  <rect x="1030" y="38" width="130" height="34" rx="17" fill="#0a2240" stroke="#0072ff" stroke-width="1.5" />
+  <text x="1095" y="60" fill="#60a5fa" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Nov 4, 2025</text>
+
+  <!-- Zscaler Z logo symbol -->
+  <g transform="translate(60, 90)" filter="url(#glowStrong)">
+    <polygon points="0,0 50,0 50,8 14,42 50,42 50,50 0,50 0,42 36,8 0,8" fill="url(#accentGrad)" opacity="0.9" />
+  </g>
+
+  <!-- Main title -->
+  <text x="130" y="130" fill="#e8f4ff" font-family="Arial Black, Arial, sans-serif" font-size="46" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">Zscaler Complete Guide</text>
+
+  <!-- Subtitle -->
+  <text x="131" y="168" fill="#60a5fa" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="2">SSL Inspection  |  Sandbox  |  AI Protection</text>
+
+  <!-- Separator line -->
+  <rect x="60" y="185" width="500" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
+
+  <!-- ── Card 1: SSL Inspection ── -->
+  <rect x="60" y="210" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#1e4a7a" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="60" y="210" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
+
+  <!-- SSL icon: lock -->
+  <g transform="translate(185, 250)" filter="url(#glow)">
+    <rect x="-22" y="-8" width="44" height="36" rx="6" fill="#0a2a4a" stroke="#00c6ff" stroke-width="2" />
+    <rect x="-14" y="-22" width="28" height="22" rx="14" fill="none" stroke="#00c6ff" stroke-width="3" />
+    <circle cx="0" cy="12" r="6" fill="#00c6ff" />
+    <rect x="-2" y="12" width="4" height="8" fill="#00c6ff" />
+  </g>
+
+  <text x="230" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">SSL Inspection</text>
+  <text x="230" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Deep packet inspection</text>
+  <text x="230" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">of encrypted HTTPS traffic</text>
+
+  <!-- SSL stats -->
+  <rect x="85" y="375" width="290" height="1" fill="#1e4a7a" />
+  <text x="100" y="398" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">TLS 1.3</text>
+  <text x="100" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Full decryption support</text>
+  <text x="240" y="398" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Zero Latency</text>
+  <text x="240" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Cloud-native speed</text>
+  <text x="100" y="438" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Certificate Pinning</text>
+  <text x="100" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Policy bypass control</text>
+  <text x="240" y="438" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Compliance</text>
+  <text x="240" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">GDPR / HIPAA ready</text>
+
+  <!-- ── Card 2: AI/ML Threat Detection ── -->
+  <rect x="430" y="210" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#1a3a6a" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="430" y="210" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
+
+  <!-- AI icon: brain/neural net nodes -->
+  <g transform="translate(600, 262)" filter="url(#glow)">
+    <circle cx="0" cy="0" r="12" fill="#0a2040" stroke="#38bdf8" stroke-width="2.5" />
+    <circle cx="-28" cy="-18" r="7" fill="#38bdf8" opacity="0.8" />
+    <circle cx="28" cy="-18" r="7" fill="#38bdf8" opacity="0.8" />
+    <circle cx="-32" cy="14" r="7" fill="#0ea5e9" opacity="0.7" />
+    <circle cx="32" cy="14" r="7" fill="#0ea5e9" opacity="0.7" />
+    <circle cx="0" cy="26" r="7" fill="#38bdf8" opacity="0.8" />
+    <line x1="0" y1="0" x2="-28" y2="-18" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
+    <line x1="0" y1="0" x2="28" y2="-18" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
+    <line x1="0" y1="0" x2="-32" y2="14" stroke="#0ea5e9" stroke-width="1.5" opacity="0.6" />
+    <line x1="0" y1="0" x2="32" y2="14" stroke="#0ea5e9" stroke-width="1.5" opacity="0.6" />
+    <line x1="0" y1="0" x2="0" y2="26" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
+    <text x="0" y="5" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">AI</text>
+  </g>
+
+  <text x="600" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AI/ML Threat Detection</text>
+  <text x="600" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Real-time behavioral analysis</text>
+  <text x="600" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and anomaly detection</text>
+
+  <rect x="455" y="375" width="290" height="1" fill="#1a3a6a" />
+  <text x="470" y="398" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">Sandbox</text>
+  <text x="470" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Zero-day detonation</text>
+  <text x="610" y="398" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">DLP Integration</text>
+  <text x="610" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Data loss prevention</text>
+  <text x="470" y="438" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">Phishing AI</text>
+  <text x="470" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">URL risk scoring</text>
+  <text x="610" y="438" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">UEBA</text>
+  <text x="610" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">User behavior analytics</text>
+
+  <!-- ── Card 3: Content Filtering ── -->
+  <rect x="800" y="210" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#1e4878" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="800" y="210" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
+
+  <!-- Shield icon -->
+  <g transform="translate(970, 262)" filter="url(#glow)">
+    <path d="M0,-28 L22,-14 L22,10 Q22,28 0,36 Q-22,28 -22,10 L-22,-14 Z" fill="#0a2840" stroke="#67e8f9" stroke-width="2.5" />
+    <path d="M-8,2 L-2,10 L12,-8" stroke="#67e8f9" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  </g>
+
+  <text x="970" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Content Filtering</text>
+  <text x="970" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Block malicious and</text>
+  <text x="970" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">inappropriate content</text>
+
+  <rect x="825" y="375" width="290" height="1" fill="#1e4878" />
+  <text x="840" y="398" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ad Blocking</text>
+  <text x="840" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Malvertising protection</text>
+  <text x="980" y="398" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">URL Categories</text>
+  <text x="980" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">200+ category policies</text>
+  <text x="840" y="438" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">DNS Security</text>
+  <text x="840" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">C2 domain blocking</text>
+  <text x="980" y="438" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">Firewall-as-a-Service</text>
+  <text x="980" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Cloud-native FWaaS</text>
+
+  <!-- Footer separator -->
+  <rect x="0" y="502" width="1200" height="1" fill="#0d2a45" />
+
+  <!-- Footer -->
+  <rect x="0" y="503" width="1200" height="127" fill="#030b16" opacity="0.8" />
+
+  <!-- Footer keywords -->
+  <g transform="translate(60, 535)">
+    <rect x="0" y="0" width="100" height="26" rx="13" fill="#0a2240" stroke="#00c6ff" stroke-width="1" />
+    <text x="50" y="18" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Zero Trust</text>
+  </g>
+  <g transform="translate(175" y="0">
+  </g>
+  <rect x="175" y="535" width="80" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
+  <text x="215" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Zscaler</text>
+  <rect x="270" y="535" width="110" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
+  <text x="325" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">SSL Inspection</text>
+  <rect x="395" y="535" width="90" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
+  <text x="440" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AI Security</text>
+  <rect x="500" y="535" width="110" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
+  <text x="555" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
+  <rect x="625" y="535" width="80" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
+  <text x="665" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">SASE</text>
+
+  <!-- Domain -->
+  <text x="1140" y="548" fill="#3a6a9a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Bottom tagline -->
+  <text x="60" y="590" fill="#2a5a8a" font-family="Arial, sans-serif" font-size="13">Comprehensive Zscaler deployment guide for enterprise security teams</text>
+  <text x="1140" y="590" fill="#1a3a5a" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
 </svg>

--- a/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
+++ b/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
@@ -1,19 +1,195 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#030f0a" />
+      <stop offset="50%" stop-color="#071a10" />
+      <stop offset="100%" stop-color="#0a2818" />
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#00e676" />
+      <stop offset="100%" stop-color="#00acc1" />
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a2a18" />
+      <stop offset="100%" stop-color="#071810" />
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#082215" />
+      <stop offset="100%" stop-color="#071810" />
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c2820" />
+      <stop offset="100%" stop-color="#071810" />
+    </linearGradient>
+    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#00e676" />
+      <stop offset="100%" stop-color="#00c853" />
+    </linearGradient>
+    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#26c6da" />
+      <stop offset="100%" stop-color="#00acc1" />
+    </linearGradient>
+    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#69f0ae" />
+      <stop offset="100%" stop-color="#00e676" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <filter id="shadowCard">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#00e676" flood-opacity="0.12" />
+    </filter>
+    <filter id="glowStrong">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0d2a1a" stroke-width="0.8" />
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Cloud Security 8Batch 3Week</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">AWS FinOps ArchitectureFr...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Dec 12, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)" />
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
+
+  <!-- Ambient orbs -->
+  <circle cx="200" cy="150" r="200" fill="#00e676" opacity="0.04" />
+  <circle cx="1000" cy="480" r="220" fill="#00acc1" opacity="0.04" />
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="250" height="34" rx="17" fill="#071a10" stroke="#00e676" stroke-width="1.5" filter="url(#glow)" />
+  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
+  <text x="97" y="60" fill="#00e676" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CLOUD SECURITY COURSE</text>
+
+  <!-- Date badge -->
+  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#071a10" stroke="#00acc1" stroke-width="1.5" />
+  <text x="1090" y="60" fill="#26c6da" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 12, 2025</text>
+
+  <!-- AWS cloud icon -->
+  <g transform="translate(60, 95)" filter="url(#glowStrong)">
+    <ellipse cx="30" cy="30" rx="30" ry="18" fill="#071a10" stroke="#00e676" stroke-width="2" />
+    <ellipse cx="50" cy="26" rx="18" ry="12" fill="#071a10" stroke="#00e676" stroke-width="1.5" />
+    <ellipse cx="14" cy="28" rx="14" ry="10" fill="#071a10" stroke="#00e676" stroke-width="1.5" />
+    <text x="30" y="35" fill="#00e676" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">AWS</text>
+  </g>
+
+  <!-- Week badge -->
+  <rect x="120" y="98" width="80" height="24" rx="12" fill="#0a2a18" stroke="#00c853" stroke-width="1" />
+  <text x="160" y="115" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle">Batch 8 W3</text>
+
+  <!-- Main title -->
+  <text x="60" y="160" fill="#e8fff4" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">AWS FinOps and ISMS-P Security Audit</text>
+
+  <!-- Subtitle -->
+  <text x="61" y="196" fill="#26c6da" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="2">Batch 8  |  Week 3  |  Complete Strategy</text>
+
+  <!-- Separator -->
+  <rect x="60" y="210" width="520" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
+
+  <!-- ── Card 1: FinOps ── -->
+  <rect x="60" y="228" width="340" height="260" rx="16" fill="url(#card1Grad)" stroke="#1a4a2a" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="60" y="228" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
+
+  <!-- Dollar/cost icon -->
+  <g transform="translate(230, 270)" filter="url(#glow)">
+    <circle cx="0" cy="0" r="28" fill="#071a10" stroke="#00e676" stroke-width="2.5" />
+    <text x="0" y="-8" fill="#00e676" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">COST</text>
+    <path d="M-10,0 Q0,-10 10,0 Q0,10 -10,0" fill="#00e676" opacity="0.3" />
+    <text x="0" y="12" fill="#00c853" font-family="Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle">$</text>
+    <path d="M-14,18 L14,18" stroke="#00e676" stroke-width="1.5" />
+    <text x="0" y="28" fill="#00e676" font-family="Arial, sans-serif" font-size="9" text-anchor="middle">-30%</text>
+  </g>
+
+  <text x="230" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">FinOps</text>
+  <text x="230" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Cloud cost optimization</text>
+  <text x="230" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and financial governance</text>
+
+  <rect x="85" y="382" width="290" height="1" fill="#1a4a2a" />
+  <text x="100" y="404" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Reserved Instances</text>
+  <text x="100" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Up to 72% savings</text>
+  <text x="240" y="404" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Savings Plans</text>
+  <text x="240" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Flexible commitment</text>
+  <text x="100" y="444" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Rightsizing</text>
+  <text x="100" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Idle resource cleanup</text>
+  <text x="240" y="444" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Cost Allocation</text>
+  <text x="240" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Tag-based reporting</text>
+
+  <!-- ── Card 2: ISMS-P Audit ── -->
+  <rect x="430" y="228" width="340" height="260" rx="16" fill="url(#card2Grad)" stroke="#154030" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="430" y="228" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
+
+  <!-- Audit/checklist icon -->
+  <g transform="translate(600, 268)" filter="url(#glow)">
+    <rect x="-22" y="-28" width="44" height="56" rx="6" fill="#071a10" stroke="#26c6da" stroke-width="2" />
+    <line x1="-14" y1="-14" x2="14" y2="-14" stroke="#26c6da" stroke-width="1.5" />
+    <path d="-14,-2 L-8,4 L-2,-2" stroke="#00e676" stroke-width="2" fill="none" stroke-linecap="round" transform="translate(-5,-2)" />
+    <line x1="-2" y1="-2" x2="14" y2="-2" stroke="#26c6da" stroke-width="1.5" />
+    <path d="M-14,10 L-8,16 L-2,10" stroke="#00e676" stroke-width="2" fill="none" stroke-linecap="round" transform="translate(-5,2)" />
+    <line x1="-2" y1="12" x2="14" y2="12" stroke="#26c6da" stroke-width="1.5" />
+  </g>
+
+  <text x="600" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">ISMS-P Audit</text>
+  <text x="600" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Korean privacy and</text>
+  <text x="600" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">information security standard</text>
+
+  <rect x="455" y="382" width="290" height="1" fill="#154030" />
+  <text x="470" y="404" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">104 Controls</text>
+  <text x="470" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Full compliance checklist</text>
+  <text x="610" y="404" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Gap Analysis</text>
+  <text x="610" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Current state mapping</text>
+  <text x="470" y="444" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Evidence Collection</text>
+  <text x="470" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Automated gathering</text>
+  <text x="610" y="444" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Remediation</text>
+  <text x="610" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Risk-based priority</text>
+
+  <!-- ── Card 3: AWS Architecture ── -->
+  <rect x="800" y="228" width="340" height="260" rx="16" fill="url(#card3Grad)" stroke="#1a4838" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="800" y="228" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
+
+  <!-- Architecture icon: layers -->
+  <g transform="translate(970, 270)" filter="url(#glow)">
+    <rect x="-28" y="-24" width="56" height="14" rx="4" fill="#071a10" stroke="#69f0ae" stroke-width="2" />
+    <rect x="-22" y="-4" width="44" height="14" rx="4" fill="#071a10" stroke="#00e676" stroke-width="2" />
+    <rect x="-16" y="16" width="32" height="14" rx="4" fill="#071a10" stroke="#26c6da" stroke-width="2" />
+    <text x="0" y="-14" fill="#69f0ae" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">VPC</text>
+    <text x="0" y="6" fill="#00e676" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">EC2</text>
+    <text x="0" y="26" fill="#26c6da" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">RDS</text>
+  </g>
+
+  <text x="970" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AWS Architecture</text>
+  <text x="970" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Well-Architected Framework</text>
+  <text x="970" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">for secure cloud design</text>
+
+  <rect x="825" y="382" width="290" height="1" fill="#1a4838" />
+  <text x="840" y="404" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Multi-Account</text>
+  <text x="840" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">AWS Organizations</text>
+  <text x="980" y="404" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Landing Zone</text>
+  <text x="980" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Control Tower setup</text>
+  <text x="840" y="444" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Hub</text>
+  <text x="840" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Centralized findings</text>
+  <text x="980" y="444" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">GuardDuty</text>
+  <text x="980" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Threat intelligence</text>
+
+  <!-- Footer -->
+  <rect x="0" y="503" width="1200" height="1" fill="#0d2a1a" />
+  <rect x="0" y="504" width="1200" height="126" fill="#020c06" opacity="0.85" />
+
+  <rect x="60" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00e676" stroke-width="1" />
+  <text x="100" y="550" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">FinOps</text>
+  <rect x="155" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
+  <text x="195" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">ISMS-P</text>
+  <rect x="250" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
+  <text x="290" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWS</text>
+  <rect x="345" y="532" width="130" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
+  <text x="410" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
+  <rect x="490" y="532" width="120" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
+  <text x="550" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cost Savings</text>
+
+  <text x="1140" y="548" fill="#2a6a4a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
+  <text x="60" y="592" fill="#1a4a2a" font-family="Arial, sans-serif" font-size="13">Cloud Security Batch 8 curriculum: AWS cost governance and compliance certification</text>
+  <text x="1140" y="592" fill="#1a3a2a" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
 </svg>

--- a/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
+++ b/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
@@ -1,19 +1,193 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0c0518" />
+      <stop offset="50%" stop-color="#130a24" />
+      <stop offset="100%" stop-color="#1a0c35" />
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#b44fff" />
+      <stop offset="100%" stop-color="#4488ff" />
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a0c30" />
+      <stop offset="100%" stop-color="#100820" />
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#14082c" />
+      <stop offset="100%" stop-color="#100820" />
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#180a2e" />
+      <stop offset="100%" stop-color="#100820" />
+    </linearGradient>
+    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff9800" />
+      <stop offset="100%" stop-color="#f57c00" />
+    </linearGradient>
+    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#c084fc" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#60a5fa" />
+      <stop offset="100%" stop-color="#3b82f6" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <filter id="shadowCard">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#b44fff" flood-opacity="0.12" />
+    </filter>
+    <filter id="glowStrong">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1a0a30" stroke-width="0.8" />
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">12 Conference Review AWSKRUG</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">OWASP Datadog Preview See...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Dec 17, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)" />
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
+
+  <!-- Ambient orbs -->
+  <circle cx="180" cy="130" r="200" fill="#b44fff" opacity="0.04" />
+  <circle cx="1020" cy="500" r="200" fill="#4488ff" opacity="0.04" />
+  <circle cx="600" cy="280" r="280" fill="#7722cc" opacity="0.03" />
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="220" height="34" rx="17" fill="#100820" stroke="#b44fff" stroke-width="1.5" filter="url(#glow)" />
+  <circle cx="82" cy="55" r="7" fill="url(#accentGrad)" />
+  <text x="97" y="60" fill="#c084fc" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CONFERENCE REVIEW</text>
+
+  <!-- Date badge -->
+  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#100820" stroke="#4488ff" stroke-width="1.5" />
+  <text x="1090" y="60" fill="#60a5fa" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 17, 2025</text>
+
+  <!-- Star/event icon -->
+  <g transform="translate(60, 100)" filter="url(#glowStrong)">
+    <polygon points="25,0 31,18 50,18 36,29 41,47 25,36 9,47 14,29 0,18 19,18" fill="none" stroke="#b44fff" stroke-width="2" opacity="0.9" />
+    <polygon points="25,8 29,20 42,20 32,28 36,40 25,32 14,40 18,28 8,20 21,20" fill="#b44fff" opacity="0.4" />
+  </g>
+
+  <!-- Main title -->
+  <text x="125" y="130" fill="#f0e8ff" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">December 2025 Conference Review</text>
+
+  <!-- Subtitle -->
+  <text x="126" y="168" fill="#9966cc" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1.5">AWSKRUG  |  OWASP  |  Datadog  |  AI and Security</text>
+
+  <!-- Separator -->
+  <rect x="60" y="185" width="540" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
+
+  <!-- ── Card 1: AWSKRUG ── -->
+  <rect x="60" y="210" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#2a1050" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="60" y="210" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
+
+  <!-- AWS orange icon -->
+  <g transform="translate(230, 260)" filter="url(#glow)">
+    <ellipse cx="0" cy="0" rx="28" ry="18" fill="#1a0c30" stroke="#ff9800" stroke-width="2.5" />
+    <ellipse cx="16" cy="-8" rx="14" ry="10" fill="#1a0c30" stroke="#ff9800" stroke-width="1.5" />
+    <ellipse cx="-16" cy="-6" rx="12" ry="8" fill="#1a0c30" stroke="#f57c00" stroke-width="1.5" />
+    <text x="0" y="5" fill="#ff9800" font-family="Arial, sans-serif" font-size="10" font-weight="900" text-anchor="middle">AWS</text>
+    <path d="M-20,12 Q0,20 20,12" stroke="#ff9800" stroke-width="2" fill="none" />
+  </g>
+
+  <text x="230" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AWSKRUG</text>
+  <text x="230" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">AWS Korea User Group</text>
+  <text x="230" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">community sessions</text>
+
+  <rect x="85" y="365" width="290" height="1" fill="#2a1050" />
+  <text x="100" y="387" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">re:Invent Preview</text>
+  <text x="100" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">2025 announcements</text>
+  <text x="240" y="387" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI/ML Sessions</text>
+  <text x="240" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Bedrock and SageMaker</text>
+  <text x="100" y="427" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Serverless</text>
+  <text x="100" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Lambda best practices</text>
+  <text x="240" y="427" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Community</text>
+  <text x="240" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">300+ attendees</text>
+  <text x="100" y="463" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Workshop</text>
+  <text x="100" y="473" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Hands-on labs</text>
+
+  <!-- ── Card 2: OWASP ── -->
+  <rect x="430" y="210" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#220840" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="430" y="210" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
+
+  <!-- OWASP purple shield -->
+  <g transform="translate(600, 258)" filter="url(#glow)">
+    <path d="M0,-30 L24,-16 L24,8 Q24,30 0,38 Q-24,30 -24,8 L-24,-16 Z" fill="#14082c" stroke="#c084fc" stroke-width="2.5" />
+    <text x="0" y="-6" fill="#c084fc" font-family="Arial, sans-serif" font-size="9" font-weight="700" text-anchor="middle">OWASP</text>
+    <text x="0" y="8" fill="#a855f7" font-family="Arial, sans-serif" font-size="8" text-anchor="middle">Top 10</text>
+    <path d="M-10,18 L0,26 L10,18" stroke="#c084fc" stroke-width="2" fill="none" stroke-linecap="round" />
+  </g>
+
+  <text x="600" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">OWASP</text>
+  <text x="600" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Open Web Application</text>
+  <text x="600" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Security Project</text>
+
+  <rect x="455" y="365" width="290" height="1" fill="#220840" />
+  <text x="470" y="387" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Top 10 2025</text>
+  <text x="470" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Updated vuln rankings</text>
+  <text x="610" y="387" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Security</text>
+  <text x="610" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">LLM risk framework</text>
+  <text x="470" y="427" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Prompt Injection</text>
+  <text x="470" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">GenAI attack vectors</text>
+  <text x="610" y="427" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">ASVS 5.0</text>
+  <text x="610" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Verification standard</text>
+  <text x="470" y="467" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Korea Chapter</text>
+  <text x="470" y="473" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Local meetup recap</text>
+
+  <!-- ── Card 3: Datadog ── -->
+  <rect x="800" y="210" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#200a3a" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="800" y="210" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
+
+  <!-- Datadog icon: monitoring chart -->
+  <g transform="translate(970, 262)" filter="url(#glow)">
+    <rect x="-28" y="-24" width="56" height="48" rx="6" fill="#100820" stroke="#60a5fa" stroke-width="2" />
+    <polyline points="-20,12 -10,-4 0,4 10,-14 20,0" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+    <circle cx="-10" cy="-4" r="3" fill="#3b82f6" />
+    <circle cx="0" cy="4" r="3" fill="#3b82f6" />
+    <circle cx="10" cy="-14" r="3" fill="#60a5fa" />
+    <text x="0" y="28" fill="#60a5fa" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">DD</text>
+  </g>
+
+  <text x="970" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Datadog</text>
+  <text x="970" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Observability platform</text>
+  <text x="970" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and monitoring insights</text>
+
+  <rect x="825" y="365" width="290" height="1" fill="#200a3a" />
+  <text x="840" y="387" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">APM</text>
+  <text x="840" y="403" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Distributed tracing</text>
+  <text x="980" y="387" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">CSPM</text>
+  <text x="980" y="403" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Cloud posture mgmt</text>
+  <text x="840" y="427" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">LLM Observability</text>
+  <text x="840" y="443" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">AI model monitoring</text>
+  <text x="980" y="427" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">Incident Mgmt</text>
+  <text x="980" y="443" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">On-call automation</text>
+  <text x="840" y="467" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Signals</text>
+  <text x="840" y="473" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Threat correlation</text>
+
+  <!-- Footer -->
+  <rect x="0" y="503" width="1200" height="1" fill="#1a0a30" />
+  <rect x="0" y="504" width="1200" height="126" fill="#080414" opacity="0.85" />
+
+  <rect x="60" y="532" width="100" height="26" rx="13" fill="#100820" stroke="#b44fff" stroke-width="1" />
+  <text x="110" y="550" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWSKRUG</text>
+  <rect x="175" y="532" width="80" height="26" rx="13" fill="#100820" stroke="#a855f7" stroke-width="1" />
+  <text x="215" y="550" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">OWASP</text>
+  <rect x="270" y="532" width="90" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
+  <text x="315" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Datadog</text>
+  <rect x="375" y="532" width="100" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
+  <text x="425" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AI Security</text>
+  <rect x="490" y="532" width="120" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
+  <text x="550" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Observability</text>
+
+  <text x="1140" y="548" fill="#4a2a7a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
+  <text x="60" y="592" fill="#2a1050" font-family="Arial, sans-serif" font-size="13">December 2025 tech conference highlights: AI, security, and observability coexistence</text>
+  <text x="1140" y="592" fill="#1a0a30" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
 </svg>

--- a/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
+++ b/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
@@ -1,19 +1,204 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0b1424" />
-      <stop offset="100%" stop-color="#1a3552" />
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#180404" />
+      <stop offset="50%" stop-color="#200808" />
+      <stop offset="100%" stop-color="#2a0e04" />
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ff4444" />
+      <stop offset="100%" stop-color="#ff8800" />
     </linearGradient>
+    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a0c0c" />
+      <stop offset="100%" stop-color="#1a0808" />
+    </linearGradient>
+    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#260a0a" />
+      <stop offset="100%" stop-color="#1a0808" />
+    </linearGradient>
+    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2c0e08" />
+      <stop offset="100%" stop-color="#1a0808" />
+    </linearGradient>
+    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff4444" />
+      <stop offset="100%" stop-color="#cc0000" />
+    </linearGradient>
+    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff8800" />
+      <stop offset="100%" stop-color="#e65c00" />
+    </linearGradient>
+    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffd700" />
+      <stop offset="100%" stop-color="#ff8800" />
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <filter id="shadowCard">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#ff4444" flood-opacity="0.14" />
+    </filter>
+    <filter id="glowStrong">
+      <feGaussianBlur stdDeviation="6" result="blur" />
+      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    </filter>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a0808" stroke-width="0.8" />
+    </pattern>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)" />
-  <rect x="60" y="70" width="1080" height="490" rx="28" fill="#0f2133" stroke="#2a4b68" stroke-width="2" />
-  <rect x="120" y="150" width="240" height="8" fill="url(#accent)" />
-  <text x="120" y="235" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="50" font-weight="700">Cloud Security 8Batch 4Week</text>
-  <text x="120" y="295" fill="#e6f1ff" font-family="Space Grotesk, Arial, sans-serif" font-size="42" font-weight="600">Integration Security Vuln...</text>
-  <text x="120" y="360" fill="#a7c3d9" font-family="Space Grotesk, Arial, sans-serif" font-size="24">Dec 19, 2025</text>
-  <text x="120" y="470" fill="#7fb0d4" font-family="Space Grotesk, Arial, sans-serif" font-size="20">Twodragon Tech Blog</text>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGrad)" />
+  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
+
+  <!-- Ambient orbs -->
+  <circle cx="200" cy="140" r="200" fill="#ff2200" opacity="0.04" />
+  <circle cx="1000" cy="490" r="200" fill="#ff8800" opacity="0.04" />
+
+  <!-- Top accent line -->
+  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
+
+  <!-- Badge -->
+  <rect x="60" y="38" width="250" height="34" rx="17" fill="#200808" stroke="#ff4444" stroke-width="1.5" filter="url(#glow)" />
+  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
+  <text x="97" y="60" fill="#ff6666" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CLOUD SECURITY COURSE</text>
+
+  <!-- Date badge -->
+  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#200808" stroke="#ff8800" stroke-width="1.5" />
+  <text x="1090" y="60" fill="#ffaa44" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 19, 2025</text>
+
+  <!-- Warning/alert icon -->
+  <g transform="translate(60, 92)" filter="url(#glowStrong)">
+    <polygon points="28,0 56,48 0,48" fill="#200808" stroke="#ff4444" stroke-width="2.5" />
+    <line x1="28" y1="16" x2="28" y2="32" stroke="#ff4444" stroke-width="3" stroke-linecap="round" />
+    <circle cx="28" cy="40" r="3" fill="#ff4444" />
+  </g>
+
+  <!-- Week badge -->
+  <rect x="128" y="98" width="80" height="24" rx="12" fill="#2a0808" stroke="#ff6600" stroke-width="1" />
+  <text x="168" y="115" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle">Batch 8 W4</text>
+
+  <!-- Main title -->
+  <text x="60" y="160" fill="#fff0e8" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">Security Vulnerability Inspection</text>
+
+  <!-- Subtitle -->
+  <text x="61" y="196" fill="#cc4422" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1.5">Batch 8  |  Week 4  |  ISMS-P Certification</text>
+
+  <!-- Separator -->
+  <rect x="60" y="212" width="540" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
+
+  <!-- ── Card 1: Vulnerability Scan ── -->
+  <rect x="60" y="228" width="340" height="265" rx="16" fill="url(#card1Grad)" stroke="#4a1010" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="60" y="228" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
+
+  <!-- Scan/radar icon -->
+  <g transform="translate(230, 268)" filter="url(#glow)">
+    <circle cx="0" cy="0" r="28" fill="#200808" stroke="#ff4444" stroke-width="2" />
+    <circle cx="0" cy="0" r="18" fill="none" stroke="#ff4444" stroke-width="1" opacity="0.5" />
+    <circle cx="0" cy="0" r="8" fill="none" stroke="#ff4444" stroke-width="1" opacity="0.4" />
+    <line x1="0" y1="-28" x2="0" y2="28" stroke="#ff4444" stroke-width="1" opacity="0.3" />
+    <line x1="-28" y1="0" x2="28" y2="0" stroke="#ff4444" stroke-width="1" opacity="0.3" />
+    <path d="M0,0 L20,-20 A28,28 0 0,1 28,0 Z" fill="#ff4444" opacity="0.2" />
+    <circle cx="14" cy="-14" r="4" fill="#ff4444" opacity="0.9" />
+    <text x="0" y="5" fill="#ff4444" font-family="Arial, sans-serif" font-size="9" font-weight="700" text-anchor="middle">SCAN</text>
+  </g>
+
+  <text x="230" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Vulnerability Scan</text>
+  <text x="230" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Automated scanning for</text>
+  <text x="230" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">known CVEs and misconfigs</text>
+
+  <rect x="85" y="375" width="290" height="1" fill="#4a1010" />
+  <text x="100" y="397" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">OWASP ZAP</text>
+  <text x="100" y="413" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">DAST scanning</text>
+  <text x="240" y="397" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">Nessus</text>
+  <text x="240" y="413" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Infrastructure audit</text>
+  <text x="100" y="437" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">AWS Inspector</text>
+  <text x="100" y="453" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Cloud workload scan</text>
+  <text x="240" y="437" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">CVE Scoring</text>
+  <text x="240" y="453" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">CVSS v3.1 metrics</text>
+  <text x="100" y="473" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">Patch Priority</text>
+  <text x="100" y="479" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Risk-based ordering</text>
+
+  <!-- ── Card 2: Penetration Test ── -->
+  <rect x="430" y="228" width="340" height="265" rx="16" fill="url(#card2Grad)" stroke="#401010" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="430" y="228" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
+
+  <!-- Pen test: crosshair/target -->
+  <g transform="translate(600, 268)" filter="url(#glow)">
+    <circle cx="0" cy="0" r="28" fill="#1a0808" stroke="#ff8800" stroke-width="2" />
+    <circle cx="0" cy="0" r="16" fill="none" stroke="#ff8800" stroke-width="1.5" />
+    <circle cx="0" cy="0" r="6" fill="#ff8800" opacity="0.8" />
+    <line x1="-28" y1="0" x2="-18" y2="0" stroke="#ff8800" stroke-width="2" />
+    <line x1="18" y1="0" x2="28" y2="0" stroke="#ff8800" stroke-width="2" />
+    <line x1="0" y1="-28" x2="0" y2="-18" stroke="#ff8800" stroke-width="2" />
+    <line x1="0" y1="18" x2="0" y2="28" stroke="#ff8800" stroke-width="2" />
+  </g>
+
+  <text x="600" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Penetration Test</text>
+  <text x="600" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Ethical hacking to validate</text>
+  <text x="600" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">security control gaps</text>
+
+  <rect x="455" y="375" width="290" height="1" fill="#401010" />
+  <text x="470" y="397" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Recon</text>
+  <text x="470" y="413" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">OSINT and footprinting</text>
+  <text x="610" y="397" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Exploitation</text>
+  <text x="610" y="413" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Metasploit framework</text>
+  <text x="470" y="437" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Web App Test</text>
+  <text x="470" y="453" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Burp Suite Pro</text>
+  <text x="610" y="437" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Post Exploitation</text>
+  <text x="610" y="453" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Lateral movement check</text>
+  <text x="470" y="477" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Report</text>
+  <text x="470" y="479" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Executive + technical</text>
+
+  <!-- ── Card 3: ISMS-P Response ── -->
+  <rect x="800" y="228" width="340" height="265" rx="16" fill="url(#card3Grad)" stroke="#481408" stroke-width="1.5" filter="url(#shadowCard)" />
+  <rect x="800" y="228" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
+
+  <!-- Certificate/medal icon -->
+  <g transform="translate(970, 268)" filter="url(#glow)">
+    <rect x="-24" y="-28" width="48" height="42" rx="6" fill="#1a0808" stroke="#ffd700" stroke-width="2" />
+    <circle cx="0" cy="22" r="12" fill="#1a0808" stroke="#ff8800" stroke-width="2" />
+    <circle cx="0" cy="22" r="7" fill="#ff8800" opacity="0.6" />
+    <text x="0" y="-12" fill="#ffd700" font-family="Arial, sans-serif" font-size="8" font-weight="700" text-anchor="middle">ISMS-P</text>
+    <line x1="-14" y1="-4" x2="14" y2="-4" stroke="#ffd700" stroke-width="1.5" />
+    <text x="0" y="4" fill="#ff8800" font-family="Arial, sans-serif" font-size="7" text-anchor="middle">CERTIFIED</text>
+    <path d="-4,34 L0,38 L4,34" stroke="#ff8800" stroke-width="1.5" fill="none" />
+  </g>
+
+  <text x="970" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">ISMS-P Response</text>
+  <text x="970" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Certification preparation</text>
+  <text x="970" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and audit remediation</text>
+
+  <rect x="825" y="375" width="290" height="1" fill="#481408" />
+  <text x="840" y="397" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">104 Controls</text>
+  <text x="840" y="413" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Full compliance mapping</text>
+  <text x="980" y="397" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Evidence Prep</text>
+  <text x="980" y="413" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Documentation pack</text>
+  <text x="840" y="437" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Vuln Remediation</text>
+  <text x="840" y="453" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Patch and hardening</text>
+  <text x="980" y="437" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Mock Audit</text>
+  <text x="980" y="453" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Pre-certification drill</text>
+  <text x="840" y="477" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Final Submission</text>
+  <text x="840" y="479" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">KISA review readiness</text>
+
+  <!-- Footer -->
+  <rect x="0" y="503" width="1200" height="1" fill="#2a0808" />
+  <rect x="0" y="504" width="1200" height="126" fill="#100404" opacity="0.85" />
+
+  <rect x="60" y="532" width="120" height="26" rx="13" fill="#200808" stroke="#ff4444" stroke-width="1" />
+  <text x="120" y="550" fill="#ff6666" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Vuln Scan</text>
+  <rect x="195" y="532" width="110" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
+  <text x="250" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Pentest</text>
+  <rect x="320" y="532" width="80" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
+  <text x="360" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">ISMS-P</text>
+  <rect x="415" y="532" width="120" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
+  <text x="475" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
+  <rect x="550" y="532" width="130" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
+  <text x="615" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Compliance</text>
+
+  <text x="1140" y="548" fill="#5a1a0a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
+  <text x="60" y="592" fill="#3a1010" font-family="Arial, sans-serif" font-size="13">Cloud Security Batch 8 Week 4: integrated vulnerability assessment and ISMS-P certification</text>
+  <text x="1140" y="592" fill="#2a0808" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
 </svg>


### PR DESCRIPTION
## Summary
- 9개 단순 텍스트 템플릿 SVG(19줄)를 풍부한 다크 테마 인포그래픽(172-211줄)으로 재설계
- 대상: Kandji macOS, Cloudflare+GitHub, CI/CD K8s, npm Security, AWS re:Inforce, Zscaler, FinOps+ISMS-P, Conference Review, Vulnerability Inspection

## Test plan
- [x] SVG XML 유효성 검증 통과 (9건)
- [x] 영어 전용 텍스트 확인
- [ ] Vercel 프리뷰 배포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)