### PR TITLE
fix: P3 mobile nav animation and mermaid accessibility

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -188,26 +188,28 @@
 }
 
 .mobile-nav {
-  display: none;
+  display: flex;
   flex-direction: column;
   padding: var(--spacing-md) var(--spacing-md) var(--spacing-lg);
   border-top: 1px solid var(--color-border);
   background-color: var(--color-bg-primary);
-  max-height: calc(100vh - var(--header-height));
-  overflow-y: auto;
-  /* Smooth slide animation */
+  max-height: 0;
+  overflow: hidden;
+  /* Smooth slide animation for both open and close */
   transform: translateY(-10px);
   opacity: 0;
-  transition: transform var(--transition-base), opacity var(--transition-base);
+  transition: max-height 0.25s ease-out, transform 0.25s ease-out, opacity 0.25s ease-out;
   pointer-events: none;
+  visibility: hidden;
 }
 
 .mobile-nav.active {
-  display: flex;
+  max-height: calc(100vh - var(--header-height));
+  overflow-y: auto;
   transform: translateY(0);
   opacity: 1;
   pointer-events: auto;
-  animation: slideDown 0.25s ease-out forwards;
+  visibility: visible;
 }
 
 @keyframes slideDown {

--- a/assets/js/mermaid-init.js
+++ b/assets/js/mermaid-init.js
@@ -100,6 +100,22 @@
   };
   document.head.appendChild(script);
 
+  // Enhance generic alt text on static mermaid SVG images
+  document.querySelectorAll('img[src*="/mermaid/"]').forEach(function(img) {
+    if (!img.alt || img.alt === 'Mermaid Diagram') {
+      var heading = null;
+      var el = img.previousElementSibling || (img.parentElement && img.parentElement.previousElementSibling);
+      while (el) {
+        if (/^H[1-6]$/.test(el.tagName)) { heading = el.textContent.trim(); break; }
+        el = el.previousElementSibling;
+      }
+      if (heading) {
+        img.alt = heading + ' diagram';
+      }
+      img.setAttribute('role', 'img');
+    }
+  });
+
   // Re-render on theme change (without page reload)
   var observer = new MutationObserver(function(mutations) {
     mutations.forEach(function(mutation) {


### PR DESCRIPTION
## Summary
- 모바일 네비게이션 닫기 애니메이션 수정 (`display:none` → `visibility`+`max-height` 전환)
- Mermaid SVG 이미지에 자동 설명 alt 텍스트 생성 (가장 가까운 제목 기반)
- Mermaid 이미지에 `role="img"` 추가하여 스크린 리더 접근성 향상

## Test plan
- [ ] 모바일에서 햄버거 메뉴 열기/닫기 애니메이션 확인
- [ ] 닫힐 때 부드러운 슬라이드업 효과 동작 확인
- [ ] Mermaid 다이어그램 포함 포스트에서 alt 텍스트 확인
- [ ] 데스크톱에서 기존 레이아웃 영향 없음 확인