### PR TITLE
fix: 3/11, 3/12 다이제스트 블록체인 뉴스 품질 개선

### DIFF
--- a/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
+++ b/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
@@ -47,9 +47,9 @@ toc: true
 | 분야 | 소스 | 핵심 내용 | 영향도 |
 |------|------|----------|--------|
 | 🔒 **Security** | Cloudflare Blog | [보안] 클라우드 보안 동향 (Cloudflare Blog) | 🔴 Critical |
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 블록체인 보안 동향 (Cointelegraph) | 🟡 Medium |
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 해외 기술 동향 (Cointelegraph) | 🟡 Medium |
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 해외 기술 동향 (Cointelegraph) | 🟡 Medium |
+| ⛓️ **Blockchain** | Cointelegraph | 비트코인 오더북 불균형 심화 — $70K 지지선 유지 여부 주목 | 🟡 Medium |
+| ⛓️ **Blockchain** | Cointelegraph | 영국 정부, 암호화폐 사기 대응 전략 발표 | 🟡 Medium |
+| ⛓️ **Blockchain** | Cointelegraph | Arthur Hayes, Hyperliquid HYPE 토큰 $150 도달 전망 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | OpenAI, Oracle과의 Stargate 데이터센터 확장 계획 철회 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | Bluesky CEO 제이 그래버, CEO 자리에서 물러나 최고혁신책임자(CIO)로 전환 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | Show GN: Obsidian을 쓰며 느낀 아쉬움 때문에, 로컬 퍼스트 노트 앱 Notaly를 만들고 있습니다 | 🟡 Medium |
@@ -194,63 +194,69 @@ index=firewall action=blocked
 
 ## 2. 블록체인 뉴스
 
-### 2.1 [블록체인] 블록체인 보안 동향 (Cointelegraph)
+### 2.1 비트코인 오더북 불균형 심화 — $70K 지지선 유지 여부 주목
 
 {% include news-card.html
-  title="[블록체인] 블록체인 보안 동향 (Cointelegraph)"
+  title="비트코인 오더북 불균형 심화 — $70K 지지선 유지 여부 주목"
   url="https://cointelegraph.com/news/bitcoin-orderbook-shows-imbalance-will-dollar70k-hold?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTAvMDE5YTJhOTMtZGU3OS03ZDQ0LThkMjAtYTQ3ZDMwMTc4YmFm.jpg"
-  summary="[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 가격 변동에 따른 보안 위협(피싱/스캠) 증가에 대비하세요."
+  summary="비트코인 오더북에서 매도 주문이 매수 주문을 크게 상회하는 불균형이 관측되며, $70K 지지선 유지 여부에 시장의 관심이 집중되고 있습니다. 급격한 가격 변동 구간에서는 피싱, 사칭 사기, 클립보드 하이재킹 등 사이버 위협이 동반 증가합니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 가격 변동에 따른 보안 위협(피싱/스캠) 증가에 대비하세요.
+비트코인 오더북에서 매도 벽(sell wall)이 매수 주문 대비 크게 우세한 불균형이 관측되고 있습니다. $70K 지지선이 무너질 경우 대규모 청산(liquidation)이 연쇄적으로 발생할 수 있어 시장 변동성이 급격히 확대될 가능성이 있습니다.
 
-**실무 포인트**: 가격 변동에 따른 보안 위협(피싱/스캠) 증가에 대비하세요.
+보안 관점에서 주목해야 할 점은 가격 급변동 시기에 사이버 위협이 동반 증가한다는 것입니다. "긴급 자산 이전" 사칭 이메일, 가짜 거래소 피싱 사이트, 비트코인 주소 클립보드 하이재킹 악성코드가 활성화되는 패턴이 반복적으로 관찰됩니다. 거래소 및 지갑 서비스 운영팀은 가격 변동 구간에서 피싱 도메인 모니터링과 고액 출금 인증 절차를 강화해야 합니다.
+
+**실무 포인트**: 가격 변동성 확대 시기에 맞춰 피싱 도메인 알림을 활성화하고, 고액 출금 요청에 대한 추가 인증(2FA + 이메일 확인) 절차를 점검하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/bitcoin-orderbook-shows-imbalance-will-dollar70k-hold?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 
 
 ---
 
-### 2.2 [블록체인] 해외 기술 동향 (Cointelegraph)
+### 2.2 영국 정부, 암호화폐 사기 대응 전략 발표
 
 {% include news-card.html
-  title="[블록체인] 해외 기술 동향 (Cointelegraph)"
+  title="영국 정부, 암호화폐 사기 대응 전략 발표"
   url="https://cointelegraph.com/news/uk-government-fraud-strategy-crypto?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2Q4MzctYWE5Ny03ZDRjLTllNDgtN2E4NzQyOGY4MjJlLmpwZw==.jpg"
-  summary="[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 AI 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요."
+  summary="영국 정부가 암호화폐 관련 사기 대응 전략을 공식 발표했습니다. 크립토 투자 사기, 로맨스 스캠, 피싱 등 급증하는 디지털 자산 범죄에 대한 규제 강화와 법 집행 역량 확대를 골자로 합니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 AI 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+영국 정부가 암호화폐 관련 사기에 대응하는 종합 전략을 발표했습니다. 크립토 투자 사기, 로맨스 스캠을 통한 암호화폐 탈취, 피싱 공격 등이 급증하는 상황에서 법 집행 역량을 강화하고 거래소-금융기관 간 정보 공유를 확대하겠다는 내용을 담고 있습니다.
 
-**실무 포인트**: 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+이번 전략은 영국이 MiCA(유럽 암호자산 시장 규제)와는 별도로 독자적인 암호화폐 사기 대응 체계를 구축하겠다는 의지를 보여줍니다. 국내외 암호화폐 서비스를 운영하거나 연계하는 조직이라면 영국 규제 환경 변화를 사전에 모니터링하고, AML/KYC 정책이 영국 기준에도 부합하는지 점검해야 합니다.
+
+**실무 포인트**: 영국 시장에 서비스를 제공하거나 영국 사용자 기반이 있는 경우, 사기 대응 규정 변경에 따른 컴플라이언스 영향을 법무팀과 사전 검토하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/uk-government-fraud-strategy-crypto?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 
 
 ---
 
-### 2.3 [블록체인] 해외 기술 동향 (Cointelegraph)
+### 2.3 Arthur Hayes, Hyperliquid HYPE 토큰 $150 도달 전망
 
 {% include news-card.html
-  title="[블록체인] 해외 기술 동향 (Cointelegraph)"
+  title="Arthur Hayes, Hyperliquid HYPE 토큰 8월까지 $150 도달 전망"
   url="https://cointelegraph.com/news/hyperliquid-hype-price-will-hit-150-by-august-predicts-arthur-hayes?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjM4YzUtNWQ2NC03ZjI5LWFmM2UtNzYzOWJiMjQyZmFkLmpwZw==.jpg"
-  summary="[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 주요 보안/기술 이슈이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요."
+  summary="BitMEX 공동 창업자 Arthur Hayes가 탈중앙 파생상품 거래소 Hyperliquid의 HYPE 토큰이 8월까지 $150에 도달할 것으로 전망했습니다. 고성능 DEX에 대한 관심이 높아지면서 관련 프로토콜을 표적으로 한 공격 시도도 증가할 수 있습니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 주요 보안/기술 이슈이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+BitMEX 공동 창업자 Arthur Hayes가 탈중앙 파생상품 거래소 Hyperliquid의 네이티브 토큰 HYPE가 8월까지 $150에 도달할 것이라고 전망했습니다. Hyperliquid는 자체 L1 블록체인 위에 구축된 고성능 영구선물(perp) 거래소로, 중앙화 거래소 수준의 속도와 탈중앙 거래소의 자산 자기관리(self-custody) 장점을 결합한 프로토콜입니다.
 
-**실무 포인트**: 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+보안 관점에서 주의할 점은 유명 인사의 가격 전망이 보도될 때마다 해당 프로토콜을 표적으로 한 공격이 증가하는 경향이 있다는 것입니다. 구체적으로 HYPE 토큰 에어드롭 사칭 피싱, 가짜 Hyperliquid 프론트엔드 사이트, 프로토콜 스마트 컨트랙트 취약점 탐색 시도가 늘어날 수 있습니다. Hyperliquid 연계 서비스가 있다면 스마트 컨트랙트 감사 현황과 비상 정지(circuit breaker) 메커니즘을 점검해야 합니다.
+
+**실무 포인트**: DEX 프로토콜 연계 시 스마트 컨트랙트 감사 보고서 확인, 프론트엔드 피싱 도메인 모니터링, 비상 정지 권한 소재를 점검하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/hyperliquid-hype-price-will-hit-150-by-august-predicts-arthur-hayes?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 

--- a/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
+++ b/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
@@ -52,9 +52,9 @@ toc: true
 
 | 분야 | 소스 | 핵심 내용 | 영향도 |
 |------|------|----------|--------|
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 해외 기술 동향 (Cointelegraph) | 🟡 Medium |
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 블록체인 보안 동향 (Cointelegraph) | 🟡 Medium |
-| ⛓️ **Blockchain** | Cointelegraph | [블록체인] 블록체인 보안 동향 (Cointelegraph) | 🟡 Medium |
+| ⛓️ **Blockchain** | Cointelegraph | Jito Foundation, SolanaFloor 인수로 Solana 생태계 저널리즘 재건 | 🟡 Medium |
+| ⛓️ **Blockchain** | Cointelegraph | Trust Wallet, 32개 EVM 체인에서 주소 오염 방지 기능 확대 | 🟠 High |
+| ⛓️ **Blockchain** | Cointelegraph | CFTC 의장, 블록체인 예측시장을 "진실 기계"로 지지 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | 누가 먹을 것인가? — Vertical AI 시대, 모든 배가 뜨지는 않는 이유 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | AI가 앱 구독 모델을 죽일 것이다 | 🟡 Medium |
 | 💻 **Tech** | GeekNews (긱뉴스) | 플로리다 판사, 적색 신호 위반 카메라 단속은 위헌이라고 판결 | 🟡 Medium |
@@ -78,63 +78,69 @@ toc: true
 
 ## 1. 블록체인 뉴스
 
-### 1.1 [블록체인] 해외 기술 동향 (Cointelegraph)
+### 1.1 Jito Foundation, SolanaFloor 인수로 Solana 생태계 저널리즘 재건
 
 {% include news-card.html
-  title="[블록체인] 해외 기술 동향 (Cointelegraph)"
+  title="Jito Foundation, SolanaFloor 인수로 Solana 생태계 저널리즘 재건"
   url="https://cointelegraph.com/news/jito-foundation-acquires-solanafloor-to-revive-solana-ecosystem-journalism?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjI2Y2EtMDM2NC03ZTAxLTgxZjYtOTAxZGJhN2FhZTI1LmpwZw==.jpg"
-  summary="[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요."
+  summary="Jito Foundation이 Solana 생태계 데이터 분석 미디어 SolanaFloor를 인수하여 독립적인 생태계 저널리즘을 재건하겠다고 발표했습니다. MEV 프로토콜 운영 주체가 정보 인프라까지 장악하는 구조가 될 수 있어 생태계 중립성에 대한 논의가 필요합니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 해외 기술 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+Jito Foundation이 Solana 생태계의 데이터 분석 미디어 플랫폼 SolanaFloor를 인수했습니다. Jito는 Solana 네트워크의 MEV(Maximal Extractable Value) 프로토콜을 운영하는 재단으로, 이번 인수를 통해 생태계 데이터 분석과 저널리즘 기능을 자체적으로 갖추게 됩니다.
 
-**실무 포인트**: 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+이 인수의 핵심 쟁점은 **정보 편향 리스크**입니다. MEV 프로토콜의 직접적 이해당사자가 생태계 뉴스와 데이터 분석 채널을 소유하게 되면, 프로토콜에 유리한 정보만 부각되거나 불리한 이슈가 축소 보도될 가능성이 있습니다. Solana 기반 서비스를 운영하는 팀이라면 SolanaFloor 외에 독립적인 데이터 소스를 병행 확보해야 합니다.
+
+**실무 포인트**: Solana 생태계 서비스를 운영 중이라면 데이터 소스의 독립성을 확인하고, Jito 프로토콜 관련 거버넌스 변화가 API 가용성이나 수수료 구조에 미치는 영향을 모니터링하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/jito-foundation-acquires-solanafloor-to-revive-solana-ecosystem-journalism?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 
 
 ---
 
-### 1.2 [블록체인] 블록체인 보안 동향 (Cointelegraph)
+### 1.2 Trust Wallet, 32개 EVM 체인에서 주소 오염 방지 기능 확대
 
 {% include news-card.html
-  title="[블록체인] 블록체인 보안 동향 (Cointelegraph)"
+  title="Trust Wallet, 32개 EVM 체인에서 주소 오염 방지 기능 확대"
   url="https://cointelegraph.com/news/trust-wallet-address-poisoning-protection-32-evm-chains?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjI3NTQtNWVlNy03MzRkLTg3MmUtZDg5OTEwNmMxMTY3LmpwZw==.jpg"
-  summary="[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요."
+  summary="Trust Wallet이 주소 오염(Address Poisoning) 공격을 탐지하는 보호 기능을 Ethereum, Polygon, BNB Chain 등 32개 EVM 호환 체인으로 확대 적용했습니다. 이는 주소 오염 공격이 대규모로 확산되고 있다는 방증이기도 합니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+Trust Wallet이 주소 오염(Address Poisoning) 공격 탐지 기능을 Ethereum, Polygon, BNB Chain, Avalanche 등 32개 EVM 호환 체인으로 확대했습니다. 주소 오염은 공격자가 피해자 지갑의 거래 내역에 앞뒤 몇 자리가 동일한 유사 주소로 소액 거래를 삽입해, 피해자가 복사-붙여넣기로 송금 시 공격자 주소로 자금을 보내도록 유도하는 기법입니다.
 
-**실무 포인트**: 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+Trust Wallet이 32개 체인에 걸쳐 탐지 기능을 배포한 것은 이 공격이 단일 체인이 아닌 **다중 체인 전반에서 대규모로 발생**하고 있음을 보여줍니다. 지갑 수준의 탐지만으로는 완전한 방어가 어렵기 때문에 서비스 백엔드에서도 체크섬 검증(EIP-55)과 화이트리스트 기반 주소 관리를 병행해야 합니다.
+
+**실무 포인트**: 서비스에서 사용 중인 지갑 SDK/라이브러리가 주소 오염 탐지를 지원하는지 확인하고, 관리 계정의 트랜잭션 서명 전 전체 주소 길이 검증 절차를 강제하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/trust-wallet-address-poisoning-protection-32-evm-chains?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 
 
 ---
 
-### 1.3 [블록체인] 블록체인 보안 동향 (Cointelegraph)
+### 1.3 CFTC 의장, 블록체인 예측시장을 "진실 기계"로 지지
 
 {% include news-card.html
-  title="[블록체인] 블록체인 보안 동향 (Cointelegraph)"
+  title="CFTC 의장, 블록체인 예측시장을 '진실 기계'로 지지"
   url="https://cointelegraph.com/news/cftc-chair-backs-blockchain-prediction-markets-truth-machines?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2Q3ZGItNGM3ZC03MGVkLWJhNGItZDJjMDg5YTNkZWMzLmpwZw==.jpg"
-  summary="[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요."
+  summary="CFTC 의장이 블록체인 기반 예측시장(Polymarket, Kalshi 등)을 '진실 기계(Truth Machine)'로 평가하며 긍정적 규제 기조를 밝혔습니다. 이는 미국 규제 기관이 블록체인 기반 금융 혁신을 공식적으로 수용하는 신호입니다."
   source="Cointelegraph"
 %}
 
 #### 개요
 
-[블록체인] 블록체인 보안 동향 (Cointelegraph) (Cointelegraph)에서 블록체인 보안 동향이 보고되었습니다. 이번 항목은 블록체인 운영 관점에서 영향도를 검토하고 우선 대응 항목을 점검해야 합니다. 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+CFTC(미국 상품선물거래위원회) 의장이 블록체인 기반 예측시장을 "진실 기계(Truth Machine)"로 공개 지지했습니다. Polymarket, Kalshi 등 블록체인 예측시장은 집단 지성을 활용해 미래 사건의 발생 확률을 거래하는 플랫폼으로, 스마트 컨트랙트를 통해 결과 정산이 자동화됩니다.
 
-**실무 포인트**: 관련 프로토콜 및 스마트 컨트랙트 영향을 확인하세요.
+이번 발언의 의미는 **미국 규제 기관이 블록체인 기반 금융 혁신을 방어적 태도에서 적극적 수용으로 전환**하고 있다는 것입니다. 다만 최근 Kalshi의 하메네이 관련 소송(3/8 포스트 참조)이나 Polymarket의 내부자 거래 의혹처럼, 예측시장의 조작 가능성과 법적 경계에 대한 논란은 여전히 진행 중입니다. 예측시장 관련 서비스를 운영하거나 연계하는 조직이라면 CFTC의 세부 규제 지침 발표를 모니터링하고, 내부 컴플라이언스 정책에 사전 반영해야 합니다.
+
+**실무 포인트**: 예측시장 프로토콜 연계 서비스를 검토 중이라면 CFTC 규제 동향을 법무팀과 공유하고, 이상 거래 탐지 및 AML 정책을 사전 수립하세요.
 
 > **출처**: [Cointelegraph](https://cointelegraph.com/news/cftc-chair-backs-blockchain-prediction-markets-truth-machines?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound)
 


### PR DESCRIPTION
## Summary
- 3/11, 3/12 다이제스트 포스트의 블록체인 뉴스 섹션에서 제네릭 템플릿 문구를 실제 기사 내용 기반 분석으로 교체
- 하이라이트 테이블의 중복 제목을 구체적 내용으로 수정

## 변경 내용

### 3/12 포스트 (3개 섹션 개선)
| 섹션 | Before | After |
|------|--------|-------|
| 1.1 | "블록체인 보안 동향이 보고되었습니다" | Jito Foundation SolanaFloor 인수 → 정보 편향 리스크 분석 |
| 1.2 | 동일 제네릭 문구 | Trust Wallet 32개 EVM 체인 주소 오염 방지 → 다중 체인 공격 분석 |
| 1.3 | 동일 제네릭 문구 | CFTC 예측시장 "진실 기계" 지지 → 규제 수용 전환 분석 |

### 3/11 포스트 (3개 섹션 개선)
| 섹션 | Before | After |
|------|--------|-------|
| 2.1 | "블록체인 보안 동향이 보고되었습니다" | 비트코인 오더북 불균형 → 가격 변동기 보안 위협 분석 |
| 2.2 | "AI 보안 동향이 보고되었습니다" | 영국 암호화폐 사기 대응 전략 → 컴플라이언스 시사점 |
| 2.3 | "주요 보안/기술 이슈이 보고되었습니다" | Hyperliquid HYPE 전망 → DEX 보안 리스크 분석 |

## Test plan
- [x] `check_posts.py` 검증 통과 (에러 0건)
- [x] 제네릭 템플릿 문구 잔존 여부 확인 (0건)
- [x] Front matter 및 마크다운 구조 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)