### PR TITLE
fix: make jekyll doctor blocking in CI

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Validate Jekyll Configuration
         run: |
-          bundle exec jekyll doctor || true
+          bundle exec jekyll doctor
           echo "✅ Jekyll configuration validation completed"
 
       - name: Validate Liquid include syntax in posts


### PR DESCRIPTION
## Summary
- Remove the `|| true` mask from `bundle exec jekyll doctor` in Jekyll CI.
- Ensure real configuration issues fail fast instead of being silently ignored.
- Keep the rest of quality/comment steps unchanged and non-blocking.