### PR TITLE
feat: add investing-focused opencode commands

### DIFF
--- a/.opencode/commands/improve-investing-post.md
+++ b/.opencode/commands/improve-investing-post.md
@@ -1,0 +1,20 @@
+---
+description: Ralph loop for continuous investing post quality and image improvement
+agent: lead
+---
+
+Run a focused Ralph loop for one investing post.
+
+Target selection:
+1. If `INVESTING_POST` is set, use that exact post path.
+2. Otherwise, pick the most recently modified `_posts/*.md` file that matches `invest|investing|투자` in filename or content.
+
+Loop rules:
+1. Improve only the selected post file.
+2. Run `python3 scripts/check_posts.py <TARGET_POST>`.
+3. Run `python3 scripts/validate_post_quality.py <TARGET_POST>` and keep iterating until score is >= 80.
+4. Regenerate the post image with `python3 scripts/generate_post_images.py <TARGET_POST> --force`.
+5. Verify image consistency with `python3 scripts/verify_images_unified.py --missing`.
+6. Keep iteration focused on quality + image issues for this target post only.
+
+Output `<promise>INVESTING_POSTS_IMPROVED</promise>` when complete.

--- a/.opencode/commands/ultrawork-investing-loop.md
+++ b/.opencode/commands/ultrawork-investing-loop.md
@@ -1,0 +1,19 @@
+---
+description: Ultrawork loop for investing post reliability, quality, and image checks
+agent: lead
+---
+
+Run an ultrawork loop dedicated to investing post improvement.
+
+Target selection:
+1. If `INVESTING_POST` is set, use that exact post path.
+2. Otherwise, select the latest `_posts/*.md` matching `invest|investing|투자` in filename or content.
+
+For each cycle:
+1. Validate target quality with `python3 scripts/check_posts.py <TARGET_POST>` and `python3 scripts/validate_post_quality.py <TARGET_POST>`.
+2. Fix post issues only in `<TARGET_POST>`.
+3. Force-refresh target image via `python3 scripts/generate_post_images.py <TARGET_POST> --force`.
+4. Run `python3 scripts/verify_images_unified.py --missing` and resolve missing-image findings that affect the target.
+5. Continue until no P0/P1 issue remains for the target post.
+
+Output `<promise>ULTRAWORK_INVESTING_LOOP_COMPLETE</promise>` when complete.


### PR DESCRIPTION
## Summary
- add a focused Ralph loop command for improving one investing post at a time
- add a matching ultrawork loop command for repeated investing post validation and image refresh

## Validation
- reviewed command frontmatter and target-selection workflow against existing .opencode command patterns