### PR TITLE
feat: Buttondown workflow_dispatch 수동 트리거 추가

### DIFF
--- a/.github/workflows/buttondown-notify.yml
+++ b/.github/workflows/buttondown-notify.yml
@@ -9,6 +9,12 @@ on:
     branches: [main]
     paths:
       - '_posts/**' # 포스트 변경 시에만 실행
+  workflow_dispatch:
+    inputs:
+      post_path:
+        description: 'Post file path (e.g. _posts/2026-03-09-Title.md)'
+        required: true
+        type: string
 
 permissions: {}
 
@@ -82,18 +88,18 @@ jobs:
           fi
 
       - name: Set up Python
-        if: steps.check_posts.outputs.has_new_posts == 'true'
+        if: steps.check_posts.outputs.has_new_posts == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install dependencies
-        if: steps.check_posts.outputs.has_new_posts == 'true'
+        if: steps.check_posts.outputs.has_new_posts == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           pip install pyyaml requests
 
       - name: Send Buttondown Email
-        if: steps.check_posts.outputs.has_new_posts == 'true'
+        if: steps.check_posts.outputs.has_new_posts == 'true' || github.event_name == 'workflow_dispatch'
         continue-on-error: true
         env:
           BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
@@ -106,11 +112,13 @@ jobs:
             exit 1
           fi
 
-          # Python 스크립트가 직접 git diff를 수행하여 포스트를 감지
-          # 이 방법이 더 안정적이고 큰 JSON을 다룰 때 문제가 없음
-          echo "📧 Processing posts detected by git diff..."
-          echo ""
-
-          # Python 스크립트를 사용하여 git diff로 포스트 감지 및 이메일 발송
-          python3 scripts/buttondown_notify_batch.py || echo "⚠️ Buttondown notification failed (non-critical)"
+          # workflow_dispatch: 지정된 포스트 발송
+          # push: git diff로 새 포스트 감지 후 발송
+          if [ -n "${{ github.event.inputs.post_path }}" ]; then
+            echo "📧 Manual dispatch: ${{ github.event.inputs.post_path }}"
+            python3 scripts/buttondown_notify.py "${{ github.event.inputs.post_path }}" || echo "⚠️ Buttondown notification failed (non-critical)"
+          else
+            echo "📧 Processing posts detected by git diff..."
+            python3 scripts/buttondown_notify_batch.py || echo "⚠️ Buttondown notification failed (non-critical)"
+          fi
           


### PR DESCRIPTION
## Summary
- Buttondown 워크플로우에 `workflow_dispatch` 트리거 추가
- 기존 포스트도 GitHub Actions UI에서 수동으로 이메일 발송 가능
- `post_path` 입력 파라미터로 발송할 포스트 경로 지정

## Usage
Actions → Buttondown Email Notification → Run workflow → post_path 입력

## Test Plan
- [x] 워크플로우 YAML 문법 확인
- [ ] workflow_dispatch로 수동 트리거 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)