### PR TITLE
fix: P2 font weights and AI summary ARIA

### DIFF
--- a/_includes/ai-summary-card.html
+++ b/_includes/ai-summary-card.html
@@ -1,6 +1,6 @@
-<div class="ai-summary-card">
+<section class="ai-summary-card" role="region" aria-label="AI 요약">
 <div class="ai-summary-header">
-  <span class="ai-badge">AI 요약</span>
+  <span class="ai-badge" aria-hidden="true">AI 요약</span>
 </div>
 <div class="ai-summary-content">
   <div class="summary-row">
@@ -31,4 +31,4 @@
 <div class="ai-summary-footer">
   이 포스팅은 AI가 쉽게 이해하고 활용할 수 있도록 구조화된 요약을 포함합니다.
 </div>
-</div>
+</section>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -164,8 +164,8 @@
   <!-- Fonts: Noto Sans KR (한글 가독성, font-display: swap, 단일 요청) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-  <noscript><link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet"></noscript>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
 
   <!-- Prefetch Resources (preload 경고 방지를 위해 prefetch 사용) -->
   <!-- 분할된 JavaScript 파일들을 prefetch로 미리 캐시 -->


### PR DESCRIPTION
## Summary
- Noto Sans KR 폰트 500/600 웨이트 추가 (CSS에서 사용하나 로드되지 않던 문제)
- AI 요약 카드에 ARIA 속성 추가 (`role="region"`, `aria-label`)
- 래퍼를 `div`에서 시맨틱 `section` 요소로 변경

## Test plan
- [ ] 폰트 500/600 웨이트 적용 확인 (인증 페이지, 코드 하이라이트)
- [ ] AI 요약 카드 스크린 리더 접근성 확인
- [ ] 기존 스타일 깨짐 없음 확인