### PR TITLE
feat: add opencode review and validation skills

### DIFF
--- a/.opencode/skills/cost-audit/SKILL.md
+++ b/.opencode/skills/cost-audit/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: cost-audit
+description: Audit AI and API usage patterns for cost efficiency
+compatibility: opencode
+license: MIT
+metadata:
+  audience: maintainers
+  domain: finops
+---
+
+Use this skill when optimizing recurring automation and model/tool usage costs.
+
+Checklist:
+1. Prefer free/local options before paid APIs.
+2. Verify cache-first behavior and TTL usage.
+3. Batch operations where possible.
+4. Use smaller models for lightweight analysis tasks.
+5. Report avoidable high-cost calls and alternatives.
+
+Deliverables:
+- Current cost-risk hotspots
+- Actionable optimization plan with priority and expected impact

--- a/.opencode/skills/post-validation/SKILL.md
+++ b/.opencode/skills/post-validation/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: post-validation
+description: Validate blog posts against project quality and compliance gates
+compatibility: opencode
+license: MIT
+metadata:
+  audience: maintainers
+  domain: content-quality
+---
+
+Use this skill to verify post quality before publication.
+
+Checklist:
+1. Front matter completeness and category/tag consistency.
+2. Link validity and image reference correctness.
+3. English-only image filenames and SVG text requirements.
+4. Required structural quality (tables, code blocks, checklist).
+5. Security and compliance checks for embedded snippets and content.
+
+Deliverables:
+- Pass/fail summary by file
+- Exact fix list with commands to rerun validation

--- a/.opencode/skills/security-review/SKILL.md
+++ b/.opencode/skills/security-review/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: security-review
+description: Perform a focused security review for changed code and scripts
+compatibility: opencode
+license: MIT
+metadata:
+  audience: maintainers
+  domain: security
+---
+
+Use this skill when reviewing code for security risks.
+
+Checklist:
+1. Secrets handling: no hardcoded credentials, tokens, or keys.
+2. Input handling: validate and sanitize untrusted input.
+3. Output safety: avoid leaking sensitive details in logs/errors.
+4. Command safety: avoid dangerous shell patterns and over-broad permissions.
+5. Data handling: enforce least privilege and safe defaults.
+
+Deliverables:
+- Priority-ranked findings (critical, warning, suggestion)
+- Concrete file references and remediation steps


### PR DESCRIPTION
## Summary
- add reusable cost-audit, post-validation, and security-review skills under .opencode/skills
- document concise checklists and deliverables for recurring review workflows

## Validation
- reviewed skill frontmatter and content format against existing .opencode skill patterns