### PR TITLE
fix: improve script dependency handling for Python 3.14

### DIFF
--- a/scripts/check_posts.py
+++ b/scripts/check_posts.py
@@ -15,10 +15,18 @@
 
 import argparse
 import re
+import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-import yaml
+try:
+    import yaml
+except ModuleNotFoundError:
+    print(
+        "❌ Missing dependency: PyYAML. Run `pip install -r scripts/requirements.txt` and retry.",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
 
 PROJECT_ROOT = Path(__file__).parent.parent
 POSTS_DIR = PROJECT_ROOT / "_posts"

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -20,7 +20,8 @@ google-generativeai>=0.3.0
 # TTS (선택적)
 gTTS>=2.3.0
 edge-tts>=6.1.0
-TTS>=0.20.0
+# Coqui TTS currently does not publish wheels for Python 3.14+
+TTS>=0.20.0; python_version < "3.14"
 
 # 비디오/SVG 처리 (선택적)
 moviepy>=1.0.3


### PR DESCRIPTION
## Summary
- Add explicit error handling in `scripts/check_posts.py` when PyYAML is missing, with a clear install hint instead of traceback.
- Make `TTS` dependency conditional in `scripts/requirements.txt` to avoid installation failures on Python 3.14+.
- Verified with local checks: `.venv` dependency install, `check_posts.py`, link/image validators, and `bundle exec jekyll build`.