### PR TITLE
feat: restore high-quality post visuals and regenerate image set

### DIFF
--- a/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
+++ b/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
@@ -1,121 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#f87171"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#ef4444" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#ef4444" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SKT : IMEI , USIM/eSIM , MFA</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Shield -->
-    <path d="M980.0,210.0 L1045.0,240.0 L1045.0,320.0 Q1045.0,370.0 980.0,390.0 Q915.0,370.0 915.0,320.0 L915.0,240.0 Z"
-          fill="none" stroke="#ef4444" stroke-width="4" opacity="0.25"/>
-    <path d="M980.0,230.0 L1028.0,254.0 L1028.0,310.0 Q1028.0,350.0 980.0,366.0 Q932.0,350.0 932.0,310.0 L932.0,254.0 Z"
-          fill="#ef4444" opacity="0.12"/>
-    <!-- Lock body -->
-    <rect x="962.0" y="285.0" width="36" height="28" rx="5" fill="#ef4444" opacity="0.7"/>
-    <!-- Shackle -->
-    <path d="M968.0,285.0 L968.0,270.0 Q968.0,255.0 980.0,255.0 Q992.0,255.0 992.0,270.0 L992.0,285.0"
-          fill="none" stroke="#ef4444" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
-    <!-- Keyhole -->
-    <circle cx="980.0" cy="297.0" r="5" fill="#0f172a"/>
-    <rect x="977.5" y="297.0" width="5" height="8" fill="#0f172a"/>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#ef4444"
-        letter-spacing="3" opacity="0.9">SECURITY</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#ef4444" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">IMEI Check, USIM/eSIM Replace</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">and MFA Importance</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#ef4444" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Security Hardening and Compliance Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">April 29, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#ef4444" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#ef4444">Top 10</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Risks</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">MITRE</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">ATT&amp;CK</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Zero Trust</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Framework</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#ef4444" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SKT : IMEI , USIM/eSIM , MFA - SK USIM</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. USIM/eSIM , IMEI , MFA , SIM ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SKT</text>
+      <rect x="72" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#MFA</text>
+      <rect x="144" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="178" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#USIM</text>
+      <rect x="225" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Incident</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
+++ b/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
@@ -1,121 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#f87171"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#ef4444" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#ef4444" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">PC , OTP,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Shield -->
-    <path d="M980.0,210.0 L1045.0,240.0 L1045.0,320.0 Q1045.0,370.0 980.0,390.0 Q915.0,370.0 915.0,320.0 L915.0,240.0 Z"
-          fill="none" stroke="#ef4444" stroke-width="4" opacity="0.25"/>
-    <path d="M980.0,230.0 L1028.0,254.0 L1028.0,310.0 Q1028.0,350.0 980.0,366.0 Q932.0,350.0 932.0,310.0 L932.0,254.0 Z"
-          fill="#ef4444" opacity="0.12"/>
-    <!-- Lock body -->
-    <rect x="962.0" y="285.0" width="36" height="28" rx="5" fill="#ef4444" opacity="0.7"/>
-    <!-- Shackle -->
-    <path d="M968.0,285.0 L968.0,270.0 Q968.0,255.0 980.0,255.0 Q992.0,255.0 992.0,270.0 L992.0,285.0"
-          fill="none" stroke="#ef4444" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
-    <!-- Keyhole -->
-    <circle cx="980.0" cy="297.0" r="5" fill="#0f172a"/>
-    <rect x="977.5" y="297.0" width="5" height="8" fill="#0f172a"/>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#ef4444"
-        letter-spacing="3" opacity="0.9">SECURITY</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#ef4444" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Passkey, OTP and Strong</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Password Management on Public</text><text x="60" y="346" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">PC</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="412" width="300" height="4" rx="2" fill="#ef4444" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="444"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Security Hardening and Compliance Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="478"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">April 30, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#ef4444" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#ef4444">Top 10</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Risks</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">MITRE</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">ATT&amp;CK</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Zero Trust</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Framework</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#ef4444" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">PC . (Passkey) WebAuthn , OTP 2FA , ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Passkey</text>
+      <rect x="108" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OTP</text>
+      <rect x="180" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Password-Manager</text>
+      <rect x="369" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="448" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Authentication</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
+++ b/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
@@ -1,114 +1,194 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#eab308"/>
-      <stop offset="100%" stop-color="#facc15"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#eab308" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#eab308" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#eab308" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <polygon points="1036.3,257.5 1036.3,322.5 980.0,355.0 923.7,322.5 923.7,257.5 980.0,225.0" fill="none" stroke="#eab308" stroke-width="3" opacity="0.2"/>
-    <polygon points="1012.9,271.0 1012.9,309.0 980.0,328.0 947.1,309.0 947.1,271.0 980.0,252.0" fill="#eab308" opacity="0.12"/>
-    <circle cx="1060.0" cy="290.0" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="1020.0" cy="359.3" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="940.0" cy="359.3" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="900.0" cy="290.0" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="940.0" cy="220.7" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="1020.0" cy="220.7" r="7" fill="#eab308" opacity="0.2"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#eab308"
-        letter-spacing="3" opacity="0.9">FINOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#eab308" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AWS Security and FinOps</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#eab308" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Cost Optimization</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 2, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#eab308" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#eab308">Cost</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Optimize</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">Reserved</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Instances</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Budget</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Alerts</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#eab308" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#eab308" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#eab308" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 3 : AWS FinOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 3 . AWS (IAM, Organizations, CloudTrail,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GuardDuty,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="87" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="115" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#FinOps</text>
+      <rect x="171" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
+      <rect x="342" y="0" width="186" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="435" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cost-Optimization</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
+++ b/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
@@ -1,209 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#050d1a"/>
-      <stop offset="50%" stop-color="#0a1e35"/>
-      <stop offset="100%" stop-color="#0d2540"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#38bdf8"/>
-      <stop offset="100%" stop-color="#818cf8"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e2a4a"/>
-      <stop offset="100%" stop-color="#0a1f38"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a2840"/>
-      <stop offset="100%" stop-color="#081c30"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c2645"/>
-      <stop offset="100%" stop-color="#091e35"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#38bdf8"/>
-      <stop offset="100%" stop-color="#0ea5e9"/>
-    </linearGradient>
-    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#818cf8"/>
-      <stop offset="100%" stop-color="#6366f1"/>
-    </linearGradient>
-    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#10b981"/>
-    </linearGradient>
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow" x="-5%" y="-5%" width="110%" height="120%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.5"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e3a5f" stroke-width="0.5" opacity="0.4"/>
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Outer glow border -->
-  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#38bdf8" stroke-width="1" opacity="0.2"/>
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Decorative circles background -->
-  <circle cx="1050" cy="120" r="180" fill="#38bdf8" opacity="0.03"/>
-  <circle cx="1050" cy="120" r="120" fill="#38bdf8" opacity="0.04"/>
-  <circle cx="150" cy="500" r="120" fill="#818cf8" opacity="0.03"/>
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="220" height="34" rx="17" fill="#0e2a4a" stroke="#38bdf8" stroke-width="1.5"/>
-  <text x="170" y="61" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">macOS MANAGEMENT</text>
-
-  <!-- Date badge -->
-  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0e2a4a" stroke="#818cf8" stroke-width="1.5"/>
-  <text x="1100" y="61" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">May 2, 2025</text>
-
-  <!-- Main title -->
-  <text x="60" y="145" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Kandji macOS Complete</text>
-  <text x="60" y="198" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Master Guide</text>
-
-  <!-- Subtitle -->
-  <text x="60" y="238" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1">Security  |  Compliance  |  All-in-One Platform</text>
-
-  <!-- Divider line -->
-  <line x1="60" y1="258" x2="640" y2="258" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
-
-  <!-- CARD 1: Device Security -->
-  <rect x="60" y="278" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#38bdf8" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="278" width="340" height="5" rx="3" fill="#38bdf8"/>
-
-  <!-- Card 1 icon: shield -->
-  <circle cx="110" cy="335" r="28" fill="#0a1f38" stroke="#38bdf8" stroke-width="1.5"/>
-  <path d="M110 313 L110 313 C110 313 124 318 124 330 L124 342 C124 350 110 357 110 357 C110 357 96 350 96 342 L96 330 C96 318 110 313 110 313Z" fill="none" stroke="#38bdf8" stroke-width="2" filter="url(#glow)"/>
-  <path d="M104 335 L108 340 L117 330" stroke="#38bdf8" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="148" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Device Security</text>
-  <text x="148" y="348" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13">Endpoint Protection</text>
-
-  <line x1="85" y1="375" x2="375" y2="375" stroke="#1e3a5f" stroke-width="1"/>
-
-  <text x="85" y="402" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">MDM Enrollment</text>
-  <rect x="330" y="390" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
-  <text x="357" y="404" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Active</text>
-
-  <text x="85" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">FileVault Encryption</text>
-  <rect x="330" y="420" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
-  <text x="357" y="434" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">ON</text>
-
-  <text x="85" y="462" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Gatekeeper Control</text>
-  <rect x="330" y="450" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
-  <text x="357" y="464" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">ON</text>
-
-  <text x="85" y="492" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">XProtect Updates</text>
-  <rect x="330" y="480" width="55" height="20" rx="10" fill="#083020" stroke="#34d399" stroke-width="1"/>
-  <text x="357" y="494" fill="#34d399" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Auto</text>
-
-  <text x="85" y="522" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SIP Enforcement</text>
-  <rect x="330" y="510" width="55" height="20" rx="10" fill="#0c3a5e" stroke="#38bdf8" stroke-width="1"/>
-  <text x="357" y="524" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Lock</text>
-
-  <!-- CARD 2: Compliance -->
-  <rect x="430" y="278" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="278" width="340" height="5" rx="3" fill="#818cf8"/>
-
-  <!-- Card 2 icon: checklist -->
-  <circle cx="480" cy="335" r="28" fill="#0a1429" stroke="#818cf8" stroke-width="1.5"/>
-  <rect x="468" y="320" width="24" height="28" rx="3" fill="none" stroke="#818cf8" stroke-width="1.8"/>
-  <line x1="472" y1="328" x2="488" y2="328" stroke="#818cf8" stroke-width="1.5"/>
-  <line x1="472" y1="334" x2="488" y2="334" stroke="#818cf8" stroke-width="1.5"/>
-  <line x1="472" y1="340" x2="483" y2="340" stroke="#818cf8" stroke-width="1.5"/>
-  <path d="M484 338 L487 342 L492 334" stroke="#818cf8" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="518" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Compliance</text>
-  <text x="518" y="348" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Policy Enforcement</text>
-
-  <line x1="455" y1="375" x2="745" y2="375" stroke="#1e3a5f" stroke-width="1"/>
-
-  <!-- Compliance progress bars -->
-  <text x="455" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">SOC 2 Type II</text>
-  <rect x="455" y="406" width="290" height="8" rx="4" fill="#0d1f33"/>
-  <rect x="455" y="406" width="261" height="8" rx="4" fill="#818cf8"/>
-  <text x="745" y="415" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">90%</text>
-
-  <text x="455" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">CIS Benchmark</text>
-  <rect x="455" y="438" width="290" height="8" rx="4" fill="#0d1f33"/>
-  <rect x="455" y="438" width="275" height="8" rx="4" fill="#818cf8"/>
-  <text x="745" y="447" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">95%</text>
-
-  <text x="455" y="464" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">NIST CSF</text>
-  <rect x="455" y="470" width="290" height="8" rx="4" fill="#0d1f33"/>
-  <rect x="455" y="470" width="246" height="8" rx="4" fill="#6366f1"/>
-  <text x="745" y="479" fill="#6366f1" font-family="Arial, sans-serif" font-size="11" text-anchor="end">85%</text>
-
-  <text x="455" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">HIPAA Controls</text>
-  <rect x="455" y="502" width="290" height="8" rx="4" fill="#0d1f33"/>
-  <rect x="455" y="502" width="232" height="8" rx="4" fill="#6366f1"/>
-  <text x="745" y="511" fill="#6366f1" font-family="Arial, sans-serif" font-size="11" text-anchor="end">80%</text>
-
-  <text x="455" y="528" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">PCI-DSS</text>
-  <rect x="455" y="534" width="290" height="8" rx="4" fill="#0d1f33"/>
-  <rect x="455" y="534" width="218" height="8" rx="4" fill="#818cf8"/>
-  <text x="745" y="543" fill="#818cf8" font-family="Arial, sans-serif" font-size="11" text-anchor="end">75%</text>
-
-  <!-- CARD 3: Deployment -->
-  <rect x="800" y="278" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#34d399" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="278" width="340" height="5" rx="3" fill="#34d399"/>
-
-  <!-- Card 3 icon: rocket/deploy -->
-  <circle cx="850" cy="335" r="28" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M850 315 C850 315 858 320 860 330 L862 344 L855 340 L850 348 L845 340 L838 344 L840 330 C842 320 850 315 850 315Z" fill="none" stroke="#34d399" stroke-width="2" filter="url(#glow)"/>
-  <circle cx="850" cy="330" r="3" fill="#34d399"/>
-
-  <text x="888" y="328" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="18" font-weight="700">Deployment</text>
-  <text x="888" y="348" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Fleet Management</text>
-
-  <line x1="825" y1="375" x2="1115" y2="375" stroke="#1e3a5f" stroke-width="1"/>
-
-  <!-- Deployment stats -->
-  <text x="825" y="405" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Zero-Touch Enrollment</text>
-  <circle cx="1100" cy="400" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M1095 400 L1098 404 L1105 396" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="825" y="432" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Auto App Deployment</text>
-  <circle cx="1100" cy="427" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M1095 427 L1098 431 L1105 423" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="825" y="459" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">OS Update Policy</text>
-  <circle cx="1100" cy="454" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M1095 454 L1098 458 L1105 450" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="825" y="486" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Blueprint Config</text>
-  <circle cx="1100" cy="481" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M1095 481 L1098 485 L1105 477" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="825" y="513" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Remote Wipe Support</text>
-  <circle cx="1100" cy="508" r="10" fill="#071e18" stroke="#34d399" stroke-width="1.5"/>
-  <path d="M1095 508 L1098 512 L1105 504" stroke="#34d399" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-
-  <text x="825" y="535" fill="#34d399" font-family="Arial, sans-serif" font-size="12" font-weight="600">Kandji Library: 150+ One-Click Apps</text>
-
-  <!-- Footer -->
-  <rect x="0" y="596" width="1200" height="34" fill="#050d1a" opacity="0.8"/>
-  <line x1="0" y1="596" x2="1200" y2="596" stroke="#1e3a5f" stroke-width="1"/>
-  <text x="60" y="618" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="600">MDM</text>
-  <text x="115" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Kandji</text>
-  <text x="190" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">macOS Security</text>
-  <text x="320" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Apple Fleet</text>
-  <text x="430" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero-Touch</text>
-  <text x="540" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Compliance</text>
-  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kandji macOS ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Kandji macOS . MDM , , ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FIDO2/WebAuthn</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kandji</text>
+      <rect x="99" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#macOS</text>
+      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#MDM</text>
+      <rect x="261" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Endpoint-Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
+++ b/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
@@ -1,118 +1,194 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 4 AWS ISMS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AWS Vulnerability Inspection</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">and ISMS Response</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 9, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 - 4 AWS ISMS - 7 4 . AWS</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Inspector, Security Hub, GuardDuty), ISMS-P</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="69" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="106" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#ISMS</text>
+      <rect x="153" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="228" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Vulnerability</text>
+      <rect x="315" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Compliance</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
+++ b/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
@@ -1,118 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 5 AWS Control Tower ZTNA</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AWS Control Tower and ZTNA</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 16, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 5 . AWS Control Tower (Landing Zone, Guardrails,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Control-Tower</text>
+      <rect x="234" y="0" width="69" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#ZTNA</text>
+      <rect x="315" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Zero-Trust</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
+++ b/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
@@ -1,172 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0f0a00"/>
-      <stop offset="50%" stop-color="#1a1200"/>
-      <stop offset="100%" stop-color="#0d1a2e"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f6821f"/>
-      <stop offset="100%" stop-color="#3b82f6"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accentGrad2" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f97316"/>
-      <stop offset="100%" stop-color="#fb923c"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a1500"/>
-      <stop offset="100%" stop-color="#1a0d00"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c1e3a"/>
-      <stop offset="100%" stop-color="#071428"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1a0d00"/>
-      <stop offset="100%" stop-color="#0f0800"/>
-    </linearGradient>
-    <filter id="glow">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a1a00" stroke-width="0.5" opacity="0.5"/>
-    </pattern>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Decorative glows -->
-  <circle cx="1080" cy="100" r="200" fill="#f6821f" opacity="0.04"/>
-  <circle cx="1080" cy="100" r="120" fill="#f6821f" opacity="0.05"/>
-  <circle cx="100" cy="520" r="150" fill="#3b82f6" opacity="0.04"/>
-
-  <!-- Outer border -->
-  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#f6821f" stroke-width="1" opacity="0.15"/>
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="250" height="34" rx="17" fill="#2a1500" stroke="#f6821f" stroke-width="1.5"/>
-  <text x="185" y="61" fill="#f6821f" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">CLOUD SECURITY COURSE</text>
-
-  <!-- Date badge -->
-  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0c1e3a" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="1100" y="61" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">May 23, 2025</text>
-
-  <!-- Main title -->
-  <text x="60" y="145" fill="#fff7ed" font-family="Arial, sans-serif" font-size="44" font-weight="800" filter="url(#glow)">Cloudflare and GitHub Security</text>
-
-  <!-- Subtitle -->
-  <text x="60" y="188" fill="#fdba74" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">Batch 7  |  Week 6  |  Practical Guide</text>
-
-  <!-- Divider -->
-  <line x1="60" y1="208" x2="760" y2="208" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
-
-  <!-- CARD 1: Cloudflare WAF -->
-  <rect x="60" y="228" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#f6821f" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="228" width="340" height="5" rx="3" fill="#f6821f"/>
-
-  <!-- WAF icon: cloud shape -->
-  <circle cx="110" cy="290" r="28" fill="#1a0d00" stroke="#f6821f" stroke-width="1.5"/>
-  <path d="M98 294 C98 287 103 282 109 282 C110 278 115 275 121 277 C124 274 129 274 131 278 C135 279 137 284 135 288 L134 294 Z" fill="none" stroke="#f6821f" stroke-width="2" filter="url(#glow)"/>
-  <path d="M101 294 L119 294" stroke="#f6821f" stroke-width="1.5"/>
-  <path d="M104 297 L116 297" stroke="#f6821f" stroke-width="1"/>
-
-  <text x="148" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">Cloudflare WAF</text>
-  <text x="148" y="303" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Web Application Firewall</text>
-
-  <line x1="85" y1="325" x2="375" y2="325" stroke="#3a1a00" stroke-width="1"/>
-
-  <text x="85" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Rule Management</text>
-  <text x="85" y="374" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Block SQLi, XSS, RCE attacks</text>
-
-  <text x="85" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Rate Limiting</text>
-  <text x="85" y="422" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Threshold-based IP blocking</text>
-
-  <text x="85" y="448" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Bot Management</text>
-  <text x="85" y="470" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">CAPTCHA and JS challenge</text>
-
-  <text x="85" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Page Shield CSP</text>
-  <text x="85" y="518" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Script integrity monitoring</text>
-
-  <!-- CARD 2: GitHub Security -->
-  <rect x="430" y="228" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="228" width="340" height="5" rx="3" fill="#3b82f6"/>
-
-  <!-- GitHub icon: cat/octocat shape simplified -->
-  <circle cx="480" cy="290" r="28" fill="#071428" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="480" cy="287" r="11" fill="none" stroke="#3b82f6" stroke-width="2"/>
-  <path d="M469 295 C469 302 475 306 480 306 C485 306 491 302 491 295" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="476" cy="285" r="1.5" fill="#3b82f6"/>
-  <circle cx="484" cy="285" r="1.5" fill="#3b82f6"/>
-
-  <text x="518" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">GitHub Security</text>
-  <text x="518" y="303" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13">Source Code Protection</text>
-
-  <line x1="455" y1="325" x2="745" y2="325" stroke="#0c1e3a" stroke-width="1"/>
-
-  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Secret Scanning</text>
-  <text x="455" y="374" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Auto-detect API keys and tokens</text>
-
-  <text x="455" y="400" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Dependabot Alerts</text>
-  <text x="455" y="422" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">CVE patch automation PRs</text>
-
-  <text x="455" y="448" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Code Scanning (CodeQL)</text>
-  <text x="455" y="470" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Static analysis in CI pipeline</text>
-
-  <text x="455" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Branch Protection Rules</text>
-  <text x="455" y="518" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Required reviews and status checks</text>
-
-  <!-- CARD 3: DDoS Protection -->
-  <rect x="800" y="228" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#fb923c" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="228" width="340" height="5" rx="3" fill="#fb923c"/>
-
-  <!-- DDoS icon: shield with lightning -->
-  <circle cx="850" cy="290" r="28" fill="#1a0d00" stroke="#fb923c" stroke-width="1.5"/>
-  <path d="M850 268 C850 268 864 274 864 284 L864 298 C864 308 850 316 850 316 C850 316 836 308 836 298 L836 284 C836 274 850 268 850 268Z" fill="none" stroke="#fb923c" stroke-width="2" filter="url(#glow)"/>
-  <path d="M855 278 L847 290 L852 290 L845 304 L857 288 L851 288 Z" fill="#fb923c"/>
-
-  <text x="888" y="283" fill="#fff7ed" font-family="Arial, sans-serif" font-size="18" font-weight="700">DDoS Protection</text>
-  <text x="888" y="303" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Attack Mitigation</text>
-
-  <line x1="825" y1="325" x2="1115" y2="325" stroke="#3a1a00" stroke-width="1"/>
-
-  <!-- Traffic visualization bars -->
-  <text x="825" y="350" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Traffic Filtering Capacity</text>
-  <text x="825" y="368" fill="#fb923c" font-family="Arial, sans-serif" font-size="20" font-weight="700">100 Tbps</text>
-  <text x="930" y="368" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Network Edge</text>
-
-  <text x="825" y="394" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">L3/L4 Volume Attacks</text>
-  <rect x="825" y="400" width="270" height="10" rx="5" fill="#1a0d00"/>
-  <rect x="825" y="400" width="230" height="10" rx="5" fill="#f6821f"/>
-  <text x="1098" y="411" fill="#f6821f" font-family="Arial, sans-serif" font-size="12" text-anchor="end">Blocked</text>
-
-  <text x="825" y="428" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">L7 HTTP Flood</text>
-  <rect x="825" y="434" width="270" height="10" rx="5" fill="#1a0d00"/>
-  <rect x="825" y="434" width="210" height="10" rx="5" fill="#fb923c"/>
-  <text x="1098" y="445" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" text-anchor="end">Filtered</text>
-
-  <text x="825" y="462" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Anycast Routing</text>
-  <text x="825" y="482" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">300+ PoPs worldwide edge nodes</text>
-
-  <text x="825" y="508" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Zero-Day Response</text>
-  <text x="825" y="528" fill="#fb923c" font-family="Arial, sans-serif" font-size="12">Emergency rule deploy in minutes</text>
-
-  <!-- Footer -->
-  <rect x="0" y="596" width="1200" height="34" fill="#0f0a00" opacity="0.9"/>
-  <line x1="0" y1="596" x2="1200" y2="596" stroke="#3a1a00" stroke-width="1"/>
-  <text x="60" y="618" fill="#f6821f" font-family="Arial, sans-serif" font-size="13" font-weight="600">Cloudflare</text>
-  <text x="145" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">WAF</text>
-  <text x="195" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">GitHub Actions</text>
-  <text x="315" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">DDoS Mitigation</text>
-  <text x="450" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero Trust</text>
-  <text x="555" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Supply Chain Security</text>
-  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 6 Cloudflare GitHub</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 6 . AWS WAF, Cloudflare (DDoS, SSL/TLS), GitHub</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Dependabot, CodeQL) .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CDN</text>
+      <rect x="144" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloudflare</text>
+      <rect x="279" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#GitHub</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
+++ b/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
@@ -1,118 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Amazon Q Developer GitHub Advanced Security AWS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Amazon Q Developer and GitHub</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Advanced Security for AWS</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 24, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Amazon Q Developer GitHub Advanced Security AWS</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="105" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Amazon-Q</text>
+      <rect x="117" y="0" width="195" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#GitHub-Advanced...</text>
+      <rect x="324" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Code-Security</text>
+      <rect x="486" y="0" width="60" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="516" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AWS</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
+++ b/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
@@ -1,112 +1,194 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#60a5fa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#1d4ed8"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#3b82f6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="925.0" y="230.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.3" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="935.0" y1="244.0" x2="1025.0" y2="244.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="933.0" y="280.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="943.0" y1="294.0" x2="1033.0" y2="294.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="941.0" y="330.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.12" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="951.0" y1="344.0" x2="1041.0" y2="344.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#3b82f6"
-        letter-spacing="3" opacity="0.9">INFRASTRUCTURE</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#3b82f6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Docker and Kubernetes</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Understanding</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#3b82f6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Container and Orchestration Security</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 30, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#3b82f6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#3b82f6">Pod</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">RBAC</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Network</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Policy</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#3b82f6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 7 : Docker Kubernetes</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Kubernetes Wheel -->
+    <g transform="translate(100, 290)">
+      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
+      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
+      <g stroke="#326ce5" stroke-width="4">
+        <line x1="50" y1="10" x2="50" y2="35"/>
+        <line x1="50" y1="65" x2="50" y2="90"/>
+        <line x1="10" y1="50" x2="35" y2="50"/>
+        <line x1="65" y1="50" x2="90" y2="50"/>
+        <line x1="22" y1="22" x2="39" y2="39"/>
+        <line x1="61" y1="61" x2="78" y2="78"/>
+        <line x1="22" y1="78" x2="39" y2="61"/>
+        <line x1="61" y1="39" x2="78" y2="22"/>
+      </g>
+    </g>
+    
+    <!-- Container Box -->
+    <g transform="translate(230, 300)">
+      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
+      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
+      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
+    </g>
+    
+    <!-- Pod Circle -->
+    <g transform="translate(340, 310)">
+      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
+      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Docker ( , , Dockerfile), Kubernetes (Control Plane, Node,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="87" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Docker</text>
+      <rect x="99" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
+      <rect x="234" y="0" width="114" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Container</text>
+      <rect x="360" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K8s</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
+++ b/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
@@ -1,112 +1,198 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#60a5fa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#1d4ed8"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#3b82f6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="925.0" y="230.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.3" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="935.0" y1="244.0" x2="1025.0" y2="244.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="933.0" y="280.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="943.0" y1="294.0" x2="1033.0" y2="294.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="941.0" y="330.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.12" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="951.0" y1="344.0" x2="1041.0" y2="344.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#3b82f6"
-        letter-spacing="3" opacity="0.9">INFRASTRUCTURE</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#3b82f6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Kubernetes Minikube and K9s</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Practice Guide</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#3b82f6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Container and Orchestration Security</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">May 30, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#3b82f6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#3b82f6">Pod</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">RBAC</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Network</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Policy</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#3b82f6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kubernetes Minikube &amp; K9s :</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Kubernetes Wheel -->
+    <g transform="translate(100, 290)">
+      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
+      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
+      <g stroke="#326ce5" stroke-width="4">
+        <line x1="50" y1="10" x2="50" y2="35"/>
+        <line x1="50" y1="65" x2="50" y2="90"/>
+        <line x1="10" y1="50" x2="35" y2="50"/>
+        <line x1="65" y1="50" x2="90" y2="50"/>
+        <line x1="22" y1="22" x2="39" y2="39"/>
+        <line x1="61" y1="61" x2="78" y2="78"/>
+        <line x1="22" y1="78" x2="39" y2="61"/>
+        <line x1="61" y1="39" x2="78" y2="22"/>
+      </g>
+    </g>
+    
+    <!-- Container Box -->
+    <g transform="translate(230, 300)">
+      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
+      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
+      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
+    </g>
+    
+    <!-- Pod Circle -->
+    <g transform="translate(340, 310)">
+      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
+      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Minikube 1.37.0+ , K9s UI , Kubernetes 2024-2025</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(User</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
+      <rect x="135" y="0" width="105" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="187" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Minikube</text>
+      <rect x="252" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K9s</text>
+      <rect x="324" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K8s</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
+++ b/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
@@ -1,121 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#0ea5e9"/>
-      <stop offset="100%" stop-color="#38bdf8"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#0ea5e9" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: SendGrid SPF, DKIM, DMARC</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Shield -->
-    <path d="M980.0,210.0 L1045.0,240.0 L1045.0,320.0 Q1045.0,370.0 980.0,390.0 Q915.0,370.0 915.0,320.0 L915.0,240.0 Z"
-          fill="none" stroke="#0ea5e9" stroke-width="4" opacity="0.25"/>
-    <path d="M980.0,230.0 L1028.0,254.0 L1028.0,310.0 Q1028.0,350.0 980.0,366.0 Q932.0,350.0 932.0,310.0 L932.0,254.0 Z"
-          fill="#0ea5e9" opacity="0.12"/>
-    <!-- Lock body -->
-    <rect x="962.0" y="285.0" width="36" height="28" rx="5" fill="#0ea5e9" opacity="0.7"/>
-    <!-- Shackle -->
-    <path d="M968.0,285.0 L968.0,270.0 Q968.0,255.0 980.0,255.0 Q992.0,255.0 992.0,270.0 L992.0,285.0"
-          fill="none" stroke="#0ea5e9" stroke-width="5" stroke-linecap="round" opacity="0.7"/>
-    <!-- Keyhole -->
-    <circle cx="980.0" cy="297.0" r="5" fill="#0f172a"/>
-    <rect x="977.5" y="297.0" width="5" height="8" fill="#0f172a"/>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#0ea5e9"
-        letter-spacing="3" opacity="0.9">EMAIL SECURITY</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#0ea5e9" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">SendGrid SPF, DKIM, DMARC</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Setup Guide</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#0ea5e9" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Email Security Configuration Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">June 5, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#0ea5e9" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#0ea5e9">SPF</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Record</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DKIM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Signing</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">DMARC</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Policy</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#0ea5e9" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#0ea5e9" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#0ea5e9" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SendGrid . SPF, DKIM, DMARC , ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SendGrid</text>
+      <rect x="117" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SPF</text>
+      <rect x="189" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DKIM</text>
+      <rect x="270" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="309" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DMARC</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
@@ -1,207 +1,194 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#04091a"/>
-      <stop offset="50%" stop-color="#080f26"/>
-      <stop offset="100%" stop-color="#050e1e"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#22d3ee"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#1d4ed8"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e1040"/>
-      <stop offset="100%" stop-color="#080b2e"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#041a28"/>
-      <stop offset="100%" stop-color="#02111c"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a1035"/>
-      <stop offset="100%" stop-color="#060b25"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <filter id="glow">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0e1540" stroke-width="0.5" opacity="0.6"/>
-    </pattern>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Glow accents -->
-  <circle cx="1100" cy="80" r="220" fill="#6366f1" opacity="0.04"/>
-  <circle cx="1100" cy="80" r="130" fill="#22d3ee" opacity="0.04"/>
-  <circle cx="80" cy="540" r="160" fill="#6366f1" opacity="0.03"/>
-
-  <!-- Outer border -->
-  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#6366f1" stroke-width="1" opacity="0.2"/>
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="250" height="34" rx="17" fill="#0e1040" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="185" y="61" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">CLOUD SECURITY COURSE</text>
-
-  <!-- Date badge -->
-  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#041a28" stroke="#22d3ee" stroke-width="1.5"/>
-  <text x="1100" y="61" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Jun 6, 2025</text>
-
-  <!-- Main title -->
-  <text x="60" y="145" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="44" font-weight="800" filter="url(#glow)">CI/CD and Kubernetes Security</text>
-
-  <!-- Subtitle -->
-  <text x="60" y="188" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">Batch 7  |  Week 8  |  Practical Guide</text>
-
-  <!-- Divider -->
-  <line x1="60" y1="208" x2="720" y2="208" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
-
-  <!-- CARD 1: CI/CD Pipeline -->
-  <rect x="60" y="228" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#6366f1" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="228" width="340" height="5" rx="3" fill="#6366f1"/>
-
-  <!-- CI/CD icon: pipeline flow -->
-  <circle cx="110" cy="290" r="28" fill="#080b2e" stroke="#6366f1" stroke-width="1.5"/>
-  <circle cx="98" cy="290" r="5" fill="#6366f1"/>
-  <line x1="103" y1="290" x2="117" y2="290" stroke="#6366f1" stroke-width="2"/>
-  <circle cx="122" cy="290" r="5" fill="#818cf8"/>
-  <!-- arrow -->
-  <path d="M108 285 L115 290 L108 295" fill="#6366f1"/>
-
-  <text x="148" y="283" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">CI/CD Pipeline</text>
-  <text x="148" y="303" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Pipeline Security</text>
-
-  <line x1="85" y1="325" x2="375" y2="325" stroke="#0e1040" stroke-width="1"/>
-
-  <!-- Pipeline steps visualization -->
-  <text x="85" y="348" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600">PIPELINE STAGES</text>
-
-  <!-- Stage blocks -->
-  <rect x="85" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
-  <text x="116" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Build</text>
-
-  <path d="M147 372 L155 372" stroke="#6366f1" stroke-width="1.5" marker-end="url(#arr)"/>
-  <text x="152" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
-
-  <rect x="159" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
-  <text x="190" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Scan</text>
-
-  <text x="224" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
-
-  <rect x="233" y="358" width="62" height="28" rx="6" fill="#1e2060" stroke="#6366f1" stroke-width="1"/>
-  <text x="264" y="377" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Sign</text>
-
-  <text x="298" y="370" fill="#6366f1" font-family="Arial, sans-serif" font-size="14">></text>
-
-  <rect x="307" y="358" width="62" height="28" rx="6" fill="#0a3a20" stroke="#22c55e" stroke-width="1"/>
-  <text x="338" y="377" fill="#86efac" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Deploy</text>
-
-  <text x="85" y="414" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SAST / DAST Scanning</text>
-  <text x="85" y="434" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">SonarQube and OWASP ZAP integration</text>
-
-  <text x="85" y="458" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Secret Detection</text>
-  <text x="85" y="478" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">Gitleaks and truffleHog pre-commit</text>
-
-  <text x="85" y="502" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Artifact Signing</text>
-  <text x="85" y="522" fill="#6366f1" font-family="Arial, sans-serif" font-size="12">Sigstore Cosign keyless signing</text>
-
-  <!-- CARD 2: K8s Runtime -->
-  <rect x="430" y="228" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#22d3ee" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="228" width="340" height="5" rx="3" fill="#22d3ee"/>
-
-  <!-- K8s icon: hexagon wheel -->
-  <circle cx="480" cy="290" r="28" fill="#02111c" stroke="#22d3ee" stroke-width="1.5"/>
-  <polygon points="480,268 494,276 494,292 480,300 466,292 466,276" fill="none" stroke="#22d3ee" stroke-width="2" filter="url(#glow)"/>
-  <circle cx="480" cy="284" r="4" fill="#22d3ee"/>
-  <line x1="480" y1="268" x2="480" y2="272" stroke="#22d3ee" stroke-width="1.5"/>
-  <line x1="494" y1="276" x2="491" y2="278" stroke="#22d3ee" stroke-width="1.5"/>
-  <line x1="494" y1="292" x2="491" y2="290" stroke="#22d3ee" stroke-width="1.5"/>
-  <line x1="480" y1="300" x2="480" y2="296" stroke="#22d3ee" stroke-width="1.5"/>
-  <line x1="466" y1="292" x2="469" y2="290" stroke="#22d3ee" stroke-width="1.5"/>
-  <line x1="466" y1="276" x2="469" y2="278" stroke="#22d3ee" stroke-width="1.5"/>
-
-  <text x="518" y="283" fill="#e0f7fa" font-family="Arial, sans-serif" font-size="18" font-weight="700">K8s Runtime</text>
-  <text x="518" y="303" fill="#67e8f9" font-family="Arial, sans-serif" font-size="13">Runtime Security</text>
-
-  <line x1="455" y1="325" x2="745" y2="325" stroke="#041a28" stroke-width="1"/>
-
-  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Falco Runtime Detection</text>
-  <text x="455" y="372" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Syscall anomaly alerting</text>
-
-  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">OPA / Kyverno Policy</text>
-  <text x="455" y="418" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Admission controller enforcement</text>
-
-  <text x="455" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Network Policy</text>
-  <text x="455" y="464" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Calico zero-trust microsegmentation</text>
-
-  <text x="455" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">RBAC Hardening</text>
-  <text x="455" y="510" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Least-privilege service accounts</text>
-
-  <text x="455" y="536" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12">Audit logging to SIEM</text>
-
-  <!-- CARD 3: Image Scanning -->
-  <rect x="800" y="228" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="228" width="340" height="5" rx="3" fill="#818cf8"/>
-
-  <!-- Scan icon: magnifier over layers -->
-  <circle cx="850" cy="290" r="28" fill="#060b25" stroke="#818cf8" stroke-width="1.5"/>
-  <rect x="838" y="280" width="18" height="16" rx="2" fill="none" stroke="#818cf8" stroke-width="1.5"/>
-  <line x1="838" y1="284" x2="856" y2="284" stroke="#818cf8" stroke-width="1"/>
-  <line x1="838" y1="288" x2="856" y2="288" stroke="#818cf8" stroke-width="1"/>
-  <circle cx="858" cy="298" r="6" fill="none" stroke="#818cf8" stroke-width="2" filter="url(#glow)"/>
-  <line x1="862" y1="302" x2="866" y2="306" stroke="#818cf8" stroke-width="2.5" stroke-linecap="round"/>
-
-  <text x="888" y="283" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">Image Scanning</text>
-  <text x="888" y="303" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Container Security</text>
-
-  <line x1="825" y1="325" x2="1115" y2="325" stroke="#0a1035" stroke-width="1"/>
-
-  <!-- CVE severity breakdown -->
-  <text x="825" y="350" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600">CVE SEVERITY BREAKDOWN</text>
-
-  <text x="825" y="376" fill="#f87171" font-family="Arial, sans-serif" font-size="13">Critical</text>
-  <rect x="885" y="365" width="190" height="14" rx="7" fill="#1a0a0a"/>
-  <rect x="885" y="365" width="38" height="14" rx="7" fill="#ef4444"/>
-  <text x="1080" y="378" fill="#f87171" font-family="Arial, sans-serif" font-size="12" text-anchor="end">2</text>
-
-  <text x="825" y="402" fill="#fb923c" font-family="Arial, sans-serif" font-size="13">High</text>
-  <rect x="885" y="391" width="190" height="14" rx="7" fill="#1a0a0a"/>
-  <rect x="885" y="391" width="76" height="14" rx="7" fill="#f97316"/>
-  <text x="1080" y="404" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" text-anchor="end">8</text>
-
-  <text x="825" y="428" fill="#fbbf24" font-family="Arial, sans-serif" font-size="13">Medium</text>
-  <rect x="885" y="417" width="190" height="14" rx="7" fill="#1a0a0a"/>
-  <rect x="885" y="417" width="114" height="14" rx="7" fill="#f59e0b"/>
-  <text x="1080" y="430" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12" text-anchor="end">12</text>
-
-  <text x="825" y="454" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">Low</text>
-  <rect x="885" y="443" width="190" height="14" rx="7" fill="#0a1035"/>
-  <rect x="885" y="443" width="152" height="14" rx="7" fill="#4b5563"/>
-  <text x="1080" y="456" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12" text-anchor="end">16</text>
-
-  <text x="825" y="480" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Trivy / Grype Scanning</text>
-  <text x="825" y="500" fill="#818cf8" font-family="Arial, sans-serif" font-size="12">Gate build on Critical and High CVEs</text>
-
-  <text x="825" y="524" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Distroless Base Images</text>
-  <text x="825" y="544" fill="#818cf8" font-family="Arial, sans-serif" font-size="12">Reduce attack surface by 80%</text>
-
-  <!-- Footer -->
-  <rect x="0" y="596" width="1200" height="34" fill="#04091a" opacity="0.9"/>
-  <line x1="0" y1="596" x2="1200" y2="596" stroke="#0e1540" stroke-width="1"/>
-  <text x="60" y="618" fill="#6366f1" font-family="Arial, sans-serif" font-size="13" font-weight="600">Kubernetes</text>
-  <text x="155" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">CI/CD Security</text>
-  <text x="275" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">OPA Policy</text>
-  <text x="375" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Falco</text>
-  <text x="430" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Trivy</text>
-  <text x="490" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 8 : CI/CD Kubernetes</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Kubernetes Wheel -->
+    <g transform="translate(100, 290)">
+      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
+      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
+      <g stroke="#326ce5" stroke-width="4">
+        <line x1="50" y1="10" x2="50" y2="35"/>
+        <line x1="50" y1="65" x2="50" y2="90"/>
+        <line x1="10" y1="50" x2="35" y2="50"/>
+        <line x1="65" y1="50" x2="90" y2="50"/>
+        <line x1="22" y1="22" x2="39" y2="39"/>
+        <line x1="61" y1="61" x2="78" y2="78"/>
+        <line x1="22" y1="78" x2="39" y2="61"/>
+        <line x1="61" y1="39" x2="78" y2="22"/>
+      </g>
+    </g>
+    
+    <!-- Container Box -->
+    <g transform="translate(230, 300)">
+      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
+      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
+      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
+    </g>
+    
+    <!-- Pod Circle -->
+    <g transform="translate(340, 310)">
+      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
+      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CI/CD (GitHub Actions, SAST/DAST, Secret ), Kubernetes</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="78" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#CI/CD</text>
+      <rect x="90" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="151" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
+      <rect x="225" y="0" width="105" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="277" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Security</text>
+      <rect x="342" y="0" width="114" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#DevSecOps</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
+++ b/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
@@ -1,123 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#8b5cf6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="910.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.15"/>
-    <text x="929.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Code</text>
-    <polygon points="948.0,278.0 954.0,284.0 948.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="955.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.2"/>
-    <text x="974.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Build</text>
-    <polygon points="993.0,278.0 999.0,284.0 993.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1000.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.25"/>
-    <text x="1019.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Test</text>
-    <polygon points="1038.0,278.0 1044.0,284.0 1038.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1045.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.30000000000000004"/>
-    <text x="1064.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Deploy</text>
-    <rect x="925.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.1"/>
-    <text x="946.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SAST</text>
-    <rect x="980.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.14"/>
-    <text x="1001.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">DAST</text>
-    <rect x="1035.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.18"/>
-    <text x="1056.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SCA</text>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#8b5cf6"
-        letter-spacing="3" opacity="0.9">DEVSECOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#8b5cf6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps Integration</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#8b5cf6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">DevSecOps Pipeline and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">June 13, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#8b5cf6">SAST</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DAST</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Test</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SCA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 9 : DevSecOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps , , AWS , DevSecOps ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
+      <rect x="126" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Integration</text>
+      <rect x="270" y="0" width="159" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Security</text>
+      <rect x="441" y="0" width="69" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#SDLC</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
+++ b/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
@@ -1,208 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#130000"/>
-      <stop offset="50%" stop-color="#1a0505"/>
-      <stop offset="100%" stop-color="#0f0000"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#f97316"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#b91c1c"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a0a0a"/>
-      <stop offset="100%" stop-color="#1a0505"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a1200"/>
-      <stop offset="100%" stop-color="#1a0c00"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a1a0a"/>
-      <stop offset="100%" stop-color="#051205"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="5" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="redGlow">
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
       <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.7"/>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a0a0a" stroke-width="0.5" opacity="0.6"/>
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Danger glow accents -->
-  <circle cx="600" cy="300" r="400" fill="#ef4444" opacity="0.02"/>
-  <circle cx="1100" cy="80" r="200" fill="#ef4444" opacity="0.04"/>
-  <circle cx="1100" cy="80" r="100" fill="#ef4444" opacity="0.05"/>
-
-  <!-- Outer border - alert red -->
-  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.3"/>
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Alert badge -->
-  <rect x="60" y="38" width="240" height="34" rx="17" fill="#2a0a0a" stroke="#ef4444" stroke-width="1.5"/>
-  <!-- Warning triangle icon -->
-  <path d="M80 55 L88 41 L96 55 Z" fill="none" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="88" y="55" fill="#ef4444" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="700">!</text>
-  <text x="175" y="61" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">SUPPLY CHAIN ATTACK</text>
-
-  <!-- Date badge -->
-  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#2a0a0a" stroke="#f97316" stroke-width="1.5"/>
-  <text x="1100" y="61" fill="#fb923c" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Sep 10, 2025</text>
-
-  <!-- Main title -->
-  <text x="60" y="145" fill="#fecaca" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#redGlow)">npm Large-Scale Security Breach</text>
-
-  <!-- Subtitle -->
-  <text x="60" y="188" fill="#fca5a5" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1">20+ Packages  |  Malware Infection  |  Supply Chain</text>
-
-  <!-- Alert count indicator -->
-  <rect x="730" y="155" width="160" height="50" rx="10" fill="#2a0a0a" stroke="#ef4444" stroke-width="2"/>
-  <text x="810" y="177" fill="#ef4444" font-family="Arial, sans-serif" font-size="28" font-weight="800" text-anchor="middle" filter="url(#glow)">20+</text>
-  <text x="810" y="196" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Infected Packages</text>
-
-  <!-- Divider -->
-  <line x1="60" y1="210" x2="900" y2="210" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.5"/>
-
-  <!-- CARD 1: Attack Vector -->
-  <rect x="60" y="230" width="340" height="310" rx="16" fill="url(#card1Grad)" stroke="#ef4444" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="230" width="340" height="5" rx="3" fill="#ef4444"/>
-
-  <!-- Attack icon: crosshair -->
-  <circle cx="110" cy="293" r="28" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="110" cy="293" r="14" fill="none" stroke="#ef4444" stroke-width="1.5" filter="url(#glow)"/>
-  <circle cx="110" cy="293" r="5" fill="#ef4444"/>
-  <line x1="110" y1="275" x2="110" y2="285" stroke="#ef4444" stroke-width="1.5"/>
-  <line x1="110" y1="301" x2="110" y2="311" stroke="#ef4444" stroke-width="1.5"/>
-  <line x1="92" y1="293" x2="102" y2="293" stroke="#ef4444" stroke-width="1.5"/>
-  <line x1="118" y1="293" x2="128" y2="293" stroke="#ef4444" stroke-width="1.5"/>
-
-  <text x="148" y="286" fill="#fecaca" font-family="Arial, sans-serif" font-size="18" font-weight="700">Attack Vector</text>
-  <text x="148" y="306" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Infection Chain</text>
-
-  <line x1="85" y1="328" x2="375" y2="328" stroke="#3a0a0a" stroke-width="1"/>
-
-  <!-- Attack chain diagram -->
-  <rect x="85" y="340" width="100" height="24" rx="5" fill="#3a0a0a" stroke="#ef4444" stroke-width="1"/>
-  <text x="135" y="357" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Typosquat</text>
-
-  <text x="188" y="356" fill="#ef4444" font-family="Arial, sans-serif" font-size="16">></text>
-
-  <rect x="198" y="340" width="100" height="24" rx="5" fill="#3a0a0a" stroke="#f97316" stroke-width="1"/>
-  <text x="248" y="357" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Postinstall</text>
-
-  <text x="301" y="356" fill="#ef4444" font-family="Arial, sans-serif" font-size="16">></text>
-
-  <rect x="311" y="340" width="50" height="24" rx="5" fill="#3a1000" stroke="#f97316" stroke-width="1"/>
-  <text x="336" y="357" fill="#fb923c" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">RCE</text>
-
-  <text x="85" y="392" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Package Name Spoofing</text>
-  <text x="85" y="412" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">lodash vs 1odash (typo hijack)</text>
-
-  <text x="85" y="436" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Malicious postinstall Hook</text>
-  <text x="85" y="456" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">Executes on npm install command</text>
-
-  <text x="85" y="480" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Data Exfiltration</text>
-  <text x="85" y="500" fill="#ef4444" font-family="Arial, sans-serif" font-size="12">ENV vars, SSH keys, secrets stolen</text>
-
-  <text x="85" y="524" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Lateral Movement</text>
-  <text x="85" y="544" fill="#f97316" font-family="Arial, sans-serif" font-size="12">CI/CD pipeline compromise</text>
-
-  <!-- CARD 2: Affected Packages -->
-  <rect x="430" y="230" width="340" height="310" rx="16" fill="url(#card2Grad)" stroke="#f97316" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="230" width="340" height="5" rx="3" fill="#f97316"/>
-
-  <!-- Package icon: box -->
-  <circle cx="480" cy="293" r="28" fill="#1a0c00" stroke="#f97316" stroke-width="1.5"/>
-  <rect x="467" y="280" width="26" height="24" rx="2" fill="none" stroke="#f97316" stroke-width="1.8"/>
-  <line x1="467" y1="288" x2="493" y2="288" stroke="#f97316" stroke-width="1.5"/>
-  <line x1="480" y1="280" x2="480" y2="288" stroke="#f97316" stroke-width="1.5"/>
-
-  <text x="518" y="286" fill="#fef3c7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Affected Packages</text>
-  <text x="518" y="306" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Compromised Libraries</text>
-
-  <line x1="455" y1="328" x2="745" y2="328" stroke="#3a1200" stroke-width="1"/>
-
-  <!-- Package list with threat level -->
-  <text x="455" y="352" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="600">PACKAGE NAME</text>
-  <text x="680" y="352" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="600">SEVERITY</text>
-
-  <text x="455" y="374" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">node-fetch-extra</text>
-  <rect x="680" y="362" width="58" height="18" rx="9" fill="#3a0a0a"/>
-  <text x="709" y="375" fill="#ef4444" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">CRITICAL</text>
-
-  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">axios-utils-plus</text>
-  <rect x="680" y="386" width="58" height="18" rx="9" fill="#3a1000"/>
-  <text x="709" y="399" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
-
-  <text x="455" y="422" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">crypto-utils-node</text>
-  <rect x="680" y="410" width="58" height="18" rx="9" fill="#3a0a0a"/>
-  <text x="709" y="423" fill="#ef4444" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">CRITICAL</text>
-
-  <text x="455" y="446" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">express-session-ext</text>
-  <rect x="680" y="434" width="58" height="18" rx="9" fill="#3a1000"/>
-  <text x="709" y="447" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
-
-  <text x="455" y="470" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13">webpack-loader-x</text>
-  <rect x="680" y="458" width="58" height="18" rx="9" fill="#3a1000"/>
-  <text x="709" y="471" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">HIGH</text>
-
-  <text x="455" y="498" fill="#64748b" font-family="Arial, sans-serif" font-size="12">... and 15 more packages</text>
-  <text x="455" y="518" fill="#f97316" font-family="Arial, sans-serif" font-size="14" font-weight="600">Total Downloads Before Takedown:</text>
-  <text x="455" y="538" fill="#fbbf24" font-family="Arial, sans-serif" font-size="20" font-weight="800">2.3M+</text>
-
-  <!-- CARD 3: Defense -->
-  <rect x="800" y="230" width="340" height="310" rx="16" fill="url(#card3Grad)" stroke="#22c55e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="230" width="340" height="5" rx="3" fill="#22c55e"/>
-
-  <!-- Defense icon: lock -->
-  <circle cx="850" cy="293" r="28" fill="#051205" stroke="#22c55e" stroke-width="1.5"/>
-  <rect x="840" y="287" width="20" height="16" rx="3" fill="none" stroke="#22c55e" stroke-width="2"/>
-  <path d="M843 287 C843 280 857 280 857 287" fill="none" stroke="#22c55e" stroke-width="2" filter="url(#glow)"/>
-  <circle cx="850" cy="295" r="2.5" fill="#22c55e"/>
-  <line x1="850" y1="297" x2="850" y2="301" stroke="#22c55e" stroke-width="2"/>
-
-  <text x="888" y="286" fill="#dcfce7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Defense</text>
-  <text x="888" y="306" fill="#86efac" font-family="Arial, sans-serif" font-size="13">Mitigation Strategies</text>
-
-  <line x1="825" y1="328" x2="1115" y2="328" stroke="#0a1a0a" stroke-width="1"/>
-
-  <text x="825" y="354" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Dependency Audit</text>
-  <text x="825" y="374" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Run npm audit and fix regularly</text>
-
-  <text x="825" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Package Lock Files</text>
-  <text x="825" y="418" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Commit package-lock.json always</text>
-
-  <text x="825" y="442" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Private Registry Mirror</text>
-  <text x="825" y="462" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Verdaccio or Artifactory proxy</text>
-
-  <text x="825" y="486" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">SCA Tools</text>
-  <text x="825" y="506" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Snyk, Socket.dev monitoring</text>
-
-  <text x="825" y="530" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">npm 2FA Enforcement</text>
-  <text x="825" y="550" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Require 2FA for all publishers</text>
-
-  <!-- Footer -->
-  <rect x="0" y="596" width="1200" height="34" fill="#130000" opacity="0.9"/>
-  <line x1="0" y1="596" x2="1200" y2="596" stroke="#3a0a0a" stroke-width="1"/>
-  <text x="60" y="618" fill="#ef4444" font-family="Arial, sans-serif" font-size="13" font-weight="600">Supply Chain</text>
-  <text x="165" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">npm Security</text>
-  <text x="280" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Malware</text>
-  <text x="360" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Typosquatting</text>
-  <text x="480" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">SCA</text>
-  <text x="530" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Dependency Risk</text>
-  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">npm : 20</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Warning Bell -->
+    <g transform="translate(80, 280)">
+      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
+            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
+      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+    </g>
+    
+    <!-- Timeline -->
+    <g transform="translate(200, 310)">
+      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
+      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
+      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
+      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
+      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    </g>
+    
+    <!-- Fire Icon -->
+    <g transform="translate(370, 285)">
+      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
+            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 9 npm 18 . debug, chalk, lodash 20</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#npm</text>
+      <rect x="72" y="0" width="141" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Supply-Chain</text>
+      <rect x="225" y="0" width="96" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="273" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Malware</text>
+      <rect x="333" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Security-Incident</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
@@ -1,195 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0a0800"/>
-      <stop offset="50%" stop-color="#161000"/>
-      <stop offset="100%" stop-color="#0a0e1a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#3b82f6"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <linearGradient id="awsOrange" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fb923c"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1e1200"/>
-      <stop offset="100%" stop-color="#120c00"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e1a2e"/>
-      <stop offset="100%" stop-color="#08101e"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a1e14"/>
-      <stop offset="100%" stop-color="#04120c"/>
-    </linearGradient>
-    <filter id="glow">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="awsGlow">
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
       <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.6"/>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1e1200" stroke-width="0.5" opacity="0.6"/>
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Glow accents -->
-  <circle cx="1100" cy="90" r="220" fill="#f59e0b" opacity="0.04"/>
-  <circle cx="1100" cy="90" r="130" fill="#f59e0b" opacity="0.05"/>
-  <circle cx="80" cy="540" r="180" fill="#3b82f6" opacity="0.04"/>
-
-  <!-- AWS smile arc decorative -->
-  <path d="M 900 50 Q 1050 110 900 170" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.15"/>
-
-  <!-- Outer border -->
-  <rect x="20" y="20" width="1160" height="590" rx="20" fill="none" stroke="#f59e0b" stroke-width="1" opacity="0.2"/>
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- AWS Badge -->
-  <rect x="60" y="38" width="240" height="34" rx="17" fill="#1e1200" stroke="#f59e0b" stroke-width="1.5"/>
-  <!-- AWS cloud icon simplified -->
-  <path d="M76 58 C76 53 79 50 83 50 C84 47 87 45 91 46 C93 44 96 44 97 47 C100 48 101 51 99 54 L98 58 Z" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <text x="165" y="61" fill="#f59e0b" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">AWS re:Inforce 2025</text>
-
-  <!-- Date badge -->
-  <rect x="1040" y="38" width="120" height="34" rx="17" fill="#0e1a2e" stroke="#3b82f6" stroke-width="1.5"/>
-  <text x="1100" y="61" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Sep 16, 2025</text>
-
-  <!-- AWS logo area top right -->
-  <text x="1080" y="150" fill="#f59e0b" font-family="Arial, sans-serif" font-size="36" font-weight="900" text-anchor="middle" opacity="0.15" filter="url(#awsGlow)">AWS</text>
-
-  <!-- Main title -->
-  <text x="60" y="140" fill="#fef3c7" font-family="Arial, sans-serif" font-size="52" font-weight="800" filter="url(#awsGlow)">AWS re:Inforce 2025</text>
-
-  <!-- Subtitle -->
-  <text x="60" y="185" fill="#fbbf24" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1">Cloud Security  |  Current and Future</text>
-
-  <!-- Divider -->
-  <line x1="60" y1="206" x2="800" y2="206" stroke="url(#accentGrad)" stroke-width="1.5" opacity="0.6"/>
-
-  <!-- CARD 1: Identity Security -->
-  <rect x="60" y="226" width="340" height="320" rx="16" fill="url(#card1Grad)" stroke="#f59e0b" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="226" width="340" height="5" rx="3" fill="#f59e0b"/>
-
-  <!-- Identity icon: person + key -->
-  <circle cx="110" cy="291" r="28" fill="#120c00" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="110" cy="283" r="7" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  <path d="M99 300 C99 294 104 291 110 291 C116 291 121 294 121 300" fill="none" stroke="#f59e0b" stroke-width="1.8" filter="url(#glow)"/>
-  <!-- key -->
-  <circle cx="107" cy="305" r="4" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
-  <line x1="111" y1="305" x2="118" y2="305" stroke="#f59e0b" stroke-width="1.5"/>
-  <line x1="116" y1="302" x2="116" y2="308" stroke="#f59e0b" stroke-width="1.5"/>
-
-  <text x="148" y="284" fill="#fef3c7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Identity Security</text>
-  <text x="148" y="304" fill="#fbbf24" font-family="Arial, sans-serif" font-size="13">IAM and Zero Trust</text>
-
-  <line x1="85" y1="326" x2="375" y2="326" stroke="#2e1a00" stroke-width="1"/>
-
-  <text x="85" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">IAM Identity Center</text>
-  <text x="85" y="372" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Centralized SSO for AWS orgs</text>
-
-  <text x="85" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Permission Boundaries</text>
-  <text x="85" y="418" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Guardrails for delegated admins</text>
-
-  <text x="85" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS Verified Access</text>
-  <text x="85" y="464" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">Zero-trust app access, no VPN</text>
-
-  <text x="85" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Access Analyzer</text>
-  <text x="85" y="510" fill="#fbbf24" font-family="Arial, sans-serif" font-size="12">External resource exposure checks</text>
-
-  <text x="85" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Cedar Policy Language</text>
-  <text x="85" y="554" fill="#f59e0b" font-family="Arial, sans-serif" font-size="12">Fine-grained authorization logic</text>
-
-  <!-- CARD 2: Threat Detection -->
-  <rect x="430" y="226" width="340" height="320" rx="16" fill="url(#card2Grad)" stroke="#3b82f6" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="226" width="340" height="5" rx="3" fill="#3b82f6"/>
-
-  <!-- Radar/detection icon -->
-  <circle cx="480" cy="291" r="28" fill="#08101e" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="480" cy="291" r="18" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.5"/>
-  <circle cx="480" cy="291" r="10" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.7"/>
-  <circle cx="480" cy="291" r="3" fill="#3b82f6"/>
-  <!-- Radar sweep line -->
-  <line x1="480" y1="291" x2="494" y2="278" stroke="#3b82f6" stroke-width="2" filter="url(#glow)" opacity="0.8"/>
-  <circle cx="492" cy="280" r="2" fill="#60a5fa"/>
-
-  <text x="518" y="284" fill="#eff6ff" font-family="Arial, sans-serif" font-size="18" font-weight="700">Threat Detection</text>
-  <text x="518" y="304" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13">AI-Powered Security</text>
-
-  <line x1="455" y1="326" x2="745" y2="326" stroke="#0e1a2e" stroke-width="1"/>
-
-  <text x="455" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Amazon GuardDuty</text>
-  <text x="455" y="372" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">ML threat detection, 30+ sources</text>
-
-  <text x="455" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS Security Hub</text>
-  <text x="455" y="418" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">CSPM aggregated findings</text>
-
-  <text x="455" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Amazon Detective</text>
-  <text x="455" y="464" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">Graph-based investigation</text>
-
-  <text x="455" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">CloudTrail Lake</text>
-  <text x="455" y="510" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12">7-year immutable audit trail</text>
-
-  <text x="455" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AI Security Findings</text>
-  <text x="455" y="554" fill="#3b82f6" font-family="Arial, sans-serif" font-size="12">Bedrock GuardRails LLM scanning</text>
-
-  <!-- CARD 3: Data Protection -->
-  <rect x="800" y="226" width="340" height="320" rx="16" fill="url(#card3Grad)" stroke="#22c55e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="226" width="340" height="5" rx="3" fill="#22c55e"/>
-
-  <!-- Data protection icon: database with shield -->
-  <circle cx="850" cy="291" r="28" fill="#04120c" stroke="#22c55e" stroke-width="1.5"/>
-  <!-- DB cylinder -->
-  <ellipse cx="850" cy="282" rx="10" ry="4" fill="none" stroke="#22c55e" stroke-width="1.5"/>
-  <line x1="840" y1="282" x2="840" y2="295" stroke="#22c55e" stroke-width="1.5"/>
-  <line x1="860" y1="282" x2="860" y2="295" stroke="#22c55e" stroke-width="1.5"/>
-  <ellipse cx="850" cy="295" rx="10" ry="4" fill="none" stroke="#22c55e" stroke-width="1.5" filter="url(#glow)"/>
-  <!-- mini shield overlay -->
-  <path d="M855 290 C855 290 860 292 860 296 L860 300 C860 303 855 305 855 305 C855 305 850 303 850 300 L850 296 C850 292 855 290 855 290Z" fill="none" stroke="#22c55e" stroke-width="1.5"/>
-
-  <text x="888" y="284" fill="#dcfce7" font-family="Arial, sans-serif" font-size="18" font-weight="700">Data Protection</text>
-  <text x="888" y="304" fill="#86efac" font-family="Arial, sans-serif" font-size="13">Encryption and Privacy</text>
-
-  <line x1="825" y1="326" x2="1115" y2="326" stroke="#0a1e14" stroke-width="1"/>
-
-  <text x="825" y="352" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS KMS Advances</text>
-  <text x="825" y="372" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">FIPS 140-3 L3 HSM modules</text>
-
-  <text x="825" y="398" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Macie S3 Classification</text>
-  <text x="825" y="418" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">PII/PCI data discovery at scale</text>
-
-  <text x="825" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">AWS PrivateLink</text>
-  <text x="825" y="464" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Private connectivity, no internet</text>
-
-  <text x="825" y="490" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">S3 Object Lock WORM</text>
-  <text x="825" y="510" fill="#22c55e" font-family="Arial, sans-serif" font-size="12">Ransomware-proof immutability</text>
-
-  <text x="825" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="14">Post-Quantum TLS</text>
-  <text x="825" y="554" fill="#4ade80" font-family="Arial, sans-serif" font-size="12">Kyber ML-KEM hybrid handshake</text>
-
-  <!-- Footer -->
-  <rect x="0" y="596" width="1200" height="34" fill="#0a0800" opacity="0.9"/>
-  <line x1="0" y1="596" x2="1200" y2="596" stroke="#2e1a00" stroke-width="1"/>
-  <text x="60" y="618" fill="#f59e0b" font-family="Arial, sans-serif" font-size="13" font-weight="600">AWS Security</text>
-  <text x="165" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">GuardDuty</text>
-  <text x="265" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">IAM</text>
-  <text x="310" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">KMS</text>
-  <text x="360" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Zero Trust</text>
-  <text x="460" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">Cloud Security</text>
-  <text x="590" y="618" fill="#475569" font-family="Arial, sans-serif" font-size="13">re:Inforce</text>
-  <text x="960" y="618" fill="#64748b" font-family="Arial, sans-serif" font-size="13" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS re:Inforce 2025:</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS re:Inforce 2025 Zero Trust , AI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="114" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#reInforce</text>
+      <rect x="198" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="277" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
+      <rect x="369" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="430" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Conference</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
+++ b/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
@@ -1,119 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f97316"/>
-      <stop offset="100%" stop-color="#fb923c"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#b91c1c"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f97316" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f97316" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f97316" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">NPM Shai-Hulud : 180</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Warning triangle -->
-    <polygon points="980.0,210.0 910.0,330.0 1050.0,330.0"
-             fill="none" stroke="#f97316" stroke-width="4" opacity="0.25"/>
-    <polygon points="980.0,235.0 930.0,320.0 1030.0,320.0"
-             fill="#f97316" opacity="0.12"/>
-    <text x="980.0" y="300.0" text-anchor="middle" font-size="42"
-          font-family="monospace" fill="#f97316" opacity="0.7">!</text>
-    <!-- Crosshair circles -->
-    <circle cx="1060.0" cy="250.0" r="22" fill="none" stroke="#f97316" stroke-width="2" opacity="0.3"/>
-    <line x1="1038.0" y1="250.0" x2="1082.0" y2="250.0" stroke="#f97316" stroke-width="1.5" opacity="0.4"/>
-    <line x1="1060.0" y1="228.0" x2="1060.0" y2="272.0" stroke="#f97316" stroke-width="1.5" opacity="0.4"/>
+    <!-- Warning Bell -->
+    <g transform="translate(80, 280)">
+      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
+            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
+      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+    </g>
+    
+    <!-- Timeline -->
+    <g transform="translate(200, 310)">
+      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
+      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
+      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
+      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
+      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    </g>
+    
+    <!-- Fire Icon -->
+    <g transform="translate(370, 285)">
+      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
+            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f97316"
-        letter-spacing="3" opacity="0.9">SUPPLY CHAIN</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f97316" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">180+ Package Breach Supply</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Chain Attack Analysis</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f97316" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Supply Chain Attack Analysis</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">September 17, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f97316" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f97316">NPM</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Registry</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">SBOM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">CVE</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f97316" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f97316" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f97316" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">NPM Shai-Hulud . SBOM</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2FA</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#npm</text>
+      <rect x="72" y="0" width="195" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="169" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Supply-Chain-At...</text>
+      <rect x="279" y="0" width="69" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="313" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Worm</text>
+      <rect x="360" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="453" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Security-Incident</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
+++ b/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
@@ -1,119 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#f87171"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#b91c1c"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#ef4444" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#ef4444" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Karpenter v1.5.3</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Warning triangle -->
-    <polygon points="980.0,210.0 910.0,330.0 1050.0,330.0"
-             fill="none" stroke="#ef4444" stroke-width="4" opacity="0.25"/>
-    <polygon points="980.0,235.0 930.0,320.0 1030.0,320.0"
-             fill="#ef4444" opacity="0.12"/>
-    <text x="980.0" y="300.0" text-anchor="middle" font-size="42"
-          font-family="monospace" fill="#ef4444" opacity="0.7">!</text>
-    <!-- Crosshair circles -->
-    <circle cx="1060.0" cy="250.0" r="22" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.3"/>
-    <line x1="1038.0" y1="250.0" x2="1082.0" y2="250.0" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-    <line x1="1060.0" y1="228.0" x2="1060.0" y2="272.0" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+    <!-- Warning Bell -->
+    <g transform="translate(80, 280)">
+      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
+            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
+      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+    </g>
+    
+    <!-- Timeline -->
+    <g transform="translate(200, 310)">
+      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
+      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
+      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
+      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
+      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    </g>
+    
+    <!-- Fire Icon -->
+    <g transform="translate(370, 285)">
+      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
+            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#ef4444"
-        letter-spacing="3" opacity="0.9">INCIDENT</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#ef4444" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Large-scale Incident Analysis</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">and Resolution</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#ef4444" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Incident Analysis and Post-Mortem</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">October 2, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#ef4444" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#ef4444">RCA</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Analysis</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">MTTR</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Response</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SLO</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Impact</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#ef4444" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#ef4444" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Karpenter v1.5.3 PodDisruptionBudget</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Karpenter</text>
+      <rect x="126" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="187" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Kubernetes</text>
+      <rect x="261" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#AWS</text>
+      <rect x="333" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
+++ b/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
@@ -1,118 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS : NLB + Security Group</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">NLB and Security Group</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Complete Guide</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">October 3, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS Network Load Balancer Security Group Zero Trust</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#NLB</text>
+      <rect x="144" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Security-Group</text>
+      <rect x="315" y="0" width="105" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="367" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Database</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
+++ b/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
@@ -1,127 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#06b6d4"/>
-      <stop offset="100%" stop-color="#22d3ee"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#06b6d4" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <line x1="980.0" y1="230.0" x2="930.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1030.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1030.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1005.0" y1="345.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <circle cx="980.0" cy="230.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="930.0" cy="290.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="1030.0" cy="290.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="955.0" cy="345.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="1005.0" cy="345.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="980.0" cy="300.0" r="10" fill="#06b6d4" opacity="0.35"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#06b6d4"
-        letter-spacing="3" opacity="0.9">AI &amp; ML</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#06b6d4" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AI Secretary and Security</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Holes</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#06b6d4" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Artificial Intelligence Security Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">October 31, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#06b6d4" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#06b6d4">LLM</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Safety</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">Prompt</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Injection</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">RAG</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#06b6d4" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#06b6d4" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#06b6d4" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI , : AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 AI AI . Shadow AI, , Rogue AI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
+      <rect x="63" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Enterprise-Secu...</text>
+      <rect x="270" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Governance</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
+++ b/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
@@ -1,211 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#050d1a" />
-      <stop offset="50%" stop-color="#071828" />
-      <stop offset="100%" stop-color="#0a2240" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#00c6ff" />
-      <stop offset="100%" stop-color="#0072ff" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e2a4a" />
-      <stop offset="100%" stop-color="#071828" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a2040" />
-      <stop offset="100%" stop-color="#071828" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c2848" />
-      <stop offset="100%" stop-color="#071828" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#00c6ff" />
-      <stop offset="100%" stop-color="#0072ff" />
-    </linearGradient>
-    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#38bdf8" />
-      <stop offset="100%" stop-color="#0ea5e9" />
-    </linearGradient>
-    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#67e8f9" />
-      <stop offset="100%" stop-color="#22d3ee" />
-    </linearGradient>
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur stdDeviation="4" result="blur" />
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
       <feMerge>
-        <feMergeNode in="blur" />
-        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <filter id="shadowCard">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#00c6ff" flood-opacity="0.15" />
-    </filter>
-    <filter id="glowStrong">
-      <feGaussianBlur stdDeviation="6" result="blur" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
       <feMerge>
-        <feMergeNode in="blur" />
-        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0d2a45" stroke-width="0.8" />
-    </pattern>
-    <clipPath id="mainClip">
-      <rect width="1200" height="630" />
-    </clipPath>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)" />
-  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
-
-  <!-- Ambient glow orbs -->
-  <circle cx="150" cy="120" r="180" fill="#0072ff" opacity="0.05" />
-  <circle cx="1050" cy="500" r="200" fill="#00c6ff" opacity="0.04" />
-  <circle cx="600" cy="300" r="260" fill="#0050cc" opacity="0.03" />
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="230" height="34" rx="17" fill="#0a2240" stroke="#00c6ff" stroke-width="1.5" filter="url(#glow)" />
-  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
-  <text x="97" y="60" fill="#00c6ff" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ZERO TRUST SECURITY</text>
-
-  <!-- Date badge -->
-  <rect x="1030" y="38" width="130" height="34" rx="17" fill="#0a2240" stroke="#0072ff" stroke-width="1.5" />
-  <text x="1095" y="60" fill="#60a5fa" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Nov 4, 2025</text>
-
-  <!-- Zscaler Z logo symbol -->
-  <g transform="translate(60, 90)" filter="url(#glowStrong)">
-    <polygon points="0,0 50,0 50,8 14,42 50,42 50,50 0,50 0,42 36,8 0,8" fill="url(#accentGrad)" opacity="0.9" />
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Main title -->
-  <text x="130" y="130" fill="#e8f4ff" font-family="Arial Black, Arial, sans-serif" font-size="46" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">Zscaler Complete Guide</text>
-
-  <!-- Subtitle -->
-  <text x="131" y="168" fill="#60a5fa" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="2">SSL Inspection  |  Sandbox  |  AI Protection</text>
-
-  <!-- Separator line -->
-  <rect x="60" y="185" width="500" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
-
-  <!-- ── Card 1: SSL Inspection ── -->
-  <rect x="60" y="210" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#1e4a7a" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="60" y="210" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
-
-  <!-- SSL icon: lock -->
-  <g transform="translate(185, 250)" filter="url(#glow)">
-    <rect x="-22" y="-8" width="44" height="36" rx="6" fill="#0a2a4a" stroke="#00c6ff" stroke-width="2" />
-    <rect x="-14" y="-22" width="28" height="22" rx="14" fill="none" stroke="#00c6ff" stroke-width="3" />
-    <circle cx="0" cy="12" r="6" fill="#00c6ff" />
-    <rect x="-2" y="12" width="4" height="8" fill="#00c6ff" />
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="230" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">SSL Inspection</text>
-  <text x="230" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Deep packet inspection</text>
-  <text x="230" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">of encrypted HTTPS traffic</text>
-
-  <!-- SSL stats -->
-  <rect x="85" y="375" width="290" height="1" fill="#1e4a7a" />
-  <text x="100" y="398" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">TLS 1.3</text>
-  <text x="100" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Full decryption support</text>
-  <text x="240" y="398" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Zero Latency</text>
-  <text x="240" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Cloud-native speed</text>
-  <text x="100" y="438" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Certificate Pinning</text>
-  <text x="100" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Policy bypass control</text>
-  <text x="240" y="438" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="700">Compliance</text>
-  <text x="240" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">GDPR / HIPAA ready</text>
-
-  <!-- ── Card 2: AI/ML Threat Detection ── -->
-  <rect x="430" y="210" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#1a3a6a" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="430" y="210" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
-
-  <!-- AI icon: brain/neural net nodes -->
-  <g transform="translate(600, 262)" filter="url(#glow)">
-    <circle cx="0" cy="0" r="12" fill="#0a2040" stroke="#38bdf8" stroke-width="2.5" />
-    <circle cx="-28" cy="-18" r="7" fill="#38bdf8" opacity="0.8" />
-    <circle cx="28" cy="-18" r="7" fill="#38bdf8" opacity="0.8" />
-    <circle cx="-32" cy="14" r="7" fill="#0ea5e9" opacity="0.7" />
-    <circle cx="32" cy="14" r="7" fill="#0ea5e9" opacity="0.7" />
-    <circle cx="0" cy="26" r="7" fill="#38bdf8" opacity="0.8" />
-    <line x1="0" y1="0" x2="-28" y2="-18" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
-    <line x1="0" y1="0" x2="28" y2="-18" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
-    <line x1="0" y1="0" x2="-32" y2="14" stroke="#0ea5e9" stroke-width="1.5" opacity="0.6" />
-    <line x1="0" y1="0" x2="32" y2="14" stroke="#0ea5e9" stroke-width="1.5" opacity="0.6" />
-    <line x1="0" y1="0" x2="0" y2="26" stroke="#38bdf8" stroke-width="1.5" opacity="0.6" />
-    <text x="0" y="5" fill="#38bdf8" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zscaler : SSL , , AI, ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="600" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AI/ML Threat Detection</text>
-  <text x="600" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Real-time behavioral analysis</text>
-  <text x="600" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and anomaly detection</text>
-
-  <rect x="455" y="375" width="290" height="1" fill="#1a3a6a" />
-  <text x="470" y="398" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">Sandbox</text>
-  <text x="470" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Zero-day detonation</text>
-  <text x="610" y="398" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">DLP Integration</text>
-  <text x="610" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Data loss prevention</text>
-  <text x="470" y="438" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">Phishing AI</text>
-  <text x="470" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">URL risk scoring</text>
-  <text x="610" y="438" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="700">UEBA</text>
-  <text x="610" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">User behavior analytics</text>
-
-  <!-- ── Card 3: Content Filtering ── -->
-  <rect x="800" y="210" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#1e4878" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="800" y="210" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
-
-  <!-- Shield icon -->
-  <g transform="translate(970, 262)" filter="url(#glow)">
-    <path d="M0,-28 L22,-14 L22,10 Q22,28 0,36 Q-22,28 -22,10 L-22,-14 Z" fill="#0a2840" stroke="#67e8f9" stroke-width="2.5" />
-    <path d="M-8,2 L-2,10 L12,-8" stroke="#67e8f9" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Zscaler . SSL , (ATP), AI/ / Zero Trust</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zscaler</text>
+      <rect x="108" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ZTNA</text>
+      <rect x="189" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SSL-Inspection</text>
+      <rect x="360" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="421" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="970" y="312" fill="#e8f4ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Content Filtering</text>
-  <text x="970" y="338" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Block malicious and</text>
-  <text x="970" y="356" fill="#7ab8d4" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">inappropriate content</text>
-
-  <rect x="825" y="375" width="290" height="1" fill="#1e4878" />
-  <text x="840" y="398" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ad Blocking</text>
-  <text x="840" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Malvertising protection</text>
-  <text x="980" y="398" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">URL Categories</text>
-  <text x="980" y="414" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">200+ category policies</text>
-  <text x="840" y="438" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">DNS Security</text>
-  <text x="840" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">C2 domain blocking</text>
-  <text x="980" y="438" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="700">Firewall-as-a-Service</text>
-  <text x="980" y="454" fill="#5a8aaa" font-family="Arial, sans-serif" font-size="11">Cloud-native FWaaS</text>
-
-  <!-- Footer separator -->
-  <rect x="0" y="502" width="1200" height="1" fill="#0d2a45" />
-
-  <!-- Footer -->
-  <rect x="0" y="503" width="1200" height="127" fill="#030b16" opacity="0.8" />
-
-  <!-- Footer keywords -->
-  <g transform="translate(60, 535)">
-    <rect x="0" y="0" width="100" height="26" rx="13" fill="#0a2240" stroke="#00c6ff" stroke-width="1" />
-    <text x="50" y="18" fill="#00c6ff" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Zero Trust</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(175" y="0">
-  </g>
-  <rect x="175" y="535" width="80" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
-  <text x="215" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Zscaler</text>
-  <rect x="270" y="535" width="110" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
-  <text x="325" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">SSL Inspection</text>
-  <rect x="395" y="535" width="90" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
-  <text x="440" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AI Security</text>
-  <rect x="500" y="535" width="110" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
-  <text x="555" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
-  <rect x="625" y="535" width="80" height="26" rx="13" fill="#0a2240" stroke="#0072ff" stroke-width="1" />
-  <text x="665" y="553" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">SASE</text>
-
-  <!-- Domain -->
-  <text x="1140" y="548" fill="#3a6a9a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-
-  <!-- Bottom tagline -->
-  <text x="60" y="590" fill="#2a5a8a" font-family="Arial, sans-serif" font-size="13">Comprehensive Zscaler deployment guide for enterprise security teams</text>
-  <text x="1140" y="590" fill="#1a3a5a" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
+++ b/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
@@ -1,107 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1424"/>
-      <stop offset="50%" stop-color="#1a1008"/>
-      <stop offset="100%" stop-color="#0f0a04"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#ef4444"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#b91c1c"/>
     </linearGradient>
-    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1e293b" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#0f172a" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="5" fill="url(#accentGrad)"/>
-
-  <!-- Subtle grid lines -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#f59e0b" stroke-width="0.3" opacity="0.08"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#f59e0b" stroke-width="0.3" opacity="0.08"/>
-  <line x1="620" y1="0" x2="620" y2="630" stroke="#f59e0b" stroke-width="0.3" opacity="0.06"/>
-
-  <!-- === RIGHT SIDE: Network topology visual === -->
-  <!-- Central hub -->
-  <circle cx="880" cy="260" r="50" fill="url(#nodeGrad)" stroke="#f59e0b" stroke-width="2.5" filter="url(#glow)"/>
-  <text x="880" y="254" font-size="11" fill="#f59e0b" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">TRAFFIC</text>
-  <text x="880" y="272" font-size="11" fill="#f59e0b" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">MANAGER</text>
-
-  <!-- CDN nodes -->
-  <!-- Cloudflare (primary - red/down) -->
-  <line x1="830" y1="240" x2="720" y2="170" stroke="#ef4444" stroke-width="2" stroke-dasharray="6,4" opacity="0.7"/>
-  <circle cx="700" cy="155" r="36" fill="url(#nodeGrad)" stroke="#ef4444" stroke-width="2"/>
-  <text x="700" y="150" font-size="10" fill="#ef4444" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600">Cloudflare</text>
-  <text x="700" y="165" font-size="9" fill="#ef4444" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">DOWN</text>
-  <!-- Warning triangle -->
-  <polygon points="700,120 710,138 690,138" fill="none" stroke="#ef4444" stroke-width="1.5"/>
-  <text x="700" y="136" font-size="10" fill="#ef4444" text-anchor="middle" font-family="sans-serif" font-weight="700">!</text>
-
-  <!-- Fastly (backup - green) -->
-  <line x1="930" y1="240" x2="1040" y2="170" stroke="#22c55e" stroke-width="2" opacity="0.6"/>
-  <circle cx="1060" cy="155" r="36" fill="url(#nodeGrad)" stroke="#22c55e" stroke-width="2"/>
-  <text x="1060" y="150" font-size="10" fill="#22c55e" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600">Fastly</text>
-  <text x="1060" y="165" font-size="9" fill="#22c55e" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">ACTIVE</text>
-
-  <!-- CloudFront (backup - green) -->
-  <line x1="880" y1="310" x2="880" y2="390" stroke="#22c55e" stroke-width="2" opacity="0.6"/>
-  <circle cx="880" cy="415" r="36" fill="url(#nodeGrad)" stroke="#22c55e" stroke-width="2"/>
-  <text x="880" y="410" font-size="10" fill="#22c55e" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600">CloudFront</text>
-  <text x="880" y="425" font-size="9" fill="#22c55e" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">STANDBY</text>
-
-  <!-- Failover arrow -->
-  <path d="M740,180 Q780,240 820,240" fill="none" stroke="#f59e0b" stroke-width="2" stroke-dasharray="4,3" opacity="0.5"/>
-  <text x="770" y="220" font-size="9" fill="#f59e0b" font-family="Space Grotesk, Inter, system-ui, sans-serif" opacity="0.7">failover</text>
-
-  <!-- Status indicators row -->
-  <circle cx="700" cy="200" r="5" fill="#ef4444" filter="url(#glow)"/>
-  <circle cx="880" cy="200" r="5" fill="#f59e0b" filter="url(#glow)"/>
-  <circle cx="1060" cy="200" r="5" fill="#22c55e" filter="url(#glow)"/>
-
-  <!-- === LEFT SIDE: Text content === -->
-  <!-- Category label -->
-  <text x="60" y="82" font-size="13" fill="#f59e0b" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600" letter-spacing="3" opacity="0.9">POST-MORTEM</text>
-
-  <!-- Main title -->
-  <text x="60" y="158" font-size="46" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Cloudflare</text>
-  <text x="60" y="215" font-size="46" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Global Incident</text>
-  <text x="60" y="272" font-size="46" fill="#f59e0b" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Response Log</text>
-
-  <!-- Accent underline -->
-  <rect x="60" y="290" width="340" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="332" font-size="21" fill="#94a3b8" font-family="Space Grotesk, Inter, system-ui, sans-serif">Multi-CDN Strategy and Auto Failover</text>
-
-  <!-- Stat cards -->
-  <rect x="60"  y="370" width="130" height="66" rx="7" fill="#1c1508" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="125" y="396" font-size="20" fill="#f59e0b" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">~1 hour</text>
-  <text x="125" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Outage Duration</text>
-  <text x="125" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Global Impact</text>
-
-  <rect x="204" y="370" width="130" height="66" rx="7" fill="#1c1508" stroke="#ef4444" stroke-width="1.2"/>
-  <text x="269" y="396" font-size="20" fill="#ef4444" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">Global</text>
-  <text x="269" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Scope</text>
-  <text x="269" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">All Regions</text>
-
-  <rect x="348" y="370" width="130" height="66" rx="7" fill="#1c1508" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="413" y="396" font-size="20" fill="#22c55e" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">5-9s</text>
-  <text x="413" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Auto Failover</text>
-  <text x="413" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Recovery Time</text>
-
-  <!-- Date and branding -->
-  <text x="60" y="530" font-size="16" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif">November 19, 2025</text>
-  <text x="60" y="560" font-size="15" fill="#475569" font-family="Space Grotesk, Inter, system-ui, sans-serif">Twodragon Tech Blog</text>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="625" width="1200" height="5" fill="url(#accentGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Post-Mortem 2025 11 18 Cloudflare</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Warning Bell -->
+    <g transform="translate(80, 280)">
+      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
+            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
+      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+    </g>
+    
+    <!-- Timeline -->
+    <g transform="translate(200, 310)">
+      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
+      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
+      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
+      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
+      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    </g>
+    
+    <!-- Fire Icon -->
+    <g transform="translate(370, 285)">
+      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
+            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 11 18 Cloudflare . Multi-CDN Failover</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Cloudflare</text>
+      <rect x="135" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
+      <rect x="279" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Incident-Response</text>
+      <rect x="477" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#CDN</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
+++ b/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
@@ -1,114 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#eab308"/>
-      <stop offset="100%" stop-color="#facc15"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#eab308" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#eab308" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#eab308" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <polygon points="1036.3,257.5 1036.3,322.5 980.0,355.0 923.7,322.5 923.7,257.5 980.0,225.0" fill="none" stroke="#eab308" stroke-width="3" opacity="0.2"/>
-    <polygon points="1012.9,271.0 1012.9,309.0 980.0,328.0 947.1,309.0 947.1,271.0 980.0,252.0" fill="#eab308" opacity="0.12"/>
-    <circle cx="1060.0" cy="290.0" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="1020.0" cy="359.3" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="940.0" cy="359.3" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="900.0" cy="290.0" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="940.0" cy="220.7" r="7" fill="#eab308" opacity="0.2"/>
-    <circle cx="1020.0" cy="220.7" r="7" fill="#eab308" opacity="0.2"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#eab308"
-        letter-spacing="3" opacity="0.9">FINOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#eab308" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps to FinOps Practical</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Talent Leap</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#eab308" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Cost Optimization</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">November 21, 2025</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#eab308" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#eab308">Cost</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Optimize</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">Reserved</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Instances</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Budget</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Alerts</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#eab308" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#eab308" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#eab308" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 OT : DevSecOps FinOps ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 9 DevSecOps FinOps , 2025 AI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="159" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="79" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Security</text>
+      <rect x="171" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="228" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
+      <rect x="297" y="0" width="87" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#FinOps</text>
+      <rect x="396" y="0" width="87" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Course</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
+++ b/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
@@ -1,118 +1,188 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security 8Batch 1Week Infrastructure Es...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Infrastructure Essence to</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Security Future</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">November 26, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 . AI , Zero Trust, Post-quantum</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="79" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Infrastructure</text>
+      <rect x="171" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
+      <rect x="342" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
+++ b/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
@@ -1,118 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a1628"/>
-      <stop offset="50%" stop-color="#0d1f3c"/>
-      <stop offset="100%" stop-color="#0a0f1e"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#FF9900"/>
-      <stop offset="100%" stop-color="#ff6b00"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#FF9900" stop-opacity="0.3"/>
-      <stop offset="100%" stop-color="#FF9900" stop-opacity="0.05"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <filter id="glow2">
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Grid pattern -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#FF9900" stroke-width="0.3" opacity="0.1"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#FF9900" stroke-width="0.3" opacity="0.1"/>
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#1e40af" stroke-width="0.3" opacity="0.15"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="5" fill="url(#accentGrad)"/>
-
-  <!-- === RIGHT SIDE: AWS Shield + Cloud visual === -->
-  <!-- Large shield shape -->
-  <path d="M860,130 L960,170 L960,320 Q960,420 860,460 Q760,420 760,320 L760,170 Z"
-        fill="url(#shieldGrad)" stroke="#FF9900" stroke-width="1.8" opacity="0.8"/>
-  <!-- Inner shield -->
-  <path d="M860,180 L930,210 L930,320 Q930,390 860,420 Q790,390 790,320 L790,210 Z"
-        fill="none" stroke="#FF9900" stroke-width="1" stroke-dasharray="5,4" opacity="0.45"/>
-
-  <!-- Lock icon in shield center -->
-  <rect x="838" y="278" width="44" height="36" rx="5" fill="#FF9900" opacity="0.9" filter="url(#glow2)"/>
-  <path d="M848,278 L848,262 Q848,248 860,248 Q872,248 872,262 L872,278" fill="none" stroke="#FF9900" stroke-width="3.5" opacity="0.9"/>
-  <circle cx="860" cy="296" r="5" fill="#0a1628"/>
-  <rect x="857" y="296" width="6" height="10" rx="2" fill="#0a1628"/>
-
-  <!-- Cloud shapes -->
-  <!-- Cloud 1 - top right -->
-  <ellipse cx="1060" cy="150" rx="55" ry="30" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.7"/>
-  <ellipse cx="1030" cy="162" rx="35" ry="22" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.7"/>
-  <ellipse cx="1085" cy="162" rx="30" ry="20" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.7"/>
-  <rect x="1005" y="162" width="115" height="20" fill="#1e3a5f" opacity="0.7"/>
-  <text x="1060" y="157" font-size="10" fill="#FF9900" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600">GuardDuty</text>
-
-  <!-- Cloud 2 - bottom right -->
-  <ellipse cx="1070" cy="470" rx="50" ry="27" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.6"/>
-  <ellipse cx="1044" cy="480" rx="32" ry="20" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.6"/>
-  <ellipse cx="1092" cy="480" rx="28" ry="18" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1" opacity="0.6"/>
-  <rect x="1016" y="480" width="108" height="18" fill="#1e3a5f" opacity="0.6"/>
-  <text x="1070" y="475" font-size="10" fill="#FF9900" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600">S3 Secure</text>
-
-  <!-- VPC box decoration -->
-  <rect x="710" y="220" width="60" height="40" rx="5" fill="none" stroke="#FF9900" stroke-width="1.2" stroke-dasharray="4,3" opacity="0.55"/>
-  <text x="740" y="245" font-size="10" fill="#FF9900" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">VPC</text>
-  <rect x="710" y="360" width="60" height="40" rx="5" fill="none" stroke="#60a5fa" stroke-width="1.2" stroke-dasharray="4,3" opacity="0.55"/>
-  <text x="740" y="385" font-size="10" fill="#60a5fa" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">IAM</text>
-
-  <!-- Connecting lines shield to clouds -->
-  <line x1="960" y1="200" x2="1005" y2="165" stroke="#FF9900" stroke-width="1" opacity="0.4" stroke-dasharray="4,3"/>
-  <line x1="960" y1="430" x2="1016" y2="480" stroke="#FF9900" stroke-width="1" opacity="0.4" stroke-dasharray="4,3"/>
-
-  <!-- AWS badge -->
-  <rect x="820" y="475" width="80" height="28" rx="6" fill="#FF9900" opacity="0.9"/>
-  <text x="860" y="494" font-size="13" fill="#0a1628" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">AWS</text>
-
-  <!-- === LEFT SIDE: Text content === -->
-  <!-- Category label -->
-  <text x="60" y="82" font-size="13" fill="#FF9900" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600" letter-spacing="3" opacity="0.9">AWS CLOUD SECURITY</text>
-
-  <!-- Main title -->
-  <text x="60" y="158" font-size="50" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">AWS Security</text>
-  <text x="60" y="218" font-size="50" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Architecture</text>
-  <text x="60" y="278" font-size="50" fill="#FF9900" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Complete Guide</text>
-
-  <!-- Accent underline -->
-  <rect x="60" y="294" width="300" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="338" font-size="21" fill="#94a3b8" font-family="Space Grotesk, Inter, system-ui, sans-serif">VPC, IAM, S3, GuardDuty Complete Guide</text>
-
-  <!-- Service cards -->
-  <rect x="60"  y="376" width="110" height="62" rx="7" fill="#0d1f3c" stroke="#FF9900" stroke-width="1.2"/>
-  <text x="115" y="401" font-size="18" fill="#FF9900" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">VPC</text>
-  <text x="115" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Network Layer</text>
-  <text x="115" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Isolation</text>
-
-  <rect x="184" y="376" width="110" height="62" rx="7" fill="#0d1f3c" stroke="#3b82f6" stroke-width="1.2"/>
-  <text x="239" y="401" font-size="18" fill="#60a5fa" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">IAM</text>
-  <text x="239" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Identity and</text>
-  <text x="239" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Access Mgmt</text>
-
-  <rect x="308" y="376" width="110" height="62" rx="7" fill="#0d1f3c" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="363" y="401" font-size="18" fill="#22c55e" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">S3</text>
-  <text x="363" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Secure Object</text>
-  <text x="363" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Storage</text>
-
-  <rect x="432" y="376" width="130" height="62" rx="7" fill="#0d1f3c" stroke="#a855f7" stroke-width="1.2"/>
-  <text x="497" y="401" font-size="15" fill="#c084fc" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">GuardDuty</text>
-  <text x="497" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Threat Detection</text>
-  <text x="497" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">AI-Powered</text>
-
-  <!-- Date and branding -->
-  <text x="60" y="530" font-size="16" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif">December 5, 2025</text>
-  <text x="60" y="560" font-size="15" fill="#475569" font-family="Space Grotesk, Inter, system-ui, sans-serif">Twodragon Tech Blog</text>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="625" width="1200" height="5" fill="url(#accentGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 2 : AWS , VPC GuardDuty</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">VPC, IAM, S3, GuardDuty AWS 2025 re:Invent</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#VPC</text>
+      <rect x="144" y="0" width="114" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#GuardDuty</text>
+      <rect x="270" y="0" width="195" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="367" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Security-Archit...</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
+++ b/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
@@ -1,195 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#030f0a" />
-      <stop offset="50%" stop-color="#071a10" />
-      <stop offset="100%" stop-color="#0a2818" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#00e676" />
-      <stop offset="100%" stop-color="#00acc1" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="finopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#14b8a6"/>
+      <stop offset="100%" style="stop-color:#0d9488"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a2a18" />
-      <stop offset="100%" stop-color="#071810" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#082215" />
-      <stop offset="100%" stop-color="#071810" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c2820" />
-      <stop offset="100%" stop-color="#071810" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#00e676" />
-      <stop offset="100%" stop-color="#00c853" />
-    </linearGradient>
-    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#26c6da" />
-      <stop offset="100%" stop-color="#00acc1" />
-    </linearGradient>
-    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#69f0ae" />
-      <stop offset="100%" stop-color="#00e676" />
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="4" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadowCard">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#00e676" flood-opacity="0.12" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowStrong">
-      <feGaussianBlur stdDeviation="6" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#0d2a1a" stroke-width="0.8" />
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)" />
-  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
-
-  <!-- Ambient orbs -->
-  <circle cx="200" cy="150" r="200" fill="#00e676" opacity="0.04" />
-  <circle cx="1000" cy="480" r="220" fill="#00acc1" opacity="0.04" />
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="250" height="34" rx="17" fill="#071a10" stroke="#00e676" stroke-width="1.5" filter="url(#glow)" />
-  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
-  <text x="97" y="60" fill="#00e676" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CLOUD SECURITY COURSE</text>
-
-  <!-- Date badge -->
-  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#071a10" stroke="#00acc1" stroke-width="1.5" />
-  <text x="1090" y="60" fill="#26c6da" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 12, 2025</text>
-
-  <!-- AWS cloud icon -->
-  <g transform="translate(60, 95)" filter="url(#glowStrong)">
-    <ellipse cx="30" cy="30" rx="30" ry="18" fill="#071a10" stroke="#00e676" stroke-width="2" />
-    <ellipse cx="50" cy="26" rx="18" ry="12" fill="#071a10" stroke="#00e676" stroke-width="1.5" />
-    <ellipse cx="14" cy="28" rx="14" ry="10" fill="#071a10" stroke="#00e676" stroke-width="1.5" />
-    <text x="30" y="35" fill="#00e676" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">AWS</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#2dd4bf" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#14b8a6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0d9488" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#14b8a6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#2dd4bf" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#2dd4bf" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#finopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">FINOPS</text>
   </g>
-
-  <!-- Week badge -->
-  <rect x="120" y="98" width="80" height="24" rx="12" fill="#0a2a18" stroke="#00c853" stroke-width="1" />
-  <text x="160" y="115" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle">Batch 8 W3</text>
-
-  <!-- Main title -->
-  <text x="60" y="160" fill="#e8fff4" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">AWS FinOps and ISMS-P Security Audit</text>
-
-  <!-- Subtitle -->
-  <text x="61" y="196" fill="#26c6da" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="2">Batch 8  |  Week 3  |  Complete Strategy</text>
-
-  <!-- Separator -->
-  <rect x="60" y="210" width="520" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
-
-  <!-- ── Card 1: FinOps ── -->
-  <rect x="60" y="228" width="340" height="260" rx="16" fill="url(#card1Grad)" stroke="#1a4a2a" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="60" y="228" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
-
-  <!-- Dollar/cost icon -->
-  <g transform="translate(230, 270)" filter="url(#glow)">
-    <circle cx="0" cy="0" r="28" fill="#071a10" stroke="#00e676" stroke-width="2.5" />
-    <text x="0" y="-8" fill="#00e676" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">COST</text>
-    <path d="M-10,0 Q0,-10 10,0 Q0,10 -10,0" fill="#00e676" opacity="0.3" />
-    <text x="0" y="12" fill="#00c853" font-family="Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle">$</text>
-    <path d="M-14,18 L14,18" stroke="#00e676" stroke-width="1.5" />
-    <text x="0" y="28" fill="#00e676" font-family="Arial, sans-serif" font-size="9" text-anchor="middle">-30%</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="230" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">FinOps</text>
-  <text x="230" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Cloud cost optimization</text>
-  <text x="230" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and financial governance</text>
-
-  <rect x="85" y="382" width="290" height="1" fill="#1a4a2a" />
-  <text x="100" y="404" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Reserved Instances</text>
-  <text x="100" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Up to 72% savings</text>
-  <text x="240" y="404" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Savings Plans</text>
-  <text x="240" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Flexible commitment</text>
-  <text x="100" y="444" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Rightsizing</text>
-  <text x="100" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Idle resource cleanup</text>
-  <text x="240" y="444" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="700">Cost Allocation</text>
-  <text x="240" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Tag-based reporting</text>
-
-  <!-- ── Card 2: ISMS-P Audit ── -->
-  <rect x="430" y="228" width="340" height="260" rx="16" fill="url(#card2Grad)" stroke="#154030" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="430" y="228" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
-
-  <!-- Audit/checklist icon -->
-  <g transform="translate(600, 268)" filter="url(#glow)">
-    <rect x="-22" y="-28" width="44" height="56" rx="6" fill="#071a10" stroke="#26c6da" stroke-width="2" />
-    <line x1="-14" y1="-14" x2="14" y2="-14" stroke="#26c6da" stroke-width="1.5" />
-    <path d="-14,-2 L-8,4 L-2,-2" stroke="#00e676" stroke-width="2" fill="none" stroke-linecap="round" transform="translate(-5,-2)" />
-    <line x1="-2" y1="-2" x2="14" y2="-2" stroke="#26c6da" stroke-width="1.5" />
-    <path d="M-14,10 L-8,16 L-2,10" stroke="#00e676" stroke-width="2" fill="none" stroke-linecap="round" transform="translate(-5,2)" />
-    <line x1="-2" y1="12" x2="14" y2="12" stroke="#26c6da" stroke-width="1.5" />
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 3 : AWS FinOps ISMS-P</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Dollar Chart -->
+    <g transform="translate(80, 280)">
+      <rect x="5" y="5" width="90" height="70" rx="5" fill="#0f172a" stroke="#14b8a6" stroke-width="2"/>
+      <polyline points="15,60 30,45 50,55 70,30 85,40" fill="none" stroke="#22d3ee" stroke-width="3"/>
+      <text x="50" y="55" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#14b8a6" text-anchor="middle">$</text>
+    </g>
+    
+    <!-- Cloud Cost -->
+    <g transform="translate(210, 290)">
+      <path d="M20 50 Q5 50 5 35 Q5 20 20 20 Q20 5 40 5 Q60 5 60 25 Q75 25 75 40 Q75 50 60 50 Z" 
+            fill="#14b8a6" stroke="#0d9488" stroke-width="2" opacity="0.8"/>
+      <text x="40" y="38" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">$</text>
+    </g>
+    
+    <!-- Savings Piggy -->
+    <g transform="translate(330, 295)">
+      <ellipse cx="40" cy="40" rx="35" ry="25" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <ellipse cx="65" cy="35" rx="8" ry="5" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="60" cy="30" r="3" fill="#0f172a"/>
+      <rect x="30" y="10" width="20" height="8" rx="2" fill="#0d9488"/>
+      <ellipse cx="25" cy="55" rx="8" ry="5" fill="#0d9488"/>
+      <ellipse cx="55" cy="55" rx="8" ry="5" fill="#0d9488"/>
+    </g>
+    
   </g>
-
-  <text x="600" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">ISMS-P Audit</text>
-  <text x="600" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Korean privacy and</text>
-  <text x="600" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">information security standard</text>
-
-  <rect x="455" y="382" width="290" height="1" fill="#154030" />
-  <text x="470" y="404" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">104 Controls</text>
-  <text x="470" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Full compliance checklist</text>
-  <text x="610" y="404" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Gap Analysis</text>
-  <text x="610" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Current state mapping</text>
-  <text x="470" y="444" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Evidence Collection</text>
-  <text x="470" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Automated gathering</text>
-  <text x="610" y="444" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="700">Remediation</text>
-  <text x="610" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Risk-based priority</text>
-
-  <!-- ── Card 3: AWS Architecture ── -->
-  <rect x="800" y="228" width="340" height="260" rx="16" fill="url(#card3Grad)" stroke="#1a4838" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="800" y="228" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
-
-  <!-- Architecture icon: layers -->
-  <g transform="translate(970, 270)" filter="url(#glow)">
-    <rect x="-28" y="-24" width="56" height="14" rx="4" fill="#071a10" stroke="#69f0ae" stroke-width="2" />
-    <rect x="-22" y="-4" width="44" height="14" rx="4" fill="#071a10" stroke="#00e676" stroke-width="2" />
-    <rect x="-16" y="16" width="32" height="14" rx="4" fill="#071a10" stroke="#26c6da" stroke-width="2" />
-    <text x="0" y="-14" fill="#69f0ae" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">VPC</text>
-    <text x="0" y="6" fill="#00e676" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">EC2</text>
-    <text x="0" y="26" fill="#26c6da" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">RDS</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#finopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#2dd4bf">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#2dd4bf"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 FinOps AWS , ISMS-P</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="87" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="115" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#FinOps</text>
+      <rect x="171" y="0" width="87" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#ISMS-P</text>
+      <rect x="270" y="0" width="78" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="309" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#Audit</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="970" y="323" fill="#e8fff4" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AWS Architecture</text>
-  <text x="970" y="348" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Well-Architected Framework</text>
-  <text x="970" y="366" fill="#6abf8a" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">for secure cloud design</text>
-
-  <rect x="825" y="382" width="290" height="1" fill="#1a4838" />
-  <text x="840" y="404" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Multi-Account</text>
-  <text x="840" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">AWS Organizations</text>
-  <text x="980" y="404" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Landing Zone</text>
-  <text x="980" y="420" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Control Tower setup</text>
-  <text x="840" y="444" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Hub</text>
-  <text x="840" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Centralized findings</text>
-  <text x="980" y="444" fill="#69f0ae" font-family="Arial, sans-serif" font-size="12" font-weight="700">GuardDuty</text>
-  <text x="980" y="460" fill="#3a7a5a" font-family="Arial, sans-serif" font-size="11">Threat intelligence</text>
-
-  <!-- Footer -->
-  <rect x="0" y="503" width="1200" height="1" fill="#0d2a1a" />
-  <rect x="0" y="504" width="1200" height="126" fill="#020c06" opacity="0.85" />
-
-  <rect x="60" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00e676" stroke-width="1" />
-  <text x="100" y="550" fill="#00e676" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">FinOps</text>
-  <rect x="155" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
-  <text x="195" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">ISMS-P</text>
-  <rect x="250" y="532" width="80" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
-  <text x="290" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWS</text>
-  <rect x="345" y="532" width="130" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
-  <text x="410" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
-  <rect x="490" y="532" width="120" height="26" rx="13" fill="#071a10" stroke="#00acc1" stroke-width="1" />
-  <text x="550" y="550" fill="#26c6da" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cost Savings</text>
-
-  <text x="1140" y="548" fill="#2a6a4a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-  <text x="60" y="592" fill="#1a4a2a" font-family="Arial, sans-serif" font-size="13">Cloud Security Batch 8 curriculum: AWS cost governance and compliance certification</text>
-  <text x="1140" y="592" fill="#1a3a2a" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#finopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
+++ b/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
@@ -1,193 +1,194 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0c0518" />
-      <stop offset="50%" stop-color="#130a24" />
-      <stop offset="100%" stop-color="#1a0c35" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#b44fff" />
-      <stop offset="100%" stop-color="#4488ff" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1a0c30" />
-      <stop offset="100%" stop-color="#100820" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#14082c" />
-      <stop offset="100%" stop-color="#100820" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#180a2e" />
-      <stop offset="100%" stop-color="#100820" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ff9800" />
-      <stop offset="100%" stop-color="#f57c00" />
-    </linearGradient>
-    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#c084fc" />
-      <stop offset="100%" stop-color="#a855f7" />
-    </linearGradient>
-    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#60a5fa" />
-      <stop offset="100%" stop-color="#3b82f6" />
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="4" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadowCard">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#b44fff" flood-opacity="0.12" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowStrong">
-      <feGaussianBlur stdDeviation="6" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#1a0a30" stroke-width="0.8" />
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)" />
-  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
-
-  <!-- Ambient orbs -->
-  <circle cx="180" cy="130" r="200" fill="#b44fff" opacity="0.04" />
-  <circle cx="1020" cy="500" r="200" fill="#4488ff" opacity="0.04" />
-  <circle cx="600" cy="280" r="280" fill="#7722cc" opacity="0.03" />
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="220" height="34" rx="17" fill="#100820" stroke="#b44fff" stroke-width="1.5" filter="url(#glow)" />
-  <circle cx="82" cy="55" r="7" fill="url(#accentGrad)" />
-  <text x="97" y="60" fill="#c084fc" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CONFERENCE REVIEW</text>
-
-  <!-- Date badge -->
-  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#100820" stroke="#4488ff" stroke-width="1.5" />
-  <text x="1090" y="60" fill="#60a5fa" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 17, 2025</text>
-
-  <!-- Star/event icon -->
-  <g transform="translate(60, 100)" filter="url(#glowStrong)">
-    <polygon points="25,0 31,18 50,18 36,29 41,47 25,36 9,47 14,29 0,18 19,18" fill="none" stroke="#b44fff" stroke-width="2" opacity="0.9" />
-    <polygon points="25,8 29,20 42,20 32,28 36,40 25,32 14,40 18,28 8,20 21,20" fill="#b44fff" opacity="0.4" />
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
   </g>
-
-  <!-- Main title -->
-  <text x="125" y="130" fill="#f0e8ff" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">December 2025 Conference Review</text>
-
-  <!-- Subtitle -->
-  <text x="126" y="168" fill="#9966cc" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1.5">AWSKRUG  |  OWASP  |  Datadog  |  AI and Security</text>
-
-  <!-- Separator -->
-  <rect x="60" y="185" width="540" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
-
-  <!-- ── Card 1: AWSKRUG ── -->
-  <rect x="60" y="210" width="340" height="270" rx="16" fill="url(#card1Grad)" stroke="#2a1050" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="60" y="210" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
-
-  <!-- AWS orange icon -->
-  <g transform="translate(230, 260)" filter="url(#glow)">
-    <ellipse cx="0" cy="0" rx="28" ry="18" fill="#1a0c30" stroke="#ff9800" stroke-width="2.5" />
-    <ellipse cx="16" cy="-8" rx="14" ry="10" fill="#1a0c30" stroke="#ff9800" stroke-width="1.5" />
-    <ellipse cx="-16" cy="-6" rx="12" ry="8" fill="#1a0c30" stroke="#f57c00" stroke-width="1.5" />
-    <text x="0" y="5" fill="#ff9800" font-family="Arial, sans-serif" font-size="10" font-weight="900" text-anchor="middle">AWS</text>
-    <path d="M-20,12 Q0,20 20,12" stroke="#ff9800" stroke-width="2" fill="none" />
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="230" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">AWSKRUG</text>
-  <text x="230" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">AWS Korea User Group</text>
-  <text x="230" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">community sessions</text>
-
-  <rect x="85" y="365" width="290" height="1" fill="#2a1050" />
-  <text x="100" y="387" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">re:Invent Preview</text>
-  <text x="100" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">2025 announcements</text>
-  <text x="240" y="387" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI/ML Sessions</text>
-  <text x="240" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Bedrock and SageMaker</text>
-  <text x="100" y="427" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Serverless</text>
-  <text x="100" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Lambda best practices</text>
-  <text x="240" y="427" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Community</text>
-  <text x="240" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">300+ attendees</text>
-  <text x="100" y="463" fill="#ff9800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Workshop</text>
-  <text x="100" y="473" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Hands-on labs</text>
-
-  <!-- ── Card 2: OWASP ── -->
-  <rect x="430" y="210" width="340" height="270" rx="16" fill="url(#card2Grad)" stroke="#220840" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="430" y="210" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
-
-  <!-- OWASP purple shield -->
-  <g transform="translate(600, 258)" filter="url(#glow)">
-    <path d="M0,-30 L24,-16 L24,8 Q24,30 0,38 Q-24,30 -24,8 L-24,-16 Z" fill="#14082c" stroke="#c084fc" stroke-width="2.5" />
-    <text x="0" y="-6" fill="#c084fc" font-family="Arial, sans-serif" font-size="9" font-weight="700" text-anchor="middle">OWASP</text>
-    <text x="0" y="8" fill="#a855f7" font-family="Arial, sans-serif" font-size="8" text-anchor="middle">Top 10</text>
-    <path d="M-10,18 L0,26 L10,18" stroke="#c084fc" stroke-width="2" fill="none" stroke-linecap="round" />
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">12 AWSKRUG, OWASP, Datadog 2025 : AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
+    
   </g>
-
-  <text x="600" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">OWASP</text>
-  <text x="600" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Open Web Application</text>
-  <text x="600" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Security Project</text>
-
-  <rect x="455" y="365" width="290" height="1" fill="#220840" />
-  <text x="470" y="387" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Top 10 2025</text>
-  <text x="470" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Updated vuln rankings</text>
-  <text x="610" y="387" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Security</text>
-  <text x="610" y="403" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">LLM risk framework</text>
-  <text x="470" y="427" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Prompt Injection</text>
-  <text x="470" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">GenAI attack vectors</text>
-  <text x="610" y="427" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">ASVS 5.0</text>
-  <text x="610" y="443" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Verification standard</text>
-  <text x="470" y="467" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="700">Korea Chapter</text>
-  <text x="470" y="473" fill="#5a3a7a" font-family="Arial, sans-serif" font-size="11">Local meetup recap</text>
-
-  <!-- ── Card 3: Datadog ── -->
-  <rect x="800" y="210" width="340" height="270" rx="16" fill="url(#card3Grad)" stroke="#200a3a" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="800" y="210" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
-
-  <!-- Datadog icon: monitoring chart -->
-  <g transform="translate(970, 262)" filter="url(#glow)">
-    <rect x="-28" y="-24" width="56" height="48" rx="6" fill="#100820" stroke="#60a5fa" stroke-width="2" />
-    <polyline points="-20,12 -10,-4 0,4 10,-14 20,0" stroke="#60a5fa" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round" />
-    <circle cx="-10" cy="-4" r="3" fill="#3b82f6" />
-    <circle cx="0" cy="4" r="3" fill="#3b82f6" />
-    <circle cx="10" cy="-14" r="3" fill="#60a5fa" />
-    <text x="0" y="28" fill="#60a5fa" font-family="Arial, sans-serif" font-size="8" text-anchor="middle" font-weight="700">DD</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWSKRUG, OWASP, Datadog 2025 AI , AWS re:Invent</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWSKRUG</text>
+      <rect x="108" y="0" width="78" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#OWASP</text>
+      <rect x="198" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Datadog</text>
+      <rect x="306" y="0" width="51" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="331" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AI</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="970" y="305" fill="#f0e8ff" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Datadog</text>
-  <text x="970" y="330" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Observability platform</text>
-  <text x="970" y="348" fill="#9a7abf" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and monitoring insights</text>
-
-  <rect x="825" y="365" width="290" height="1" fill="#200a3a" />
-  <text x="840" y="387" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">APM</text>
-  <text x="840" y="403" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Distributed tracing</text>
-  <text x="980" y="387" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">CSPM</text>
-  <text x="980" y="403" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Cloud posture mgmt</text>
-  <text x="840" y="427" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">LLM Observability</text>
-  <text x="840" y="443" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">AI model monitoring</text>
-  <text x="980" y="427" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">Incident Mgmt</text>
-  <text x="980" y="443" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">On-call automation</text>
-  <text x="840" y="467" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Signals</text>
-  <text x="840" y="473" fill="#3a2a5a" font-family="Arial, sans-serif" font-size="11">Threat correlation</text>
-
-  <!-- Footer -->
-  <rect x="0" y="503" width="1200" height="1" fill="#1a0a30" />
-  <rect x="0" y="504" width="1200" height="126" fill="#080414" opacity="0.85" />
-
-  <rect x="60" y="532" width="100" height="26" rx="13" fill="#100820" stroke="#b44fff" stroke-width="1" />
-  <text x="110" y="550" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWSKRUG</text>
-  <rect x="175" y="532" width="80" height="26" rx="13" fill="#100820" stroke="#a855f7" stroke-width="1" />
-  <text x="215" y="550" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">OWASP</text>
-  <rect x="270" y="532" width="90" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
-  <text x="315" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Datadog</text>
-  <rect x="375" y="532" width="100" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
-  <text x="425" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AI Security</text>
-  <rect x="490" y="532" width="120" height="26" rx="13" fill="#100820" stroke="#4488ff" stroke-width="1" />
-  <text x="550" y="550" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Observability</text>
-
-  <text x="1140" y="548" fill="#4a2a7a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-  <text x="60" y="592" fill="#2a1050" font-family="Arial, sans-serif" font-size="13">December 2025 tech conference highlights: AI, security, and observability coexistence</text>
-  <text x="1140" y="592" fill="#1a0a30" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
+++ b/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
@@ -1,204 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#180404" />
-      <stop offset="50%" stop-color="#200808" />
-      <stop offset="100%" stop-color="#2a0e04" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ff4444" />
-      <stop offset="100%" stop-color="#ff8800" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a0c0c" />
-      <stop offset="100%" stop-color="#1a0808" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#260a0a" />
-      <stop offset="100%" stop-color="#1a0808" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2c0e08" />
-      <stop offset="100%" stop-color="#1a0808" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="iconGrad1" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ff4444" />
-      <stop offset="100%" stop-color="#cc0000" />
-    </linearGradient>
-    <linearGradient id="iconGrad2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ff8800" />
-      <stop offset="100%" stop-color="#e65c00" />
-    </linearGradient>
-    <linearGradient id="iconGrad3" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ffd700" />
-      <stop offset="100%" stop-color="#ff8800" />
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="4" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadowCard">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#ff4444" flood-opacity="0.14" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowStrong">
-      <feGaussianBlur stdDeviation="6" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#2a0808" stroke-width="0.8" />
-    </pattern>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)" />
-  <rect width="1200" height="630" fill="url(#grid)" opacity="0.6" />
-
-  <!-- Ambient orbs -->
-  <circle cx="200" cy="140" r="200" fill="#ff2200" opacity="0.04" />
-  <circle cx="1000" cy="490" r="200" fill="#ff8800" opacity="0.04" />
-
-  <!-- Top accent line -->
-  <rect x="0" y="0" width="1200" height="3" fill="url(#accentGrad)" />
-
-  <!-- Badge -->
-  <rect x="60" y="38" width="250" height="34" rx="17" fill="#200808" stroke="#ff4444" stroke-width="1.5" filter="url(#glow)" />
-  <circle cx="82" cy="55" r="7" fill="url(#iconGrad1)" />
-  <text x="97" y="60" fill="#ff6666" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.2">CLOUD SECURITY COURSE</text>
-
-  <!-- Date badge -->
-  <rect x="1020" y="38" width="140" height="34" rx="17" fill="#200808" stroke="#ff8800" stroke-width="1.5" />
-  <text x="1090" y="60" fill="#ffaa44" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Dec 19, 2025</text>
-
-  <!-- Warning/alert icon -->
-  <g transform="translate(60, 92)" filter="url(#glowStrong)">
-    <polygon points="28,0 56,48 0,48" fill="#200808" stroke="#ff4444" stroke-width="2.5" />
-    <line x1="28" y1="16" x2="28" y2="32" stroke="#ff4444" stroke-width="3" stroke-linecap="round" />
-    <circle cx="28" cy="40" r="3" fill="#ff4444" />
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Week badge -->
-  <rect x="128" y="98" width="80" height="24" rx="12" fill="#2a0808" stroke="#ff6600" stroke-width="1" />
-  <text x="168" y="115" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle">Batch 8 W4</text>
-
-  <!-- Main title -->
-  <text x="60" y="160" fill="#fff0e8" font-family="Arial Black, Arial, sans-serif" font-size="42" font-weight="900" letter-spacing="-0.5" filter="url(#glow)">Security Vulnerability Inspection</text>
-
-  <!-- Subtitle -->
-  <text x="61" y="196" fill="#cc4422" font-family="Arial, sans-serif" font-size="19" font-weight="400" letter-spacing="1.5">Batch 8  |  Week 4  |  ISMS-P Certification</text>
-
-  <!-- Separator -->
-  <rect x="60" y="212" width="540" height="2" rx="1" fill="url(#accentGrad)" opacity="0.7" />
-
-  <!-- ── Card 1: Vulnerability Scan ── -->
-  <rect x="60" y="228" width="340" height="265" rx="16" fill="url(#card1Grad)" stroke="#4a1010" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="60" y="228" width="340" height="4" rx="2" fill="url(#iconGrad1)" />
-
-  <!-- Scan/radar icon -->
-  <g transform="translate(230, 268)" filter="url(#glow)">
-    <circle cx="0" cy="0" r="28" fill="#200808" stroke="#ff4444" stroke-width="2" />
-    <circle cx="0" cy="0" r="18" fill="none" stroke="#ff4444" stroke-width="1" opacity="0.5" />
-    <circle cx="0" cy="0" r="8" fill="none" stroke="#ff4444" stroke-width="1" opacity="0.4" />
-    <line x1="0" y1="-28" x2="0" y2="28" stroke="#ff4444" stroke-width="1" opacity="0.3" />
-    <line x1="-28" y1="0" x2="28" y2="0" stroke="#ff4444" stroke-width="1" opacity="0.3" />
-    <path d="M0,0 L20,-20 A28,28 0 0,1 28,0 Z" fill="#ff4444" opacity="0.2" />
-    <circle cx="14" cy="-14" r="4" fill="#ff4444" opacity="0.9" />
-    <text x="0" y="5" fill="#ff4444" font-family="Arial, sans-serif" font-size="9" font-weight="700" text-anchor="middle">SCAN</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="230" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Vulnerability Scan</text>
-  <text x="230" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Automated scanning for</text>
-  <text x="230" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">known CVEs and misconfigs</text>
-
-  <rect x="85" y="375" width="290" height="1" fill="#4a1010" />
-  <text x="100" y="397" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">OWASP ZAP</text>
-  <text x="100" y="413" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">DAST scanning</text>
-  <text x="240" y="397" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">Nessus</text>
-  <text x="240" y="413" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Infrastructure audit</text>
-  <text x="100" y="437" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">AWS Inspector</text>
-  <text x="100" y="453" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Cloud workload scan</text>
-  <text x="240" y="437" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">CVE Scoring</text>
-  <text x="240" y="453" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">CVSS v3.1 metrics</text>
-  <text x="100" y="473" fill="#ff4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">Patch Priority</text>
-  <text x="100" y="479" fill="#7a3030" font-family="Arial, sans-serif" font-size="11">Risk-based ordering</text>
-
-  <!-- ── Card 2: Penetration Test ── -->
-  <rect x="430" y="228" width="340" height="265" rx="16" fill="url(#card2Grad)" stroke="#401010" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="430" y="228" width="340" height="4" rx="2" fill="url(#iconGrad2)" />
-
-  <!-- Pen test: crosshair/target -->
-  <g transform="translate(600, 268)" filter="url(#glow)">
-    <circle cx="0" cy="0" r="28" fill="#1a0808" stroke="#ff8800" stroke-width="2" />
-    <circle cx="0" cy="0" r="16" fill="none" stroke="#ff8800" stroke-width="1.5" />
-    <circle cx="0" cy="0" r="6" fill="#ff8800" opacity="0.8" />
-    <line x1="-28" y1="0" x2="-18" y2="0" stroke="#ff8800" stroke-width="2" />
-    <line x1="18" y1="0" x2="28" y2="0" stroke="#ff8800" stroke-width="2" />
-    <line x1="0" y1="-28" x2="0" y2="-18" stroke="#ff8800" stroke-width="2" />
-    <line x1="0" y1="18" x2="0" y2="28" stroke="#ff8800" stroke-width="2" />
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 4 : ISMS-P</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="600" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">Penetration Test</text>
-  <text x="600" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Ethical hacking to validate</text>
-  <text x="600" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">security control gaps</text>
-
-  <rect x="455" y="375" width="290" height="1" fill="#401010" />
-  <text x="470" y="397" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Recon</text>
-  <text x="470" y="413" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">OSINT and footprinting</text>
-  <text x="610" y="397" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Exploitation</text>
-  <text x="610" y="413" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Metasploit framework</text>
-  <text x="470" y="437" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Web App Test</text>
-  <text x="470" y="453" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Burp Suite Pro</text>
-  <text x="610" y="437" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Post Exploitation</text>
-  <text x="610" y="453" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Lateral movement check</text>
-  <text x="470" y="477" fill="#ff8800" font-family="Arial, sans-serif" font-size="12" font-weight="700">Report</text>
-  <text x="470" y="479" fill="#7a3020" font-family="Arial, sans-serif" font-size="11">Executive + technical</text>
-
-  <!-- ── Card 3: ISMS-P Response ── -->
-  <rect x="800" y="228" width="340" height="265" rx="16" fill="url(#card3Grad)" stroke="#481408" stroke-width="1.5" filter="url(#shadowCard)" />
-  <rect x="800" y="228" width="340" height="4" rx="2" fill="url(#iconGrad3)" />
-
-  <!-- Certificate/medal icon -->
-  <g transform="translate(970, 268)" filter="url(#glow)">
-    <rect x="-24" y="-28" width="48" height="42" rx="6" fill="#1a0808" stroke="#ffd700" stroke-width="2" />
-    <circle cx="0" cy="22" r="12" fill="#1a0808" stroke="#ff8800" stroke-width="2" />
-    <circle cx="0" cy="22" r="7" fill="#ff8800" opacity="0.6" />
-    <text x="0" y="-12" fill="#ffd700" font-family="Arial, sans-serif" font-size="8" font-weight="700" text-anchor="middle">ISMS-P</text>
-    <line x1="-14" y1="-4" x2="14" y2="-4" stroke="#ffd700" stroke-width="1.5" />
-    <text x="0" y="4" fill="#ff8800" font-family="Arial, sans-serif" font-size="7" text-anchor="middle">CERTIFIED</text>
-    <path d="-4,34 L0,38 L4,34" stroke="#ff8800" stroke-width="1.5" fill="none" />
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">ISMS-P .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Vulnerability</text>
+      <rect x="162" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ISMS-P</text>
+      <rect x="261" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Compliance</text>
+      <rect x="396" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Audit</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="970" y="316" fill="#fff0e8" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle">ISMS-P Response</text>
-  <text x="970" y="341" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">Certification preparation</text>
-  <text x="970" y="359" fill="#aa6655" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">and audit remediation</text>
-
-  <rect x="825" y="375" width="290" height="1" fill="#481408" />
-  <text x="840" y="397" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">104 Controls</text>
-  <text x="840" y="413" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Full compliance mapping</text>
-  <text x="980" y="397" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Evidence Prep</text>
-  <text x="980" y="413" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Documentation pack</text>
-  <text x="840" y="437" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Vuln Remediation</text>
-  <text x="840" y="453" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Patch and hardening</text>
-  <text x="980" y="437" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Mock Audit</text>
-  <text x="980" y="453" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">Pre-certification drill</text>
-  <text x="840" y="477" fill="#ffd700" font-family="Arial, sans-serif" font-size="12" font-weight="700">Final Submission</text>
-  <text x="840" y="479" fill="#7a4020" font-family="Arial, sans-serif" font-size="11">KISA review readiness</text>
-
-  <!-- Footer -->
-  <rect x="0" y="503" width="1200" height="1" fill="#2a0808" />
-  <rect x="0" y="504" width="1200" height="126" fill="#100404" opacity="0.85" />
-
-  <rect x="60" y="532" width="120" height="26" rx="13" fill="#200808" stroke="#ff4444" stroke-width="1" />
-  <text x="120" y="550" fill="#ff6666" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Vuln Scan</text>
-  <rect x="195" y="532" width="110" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
-  <text x="250" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Pentest</text>
-  <rect x="320" y="532" width="80" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
-  <text x="360" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">ISMS-P</text>
-  <rect x="415" y="532" width="120" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
-  <text x="475" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Cloud Security</text>
-  <rect x="550" y="532" width="130" height="26" rx="13" fill="#200808" stroke="#ff8800" stroke-width="1" />
-  <text x="615" y="550" fill="#ffaa44" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Compliance</text>
-
-  <text x="1140" y="548" fill="#5a1a0a" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-  <text x="60" y="592" fill="#3a1010" font-family="Arial, sans-serif" font-size="13">Cloud Security Batch 8 Week 4: integrated vulnerability assessment and ISMS-P certification</text>
-  <text x="1140" y="592" fill="#2a0808" font-family="Arial, sans-serif" font-size="12" text-anchor="end">DevSecOps Blog</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
+++ b/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
@@ -1,118 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 5 : AWS Control Tower/SCP Datadog SIEM, Clo...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AWS Control Tower SCP</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Governance and Datadog SIEM</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">December 24, 2025</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS Control Tower/SCP , Datadog SIEM Cloudflare</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Control-Tower</text>
+      <rect x="234" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#SCP</text>
+      <rect x="306" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Datadog</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
+++ b/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
@@ -1,114 +1,195 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#a855f7"/>
-      <stop offset="100%" stop-color="#c084fc"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#a855f7" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#a855f7" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#a855f7" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <polygon points="1036.3,257.5 1036.3,322.5 980.0,355.0 923.7,322.5 923.7,257.5 980.0,225.0" fill="none" stroke="#a855f7" stroke-width="3" opacity="0.2"/>
-    <polygon points="1012.9,271.0 1012.9,309.0 980.0,328.0 947.1,309.0 947.1,271.0 980.0,252.0" fill="#a855f7" opacity="0.12"/>
-    <circle cx="1060.0" cy="290.0" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="1020.0" cy="359.3" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="940.0" cy="359.3" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="900.0" cy="290.0" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="940.0" cy="220.7" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="1020.0" cy="220.7" r="7" fill="#a855f7" opacity="0.2"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#a855f7"
-        letter-spacing="3" opacity="0.9">AUTOMOTIVE</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#a855f7" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Model Y Juniper Security and</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#a855f7" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Automotive Cybersecurity Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 1, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#a855f7" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#a855f7">FSD</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Safety</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">OTA</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Updates</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">CAN</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#a855f7" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#a855f7" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#a855f7" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">FSD 2026 : Model Y Juniper , , DevSecOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FSD 2026 . FSD v14.2.1 ( , ), Model Y</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Juniper( 49,990 ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="78" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Tesla</text>
+      <rect x="90" y="0" width="60" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="120" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#FSD</text>
+      <rect x="162" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Model Y</text>
+      <rect x="270" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Juniper</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
+++ b/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
@@ -1,118 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1a2e"/>
-      <stop offset="100%" stop-color="#060d1a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#0066CC"/>
-      <stop offset="100%" stop-color="#0ea5e9"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0066CC" stop-opacity="0.3"/>
-      <stop offset="100%" stop-color="#0066CC" stop-opacity="0.05"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <filter id="glow3">
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Subtle grid -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#0066CC" stroke-width="0.3" opacity="0.12"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#0066CC" stroke-width="0.3" opacity="0.12"/>
-  <line x1="620" y1="0" x2="620" y2="630" stroke="#0066CC" stroke-width="0.3" opacity="0.1"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="5" fill="url(#accentGrad)"/>
-
-  <!-- === RIGHT SIDE: OWASP numbered list visual + shield + AI brain === -->
-  <!-- Shield -->
-  <path d="M920,120 L1010,155 L1010,300 Q1010,390 920,425 Q830,390 830,300 L830,155 Z"
-        fill="url(#shieldGrad)" stroke="#0066CC" stroke-width="1.8" opacity="0.8"/>
-  <path d="M920,165 L980,192 L980,300 Q980,365 920,392 Q860,365 860,300 L860,192 Z"
-        fill="none" stroke="#0ea5e9" stroke-width="1" stroke-dasharray="5,4" opacity="0.4"/>
-
-  <!-- Checkmark / tick in shield -->
-  <polyline points="895,285 913,305 948,260" fill="none" stroke="#0ea5e9" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" opacity="0.9" filter="url(#glow3)"/>
-
-  <!-- OWASP ranking list - floating cards right -->
-  <rect x="700" y="130" width="100" height="30" rx="5" fill="#0d1f40" stroke="#0066CC" stroke-width="1.2" opacity="0.9"/>
-  <rect x="700" y="130" width="26" height="30" rx="5" fill="#0066CC" opacity="0.85"/>
-  <text x="713" y="150" font-size="13" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">A1</text>
-  <text x="762" y="150" font-size="11" fill="#93c5fd" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">Broken Auth</text>
-
-  <rect x="700" y="170" width="100" height="30" rx="5" fill="#0d1f40" stroke="#0066CC" stroke-width="1.2" opacity="0.9"/>
-  <rect x="700" y="170" width="26" height="30" rx="5" fill="#0066CC" opacity="0.75"/>
-  <text x="713" y="190" font-size="13" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">A2</text>
-  <text x="762" y="190" font-size="11" fill="#93c5fd" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">Injection</text>
-
-  <rect x="700" y="210" width="100" height="30" rx="5" fill="#0d1f40" stroke="#0066CC" stroke-width="1.2" opacity="0.9"/>
-  <rect x="700" y="210" width="26" height="30" rx="5" fill="#0066CC" opacity="0.65"/>
-  <text x="713" y="230" font-size="13" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">A3</text>
-  <text x="762" y="230" font-size="11" fill="#93c5fd" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">XSS / SSRF</text>
-
-  <!-- AI brain icon (abstract circles) -->
-  <circle cx="1070" cy="440" r="55" fill="none" stroke="#0ea5e9" stroke-width="1.5" opacity="0.4" stroke-dasharray="8,5"/>
-  <circle cx="1070" cy="440" r="35" fill="#0d1f40" stroke="#0066CC" stroke-width="1.5" opacity="0.7"/>
-  <circle cx="1070" cy="440" r="16" fill="#0066CC" opacity="0.85" filter="url(#glow3)"/>
-  <!-- AI label -->
-  <text x="1070" y="445" font-size="11" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">AI</text>
-  <!-- Brain node connectors -->
-  <line x1="1035" y1="415" x2="1020" y2="400" stroke="#0ea5e9" stroke-width="1" opacity="0.5"/>
-  <line x1="1105" y1="415" x2="1118" y2="400" stroke="#0ea5e9" stroke-width="1" opacity="0.5"/>
-  <line x1="1070" y1="405" x2="1070" y2="388" stroke="#0ea5e9" stroke-width="1" opacity="0.5"/>
-  <line x1="1035" y1="465" x2="1020" y2="480" stroke="#0ea5e9" stroke-width="1" opacity="0.5"/>
-  <line x1="1105" y1="465" x2="1118" y2="480" stroke="#0ea5e9" stroke-width="1" opacity="0.5"/>
-  <circle cx="1020" cy="400" r="5" fill="#0ea5e9" opacity="0.7"/>
-  <circle cx="1118" cy="400" r="5" fill="#0ea5e9" opacity="0.7"/>
-  <circle cx="1070" cy="388" r="5" fill="#0ea5e9" opacity="0.7"/>
-  <circle cx="1020" cy="480" r="5" fill="#0ea5e9" opacity="0.5"/>
-  <circle cx="1118" cy="480" r="5" fill="#0ea5e9" opacity="0.5"/>
-
-  <!-- OWASP badge -->
-  <rect x="875" y="445" width="90" height="28" rx="6" fill="#0066CC" opacity="0.9"/>
-  <text x="920" y="464" font-size="12" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">OWASP 2025</text>
-
-  <!-- === LEFT SIDE: Text content === -->
-  <!-- Category label -->
-  <text x="60" y="82" font-size="13" fill="#0ea5e9" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600" letter-spacing="3" opacity="0.9">SECURITY STANDARD</text>
-
-  <!-- Main title -->
-  <text x="60" y="158" font-size="50" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">OWASP 2025</text>
-  <text x="60" y="218" font-size="50" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Top 10</text>
-  <text x="60" y="278" font-size="50" fill="#0ea5e9" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Update</text>
-
-  <!-- Accent underline -->
-  <rect x="60" y="294" width="300" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="338" font-size="22" fill="#94a3b8" font-family="Space Grotesk, Inter, system-ui, sans-serif">Agentic AI Security Complete Guide</text>
-
-  <!-- Info boxes -->
-  <rect x="60"  y="376" width="140" height="62" rx="7" fill="#0d1f40" stroke="#0066CC" stroke-width="1.2"/>
-  <text x="130" y="402" font-size="14" fill="#0ea5e9" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">Top 10</text>
-  <text x="130" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Security Risks</text>
-  <text x="130" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">2025 Edition</text>
-
-  <rect x="214" y="376" width="140" height="62" rx="7" fill="#0d1f40" stroke="#0ea5e9" stroke-width="1.2"/>
-  <text x="284" y="402" font-size="14" fill="#38bdf8" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">Agentic AI</text>
-  <text x="284" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">New Attack</text>
-  <text x="284" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Vectors</text>
-
-  <rect x="368" y="376" width="140" height="62" rx="7" fill="#0d1f40" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="438" y="402" font-size="14" fill="#22c55e" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">Mitigation</text>
-  <text x="438" y="420" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Defense</text>
-  <text x="438" y="432" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Strategies</text>
-
-  <!-- Date and branding -->
-  <text x="60" y="530" font-size="16" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif">January 3, 2026</text>
-  <text x="60" y="560" font-size="15" fill="#475569" font-family="Space Grotesk, Inter, system-ui, sans-serif">Twodragon Tech Blog</text>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="625" width="1200" height="5" fill="url(#accentGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OWASP 2025 : Top 10 AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">OWASP 2025 . OWASP Top 10 2025 Software Supply Chain</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Failures,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OWASP</text>
+      <rect x="90" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
+      <rect x="207" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Top10</text>
+      <rect x="297" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
+++ b/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
@@ -1,114 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#a855f7"/>
-      <stop offset="100%" stop-color="#c084fc"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#a855f7" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#a855f7" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#a855f7" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <polygon points="1036.3,257.5 1036.3,322.5 980.0,355.0 923.7,322.5 923.7,257.5 980.0,225.0" fill="none" stroke="#a855f7" stroke-width="3" opacity="0.2"/>
-    <polygon points="1012.9,271.0 1012.9,309.0 980.0,328.0 947.1,309.0 947.1,271.0 980.0,252.0" fill="#a855f7" opacity="0.12"/>
-    <circle cx="1060.0" cy="290.0" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="1020.0" cy="359.3" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="940.0" cy="359.3" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="900.0" cy="290.0" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="940.0" cy="220.7" r="7" fill="#a855f7" opacity="0.2"/>
-    <circle cx="1020.0" cy="220.7" r="7" fill="#a855f7" opacity="0.2"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#a855f7"
-        letter-spacing="3" opacity="0.9">AUTOMOTIVE</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#a855f7" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Connected Car Era</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#a855f7" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Automotive Cybersecurity Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 6, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#a855f7" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#a855f7">FSD</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Safety</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">OTA</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Updates</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">CAN</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#a855f7" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#a855f7" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#a855f7" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevSecOps :</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps . SDV(Software Defined Vehicle) ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
+      <rect x="126" y="0" width="195" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Automotive-Secu...</text>
+      <rect x="333" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Connected-Car</text>
+      <rect x="495" y="0" width="69" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="529" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#SAST</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
+++ b/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
@@ -1,127 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#34d399"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#10b981" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#10b981" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#10b981" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <line x1="980.0" y1="230.0" x2="930.0" y2="290.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1030.0" y2="290.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="955.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1005.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="980.0" y2="300.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1030.0" y2="290.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="955.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="980.0" y2="300.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="955.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="980.0" y2="300.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="1005.0" y2="345.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="980.0" y2="300.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1005.0" y1="345.0" x2="980.0" y2="300.0" stroke="#10b981" stroke-width="1.5" opacity="0.25"/>
-    <circle cx="980.0" cy="230.0" r="10" fill="#10b981" opacity="0.35"/>
-    <circle cx="930.0" cy="290.0" r="10" fill="#10b981" opacity="0.35"/>
-    <circle cx="1030.0" cy="290.0" r="10" fill="#10b981" opacity="0.35"/>
-    <circle cx="955.0" cy="345.0" r="10" fill="#10b981" opacity="0.35"/>
-    <circle cx="1005.0" cy="345.0" r="10" fill="#10b981" opacity="0.35"/>
-    <circle cx="980.0" cy="300.0" r="10" fill="#10b981" opacity="0.35"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#10b981"
-        letter-spacing="3" opacity="0.9">BLOCKCHAIN</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#10b981" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps and GitHub Security</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Tools</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#10b981" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Blockchain and Crypto Security</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 8, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">DeFi</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Protocol</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">Smart</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Contract</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Web3</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#10b981" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#10b981" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#10b981" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: DevSecOps GitHub</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. 2024-2025 34 ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Slither/Mythril), CI/CD , DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Blockchain</text>
+      <rect x="135" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cryptocurrency</text>
+      <rect x="306" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Bitcoin</text>
+      <rect x="414" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="466" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ethereum</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
+++ b/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
@@ -1,123 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#8b5cf6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="910.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.15"/>
-    <text x="929.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Code</text>
-    <polygon points="948.0,278.0 954.0,284.0 948.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="955.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.2"/>
-    <text x="974.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Build</text>
-    <polygon points="993.0,278.0 999.0,284.0 993.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1000.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.25"/>
-    <text x="1019.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Test</text>
-    <polygon points="1038.0,278.0 1044.0,284.0 1038.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1045.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.30000000000000004"/>
-    <text x="1064.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Deploy</text>
-    <rect x="925.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.1"/>
-    <text x="946.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SAST</text>
-    <rect x="980.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.14"/>
-    <text x="1001.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">DAST</text>
-    <rect x="1035.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.18"/>
-    <text x="1056.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SCA</text>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#8b5cf6"
-        letter-spacing="3" opacity="0.9">DEVSECOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#8b5cf6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AWS WAF CloudFront and GitHub</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#8b5cf6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">DevSecOps Pipeline and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 8, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#8b5cf6">SAST</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DAST</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Test</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SCA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 6 : AWS WAF/CloudFront GitHub DevSecOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 6 . AWS WAF/CloudFront (OAI/OAC, WAF ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Geo-blocking),</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="133" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CloudFront</text>
+      <rect x="207" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#cloudsecurity</text>
+      <rect x="369" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="444" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cybersecurity</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
+++ b/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
@@ -1,123 +1,191 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#8b5cf6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="910.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.15"/>
-    <text x="929.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Code</text>
-    <polygon points="948.0,278.0 954.0,284.0 948.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="955.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.2"/>
-    <text x="974.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Build</text>
-    <polygon points="993.0,278.0 999.0,284.0 993.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1000.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.25"/>
-    <text x="1019.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Test</text>
-    <polygon points="1038.0,278.0 1044.0,284.0 1038.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1045.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.30000000000000004"/>
-    <text x="1064.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Deploy</text>
-    <rect x="925.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.1"/>
-    <text x="946.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SAST</text>
-    <rect x="980.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.14"/>
-    <text x="1001.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">DAST</text>
-    <rect x="1035.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.18"/>
-    <text x="1056.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SCA</text>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#8b5cf6"
-        letter-spacing="3" opacity="0.9">DEVSECOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#8b5cf6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">roadmap.sh Analysis</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#8b5cf6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">DevSecOps Pipeline and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 10, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#8b5cf6">SAST</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DAST</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Test</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SCA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 DevSecOps : roadmap.sh</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">roadmap.sh 2026 DevSecOps . 93 , OWASP Top 10:2025,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">NIST</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
+      <rect x="126" y="0" width="42" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#-</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
+++ b/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
@@ -1,123 +1,199 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#8b5cf6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="910.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.15"/>
-    <text x="929.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Code</text>
-    <polygon points="948.0,278.0 954.0,284.0 948.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="955.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.2"/>
-    <text x="974.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Build</text>
-    <polygon points="993.0,278.0 999.0,284.0 993.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1000.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.25"/>
-    <text x="1019.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Test</text>
-    <polygon points="1038.0,278.0 1044.0,284.0 1038.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1045.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.30000000000000004"/>
-    <text x="1064.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Deploy</text>
-    <rect x="925.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.1"/>
-    <text x="946.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SAST</text>
-    <rect x="980.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.14"/>
-    <text x="1001.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">DAST</text>
-    <rect x="1035.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.18"/>
-    <text x="1056.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SCA</text>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#8b5cf6"
-        letter-spacing="3" opacity="0.9">DEVSECOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#8b5cf6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">DevSecOps Perspective on</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Generative AI</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#8b5cf6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">DevSecOps Pipeline and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 11, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#8b5cf6">SAST</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DAST</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Test</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SCA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : DevSecOps AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI . Suno V5 MIDI Export, Veo 3 1080p ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Midjourney Video V1 DevSecOps (API , Zero-Trust)</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="51" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AI</text>
+      <rect x="63" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Generative-AI</text>
+      <rect x="225" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Music-Video</text>
+      <rect x="369" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
+++ b/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
@@ -1,185 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#071a0e"/>
-      <stop offset="50%" stop-color="#0a2318"/>
-      <stop offset="100%" stop-color="#0d2f24"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#34d399"/>
-      <stop offset="100%" stop-color="#06b6d4"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#064e3b" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#022c22" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e4a52" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#052e36" stop-opacity="0.95"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1a3a5c" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#0c2240" stop-opacity="0.95"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="badgeGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#059669"/>
-      <stop offset="100%" stop-color="#0891b2"/>
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000000" flood-opacity="0.5"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="6" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Background grid pattern -->
-  <line x1="0" y1="105" x2="1200" y2="105" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="315" x2="1200" y2="315" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="525" x2="1200" y2="525" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="200" y1="0" x2="200" y2="630" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="1000" y1="0" x2="1000" y2="630" stroke="#1a4a2e" stroke-width="0.5" stroke-opacity="0.4"/>
-
-  <!-- Glow orbs -->
-  <circle cx="150" cy="150" r="180" fill="#059669" fill-opacity="0.06"/>
-  <circle cx="1050" cy="480" r="160" fill="#06b6d4" fill-opacity="0.06"/>
-  <circle cx="600" cy="320" r="200" fill="#10b981" fill-opacity="0.04"/>
-
-  <!-- Top badge -->
-  <rect x="40" y="28" width="220" height="34" rx="17" fill="url(#badgeGrad)"/>
-  <text x="150" y="50" fill="#ffffff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">ISMS-P CERTIFICATION</text>
-
-  <!-- Date badge -->
-  <rect x="980" y="28" width="180" height="34" rx="17" fill="#0f2d1e" stroke="#34d399" stroke-width="1.5"/>
-  <text x="1070" y="50" fill="#34d399" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 14, 2026</text>
-
-  <!-- Shield icon -->
-  <g transform="translate(40, 78)">
-    <path d="M30 0 L60 12 L60 36 Q60 54 30 66 Q0 54 0 36 L0 12 Z" fill="none" stroke="#34d399" stroke-width="2.5" stroke-linejoin="round"/>
-    <path d="M18 33 L26 41 L42 25" fill="none" stroke="#34d399" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Main title -->
-  <text x="120" y="112" fill="url(#titleGrad)" font-family="Arial, sans-serif" font-size="42" font-weight="800" filter="url(#titleGlow)">ISMS-P Certification Complete Guide</text>
-
-  <!-- Subtitle -->
-  <text x="120" y="148" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="20" font-weight="500" letter-spacing="3">AWS  |  Management System  |  Protection Measures</text>
-
-  <!-- Divider line -->
-  <rect x="120" y="162" width="960" height="2" rx="1" fill="url(#titleGrad)" opacity="0.5"/>
-
-  <!-- CARD 1: Governance -->
-  <rect x="60" y="185" width="340" height="310" rx="16" fill="url(#card1Grad)" stroke="#34d399" stroke-width="1.5" filter="url(#cardShadow)"/>
-
-  <!-- Card 1 top accent -->
-  <rect x="60" y="185" width="340" height="4" rx="2" fill="#34d399"/>
-
-  <!-- Card 1 icon: document/policy -->
-  <g transform="translate(88, 210)">
-    <rect x="0" y="0" width="44" height="54" rx="5" fill="none" stroke="#34d399" stroke-width="2"/>
-    <line x1="8" y1="15" x2="36" y2="15" stroke="#34d399" stroke-width="2" stroke-linecap="round"/>
-    <line x1="8" y1="25" x2="36" y2="25" stroke="#34d399" stroke-width="2" stroke-linecap="round"/>
-    <line x1="8" y1="35" x2="24" y2="35" stroke="#34d399" stroke-width="2" stroke-linecap="round"/>
-    <circle cx="34" cy="42" r="8" fill="#071a0e" stroke="#34d399" stroke-width="1.5"/>
-    <text x="34" y="46" fill="#34d399" font-family="Arial" font-size="9" font-weight="700" text-anchor="middle">OK</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="148" y="228" fill="#34d399" font-family="Arial, sans-serif" font-size="18" font-weight="700">Governance</text>
-  <text x="88" y="286" fill="#a7f3d0" font-family="Arial, sans-serif" font-size="14" font-weight="600">Policy Establishment</text>
-  <text x="88" y="308" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- Information security policy</text>
-  <text x="88" y="326" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- Risk assessment framework</text>
-  <text x="88" y="344" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- PDCA cycle management</text>
-  <text x="88" y="374" fill="#a7f3d0" font-family="Arial, sans-serif" font-size="14" font-weight="600">Key Areas</text>
-  <text x="88" y="396" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- Leadership commitment</text>
-  <text x="88" y="414" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- Scope definition</text>
-  <text x="88" y="432" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="12">- Stakeholder management</text>
-  <text x="88" y="466" fill="#34d399" font-family="Arial, sans-serif" font-size="13" font-weight="700">ISMS Management</text>
-  <rect x="88" y="474" width="100" height="4" rx="2" fill="#34d399" opacity="0.5"/>
-
-  <!-- CARD 2: Technical Controls -->
-  <rect x="430" y="185" width="340" height="310" rx="16" fill="url(#card2Grad)" stroke="#06b6d4" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="430" y="185" width="340" height="4" rx="2" fill="#06b6d4"/>
-
-  <!-- Card 2 icon: shield/lock -->
-  <g transform="translate(458, 210)">
-    <rect x="0" y="6" width="44" height="38" rx="4" fill="none" stroke="#06b6d4" stroke-width="2"/>
-    <path d="M8 6 L8 0 Q8 -6 22 -6 Q36 -6 36 0 L36 6" fill="none" stroke="#06b6d4" stroke-width="2" stroke-linecap="round"/>
-    <circle cx="22" cy="26" r="6" fill="none" stroke="#06b6d4" stroke-width="2"/>
-    <line x1="22" y1="32" x2="22" y2="38" stroke="#06b6d4" stroke-width="2" stroke-linecap="round"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2025 ISMS-P : AWS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="518" y="228" fill="#06b6d4" font-family="Arial, sans-serif" font-size="18" font-weight="700">Technical Controls</text>
-  <text x="458" y="286" fill="#bae6fd" font-family="Arial, sans-serif" font-size="14" font-weight="600">AWS Security Services</text>
-  <text x="458" y="308" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- CloudTrail audit logging</text>
-  <text x="458" y="326" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- AWS Config compliance</text>
-  <text x="458" y="344" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- GuardDuty threat detection</text>
-  <text x="458" y="374" fill="#bae6fd" font-family="Arial, sans-serif" font-size="14" font-weight="600">Protection Measures</text>
-  <text x="458" y="396" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Encryption at rest/transit</text>
-  <text x="458" y="414" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- IAM least privilege</text>
-  <text x="458" y="432" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Network segmentation</text>
-  <text x="458" y="466" fill="#06b6d4" font-family="Arial, sans-serif" font-size="13" font-weight="700">AWS Security</text>
-  <rect x="458" y="474" width="100" height="4" rx="2" fill="#06b6d4" opacity="0.5"/>
-
-  <!-- CARD 3: Compliance -->
-  <rect x="800" y="185" width="340" height="310" rx="16" fill="url(#card3Grad)" stroke="#60a5fa" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="800" y="185" width="340" height="4" rx="2" fill="#60a5fa"/>
-
-  <!-- Card 3 icon: checkmark/audit -->
-  <g transform="translate(828, 210)">
-    <circle cx="22" cy="22" r="22" fill="none" stroke="#60a5fa" stroke-width="2"/>
-    <path d="M10 22 L18 30 L34 14" fill="none" stroke="#60a5fa" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 ISMS-P (101 ) . AWS , , NIST</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CSF 2.0 , AI .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ISMS-P</text>
+      <rect x="99" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
+      <rect x="171" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
+      <rect x="288" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Compliance</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="888" y="228" fill="#60a5fa" font-family="Arial, sans-serif" font-size="18" font-weight="700">Compliance Audit</text>
-  <text x="828" y="286" fill="#bfdbfe" font-family="Arial, sans-serif" font-size="14" font-weight="600">Certification Review</text>
-  <text x="828" y="308" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- Document preparation</text>
-  <text x="828" y="326" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- On-site audit process</text>
-  <text x="828" y="344" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- Evidence collection</text>
-  <text x="828" y="374" fill="#bfdbfe" font-family="Arial, sans-serif" font-size="14" font-weight="600">Audit Domains</text>
-  <text x="828" y="396" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- 102 control items (ISMS)</text>
-  <text x="828" y="414" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- 22 personal info controls</text>
-  <text x="828" y="432" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12">- Annual review cycle</text>
-  <text x="828" y="466" fill="#60a5fa" font-family="Arial, sans-serif" font-size="13" font-weight="700">Certification</text>
-  <rect x="828" y="474" width="100" height="4" rx="2" fill="#60a5fa" opacity="0.5"/>
-
-  <!-- Footer bar -->
-  <rect x="0" y="516" width="1200" height="114" fill="#040f08" fill-opacity="0.9"/>
-  <rect x="0" y="516" width="1200" height="2" fill="url(#titleGrad)" opacity="0.6"/>
-
-  <!-- Footer keywords -->
-  <g transform="translate(60, 545)">
-    <rect x="0" y="0" width="88" height="26" rx="13" fill="#064e3b" stroke="#34d399" stroke-width="1"/>
-    <text x="44" y="17" fill="#34d399" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">ISMS-P</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(162, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#0e4a52" stroke="#06b6d4" stroke-width="1"/>
-    <text x="54" y="17" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWS Security</text>
-  </g>
-  <g transform="translate(284, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#1a3a5c" stroke="#60a5fa" stroke-width="1"/>
-    <text x="54" y="17" fill="#60a5fa" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Compliance</text>
-  </g>
-  <g transform="translate(406, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#064e3b" stroke="#34d399" stroke-width="1"/>
-    <text x="54" y="17" fill="#34d399" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Protection</text>
-  </g>
-
-  <!-- Footer site -->
-  <text x="1140" y="558" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-
-  <!-- Footer description -->
-  <text x="60" y="598" fill="#4b7a5e" font-family="Arial, sans-serif" font-size="13">Complete guide to achieving ISMS-P certification in AWS cloud environments with management system establishment and protection measures</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
@@ -1,118 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS : IAM EKS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">IAM to EKS Practical Security</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Architecture</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 14, 2026</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS : IAM EKS - AWS</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. IAM, VPC, S3, RDS, EKS</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="124" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
+      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#IAM</text>
+      <rect x="261" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VPC</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
+++ b/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
@@ -1,197 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0d0718"/>
-      <stop offset="50%" stop-color="#160b2e"/>
-      <stop offset="100%" stop-color="#1a0f3a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#c084fc"/>
-      <stop offset="100%" stop-color="#e879f9"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#3b0764" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#1e0440" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#4a1942" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#2d0e28" stop-opacity="0.95"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1e3a5f" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#0f1f3a" stop-opacity="0.95"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="badgeGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#7c3aed"/>
-      <stop offset="100%" stop-color="#db2777"/>
-    </linearGradient>
-    <filter id="glow">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="10" flood-color="#7c3aed" flood-opacity="0.2"/>
-    </filter>
-    <filter id="titleGlow">
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
       <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Background grid -->
-  <line x1="0" y1="105" x2="1200" y2="105" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="315" x2="1200" y2="315" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="525" x2="1200" y2="525" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="200" y1="0" x2="200" y2="630" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="1000" y1="0" x2="1000" y2="630" stroke="#3b0764" stroke-width="0.5" stroke-opacity="0.4"/>
-
-  <!-- Glow orbs -->
-  <circle cx="100" cy="200" r="200" fill="#7c3aed" fill-opacity="0.07"/>
-  <circle cx="1100" cy="400" r="180" fill="#db2777" fill-opacity="0.07"/>
-  <circle cx="600" cy="300" r="220" fill="#9333ea" fill-opacity="0.04"/>
-
-  <!-- Top badge -->
-  <rect x="40" y="28" width="230" height="34" rx="17" fill="url(#badgeGrad)"/>
-  <text x="155" y="50" fill="#ffffff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">CSPM SECURITY GUIDE</text>
-
-  <!-- Date badge -->
-  <rect x="980" y="28" width="180" height="34" rx="17" fill="#1e0440" stroke="#c084fc" stroke-width="1.5"/>
-  <text x="1070" y="50" fill="#c084fc" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 14, 2026</text>
-
-  <!-- Radar/eye icon -->
-  <g transform="translate(40, 78)">
-    <circle cx="30" cy="30" r="28" fill="none" stroke="#c084fc" stroke-width="2"/>
-    <circle cx="30" cy="30" r="18" fill="none" stroke="#c084fc" stroke-width="1.5" stroke-opacity="0.6"/>
-    <circle cx="30" cy="30" r="8" fill="none" stroke="#c084fc" stroke-width="1.5"/>
-    <circle cx="30" cy="30" r="3" fill="#c084fc"/>
-    <line x1="30" y1="2" x2="30" y2="58" stroke="#c084fc" stroke-width="1" stroke-opacity="0.3"/>
-    <line x1="2" y1="30" x2="58" y2="30" stroke="#c084fc" stroke-width="1" stroke-opacity="0.3"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Main title -->
-  <text x="120" y="112" fill="url(#titleGrad)" font-family="Arial, sans-serif" font-size="42" font-weight="800" filter="url(#titleGlow)">CSPM DataDog AWS Security Guide</text>
-
-  <!-- Subtitle -->
-  <text x="120" y="148" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="20" font-weight="500" letter-spacing="3">Configuration  |  Verification  |  Compliance</text>
-
-  <!-- Divider line -->
-  <rect x="120" y="162" width="960" height="2" rx="1" fill="url(#titleGrad)" opacity="0.5"/>
-
-  <!-- CARD 1: DataDog CSPM -->
-  <rect x="60" y="185" width="340" height="310" rx="16" fill="url(#card1Grad)" stroke="#c084fc" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="60" y="185" width="340" height="4" rx="2" fill="#c084fc"/>
-
-  <!-- Card 1 icon: monitoring bars -->
-  <g transform="translate(88, 210)">
-    <rect x="0" y="20" width="10" height="34" rx="2" fill="#c084fc" opacity="0.8"/>
-    <rect x="14" y="10" width="10" height="44" rx="2" fill="#c084fc"/>
-    <rect x="28" y="28" width="10" height="26" rx="2" fill="#c084fc" opacity="0.8"/>
-    <rect x="42" y="4" width="10" height="50" rx="2" fill="#c084fc"/>
-    <line x1="0" y1="58" x2="56" y2="58" stroke="#c084fc" stroke-width="1.5" stroke-linecap="round"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="158" y="228" fill="#c084fc" font-family="Arial, sans-serif" font-size="18" font-weight="700">DataDog CSPM</text>
-  <text x="88" y="286" fill="#e9d5ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Monitoring Features</text>
-  <text x="88" y="308" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Misconfig detection</text>
-  <text x="88" y="326" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Real-time posture scoring</text>
-  <text x="88" y="344" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Drift detection alerts</text>
-  <text x="88" y="374" fill="#e9d5ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Dashboard</text>
-  <text x="88" y="396" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Security findings view</text>
-  <text x="88" y="414" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Resource inventory</text>
-  <text x="88" y="432" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="12">- Compliance reports</text>
-  <text x="88" y="466" fill="#c084fc" font-family="Arial, sans-serif" font-size="13" font-weight="700">Cloud Monitoring</text>
-  <rect x="88" y="474" width="110" height="4" rx="2" fill="#c084fc" opacity="0.5"/>
-
-  <!-- CARD 2: AWS Config -->
-  <rect x="430" y="185" width="340" height="310" rx="16" fill="url(#card2Grad)" stroke="#f472b6" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="430" y="185" width="340" height="4" rx="2" fill="#f472b6"/>
-
-  <!-- Card 2 icon: gear/config -->
-  <g transform="translate(458, 208)">
-    <circle cx="22" cy="22" r="18" fill="none" stroke="#f472b6" stroke-width="2"/>
-    <circle cx="22" cy="22" r="8" fill="none" stroke="#f472b6" stroke-width="2"/>
-    <line x1="22" y1="2" x2="22" y2="8" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="22" y1="36" x2="22" y2="42" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="2" y1="22" x2="8" y2="22" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="36" y1="22" x2="42" y2="22" stroke="#f472b6" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="6" y1="6" x2="10" y2="10" stroke="#f472b6" stroke-width="2" stroke-linecap="round"/>
-    <line x1="34" y1="34" x2="38" y2="38" stroke="#f472b6" stroke-width="2" stroke-linecap="round"/>
-    <line x1="38" y1="6" x2="34" y2="10" stroke="#f472b6" stroke-width="2" stroke-linecap="round"/>
-    <line x1="10" y1="34" x2="6" y2="38" stroke="#f472b6" stroke-width="2" stroke-linecap="round"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CSPM(DataDog) AWS :</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="518" y="228" fill="#f472b6" font-family="Arial, sans-serif" font-size="18" font-weight="700">AWS Config</text>
-  <text x="458" y="286" fill="#fce7f3" font-family="Arial, sans-serif" font-size="14" font-weight="600">Configuration Verification</text>
-  <text x="458" y="308" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- Config rules evaluation</text>
-  <text x="458" y="326" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- Resource change timeline</text>
-  <text x="458" y="344" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- Conformance packs</text>
-  <text x="458" y="374" fill="#fce7f3" font-family="Arial, sans-serif" font-size="14" font-weight="600">Auto Remediation</text>
-  <text x="458" y="396" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- SSM Automation docs</text>
-  <text x="458" y="414" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- Lambda remediation</text>
-  <text x="458" y="432" fill="#fbcfe8" font-family="Arial, sans-serif" font-size="12">- EventBridge triggers</text>
-  <text x="458" y="466" fill="#f472b6" font-family="Arial, sans-serif" font-size="13" font-weight="700">AWS Config Rules</text>
-  <rect x="458" y="474" width="110" height="4" rx="2" fill="#f472b6" opacity="0.5"/>
-
-  <!-- CARD 3: Compliance -->
-  <rect x="800" y="185" width="340" height="310" rx="16" fill="url(#card3Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="800" y="185" width="340" height="4" rx="2" fill="#818cf8"/>
-
-  <!-- Card 3 icon: checklist -->
-  <g transform="translate(828, 208)">
-    <rect x="0" y="0" width="44" height="52" rx="5" fill="none" stroke="#818cf8" stroke-width="2"/>
-    <line x1="10" y1="14" x2="34" y2="14" stroke="#818cf8" stroke-width="2" stroke-linecap="round"/>
-    <line x1="10" y1="24" x2="34" y2="24" stroke="#818cf8" stroke-width="2" stroke-linecap="round"/>
-    <line x1="10" y1="34" x2="24" y2="34" stroke="#818cf8" stroke-width="2" stroke-linecap="round"/>
-    <rect x="5" y="10" width="4" height="4" rx="1" fill="#818cf8"/>
-    <rect x="5" y="20" width="4" height="4" rx="1" fill="#818cf8"/>
-    <rect x="5" y="30" width="4" height="4" rx="1" fill="#818cf8" opacity="0.5"/>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DataDog CSPM AWS .</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Misconfiguration , CIS Benchmark, ISMS-P .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="34" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CSPM</text>
+      <rect x="81" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DataDog</text>
+      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
+      <rect x="261" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="313" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="888" y="228" fill="#818cf8" font-family="Arial, sans-serif" font-size="18" font-weight="700">Compliance Monitoring</text>
-  <text x="828" y="286" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Standards Coverage</text>
-  <text x="828" y="308" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- CIS AWS Benchmark</text>
-  <text x="828" y="326" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- PCI DSS controls</text>
-  <text x="828" y="344" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- SOC 2 requirements</text>
-  <text x="828" y="374" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Reporting</text>
-  <text x="828" y="396" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Compliance score trends</text>
-  <text x="828" y="414" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Failed rule details</text>
-  <text x="828" y="432" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Audit evidence export</text>
-  <text x="828" y="466" fill="#818cf8" font-family="Arial, sans-serif" font-size="13" font-weight="700">Compliance Reporting</text>
-  <rect x="828" y="474" width="130" height="4" rx="2" fill="#818cf8" opacity="0.5"/>
-
-  <!-- Footer bar -->
-  <rect x="0" y="516" width="1200" height="114" fill="#060210" fill-opacity="0.95"/>
-  <rect x="0" y="516" width="1200" height="2" fill="url(#titleGrad)" opacity="0.6"/>
-
-  <!-- Footer keywords -->
-  <g transform="translate(60, 545)">
-    <rect x="0" y="0" width="72" height="26" rx="13" fill="#3b0764" stroke="#c084fc" stroke-width="1"/>
-    <text x="36" y="17" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">CSPM</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(146, 545)">
-    <rect x="0" y="0" width="90" height="26" rx="13" fill="#4a1942" stroke="#f472b6" stroke-width="1"/>
-    <text x="45" y="17" fill="#f472b6" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">DataDog</text>
-  </g>
-  <g transform="translate(250, 545)">
-    <rect x="0" y="0" width="100" height="26" rx="13" fill="#1e3a5f" stroke="#818cf8" stroke-width="1"/>
-    <text x="50" y="17" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">AWS Config</text>
-  </g>
-  <g transform="translate(364, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#3b0764" stroke="#c084fc" stroke-width="1"/>
-    <text x="54" y="17" fill="#c084fc" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Compliance</text>
-  </g>
-
-  <!-- Footer site -->
-  <text x="1140" y="558" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-
-  <!-- Footer description -->
-  <text x="60" y="598" fill="#5b3a7a" font-family="Arial, sans-serif" font-size="13">Automated security configuration verification and compliance monitoring using DataDog CSPM and AWS Config in cloud environments</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
@@ -1,220 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#060e1a"/>
-      <stop offset="50%" stop-color="#0a1628"/>
-      <stop offset="100%" stop-color="#0d1c34"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#4285f4"/>
-      <stop offset="33%" stop-color="#ea4335"/>
-      <stop offset="66%" stop-color="#fbbc04"/>
-      <stop offset="100%" stop-color="#34a853"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1a3a6e" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#0d1f40" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#5a1a1a" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#320d0d" stop-opacity="0.95"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#4a3800" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#2a1f00" stop-opacity="0.95"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="card4Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a3d1e" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#052210" stop-opacity="0.95"/>
-    </linearGradient>
-    <linearGradient id="badgeGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#4285f4"/>
-      <stop offset="100%" stop-color="#34a853"/>
-    </linearGradient>
-    <filter id="cardShadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000000" flood-opacity="0.5"/>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="6" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Background grid -->
-  <line x1="0" y1="105" x2="1200" y2="105" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="315" x2="1200" y2="315" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="0" y1="525" x2="1200" y2="525" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="300" y1="0" x2="300" y2="630" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-  <line x1="900" y1="0" x2="900" y2="630" stroke="#1a2e52" stroke-width="0.5" stroke-opacity="0.4"/>
-
-  <!-- Glow orbs with Google colors -->
-  <circle cx="100" cy="150" r="150" fill="#4285f4" fill-opacity="0.06"/>
-  <circle cx="400" cy="400" r="120" fill="#ea4335" fill-opacity="0.05"/>
-  <circle cx="800" cy="150" r="130" fill="#fbbc04" fill-opacity="0.05"/>
-  <circle cx="1100" cy="400" r="140" fill="#34a853" fill-opacity="0.06"/>
-
-  <!-- Top badge -->
-  <rect x="40" y="28" width="210" height="34" rx="17" fill="url(#badgeGrad)"/>
-  <text x="145" y="50" fill="#ffffff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">GCP SECURITY 2026</text>
-
-  <!-- Date badge -->
-  <rect x="980" y="28" width="180" height="34" rx="17" fill="#0d1c34" stroke="#4285f4" stroke-width="1.5"/>
-  <text x="1070" y="50" fill="#4285f4" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 14, 2026</text>
-
-  <!-- GCP logo-inspired icon -->
-  <g transform="translate(40, 78)">
-    <polygon points="30,4 56,48 4,48" fill="none" stroke="#4285f4" stroke-width="2.5" stroke-linejoin="round"/>
-    <circle cx="30" cy="48" r="12" fill="none" stroke="#ea4335" stroke-width="2"/>
-    <circle cx="4" cy="48" r="8" fill="none" stroke="#fbbc04" stroke-width="2"/>
-    <circle cx="56" cy="48" r="8" fill="none" stroke="#34a853" stroke-width="2"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Main title -->
-  <text x="120" y="112" fill="url(#titleGrad)" font-family="Arial, sans-serif" font-size="42" font-weight="800" filter="url(#titleGlow)">GCP Cloud Security Complete Guide</text>
-
-  <!-- Subtitle -->
-  <text x="120" y="148" fill="#93c5fd" font-family="Arial, sans-serif" font-size="20" font-weight="500" letter-spacing="3">IAM  |  GKE  |  Security Architecture</text>
-
-  <!-- Divider line -->
-  <rect x="120" y="162" width="960" height="2" rx="1" fill="url(#titleGrad)" opacity="0.5"/>
-
-  <!-- 4 cards layout: 2 top, 2 bottom -->
-  <!-- CARD 1: IAM (blue) -->
-  <rect x="60" y="185" width="250" height="290" rx="14" fill="url(#card1Grad)" stroke="#4285f4" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="60" y="185" width="250" height="4" rx="2" fill="#4285f4"/>
-
-  <!-- IAM icon: person with key -->
-  <g transform="translate(82, 205)">
-    <circle cx="16" cy="10" r="10" fill="none" stroke="#4285f4" stroke-width="2"/>
-    <path d="M0 40 Q0 28 16 28 Q32 28 32 40" fill="none" stroke="#4285f4" stroke-width="2"/>
-    <rect x="34" y="20" width="18" height="12" rx="3" fill="none" stroke="#4285f4" stroke-width="1.5"/>
-    <circle cx="37" cy="26" r="3" fill="none" stroke="#4285f4" stroke-width="1.5"/>
-    <line x1="37" y1="29" x2="37" y2="32" stroke="#4285f4" stroke-width="1.5" stroke-linecap="round"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="155" y="222" fill="#4285f4" font-family="Arial, sans-serif" font-size="16" font-weight="700">IAM</text>
-  <text x="80" y="270" fill="#bfdbfe" font-family="Arial, sans-serif" font-size="13" font-weight="600">Identity Management</text>
-  <text x="80" y="290" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Service accounts</text>
-  <text x="80" y="308" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Workload Identity</text>
-  <text x="80" y="326" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Role bindings</text>
-  <text x="80" y="346" fill="#bfdbfe" font-family="Arial, sans-serif" font-size="13" font-weight="600">Least Privilege</text>
-  <text x="80" y="366" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Predefined roles</text>
-  <text x="80" y="384" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Custom roles</text>
-  <text x="80" y="402" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11">- Org policy</text>
-  <text x="80" y="450" fill="#4285f4" font-family="Arial, sans-serif" font-size="12" font-weight="700">Access Control</text>
-  <rect x="80" y="458" width="80" height="3" rx="1" fill="#4285f4" opacity="0.5"/>
-
-  <!-- CARD 2: VPC (red) -->
-  <rect x="330" y="185" width="250" height="290" rx="14" fill="url(#card2Grad)" stroke="#ea4335" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="330" y="185" width="250" height="4" rx="2" fill="#ea4335"/>
-
-  <!-- VPC icon: network -->
-  <g transform="translate(352, 205)">
-    <rect x="8" y="0" width="24" height="16" rx="3" fill="none" stroke="#ea4335" stroke-width="1.5"/>
-    <rect x="0" y="28" width="20" height="14" rx="3" fill="none" stroke="#ea4335" stroke-width="1.5"/>
-    <rect x="20" y="28" width="20" height="14" rx="3" fill="none" stroke="#ea4335" stroke-width="1.5"/>
-    <line x1="20" y1="16" x2="10" y2="28" stroke="#ea4335" stroke-width="1.5"/>
-    <line x1="20" y1="16" x2="30" y2="28" stroke="#ea4335" stroke-width="1.5"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">GCP : IAM GKE</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="415" y="222" fill="#ea4335" font-family="Arial, sans-serif" font-size="16" font-weight="700">VPC Network</text>
-  <text x="350" y="270" fill="#fecaca" font-family="Arial, sans-serif" font-size="13" font-weight="600">Network Security</text>
-  <text x="350" y="290" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- VPC firewall rules</text>
-  <text x="350" y="308" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- Private Google Access</text>
-  <text x="350" y="326" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- VPC Service Controls</text>
-  <text x="350" y="346" fill="#fecaca" font-family="Arial, sans-serif" font-size="13" font-weight="600">Segmentation</text>
-  <text x="350" y="366" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- Shared VPC</text>
-  <text x="350" y="384" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- Cloud NAT</text>
-  <text x="350" y="402" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11">- Cloud Armor DDoS</text>
-  <text x="350" y="450" fill="#ea4335" font-family="Arial, sans-serif" font-size="12" font-weight="700">Network Isolation</text>
-  <rect x="350" y="458" width="100" height="3" rx="1" fill="#ea4335" opacity="0.5"/>
-
-  <!-- CARD 3: GKE (yellow) -->
-  <rect x="600" y="185" width="250" height="290" rx="14" fill="url(#card3Grad)" stroke="#fbbc04" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="600" y="185" width="250" height="4" rx="2" fill="#fbbc04"/>
-
-  <!-- GKE icon: container/helm wheel -->
-  <g transform="translate(622, 205)">
-    <circle cx="20" cy="22" r="18" fill="none" stroke="#fbbc04" stroke-width="2"/>
-    <circle cx="20" cy="22" r="7" fill="none" stroke="#fbbc04" stroke-width="2"/>
-    <line x1="20" y1="4" x2="20" y2="15" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="20" y1="29" x2="20" y2="40" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="3" y1="13" x2="13" y2="18" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="27" y1="26" x2="37" y2="31" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="37" y1="13" x2="27" y2="18" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="13" y1="26" x2="3" y2="31" stroke="#fbbc04" stroke-width="2.5" stroke-linecap="round"/>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GCP : IAM , VPC , Cloud SQL , Cloud</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Storage</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#GCP</text>
+      <rect x="72" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="124" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
+      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#IAM</text>
+      <rect x="261" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-SQL</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="680" y="222" fill="#fbbc04" font-family="Arial, sans-serif" font-size="16" font-weight="700">GKE Security</text>
-  <text x="620" y="270" fill="#fef3c7" font-family="Arial, sans-serif" font-size="13" font-weight="600">Container Security</text>
-  <text x="620" y="290" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- Workload Identity</text>
-  <text x="620" y="308" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- Binary Authorization</text>
-  <text x="620" y="326" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- Network policies</text>
-  <text x="620" y="346" fill="#fef3c7" font-family="Arial, sans-serif" font-size="13" font-weight="600">Runtime Protection</text>
-  <text x="620" y="366" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- Pod security standards</text>
-  <text x="620" y="384" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- RBAC enforcement</text>
-  <text x="620" y="402" fill="#fde68a" font-family="Arial, sans-serif" font-size="11">- Shielded GKE nodes</text>
-  <text x="620" y="450" fill="#fbbc04" font-family="Arial, sans-serif" font-size="12" font-weight="700">Kubernetes Hardening</text>
-  <rect x="620" y="458" width="120" height="3" rx="1" fill="#fbbc04" opacity="0.5"/>
-
-  <!-- CARD 4: SCC (green) -->
-  <rect x="870" y="185" width="270" height="290" rx="14" fill="url(#card4Grad)" stroke="#34a853" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="870" y="185" width="270" height="4" rx="2" fill="#34a853"/>
-
-  <!-- SCC icon: security center -->
-  <g transform="translate(892, 205)">
-    <rect x="0" y="0" width="44" height="44" rx="8" fill="none" stroke="#34a853" stroke-width="2"/>
-    <path d="M22 8 L34 14 L34 26 Q34 34 22 40 Q10 34 10 26 L10 14 Z" fill="none" stroke="#34a853" stroke-width="2" stroke-linejoin="round"/>
-    <path d="M16 24 L20 28 L28 20" fill="none" stroke="#34a853" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <text x="952" y="222" fill="#34a853" font-family="Arial, sans-serif" font-size="16" font-weight="700">Security Command Center</text>
-  <text x="890" y="270" fill="#bbf7d0" font-family="Arial, sans-serif" font-size="13" font-weight="600">Threat Detection</text>
-  <text x="890" y="290" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Vulnerability scanning</text>
-  <text x="890" y="308" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Anomaly detection</text>
-  <text x="890" y="326" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Threat Intelligence</text>
-  <text x="890" y="346" fill="#bbf7d0" font-family="Arial, sans-serif" font-size="13" font-weight="600">Asset Security</text>
-  <text x="890" y="366" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Asset inventory</text>
-  <text x="890" y="384" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Compliance posture</text>
-  <text x="890" y="402" fill="#86efac" font-family="Arial, sans-serif" font-size="11">- Finding management</text>
-  <text x="890" y="450" fill="#34a853" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Operations</text>
-  <rect x="890" y="458" width="120" height="3" rx="1" fill="#34a853" opacity="0.5"/>
-
-  <!-- Footer bar -->
-  <rect x="0" y="516" width="1200" height="114" fill="#040810" fill-opacity="0.95"/>
-  <rect x="0" y="516" width="1200" height="2" fill="url(#titleGrad)" opacity="0.6"/>
-
-  <!-- Footer keywords -->
-  <g transform="translate(60, 545)">
-    <rect x="0" y="0" width="56" height="26" rx="13" fill="#1a3a6e" stroke="#4285f4" stroke-width="1"/>
-    <text x="28" y="17" fill="#4285f4" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">GCP</text>
-  </g>
-  <g transform="translate(130, 545)">
-    <rect x="0" y="0" width="56" height="26" rx="13" fill="#1a3a6e" stroke="#4285f4" stroke-width="1"/>
-    <text x="28" y="17" fill="#4285f4" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">IAM</text>
-  </g>
-  <g transform="translate(200, 545)">
-    <rect x="0" y="0" width="56" height="26" rx="13" fill="#5a1a1a" stroke="#ea4335" stroke-width="1"/>
-    <text x="28" y="17" fill="#ea4335" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">VPC</text>
-  </g>
-  <g transform="translate(270, 545)">
-    <rect x="0" y="0" width="56" height="26" rx="13" fill="#4a3800" stroke="#fbbc04" stroke-width="1"/>
-    <text x="28" y="17" fill="#fbbc04" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">GKE</text>
-  </g>
-  <g transform="translate(340, 545)">
-    <rect x="0" y="0" width="100" height="26" rx="13" fill="#0a3d1e" stroke="#34a853" stroke-width="1"/>
-    <text x="50" y="17" fill="#34a853" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">SCC</text>
-  </g>
-
-  <!-- Footer site -->
-  <text x="1140" y="558" fill="#86efac" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-
-  <!-- Footer description -->
-  <text x="60" y="598" fill="#2a4a3a" font-family="Arial, sans-serif" font-size="13">Practical GCP cloud security architecture covering IAM, VPC networking, GKE container security, and Security Command Center operations</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
@@ -1,112 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#60a5fa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#3b82f6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="925.0" y="230.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.3" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="935.0" y1="244.0" x2="1025.0" y2="244.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="933.0" y="280.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="943.0" y1="294.0" x2="1033.0" y2="294.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-    <rect x="941.0" y="330.0" width="110" height="42" rx="6" fill="#3b82f6" opacity="0.12" stroke="#3b82f6" stroke-width="1.5" stroke-opacity="0.4"/>
-    <line x1="951.0" y1="344.0" x2="1041.0" y2="344.0" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#3b82f6"
-        letter-spacing="3" opacity="0.9">INFRASTRUCTURE</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#3b82f6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Docker and Kubernetes Security</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Practical Guide</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#3b82f6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Container and Orchestration Security</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 15, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#3b82f6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#3b82f6">Pod</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">RBAC</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">Network</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Policy</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#3b82f6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#3b82f6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 7 : Docker &amp; Kubernetes -</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 7 : Docker &amp; Kubernetes - -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 7 : Docker ( , Secret , ),...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Docker</text>
+      <rect x="99" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
+      <rect x="234" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="331" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Container-Security</text>
+      <rect x="441" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#K8s</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
+++ b/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
@@ -1,101 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f0a0a"/>
-      <stop offset="50%" stop-color="#1a0d0d"/>
-      <stop offset="100%" stop-color="#0a0808"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#b91c1c"/>
     </linearGradient>
-    <linearGradient id="terminalGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e" stop-opacity="0.95"/>
-      <stop offset="100%" stop-color="#0f0a14" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <filter id="glow4">
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="5" fill="url(#accentGrad)"/>
-
-  <!-- Subtle grid (monospace terminal feel) -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#ef4444" stroke-width="0.3" opacity="0.1"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#ef4444" stroke-width="0.3" opacity="0.1"/>
-  <line x1="620" y1="0" x2="620" y2="630" stroke="#ef4444" stroke-width="0.3" opacity="0.08"/>
-
-  <!-- === RIGHT SIDE: Terminal window visual === -->
-  <!-- Terminal outer frame -->
-  <rect x="650" y="110" width="490" height="350" rx="10" fill="url(#terminalGrad)" stroke="#374151" stroke-width="2"/>
-  <!-- Terminal title bar -->
-  <rect x="650" y="110" width="490" height="36" rx="10" fill="#1f2937"/>
-  <rect x="650" y="130" width="490" height="16" fill="#1f2937"/>
-  <!-- Traffic lights -->
-  <circle cx="676" cy="128" r="7" fill="#ef4444" opacity="0.9"/>
-  <circle cx="698" cy="128" r="7" fill="#f59e0b" opacity="0.9"/>
-  <circle cx="720" cy="128" r="7" fill="#22c55e" opacity="0.9"/>
-  <!-- Terminal title -->
-  <text x="895" y="133" font-size="13" fill="#9ca3af" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif">incident-analysis.log</text>
-
-  <!-- Terminal content lines -->
-  <text x="672" y="174" font-size="12" fill="#6b7280" font-family="'Courier New', monospace">$  tail -f /var/log/alb/access.log</text>
-  <text x="672" y="196" font-size="12" fill="#ef4444" font-family="'Courier New', monospace">[ERROR] 503 Service Unavailable</text>
-  <text x="672" y="218" font-size="12" fill="#ef4444" font-family="'Courier New', monospace">[ERROR] 502 Bad Gateway - upstream</text>
-  <text x="672" y="240" font-size="12" fill="#f59e0b" font-family="'Courier New', monospace">[WARN]  Cloudflare WAF rule 100013</text>
-  <text x="672" y="262" font-size="12" fill="#f59e0b" font-family="'Courier New', monospace">[WARN]  ALB target unhealthy x3</text>
-  <text x="672" y="284" font-size="12" fill="#ef4444" font-family="'Courier New', monospace">[ERROR] SSR render timeout 30002ms</text>
-  <text x="672" y="306" font-size="12" fill="#6b7280" font-family="'Courier New', monospace">      at getServerSideProps (page.js)</text>
-  <text x="672" y="328" font-size="12" fill="#6b7280" font-family="'Courier New', monospace">      at render (next-server.js:284)</text>
-  <text x="672" y="350" font-size="12" fill="#22c55e" font-family="'Courier New', monospace">[FIX]  Bypass rule added, failover OK</text>
-  <text x="672" y="372" font-size="12" fill="#22c55e" font-family="'Courier New', monospace">[OK]   200 response time: 142ms</text>
-  <!-- Cursor blink -->
-  <rect x="672" y="398" width="9" height="16" rx="1" fill="#ef4444" opacity="0.9" filter="url(#glow4)"/>
-
-  <!-- Error code badge overlay -->
-  <rect x="870" y="415" width="120" height="40" rx="8" fill="#ef4444" opacity="0.9"/>
-  <text x="930" y="440" font-size="20" fill="white" text-anchor="middle" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700">5XX</text>
-
-  <!-- === LEFT SIDE: Text content === -->
-  <!-- Category label -->
-  <text x="60" y="82" font-size="13" fill="#ef4444" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="600" letter-spacing="3" opacity="0.9">INCIDENT ANALYSIS</text>
-
-  <!-- Main title -->
-  <text x="60" y="158" font-size="48" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Next.js SSR</text>
-  <text x="60" y="215" font-size="48" fill="white" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Error</text>
-  <text x="60" y="272" font-size="48" fill="#ef4444" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" letter-spacing="-1">Post-Mortem</text>
-
-  <!-- Accent underline -->
-  <rect x="60" y="288" width="300" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="332" font-size="21" fill="#94a3b8" font-family="Space Grotesk, Inter, system-ui, sans-serif">Cloudflare WAF and ALB 5XX Analysis</text>
-
-  <!-- Stat cards -->
-  <rect x="60"  y="370" width="120" height="66" rx="7" fill="#1c0e0e" stroke="#ef4444" stroke-width="1.2"/>
-  <text x="120" y="396" font-size="22" fill="#ef4444" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">503</text>
-  <text x="120" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Primary Error</text>
-  <text x="120" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">WAF Block</text>
-
-  <rect x="194" y="370" width="120" height="66" rx="7" fill="#1c0e0e" stroke="#f59e0b" stroke-width="1.2"/>
-  <text x="254" y="396" font-size="22" fill="#f59e0b" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">30s</text>
-  <text x="254" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">SSR Timeout</text>
-  <text x="254" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Threshold</text>
-
-  <rect x="328" y="370" width="120" height="66" rx="7" fill="#1c0e0e" stroke="#22c55e" stroke-width="1.2"/>
-  <text x="388" y="396" font-size="22" fill="#22c55e" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-weight="700" text-anchor="middle">142ms</text>
-  <text x="388" y="414" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">After Fix</text>
-  <text x="388" y="428" font-size="10" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif" text-anchor="middle">Response Time</text>
-
-  <!-- Date and branding -->
-  <text x="60" y="530" font-size="16" fill="#64748b" font-family="Space Grotesk, Inter, system-ui, sans-serif">January 16, 2026</text>
-  <text x="60" y="560" font-size="15" fill="#475569" font-family="Space Grotesk, Inter, system-ui, sans-serif">Twodragon Tech Blog</text>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="625" width="1200" height="5" fill="url(#accentGrad)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Post-Mortem Next.js SSR Cloudflare ALB 5XX</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Warning Bell -->
+    <g transform="translate(80, 280)">
+      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
+            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
+      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
+      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+    </g>
+    
+    <!-- Timeline -->
+    <g transform="translate(200, 310)">
+      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
+      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
+      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
+      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
+      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    </g>
+    
+    <!-- Fire Icon -->
+    <g transform="translate(370, 285)">
+      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
+            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#f87171"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Post-Mortem: Next.js SSR location ReferenceError, Cloudflare</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="66" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
+      <rect x="144" y="0" width="96" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Next.js</text>
+      <rect x="252" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#SSR</text>
+      <rect x="324" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Cloudflare</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
+++ b/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
@@ -1,187 +1,205 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#07040f" />
-      <stop offset="60%" stop-color="#0f0a1e" />
-      <stop offset="100%" stop-color="#160d30" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#a855f7" />
-      <stop offset="100%" stop-color="#3b82f6" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#4f46e5"/>
     </linearGradient>
-    <linearGradient id="barClaude" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#f97316" />
-      <stop offset="100%" stop-color="#fb923c" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="barGPT" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#10b981" />
-      <stop offset="100%" stop-color="#34d399" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="barGemini" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#3b82f6" />
-      <stop offset="100%" stop-color="#60a5fa" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="barDeepSeek" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#8b5cf6" />
-      <stop offset="100%" stop-color="#a78bfa" />
-    </linearGradient>
-    <linearGradient id="barOpenCode" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ec4899" />
-      <stop offset="100%" stop-color="#f472b6" />
-    </linearGradient>
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur stdDeviation="3" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000000" flood-opacity="0.5" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowPurple" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="6" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)" />
-
-  <!-- Subtle grid lines -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.4" />
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.4" />
-  <line x1="300" y1="0" x2="300" y2="630" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.3" />
-  <line x1="700" y1="0" x2="700" y2="630" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.3" />
-
-  <!-- Top badge -->
-  <rect x="50" y="28" width="230" height="32" rx="16" fill="#a855f7" fill-opacity="0.18" stroke="#a855f7" stroke-width="1.5" />
-  <circle cx="70" cy="44" r="5" fill="#a855f7" filter="url(#glow)" />
-  <text x="84" y="49" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">AI RESEARCH 2025-2026</text>
-
-  <!-- Accent bar -->
-  <rect x="50" y="78" width="380" height="4" rx="2" fill="url(#accentGrad)" filter="url(#glowPurple)" />
-
-  <!-- Main title -->
-  <text x="50" y="130" fill="#faf5ff" font-family="Arial, sans-serif" font-size="40" font-weight="800" letter-spacing="-0.5">AI Coding Assistants Comparison</text>
-
-  <!-- Subtitle -->
-  <text x="50" y="168" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="18" font-weight="400" letter-spacing="1">Gemini  |  Claude Code  |  ChatGPT  |  OpenCode  |  DeepSeek</text>
-
-  <!-- Chart area background -->
-  <rect x="50" y="198" width="700" height="310" rx="14" fill="#0d0824" fill-opacity="0.8" stroke="#2d1b69" stroke-width="1" filter="url(#shadow)" />
-
-  <!-- Chart title -->
-  <text x="400" y="222" fill="#6b7280" font-family="Arial, sans-serif" font-size="11" font-weight="600" letter-spacing="3" text-anchor="middle">BENCHMARK SCORES</text>
-
-  <!-- Benchmark axis labels -->
-  <text x="280" y="245" fill="#4b5563" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">70%</text>
-  <text x="400" y="245" fill="#4b5563" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">80%</text>
-  <text x="520" y="245" fill="#4b5563" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">90%</text>
-  <text x="640" y="245" fill="#4b5563" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">100%</text>
-  <line x1="280" y1="248" x2="280" y2="490" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 3" />
-  <line x1="400" y1="248" x2="400" y2="490" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 3" />
-  <line x1="520" y1="248" x2="520" y2="490" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 3" />
-  <line x1="640" y1="248" x2="640" y2="490" stroke="#2d1b69" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 3" />
-
-  <!-- Row 1: Claude Code - SWE-Bench 80.9% -->
-  <rect x="66" y="258" width="668" height="44" rx="6" fill="#f97316" fill-opacity="0.06" />
-  <text x="76" y="283" fill="#fdba74" font-family="Arial, sans-serif" font-size="13" font-weight="700">Claude Code</text>
-  <text x="76" y="297" fill="#6b7280" font-family="Arial, sans-serif" font-size="10">Anthropic</text>
-  <!-- bar: 80.9% of range 65-100 = (80.9-65)/(100-65)*440+200 = 200+200 = ~400 -->
-  <rect x="200" y="265" width="364" height="14" rx="7" fill="#1c1033" />
-  <rect x="200" y="265" width="331" height="14" rx="7" fill="url(#barClaude)" />
-  <text x="538" y="276" fill="#fdba74" font-family="Arial, sans-serif" font-size="11" font-weight="700">80.9%</text>
-  <rect x="600" y="263" width="100" height="18" rx="9" fill="#f97316" fill-opacity="0.2" stroke="#f97316" stroke-width="1" />
-  <text x="650" y="276" fill="#fb923c" font-family="Arial, sans-serif" font-size="10" font-weight="600" text-anchor="middle">SWE-Bench</text>
-
-  <!-- Row 2: ChatGPT/GPT-5 - SWE-Bench 76.3% -->
-  <rect x="66" y="310" width="668" height="44" rx="6" fill="#10b981" fill-opacity="0.06" />
-  <text x="76" y="335" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13" font-weight="700">ChatGPT / GPT-5-Codex</text>
-  <text x="76" y="349" fill="#6b7280" font-family="Arial, sans-serif" font-size="10">OpenAI</text>
-  <rect x="200" y="317" width="364" height="14" rx="7" fill="#1c1033" />
-  <rect x="200" y="317" width="315" height="14" rx="7" fill="url(#barGPT)" />
-  <text x="522" y="328" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="11" font-weight="700">76.3%</text>
-  <rect x="600" y="315" width="100" height="18" rx="9" fill="#10b981" fill-opacity="0.2" stroke="#10b981" stroke-width="1" />
-  <text x="650" y="328" fill="#34d399" font-family="Arial, sans-serif" font-size="10" font-weight="600" text-anchor="middle">SWE-Bench</text>
-
-  <!-- Row 3: Gemini - SWE-Bench 76.2% -->
-  <rect x="66" y="362" width="668" height="44" rx="6" fill="#3b82f6" fill-opacity="0.06" />
-  <text x="76" y="387" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13" font-weight="700">Gemini Code Assist</text>
-  <text x="76" y="401" fill="#6b7280" font-family="Arial, sans-serif" font-size="10">Google</text>
-  <rect x="200" y="369" width="364" height="14" rx="7" fill="#1c1033" />
-  <rect x="200" y="369" width="314" height="14" rx="7" fill="url(#barGemini)" />
-  <text x="521" y="380" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11" font-weight="700">76.2%</text>
-  <rect x="600" y="367" width="100" height="18" rx="9" fill="#3b82f6" fill-opacity="0.2" stroke="#3b82f6" stroke-width="1" />
-  <text x="650" y="380" fill="#60a5fa" font-family="Arial, sans-serif" font-size="10" font-weight="600" text-anchor="middle">SWE-Bench</text>
-
-  <!-- Row 4: DeepSeek - HumanEval 90.2% -->
-  <rect x="66" y="414" width="668" height="44" rx="6" fill="#8b5cf6" fill-opacity="0.06" />
-  <text x="76" y="439" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="13" font-weight="700">DeepSeek Coder</text>
-  <text x="76" y="453" fill="#6b7280" font-family="Arial, sans-serif" font-size="10">DeepSeek AI</text>
-  <rect x="200" y="421" width="364" height="14" rx="7" fill="#1c1033" />
-  <rect x="200" y="421" width="354" height="14" rx="7" fill="url(#barDeepSeek)" />
-  <text x="561" y="432" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="11" font-weight="700">90.2%</text>
-  <rect x="600" y="419" width="110" height="18" rx="9" fill="#8b5cf6" fill-opacity="0.2" stroke="#8b5cf6" stroke-width="1" />
-  <text x="655" y="432" fill="#a78bfa" font-family="Arial, sans-serif" font-size="10" font-weight="600" text-anchor="middle">HumanEval</text>
-
-  <!-- Row 5: OpenCode (open source) -->
-  <rect x="66" y="466" width="668" height="36" rx="6" fill="#ec4899" fill-opacity="0.06" />
-  <text x="76" y="487" fill="#f9a8d4" font-family="Arial, sans-serif" font-size="13" font-weight="700">OpenCode</text>
-  <text x="76" y="499" fill="#6b7280" font-family="Arial, sans-serif" font-size="10">Open Source</text>
-  <rect x="200" y="473" width="364" height="14" rx="7" fill="#1c1033" />
-  <rect x="200" y="473" width="220" height="14" rx="7" fill="url(#barOpenCode)" />
-  <text x="428" y="484" fill="#f9a8d4" font-family="Arial, sans-serif" font-size="11" font-weight="700">Community</text>
-  <rect x="600" y="471" width="110" height="18" rx="9" fill="#ec4899" fill-opacity="0.2" stroke="#ec4899" stroke-width="1" />
-  <text x="655" y="484" fill="#f472b6" font-family="Arial, sans-serif" font-size="10" font-weight="600" text-anchor="middle">Open Source</text>
-
-  <!-- Right side info panel -->
-  <rect x="770" y="198" width="380" height="310" rx="14" fill="#0d0824" fill-opacity="0.8" stroke="#2d1b69" stroke-width="1" filter="url(#shadow)" />
-  <text x="960" y="222" fill="#6b7280" font-family="Arial, sans-serif" font-size="11" font-weight="600" letter-spacing="3" text-anchor="middle">KEY METRICS</text>
-
-  <!-- Metric cards right panel -->
-  <!-- Top performer -->
-  <rect x="786" y="232" width="348" height="70" rx="10" fill="#f97316" fill-opacity="0.08" stroke="#f97316" stroke-width="1" />
-  <text x="800" y="256" fill="#fb923c" font-family="Arial, sans-serif" font-size="11" font-weight="700" letter-spacing="1">TOP PERFORMER</text>
-  <text x="800" y="278" fill="#fef3c7" font-family="Arial, sans-serif" font-size="22" font-weight="800">Claude Code</text>
-  <text x="800" y="296" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">SWE-Bench: 80.9% (Anthropic)</text>
-
-  <!-- Best HumanEval -->
-  <rect x="786" y="312" width="348" height="70" rx="10" fill="#8b5cf6" fill-opacity="0.08" stroke="#8b5cf6" stroke-width="1" />
-  <text x="800" y="336" fill="#a78bfa" font-family="Arial, sans-serif" font-size="11" font-weight="700" letter-spacing="1">BEST HUMANEVAL</text>
-  <text x="800" y="358" fill="#ede9fe" font-family="Arial, sans-serif" font-size="22" font-weight="800">DeepSeek Coder</text>
-  <text x="800" y="376" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="13">HumanEval: 90.2% (DeepSeek AI)</text>
-
-  <!-- Open Source pick -->
-  <rect x="786" y="392" width="348" height="56" rx="10" fill="#ec4899" fill-opacity="0.08" stroke="#ec4899" stroke-width="1" />
-  <text x="800" y="416" fill="#f472b6" font-family="Arial, sans-serif" font-size="11" font-weight="700" letter-spacing="1">OPEN SOURCE PICK</text>
-  <text x="800" y="437" fill="#fce7f3" font-family="Arial, sans-serif" font-size="18" font-weight="800">OpenCode  --  Community</text>
-
-  <!-- Year label -->
-  <rect x="786" y="458" width="160" height="34" rx="10" fill="#3b82f6" fill-opacity="0.10" stroke="#3b82f6" stroke-width="1" />
-  <text x="866" y="480" fill="#93c5fd" font-family="Arial, sans-serif" font-size="16" font-weight="800" text-anchor="middle">2025 / 2026</text>
-
-  <rect x="958" y="458" width="176" height="34" rx="10" fill="#10b981" fill-opacity="0.10" stroke="#10b981" stroke-width="1" />
-  <text x="1046" y="480" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle">Reproducible Data</text>
-
-  <!-- Footer separator -->
-  <line x1="50" y1="526" x2="1150" y2="526" stroke="#2d1b69" stroke-width="1" />
-
-  <!-- Footer stats badges -->
-  <rect x="50" y="538" width="130" height="26" rx="13" fill="#a855f7" fill-opacity="0.12" stroke="#a855f7" stroke-width="1" />
-  <text x="115" y="555" fill="#d8b4fe" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">5 Assistants</text>
-
-  <rect x="190" y="538" width="130" height="26" rx="13" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1" />
-  <text x="255" y="555" fill="#fdba74" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">SWE-Bench</text>
-
-  <rect x="330" y="538" width="130" height="26" rx="13" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1" />
-  <text x="395" y="555" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">HumanEval</text>
-
-  <rect x="470" y="538" width="155" height="26" rx="13" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1" />
-  <text x="547" y="555" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Reproducibility</text>
-
-  <!-- Footer right: domain -->
-  <circle cx="1086" cy="551" r="5" fill="#a855f7" fill-opacity="0.7" />
-  <text x="1098" y="555" fill="#475569" font-family="Arial, sans-serif" font-size="12" font-weight="500" text-anchor="start">tech.2twodragon.com</text>
-
-  <!-- Date label -->
-  <text x="50" y="601" fill="#374151" font-family="Arial, sans-serif" font-size="12">Jan 17, 2026</text>
-  <text x="1150" y="601" fill="#4c1d95" font-family="Arial, sans-serif" font-size="12" text-anchor="end" font-weight="600">Twodragon Tech Blog</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : Gemini, Claude Code, ChatGPT, OpenCode -...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Brain/Neural Network -->
+    <g transform="translate(80, 280)">
+      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
+      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
+      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
+      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+    </g>
+    
+    <!-- Robot Head -->
+    <g transform="translate(210, 285)">
+      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
+      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
+      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
+      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
+      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
+    </g>
+    
+    <!-- Chip/Processor -->
+    <g transform="translate(330, 295)">
+      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
+      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
+      <g stroke="#7c3aed" stroke-width="3">
+        <line x1="40" y1="5" x2="40" y2="15"/>
+        <line x1="40" y1="65" x2="40" y2="75"/>
+        <line x1="5" y1="40" x2="15" y2="40"/>
+        <line x1="65" y1="40" x2="75" y2="40"/>
+      </g>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI : Gemini, Claude Code, ChatGPT, OpenCode - 2025-2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">- 2025-2026 AI . Gemini,</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Claude</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="51" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#AI</text>
+      <rect x="63" y="0" width="186" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="156" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Coding-Assistants</text>
+      <rect x="261" y="0" width="87" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="304" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Gemini</text>
+      <rect x="360" y="0" width="132" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Claude-Code</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
+++ b/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
@@ -1,118 +1,198 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f59e0b"/>
-      <stop offset="100%" stop-color="#fbbf24"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0ea5e9"/>
+      <stop offset="100%" style="stop-color:#0284c7"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#f59e0b" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS/GCP 2026 1 : EC2 G7e/X8i , Bangkok , Euro...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Cloud layers -->
-    <ellipse cx="980.0" cy="310.0" rx="70" ry="35" fill="#f59e0b" opacity="0.08"/>
-    <ellipse cx="960.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="1000.0" cy="290.0" rx="50" ry="28" fill="#f59e0b" opacity="0.15"/>
-    <ellipse cx="980.0" cy="270.0" rx="60" ry="30" fill="#f59e0b" opacity="0.20"/>
-    <ellipse cx="980.0" cy="270.0" rx="42" ry="22" fill="#f59e0b" opacity="0.25"/>
-    <!-- Small accent dots -->
-    <circle cx="925.0" cy="330.0" r="6" fill="#f59e0b" opacity="0.3"/>
-    <circle cx="1035.0" cy="330.0" r="4" fill="#f59e0b" opacity="0.2"/>
-    <circle cx="980.0" cy="345.0" r="5" fill="#f59e0b" opacity="0.25"/>
+    <!-- Cloud Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
+            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+    </g>
+    
+    <!-- Server Stack -->
+    <g transform="translate(200, 290)">
+      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
+      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
+      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    </g>
+    
+    <!-- Network Node -->
+    <g transform="translate(330, 300)">
+      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
+      <circle cx="30" cy="30" r="8" fill="white"/>
+      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
+      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#f59e0b"
-        letter-spacing="3" opacity="0.9">CLOUD</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#f59e0b" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">EC2 G7e X8i Bangkok Region</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#f59e0b" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Cloud Security Architecture and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 22, 2026</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">VPC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Network</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">IAM</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Access</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">GuardDuty</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Detection</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#f59e0b" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#f59e0b" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS/GCP 2026 1 : EC2 G7e/X8i , Bangkok , European</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Sovereign - 2026 1 AWS GCP : AWS EC2 G7e NVIDIA Blackwell</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GPU, EC2 X8i</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
+      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#GCP</text>
+      <rect x="144" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#EC2-G7e</text>
+      <rect x="252" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="300" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#EC2-X8i</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
@@ -1,196 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#060e1a"/>
-      <stop offset="50%" stop-color="#071628"/>
-      <stop offset="100%" stop-color="#091c38"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#38bdf8"/>
-      <stop offset="100%" stop-color="#818cf8"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c2a4a" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#061628" stop-opacity="0.95"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0c3040" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#061a28" stop-opacity="0.95"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1a1a4a" stop-opacity="0.9"/>
-      <stop offset="100%" stop-color="#0d0d2e" stop-opacity="0.95"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="badgeGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#0ea5e9"/>
-      <stop offset="100%" stop-color="#6366f1"/>
-    </linearGradient>
-    <filter id="cardShadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#0ea5e9" flood-opacity="0.2"/>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="6" result="blur"/>
-      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Background grid -->
-  <line x1="0" y1="105" x2="1200" y2="105" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="0" y1="315" x2="1200" y2="315" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="0" y1="525" x2="1200" y2="525" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="200" y1="0" x2="200" y2="630" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-  <line x1="1000" y1="0" x2="1000" y2="630" stroke="#0e2a4a" stroke-width="0.5" stroke-opacity="0.5"/>
-
-  <!-- Glow orbs -->
-  <circle cx="150" cy="150" r="180" fill="#0ea5e9" fill-opacity="0.06"/>
-  <circle cx="1050" cy="450" r="160" fill="#6366f1" fill-opacity="0.07"/>
-  <circle cx="600" cy="320" r="200" fill="#38bdf8" fill-opacity="0.04"/>
-
-  <!-- Pipeline flow background decoration -->
-  <line x1="180" y1="90" x2="1020" y2="90" stroke="#0ea5e9" stroke-width="1" stroke-opacity="0.15" stroke-dasharray="8,4"/>
-  <circle cx="180" cy="90" r="5" fill="#0ea5e9" fill-opacity="0.3"/>
-  <circle cx="440" cy="90" r="5" fill="#0ea5e9" fill-opacity="0.3"/>
-  <circle cx="700" cy="90" r="5" fill="#0ea5e9" fill-opacity="0.3"/>
-  <circle cx="960" cy="90" r="5" fill="#0ea5e9" fill-opacity="0.3"/>
-
-  <!-- Top badge -->
-  <rect x="40" y="28" width="240" height="34" rx="17" fill="url(#badgeGrad)"/>
-  <text x="160" y="50" fill="#ffffff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">CLOUD SECURITY COURSE</text>
-
-  <!-- Date badge -->
-  <rect x="980" y="28" width="180" height="34" rx="17" fill="#091838" stroke="#38bdf8" stroke-width="1.5"/>
-  <text x="1070" y="50" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 22, 2026</text>
-
-  <!-- Pipeline icon -->
-  <g transform="translate(40, 78)">
-    <rect x="0" y="10" width="18" height="18" rx="4" fill="none" stroke="#38bdf8" stroke-width="2"/>
-    <line x1="18" y1="19" x2="30" y2="19" stroke="#38bdf8" stroke-width="2" stroke-linecap="round"/>
-    <rect x="30" y="10" width="18" height="18" rx="4" fill="none" stroke="#38bdf8" stroke-width="2"/>
-    <line x1="48" y1="19" x2="60" y2="19" stroke="#38bdf8" stroke-width="2" stroke-linecap="round"/>
-    <rect x="60" y="10" width="18" height="18" rx="4" fill="none" stroke="#818cf8" stroke-width="2"/>
-    <path d="M34 15 L40 19 L34 23" fill="#38bdf8"/>
-    <path d="M64 15 L70 19 L64 23" fill="#818cf8"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Main title -->
-  <text x="130" y="112" fill="url(#titleGrad)" font-family="Arial, sans-serif" font-size="42" font-weight="800" filter="url(#titleGlow)">CI/CD and Kubernetes Security</text>
-
-  <!-- Subtitle -->
-  <text x="130" y="148" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="20" font-weight="500" letter-spacing="3">Batch 8  |  Week 8  |  Practical Guide</text>
-
-  <!-- Divider line -->
-  <rect x="130" y="162" width="940" height="2" rx="1" fill="url(#titleGrad)" opacity="0.5"/>
-
-  <!-- CARD 1: CI/CD Pipeline -->
-  <rect x="60" y="185" width="340" height="310" rx="16" fill="url(#card1Grad)" stroke="#38bdf8" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="60" y="185" width="340" height="4" rx="2" fill="#38bdf8"/>
-
-  <!-- Card 1 icon: pipeline flow -->
-  <g transform="translate(88, 207)">
-    <rect x="0" y="8" width="16" height="16" rx="3" fill="none" stroke="#38bdf8" stroke-width="2"/>
-    <line x1="16" y1="16" x2="24" y2="16" stroke="#38bdf8" stroke-width="2"/>
-    <rect x="24" y="8" width="16" height="16" rx="3" fill="none" stroke="#38bdf8" stroke-width="2"/>
-    <line x1="40" y1="16" x2="48" y2="16" stroke="#38bdf8" stroke-width="2"/>
-    <rect x="48" y="4" width="16" height="24" rx="3" fill="#38bdf8" fill-opacity="0.3" stroke="#38bdf8" stroke-width="2"/>
-    <path d="M52 12 L56 16 L52 20" fill="none" stroke="#38bdf8" stroke-width="1.5" stroke-linecap="round"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <text x="160" y="226" fill="#38bdf8" font-family="Arial, sans-serif" font-size="18" font-weight="700">CI/CD Pipeline</text>
-  <text x="88" y="280" fill="#bae6fd" font-family="Arial, sans-serif" font-size="14" font-weight="600">Build Security</text>
-  <text x="88" y="302" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- SAST / DAST scanning</text>
-  <text x="88" y="320" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Container image scan</text>
-  <text x="88" y="338" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Dependency audit</text>
-  <text x="88" y="364" fill="#bae6fd" font-family="Arial, sans-serif" font-size="14" font-weight="600">Deploy Security</text>
-  <text x="88" y="386" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- IaC security scanning</text>
-  <text x="88" y="404" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Signed image deploy</text>
-  <text x="88" y="422" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="12">- Secrets management</text>
-  <text x="88" y="460" fill="#38bdf8" font-family="Arial, sans-serif" font-size="13" font-weight="700">Pipeline Security</text>
-  <rect x="88" y="468" width="110" height="4" rx="2" fill="#38bdf8" opacity="0.5"/>
-
-  <!-- CARD 2: Kubernetes Security -->
-  <rect x="430" y="185" width="340" height="310" rx="16" fill="url(#card2Grad)" stroke="#22d3ee" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="430" y="185" width="340" height="4" rx="2" fill="#22d3ee"/>
-
-  <!-- Card 2 icon: kubernetes wheel -->
-  <g transform="translate(458, 205)">
-    <circle cx="22" cy="22" r="20" fill="none" stroke="#22d3ee" stroke-width="2"/>
-    <circle cx="22" cy="22" r="6" fill="none" stroke="#22d3ee" stroke-width="2"/>
-    <line x1="22" y1="2" x2="22" y2="16" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="22" y1="28" x2="22" y2="42" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="4" y1="12" x2="15" y2="18" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="29" y1="26" x2="40" y2="32" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="40" y1="12" x2="29" y2="18" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
-    <line x1="15" y1="26" x2="4" y2="32" stroke="#22d3ee" stroke-width="2.5" stroke-linecap="round"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 8 : CI/CD Kubernetes - DevSecOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <text x="520" y="226" fill="#22d3ee" font-family="Arial, sans-serif" font-size="18" font-weight="700">Kubernetes Security</text>
-  <text x="458" y="280" fill="#a5f3fc" font-family="Arial, sans-serif" font-size="14" font-weight="600">Runtime Controls</text>
-  <text x="458" y="302" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- Pod Security Admission</text>
-  <text x="458" y="320" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- RBAC configuration</text>
-  <text x="458" y="338" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- Network policy rules</text>
-  <text x="458" y="364" fill="#a5f3fc" font-family="Arial, sans-serif" font-size="14" font-weight="600">Threat Response</text>
-  <text x="458" y="386" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- Falco runtime monitor</text>
-  <text x="458" y="404" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- Audit log analysis</text>
-  <text x="458" y="422" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12">- Incident response SOP</text>
-  <text x="458" y="460" fill="#22d3ee" font-family="Arial, sans-serif" font-size="13" font-weight="700">Runtime Security</text>
-  <rect x="458" y="468" width="110" height="4" rx="2" fill="#22d3ee" opacity="0.5"/>
-
-  <!-- CARD 3: DevSecOps -->
-  <rect x="800" y="185" width="340" height="310" rx="16" fill="url(#card3Grad)" stroke="#818cf8" stroke-width="1.5" filter="url(#cardShadow)"/>
-  <rect x="800" y="185" width="340" height="4" rx="2" fill="#818cf8"/>
-
-  <!-- Card 3 icon: infinity loop / DevOps -->
-  <g transform="translate(828, 205)">
-    <path d="M10 22 Q10 6 22 6 Q34 6 34 22 Q34 38 46 38 Q58 38 58 22 Q58 6 46 6 Q34 6 34 22 Q34 38 22 38 Q10 38 10 22 Z" fill="none" stroke="#818cf8" stroke-width="2.5"/>
-    <circle cx="22" cy="22" r="4" fill="#818cf8"/>
-    <circle cx="46" cy="22" r="4" fill="#818cf8"/>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 8 : CI/CD (Trivy, Snyk, Vault), Kubernetes</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CI/CD</text>
+      <rect x="90" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="151" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
+      <rect x="225" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="351" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="421" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#K8s-Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <text x="904" y="226" fill="#818cf8" font-family="Arial, sans-serif" font-size="18" font-weight="700">DevSecOps</text>
-  <text x="828" y="280" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Integration Points</text>
-  <text x="828" y="302" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Shift-left security</text>
-  <text x="828" y="320" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Pre-commit hooks</text>
-  <text x="828" y="338" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Policy as code</text>
-  <text x="828" y="364" fill="#e0e7ff" font-family="Arial, sans-serif" font-size="14" font-weight="600">Toolchain</text>
-  <text x="828" y="386" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- Trivy / Snyk scanning</text>
-  <text x="828" y="404" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- OPA / Kyverno policy</text>
-  <text x="828" y="422" fill="#c7d2fe" font-family="Arial, sans-serif" font-size="12">- ArgoCD GitOps deploy</text>
-  <text x="828" y="460" fill="#818cf8" font-family="Arial, sans-serif" font-size="13" font-weight="700">Security Integration</text>
-  <rect x="828" y="468" width="120" height="4" rx="2" fill="#818cf8" opacity="0.5"/>
-
-  <!-- Footer bar -->
-  <rect x="0" y="516" width="1200" height="114" fill="#040810" fill-opacity="0.95"/>
-  <rect x="0" y="516" width="1200" height="2" fill="url(#titleGrad)" opacity="0.6"/>
-
-  <!-- Footer keywords -->
-  <g transform="translate(60, 545)">
-    <rect x="0" y="0" width="72" height="26" rx="13" fill="#0c2a4a" stroke="#38bdf8" stroke-width="1"/>
-    <text x="36" y="17" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">CI/CD</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(146, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#0c3040" stroke="#22d3ee" stroke-width="1"/>
-    <text x="54" y="17" fill="#22d3ee" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Kubernetes</text>
-  </g>
-  <g transform="translate(268, 545)">
-    <rect x="0" y="0" width="108" height="26" rx="13" fill="#1a1a4a" stroke="#818cf8" stroke-width="1"/>
-    <text x="54" y="17" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">DevSecOps</text>
-  </g>
-  <g transform="translate(390, 545)">
-    <rect x="0" y="0" width="140" height="26" rx="13" fill="#0c2a4a" stroke="#38bdf8" stroke-width="1"/>
-    <text x="70" y="17" fill="#38bdf8" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Pipeline Security</text>
-  </g>
-
-  <!-- Footer site -->
-  <text x="1140" y="558" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="end">tech.2twodragon.com</text>
-
-  <!-- Footer description -->
-  <text x="60" y="598" fill="#1e3a5a" font-family="Arial, sans-serif" font-size="13">Practical CI/CD pipeline security and Kubernetes runtime protection for cloud security course Batch 8, Week 8 practical training</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
@@ -1,192 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#050e1f"/>
-      <stop offset="50%" stop-color="#071828"/>
-      <stop offset="100%" stop-color="#0a1f3a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#06b6d4"/>
-      <stop offset="100%" stop-color="#3b82f6"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e2a45"/>
-      <stop offset="100%" stop-color="#071a2e"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e2a45"/>
-      <stop offset="100%" stop-color="#071a2e"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3Grad" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0e2a45"/>
-      <stop offset="100%" stop-color="#071a2e"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="statGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#06b6d4"/>
-      <stop offset="100%" stop-color="#3b82f6"/>
-    </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.5"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="6" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Subtle grid lines -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#0d2540" stroke-width="1" opacity="0.5"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#0d2540" stroke-width="1" opacity="0.5"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#0d2540" stroke-width="1" opacity="0.3"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#0d2540" stroke-width="1" opacity="0.3"/>
-
-  <!-- Decorative circles background -->
-  <circle cx="1100" cy="80" r="120" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.07"/>
-  <circle cx="1100" cy="80" r="80" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.07"/>
-  <circle cx="100" cy="560" r="100" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.07"/>
-
-  <!-- Top badge -->
-  <rect x="60" y="30" width="230" height="34" rx="17" fill="url(#accentGrad)" filter="url(#shadow)"/>
-  <text x="175" y="52" fill="#fff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">SECURITY TRENDS 2026</text>
-
-  <!-- Date badge -->
-  <rect x="1030" y="30" width="120" height="34" rx="17" fill="#0e2a45" stroke="#1e4a70" stroke-width="1"/>
-  <text x="1090" y="52" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 22, 2026</text>
-
-  <!-- Main title -->
-  <text x="60" y="115" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Cloud Security Trends</text>
-  <text x="60" y="165" fill="url(#accentGrad)" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">January 2026</text>
-
-  <!-- Subtitle pills -->
-  <rect x="60" y="185" width="130" height="26" rx="13" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="125" y="202" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Kubernetes</text>
-  <rect x="200" y="185" width="120" height="26" rx="13" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="260" y="202" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">VS Code</text>
-  <rect x="330" y="185" width="145" height="26" rx="13" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="402" y="202" fill="#67e8f9" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">CNCF Survey</text>
-
-  <!-- Accent line -->
-  <rect x="60" y="225" width="480" height="3" rx="2" fill="url(#accentGrad)" opacity="0.7"/>
-
-  <!-- Card 1: Kubernetes 82% Production -->
-  <rect x="60" y="248" width="340" height="290" rx="16" fill="url(#card1Grad)" stroke="#1a4a6e" stroke-width="1.5" filter="url(#shadow)"/>
-  <!-- Card 1 top accent -->
-  <rect x="60" y="248" width="340" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Kubernetes icon: hexagon -->
-  <polygon points="130,285 150,274 170,285 170,307 150,318 130,307" fill="none" stroke="#06b6d4" stroke-width="2.5" filter="url(#glow)"/>
-  <text x="150" y="300" fill="#06b6d4" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">K8s</text>
-
-  <text x="190" y="290" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="15" font-weight="700">Kubernetes</text>
-  <text x="190" y="308" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Production Adoption</text>
-
-  <!-- Big stat -->
-  <text x="230" y="380" fill="url(#statGrad)" font-family="Arial, sans-serif" font-size="72" font-weight="900" text-anchor="middle" filter="url(#titleGlow)">82%</text>
-  <text x="230" y="405" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="13" text-anchor="middle">of enterprises in production</text>
-
-  <!-- Progress bar -->
-  <rect x="90" y="422" width="280" height="8" rx="4" fill="#0a1f3a"/>
-  <rect x="90" y="422" width="230" height="8" rx="4" fill="url(#accentGrad)"/>
-
-  <text x="90" y="450" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Security remains top challenge</text>
-  <text x="90" y="468" fill="#64748b" font-family="Arial, sans-serif" font-size="11">CNCF Annual Survey 2025</text>
-
-  <!-- Bullet points -->
-  <circle cx="97" cy="492" r="3" fill="#06b6d4"/>
-  <text x="108" y="496" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Runtime security controls</text>
-  <circle cx="97" cy="514" r="3" fill="#06b6d4"/>
-  <text x="108" y="518" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">RBAC policy enforcement</text>
-
-  <!-- Card 2: VS Code Threats -->
-  <rect x="430" y="248" width="340" height="290" rx="16" fill="url(#card2Grad)" stroke="#1e3a6e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="248" width="340" height="4" rx="2" fill="#3b82f6"/>
-
-  <!-- VS Code icon: code brackets -->
-  <text x="500" y="302" fill="#3b82f6" font-family="Arial, sans-serif" font-size="28" font-weight="700" filter="url(#glow)">&lt;/&gt;</text>
-
-  <text x="540" y="290" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="15" font-weight="700">VS Code Threats</text>
-  <text x="540" y="308" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Extension Security</text>
-
-  <!-- Threat items -->
-  <rect x="455" y="328" width="290" height="44" rx="8" fill="#0a1f3a" stroke="#1e3a6e" stroke-width="1"/>
-  <rect x="455" y="328" width="4" height="44" rx="2" fill="#ef4444"/>
-  <text x="470" y="346" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600">Malicious Extensions</text>
-  <text x="470" y="362" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Supply chain compromise vector</text>
-
-  <rect x="455" y="382" width="290" height="44" rx="8" fill="#0a1f3a" stroke="#1e3a6e" stroke-width="1"/>
-  <rect x="455" y="382" width="4" height="44" rx="2" fill="#f59e0b"/>
-  <text x="470" y="400" fill="#fcd34d" font-family="Arial, sans-serif" font-size="13" font-weight="600">Remote Code Execution</text>
-  <text x="470" y="416" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Workspace trust bypass</text>
-
-  <rect x="455" y="436" width="290" height="44" rx="8" fill="#0a1f3a" stroke="#1e3a6e" stroke-width="1"/>
-  <rect x="455" y="436" width="4" height="44" rx="2" fill="#3b82f6"/>
-  <text x="470" y="454" fill="#93c5fd" font-family="Arial, sans-serif" font-size="13" font-weight="600">Credential Exfiltration</text>
-  <text x="470" y="470" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Dev environment targeting</text>
-
-  <text x="455" y="508" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Recommendation: audit installed extensions</text>
-  <text x="455" y="524" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Enable extension verification</text>
-
-  <!-- Card 3: CNCF Survey Results -->
-  <rect x="800" y="248" width="340" height="290" rx="16" fill="url(#card3Grad)" stroke="#1a4a6e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="248" width="340" height="4" rx="2" fill="url(#accentGrad)"/>
-
-  <!-- Survey icon: chart bars -->
-  <rect x="830" y="282" width="14" height="30" rx="2" fill="#06b6d4" opacity="0.8"/>
-  <rect x="850" y="274" width="14" height="38" rx="2" fill="#3b82f6" opacity="0.9"/>
-  <rect x="870" y="268" width="14" height="44" rx="2" fill="#06b6d4"/>
-
-  <text x="900" y="290" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="15" font-weight="700">CNCF Survey Results</text>
-  <text x="900" y="308" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Cloud Native Landscape</text>
-
-  <!-- Survey stats -->
-  <text x="825" y="350" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Container Adoption</text>
-  <rect x="825" y="358" width="290" height="10" rx="5" fill="#0a1f3a"/>
-  <rect x="825" y="358" width="261" height="10" rx="5" fill="url(#accentGrad)"/>
-  <text x="1120" y="368" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" text-anchor="end">90%</text>
-
-  <text x="825" y="390" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Security Automation</text>
-  <rect x="825" y="398" width="290" height="10" rx="5" fill="#0a1f3a"/>
-  <rect x="825" y="398" width="202" height="10" rx="5" fill="#3b82f6"/>
-  <text x="1120" y="408" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" text-anchor="end">70%</text>
-
-  <text x="825" y="430" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Multi-cloud Strategy</text>
-  <rect x="825" y="438" width="290" height="10" rx="5" fill="#0a1f3a"/>
-  <rect x="825" y="438" width="174" height="10" rx="5" fill="#06b6d4"/>
-  <text x="1120" y="448" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" text-anchor="end">60%</text>
-
-  <text x="825" y="470" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Service Mesh Usage</text>
-  <rect x="825" y="478" width="290" height="10" rx="5" fill="#0a1f3a"/>
-  <rect x="825" y="478" width="130" height="10" rx="5" fill="#0ea5e9"/>
-  <text x="1120" y="488" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" text-anchor="end">45%</text>
-
-  <circle cx="830" cy="512" r="3" fill="#06b6d4"/>
-  <text x="840" y="516" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">1,200+ respondents worldwide</text>
-  <circle cx="830" cy="530" r="3" fill="#3b82f6"/>
-  <text x="840" y="534" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Security top concern 3 years running</text>
-
-  <!-- Footer bar -->
-  <rect x="0" y="570" width="1200" height="60" fill="#030c18" opacity="0.9"/>
-  <rect x="0" y="570" width="1200" height="2" fill="url(#accentGrad)" opacity="0.5"/>
-
-  <!-- Footer tags -->
-  <rect x="60" y="585" width="140" height="24" rx="12" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="130" y="601" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Kubernetes 82%</text>
-
-  <rect x="212" y="585" width="130" height="24" rx="12" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="277" y="601" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">VS Code Threats</text>
-
-  <rect x="354" y="585" width="120" height="24" rx="12" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="414" y="601" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">CNCF Survey</text>
-
-  <rect x="486" y="585" width="120" height="24" rx="12" fill="#0c2236" stroke="#1a4a6e" stroke-width="1"/>
-  <text x="546" y="601" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Cloud Native</text>
-
-  <text x="1140" y="601" fill="#3b82f6" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="end">tech.2twodragon.com</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 1 : Kubernetes 82 , VS Code , CNCF</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 1 . CNCF Kubernetes 82 , VS Code</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
+      <rect x="135" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="306" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CNCF</text>
+      <rect x="387" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VS-Code-Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
+++ b/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
@@ -1,119 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#dc2626"/>
-      <stop offset="100%" stop-color="#ef4444"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#dc2626" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#dc2626" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#dc2626" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2025 3 : KARA</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <!-- Warning triangle -->
-    <polygon points="980.0,210.0 910.0,330.0 1050.0,330.0"
-             fill="none" stroke="#dc2626" stroke-width="4" opacity="0.25"/>
-    <polygon points="980.0,235.0 930.0,320.0 1030.0,320.0"
-             fill="#dc2626" opacity="0.12"/>
-    <text x="980.0" y="300.0" text-anchor="middle" font-size="42"
-          font-family="monospace" fill="#dc2626" opacity="0.7">!</text>
-    <!-- Crosshair circles -->
-    <circle cx="1060.0" cy="250.0" r="22" fill="none" stroke="#dc2626" stroke-width="2" opacity="0.3"/>
-    <line x1="1038.0" y1="250.0" x2="1082.0" y2="250.0" stroke="#dc2626" stroke-width="1.5" opacity="0.4"/>
-    <line x1="1060.0" y1="228.0" x2="1060.0" y2="272.0" stroke="#dc2626" stroke-width="1.5" opacity="0.4"/>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
     
   </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#dc2626"
-        letter-spacing="3" opacity="0.9">THREAT INTEL</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#dc2626" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">SK Shieldus EQST Analysis</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="296" width="300" height="4" rx="2" fill="#dc2626" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="328"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Threat Intelligence and Attack Analysis</text>
-
-  <!-- Date -->
-  <text x="60" y="362"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 22, 2026</text>
-
-  <!-- Stat cards -->
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#dc2626" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#dc2626">IOC</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Feeds</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">TTPs</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">MITRE</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">YARA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Rules</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#dc2626" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#dc2626" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#dc2626" opacity="0.25"/>
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SK EQST insight 2025 3 . KARA (LockBit</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">5.0,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
+      <rect x="135" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="169" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KARA</text>
+      <rect x="216" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SK-Shieldus</text>
+      <rect x="360" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LockBit</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
+++ b/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
@@ -1,214 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#0f0508"/>
-      <stop offset="50%" stop-color="#1a0808"/>
-      <stop offset="100%" stop-color="#1f0d05"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentRed" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#f97316"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="card1G" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a0a0a"/>
-      <stop offset="100%" stop-color="#1a0505"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2G" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#2a1a0a"/>
-      <stop offset="100%" stop-color="#1a0e05"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3G" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a1a2a"/>
-      <stop offset="100%" stop-color="#05101a"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <filter id="redGlow">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="10" flood-color="#000" flood-opacity="0.6"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="5" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Grid -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#2a0808" stroke-width="1" opacity="0.6"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#2a0808" stroke-width="1" opacity="0.6"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#2a0808" stroke-width="1" opacity="0.3"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#2a0808" stroke-width="1" opacity="0.3"/>
-
-  <!-- Decorative circles -->
-  <circle cx="1100" cy="80" r="130" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.06"/>
-  <circle cx="1100" cy="80" r="85" fill="none" stroke="#f97316" stroke-width="1" opacity="0.06"/>
-  <circle cx="80" cy="560" r="110" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.06"/>
-
-  <!-- Top badge: KISA -->
-  <rect x="60" y="30" width="175" height="34" rx="17" fill="url(#accentRed)" filter="url(#shadow)"/>
-  <text x="147" y="52" fill="#fff" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle" letter-spacing="2">KISA ADVISORY</text>
-
-  <!-- Date badge -->
-  <rect x="1030" y="30" width="120" height="34" rx="17" fill="#2a0808" stroke="#4a1010" stroke-width="1"/>
-  <text x="1090" y="52" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Jan 22, 2026</text>
-
-  <!-- Warning triangle icon -->
-  <polygon points="1130,38 1155,82 1105,82" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.3" filter="url(#redGlow)"/>
-  <text x="1130" y="72" fill="#ef4444" font-family="Arial, sans-serif" font-size="18" font-weight="900" text-anchor="middle" opacity="0.3">!</text>
-
-  <!-- Main title -->
-  <text x="60" y="115" fill="#fff1f2" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">KISA Security Advisory</text>
-  <text x="60" y="165" fill="url(#accentRed)" font-family="Arial, sans-serif" font-size="32" font-weight="700" filter="url(#titleGlow)">Ransomware Prevention | Linux Rootkit Detection</text>
-
-  <!-- Subtitle pills -->
-  <rect x="60" y="185" width="150" height="26" rx="13" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="135" y="202" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Ransomware</text>
-  <rect x="222" y="185" width="145" height="26" rx="13" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="294" y="202" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Linux Rootkit</text>
-  <rect x="379" y="185" width="155" height="26" rx="13" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="456" y="202" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Incident Response</text>
-
-  <!-- Accent line -->
-  <rect x="60" y="225" width="520" height="3" rx="2" fill="url(#accentRed)" opacity="0.7"/>
-
-  <!-- Card 1: Ransomware -->
-  <rect x="60" y="248" width="340" height="290" rx="16" fill="url(#card1G)" stroke="#5a1515" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="248" width="340" height="4" rx="2" fill="url(#accentRed)"/>
-
-  <!-- Skull/threat icon -->
-  <circle cx="120" cy="295" r="22" fill="none" stroke="#ef4444" stroke-width="2" filter="url(#redGlow)"/>
-  <circle cx="113" cy="291" r="3" fill="#ef4444"/>
-  <circle cx="127" cy="291" r="3" fill="#ef4444"/>
-  <rect x="113" y="300" width="14" height="3" rx="1" fill="#ef4444"/>
-
-  <text x="155" y="288" fill="#fee2e2" font-family="Arial, sans-serif" font-size="15" font-weight="700">Ransomware</text>
-  <text x="155" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Threat and Defense</text>
-
-  <!-- Attack chain -->
-  <text x="85" y="342" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="700">ATTACK CHAIN</text>
-
-  <rect x="85" y="352" width="290" height="36" rx="6" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="85" y="352" width="4" height="36" rx="2" fill="#ef4444"/>
-  <text x="100" y="368" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600">Phishing Email</text>
-  <text x="100" y="382" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Initial access vector</text>
-
-  <text x="230" y="395" fill="#ef4444" font-family="Arial, sans-serif" font-size="14" text-anchor="middle">v</text>
-
-  <rect x="85" y="398" width="290" height="36" rx="6" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="85" y="398" width="4" height="36" rx="2" fill="#f97316"/>
-  <text x="100" y="414" fill="#fdba74" font-family="Arial, sans-serif" font-size="12" font-weight="600">Lateral Movement</text>
-  <text x="100" y="428" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Credential theft and escalation</text>
-
-  <text x="230" y="441" fill="#f97316" font-family="Arial, sans-serif" font-size="14" text-anchor="middle">v</text>
-
-  <rect x="85" y="444" width="290" height="36" rx="6" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="85" y="444" width="4" height="36" rx="2" fill="#dc2626"/>
-  <text x="100" y="460" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600">Data Encryption</text>
-  <text x="100" y="474" fill="#64748b" font-family="Arial, sans-serif" font-size="10">AES-256 file encryption</text>
-
-  <circle cx="90" cy="506" r="3" fill="#f97316"/>
-  <text x="101" y="510" fill="#94a3b8" font-family="Arial, sans-serif" font-size="11">Offline backup essential</text>
-  <circle cx="90" cy="524" r="3" fill="#f97316"/>
-  <text x="101" y="528" fill="#94a3b8" font-family="Arial, sans-serif" font-size="11">Email filtering and MFA required</text>
-
-  <!-- Card 2: Linux Rootkit -->
-  <rect x="430" y="248" width="340" height="290" rx="16" fill="url(#card2G)" stroke="#5a3015" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="248" width="340" height="4" rx="2" fill="#f97316"/>
-
-  <!-- Terminal icon -->
-  <rect x="455" y="272" width="44" height="36" rx="4" fill="none" stroke="#f97316" stroke-width="2" filter="url(#redGlow)"/>
-  <text x="477" y="293" fill="#f97316" font-family="Arial, sans-serif" font-size="11" font-weight="700" text-anchor="middle">root</text>
-  <text x="477" y="304" fill="#f97316" font-family="Arial, sans-serif" font-size="9" text-anchor="middle">$_</text>
-
-  <text x="510" y="288" fill="#fee2e2" font-family="Arial, sans-serif" font-size="15" font-weight="700">Linux Rootkit</text>
-  <text x="510" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Detection Techniques</text>
-
-  <!-- Detection methods -->
-  <text x="455" y="338" fill="#f97316" font-family="Arial, sans-serif" font-size="12" font-weight="700">DETECTION METHODS</text>
-
-  <rect x="455" y="348" width="290" height="38" rx="6" fill="#1a0e05" stroke="#5a3015" stroke-width="1"/>
-  <circle cx="470" cy="367" r="6" fill="#f97316"/>
-  <text x="484" y="363" fill="#fdba74" font-family="Arial, sans-serif" font-size="12" font-weight="600">Integrity Checking</text>
-  <text x="484" y="377" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Tripwire, AIDE, chkrootkit</text>
-
-  <rect x="455" y="396" width="290" height="38" rx="6" fill="#1a0e05" stroke="#5a3015" stroke-width="1"/>
-  <circle cx="470" cy="415" r="6" fill="#fb923c"/>
-  <text x="484" y="411" fill="#fdba74" font-family="Arial, sans-serif" font-size="12" font-weight="600">Kernel Module Analysis</text>
-  <text x="484" y="425" fill="#64748b" font-family="Arial, sans-serif" font-size="10">lsmod and /proc inspection</text>
-
-  <rect x="455" y="444" width="290" height="38" rx="6" fill="#1a0e05" stroke="#5a3015" stroke-width="1"/>
-  <circle cx="470" cy="463" r="6" fill="#fbbf24"/>
-  <text x="484" y="459" fill="#fdba74" font-family="Arial, sans-serif" font-size="12" font-weight="600">Network Anomaly Detection</text>
-  <text x="484" y="473" fill="#64748b" font-family="Arial, sans-serif" font-size="10">ss, netstat hidden connections</text>
-
-  <circle cx="460" cy="500" r="3" fill="#f97316"/>
-  <text x="471" y="504" fill="#94a3b8" font-family="Arial, sans-serif" font-size="11">Syscall hooking indicators</text>
-  <circle cx="460" cy="520" r="3" fill="#f97316"/>
-  <text x="471" y="524" fill="#94a3b8" font-family="Arial, sans-serif" font-size="11">Bootloader verification (Secure Boot)</text>
-
-  <!-- Card 3: Incident Response -->
-  <rect x="800" y="248" width="340" height="290" rx="16" fill="url(#card3G)" stroke="#1e3a6e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="248" width="340" height="4" rx="2" fill="#3b82f6"/>
-
-  <!-- Shield icon -->
-  <path d="M838,272 L862,272 L862,296 L850,308 L838,296 Z" fill="none" stroke="#3b82f6" stroke-width="2.5" filter="url(#redGlow)"/>
-  <text x="850" y="294" fill="#3b82f6" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="middle">IR</text>
-
-  <text x="880" y="288" fill="#fee2e2" font-family="Arial, sans-serif" font-size="15" font-weight="700">Incident Response</text>
-  <text x="880" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">KISA Guidelines</text>
-
-  <!-- Response steps timeline -->
-  <text x="825" y="338" fill="#3b82f6" font-family="Arial, sans-serif" font-size="12" font-weight="700">RESPONSE PHASES</text>
-
-  <!-- Step 1 -->
-  <circle cx="835" cy="360" r="10" fill="#1e3a5f" stroke="#3b82f6" stroke-width="2"/>
-  <text x="835" y="364" fill="#3b82f6" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">1</text>
-  <text x="853" y="358" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12" font-weight="600">Isolation</text>
-  <text x="853" y="372" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Network segment isolation</text>
-  <line x1="835" y1="370" x2="835" y2="390" stroke="#1e3a6e" stroke-width="1.5" stroke-dasharray="3,2"/>
-
-  <!-- Step 2 -->
-  <circle cx="835" cy="400" r="10" fill="#1e3a5f" stroke="#3b82f6" stroke-width="2"/>
-  <text x="835" y="404" fill="#3b82f6" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">2</text>
-  <text x="853" y="398" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12" font-weight="600">Evidence Collection</text>
-  <text x="853" y="412" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Forensic imaging and logs</text>
-  <line x1="835" y1="410" x2="835" y2="430" stroke="#1e3a6e" stroke-width="1.5" stroke-dasharray="3,2"/>
-
-  <!-- Step 3 -->
-  <circle cx="835" cy="440" r="10" fill="#1e3a5f" stroke="#3b82f6" stroke-width="2"/>
-  <text x="835" y="444" fill="#3b82f6" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">3</text>
-  <text x="853" y="438" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12" font-weight="600">Eradication</text>
-  <text x="853" y="452" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Clean OS reinstall and patch</text>
-  <line x1="835" y1="450" x2="835" y2="470" stroke="#1e3a6e" stroke-width="1.5" stroke-dasharray="3,2"/>
-
-  <!-- Step 4 -->
-  <circle cx="835" cy="480" r="10" fill="#1e3a5f" stroke="#60a5fa" stroke-width="2"/>
-  <text x="835" y="484" fill="#60a5fa" font-family="Arial, sans-serif" font-size="10" font-weight="700" text-anchor="middle">4</text>
-  <text x="853" y="478" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12" font-weight="600">Recovery</text>
-  <text x="853" y="492" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Restore from verified backup</text>
-
-  <text x="825" y="518" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Report to KISA within 24 hours</text>
-  <text x="825" y="533" fill="#64748b" font-family="Arial, sans-serif" font-size="11">KISA hotline: 118</text>
-
-  <!-- Footer -->
-  <rect x="0" y="570" width="1200" height="60" fill="#060003" opacity="0.95"/>
-  <rect x="0" y="570" width="1200" height="2" fill="url(#accentRed)" opacity="0.5"/>
-
-  <rect x="60" y="585" width="115" height="24" rx="12" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="117" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Ransomware</text>
-
-  <rect x="187" y="585" width="120" height="24" rx="12" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="247" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Linux Rootkit</text>
-
-  <rect x="319" y="585" width="105" height="24" rx="12" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="371" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Detection</text>
-
-  <rect x="436" y="585" width="75" height="24" rx="12" fill="#2a0808" stroke="#5a1515" stroke-width="1"/>
-  <text x="473" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">KISA</text>
-
-  <text x="1140" y="601" fill="#ef4444" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="end">tech.2twodragon.com</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kisa Security Advisory Ransomware Prevention ...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">KISA : 3-2-1 , (chkrootkit,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="34" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KISA</text>
+      <rect x="81" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
+      <rect x="216" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Linux-Rootkit</text>
+      <rect x="378" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Advisory</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
+++ b/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
@@ -1,122 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M90 120 L30 120 C13 120 0 107 0 90 C0 75 10 63 24 60 C24 35 45 15 70 15 C92 15 110 30 115 50 C128 52 138 63 138 78 C138 95 125 108 108 108" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M50 75 L65 90 L90 60" fill="none" stroke="#94a3b8" stroke-width="3"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">(2026 01 22 )</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Security Vendor</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Blog Weekly Review</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: VS Code , ACME , AI Zero Trust NHI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="97" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Vendor...</text>
+      <rect x="207" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="333" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="412" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="504" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="561" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Hashicorp</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 22, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ff9900" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AWS</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AWS</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="127" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="180" y="0" width="57" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="208" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">AWS</text>
-    <rect x="252" y="0" width="111" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="307" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="124" cy="77" r="3" fill="#f87171"/>
-    <circle cx="141" cy="141" r="4" fill="#fb923c"/>
-    <circle cx="93" cy="157" r="5" fill="#818cf8"/>
-    <circle cx="62" cy="161" r="6" fill="#34d399"/>
-    <circle cx="59" cy="62" r="3" fill="#fbbf24"/>
-    <circle cx="208" cy="88" r="4" fill="#f87171"/>
-    <circle cx="177" cy="144" r="5" fill="#fb923c"/>
-    <circle cx="98" cy="208" r="6" fill="#818cf8"/>
-    <circle cx="138" cy="124" r="3" fill="#34d399"/>
-    <circle cx="43" cy="103" r="4" fill="#fbbf24"/>
-    <line x1="124" y1="77" x2="141" y2="141" stroke="#475569" stroke-width="1"/>
-    <line x1="141" y1="141" x2="93" y2="157" stroke="#475569" stroke-width="1"/>
-    <line x1="93" y1="157" x2="62" y2="161" stroke="#475569" stroke-width="1"/>
-    <line x1="62" y1="161" x2="59" y2="62" stroke="#475569" stroke-width="1"/>
-    <line x1="59" y1="62" x2="208" y2="88" stroke="#475569" stroke-width="1"/>
-    <line x1="208" y1="88" x2="177" y2="144" stroke="#475569" stroke-width="1"/>
-    <line x1="177" y1="144" x2="98" y2="208" stroke="#475569" stroke-width="1"/>
-    <line x1="98" y1="208" x2="138" y2="124" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | Cloud | AWS | DevSecOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
@@ -1,124 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <rect x="5" y="30" width="110" height="80" rx="6" fill="url(#accent)" opacity="0.2" stroke="#6366f1" stroke-width="2"/>
-    <polyline points="5,30 60,80 115,30" fill="none" stroke="#fecaca" stroke-width="2"/>
-    <line x1="5" y1="110" x2="40" y2="75" stroke="#6366f1" stroke-width="1.5" opacity="0.5"/>
-    <line x1="115" y1="110" x2="80" y2="75" stroke="#6366f1" stroke-width="1.5" opacity="0.5"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#ef4444" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#ef4444" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft AitM , Agentic AI Zero Trust, Ope...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest Microsoft AitM</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="32" font-weight="300">Phishing Agentic AI Zero Trust OpenAI PostgreSQL</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft AitM , Agentic AI Zero Trust, - 2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 23 / : Microsoft AitM , HashiCorp Agentic AI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="255" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AitM-Phishing</text>
+      <rect x="342" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#BEC</text>
+      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 23, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#f87171" font-family="Arial, sans-serif" font-size="12" font-weight="bold">PHISHING</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Phishing</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="102" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="51" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Phishing</text>
-    <rect x="117" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="154" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="207" y="0" width="57" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="235" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="279" y="0" width="102" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="330" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">AI Agent</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="218" cy="224" r="3" fill="#f87171"/>
-    <circle cx="228" cy="228" r="4" fill="#fb923c"/>
-    <circle cx="79" cy="129" r="5" fill="#818cf8"/>
-    <circle cx="61" cy="154" r="6" fill="#34d399"/>
-    <circle cx="133" cy="61" r="3" fill="#fbbf24"/>
-    <circle cx="167" cy="37" r="4" fill="#f87171"/>
-    <circle cx="197" cy="181" r="5" fill="#fb923c"/>
-    <circle cx="100" cy="167" r="6" fill="#818cf8"/>
-    <circle cx="138" cy="164" r="3" fill="#34d399"/>
-    <circle cx="43" cy="113" r="4" fill="#fbbf24"/>
-    <line x1="218" y1="224" x2="228" y2="228" stroke="#475569" stroke-width="1"/>
-    <line x1="228" y1="228" x2="79" y2="129" stroke="#475569" stroke-width="1"/>
-    <line x1="79" y1="129" x2="61" y2="154" stroke="#475569" stroke-width="1"/>
-    <line x1="61" y1="154" x2="133" y2="61" stroke="#475569" stroke-width="1"/>
-    <line x1="133" y1="61" x2="167" y2="37" stroke="#475569" stroke-width="1"/>
-    <line x1="167" y1="37" x2="197" y2="181" stroke="#475569" stroke-width="1"/>
-    <line x1="197" y1="181" x2="100" y2="167" stroke="#475569" stroke-width="1"/>
-    <line x1="100" y1="167" x2="138" y2="164" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">13 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Phishing | AI/ML | LLM | AI Agent</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
@@ -1,125 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft BitLocker FBI , Cloudflare Route ...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest BitLocker FBI</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="32" font-weight="300">Cloudflare Route Leak Agentic Enterprise Docker</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft BitLocker FBI , Cloudflare Route - 2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 24 / : Microsoft FBI BitLocker</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#BitLocker</text>
+      <rect x="306" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#FBI</text>
+      <rect x="378" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Encryption</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 24, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#a78bfa" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI AGENT</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI Agent</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">OPENAI</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">OpenAI</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="102" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="141" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI Agent</text>
-    <rect x="207" y="0" width="84" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="249" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">OpenAI</text>
-    <rect x="306" y="0" width="84" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="348" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Docker</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="223" cy="226" r="3" fill="#f87171"/>
-    <circle cx="79" cy="79" r="4" fill="#fb923c"/>
-    <circle cx="36" cy="42" r="5" fill="#818cf8"/>
-    <circle cx="80" cy="33" r="6" fill="#34d399"/>
-    <circle cx="136" cy="80" r="3" fill="#fbbf24"/>
-    <circle cx="143" cy="42" r="4" fill="#f87171"/>
-    <circle cx="119" cy="83" r="5" fill="#fb923c"/>
-    <circle cx="41" cy="143" r="6" fill="#818cf8"/>
-    <circle cx="81" cy="208" r="3" fill="#34d399"/>
-    <circle cx="36" cy="74" r="4" fill="#fbbf24"/>
-    <line x1="223" y1="226" x2="79" y2="79" stroke="#475569" stroke-width="1"/>
-    <line x1="79" y1="79" x2="36" y2="42" stroke="#475569" stroke-width="1"/>
-    <line x1="36" y1="42" x2="80" y2="33" stroke="#475569" stroke-width="1"/>
-    <line x1="80" y1="33" x2="136" y2="80" stroke="#475569" stroke-width="1"/>
-    <line x1="136" y1="80" x2="143" y2="42" stroke="#475569" stroke-width="1"/>
-    <line x1="143" y1="42" x2="119" y2="83" stroke="#475569" stroke-width="1"/>
-    <line x1="119" y1="83" x2="41" y2="143" stroke="#475569" stroke-width="1"/>
-    <line x1="41" y1="143" x2="81" y2="208" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">15 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | AI Agent | OpenAI | Docker</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
@@ -1,127 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <ellipse cx="60" cy="80" rx="35" ry="45" fill="url(#accent)" opacity="0.9"/>
-    <circle cx="48" cy="60" r="8" fill="white" opacity="0.8"/>
-    <circle cx="72" cy="60" r="8" fill="white" opacity="0.8"/>
-    <line x1="20" y1="60" x2="35" y2="70" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="100" y1="60" x2="85" y2="70" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="15" y1="90" x2="30" y2="85" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="105" y1="90" x2="90" y2="85" stroke="#fca5a5" stroke-width="2"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: VMware vCenter KEV , Fortinet SSO , Sandwor...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest VMware vCenter</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="32" font-weight="300">Fortinet SSO Sandworm DynoWiper AI Agents</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: VMware vCenter KEV , Fortinet SSO , - 2026 1</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">25 / : CISA KEV VMware vCenter CVE-2024-37079</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VMware</text>
+      <rect x="279" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="327" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#vCenter</text>
+      <rect x="387" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CISA-KEV</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 25, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">MALWARE</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Malware</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">SECURITY</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Security</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="93" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="46" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Malware</text>
-    <rect x="108" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="145" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="198" y="0" width="102" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="249" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Security</text>
-    <rect x="315" y="0" width="120" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="375" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Zero Trust</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="91" cy="60" r="3" fill="#f87171"/>
-    <circle cx="87" cy="87" r="4" fill="#fb923c"/>
-    <circle cx="212" cy="194" r="5" fill="#818cf8"/>
-    <circle cx="102" cy="121" r="6" fill="#34d399"/>
-    <circle cx="64" cy="102" r="3" fill="#fbbf24"/>
-    <circle cx="84" cy="98" r="4" fill="#f87171"/>
-    <circle cx="186" cy="47" r="5" fill="#fb923c"/>
-    <circle cx="224" cy="84" r="6" fill="#818cf8"/>
-    <circle cx="54" cy="143" r="3" fill="#34d399"/>
-    <circle cx="58" cy="208" r="4" fill="#fbbf24"/>
-    <line x1="91" y1="60" x2="87" y2="87" stroke="#475569" stroke-width="1"/>
-    <line x1="87" y1="87" x2="212" y2="194" stroke="#475569" stroke-width="1"/>
-    <line x1="212" y1="194" x2="102" y2="121" stroke="#475569" stroke-width="1"/>
-    <line x1="102" y1="121" x2="64" y2="102" stroke="#475569" stroke-width="1"/>
-    <line x1="64" y1="102" x2="84" y2="98" stroke="#475569" stroke-width="1"/>
-    <line x1="84" y1="98" x2="186" y2="47" stroke="#475569" stroke-width="1"/>
-    <line x1="186" y1="47" x2="224" y2="84" stroke="#475569" stroke-width="1"/>
-    <line x1="224" y1="84" x2="54" y2="143" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">16 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Malware | AI/ML | Security | Zero Trust</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
+++ b/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
@@ -1,125 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Zero Trust for AI Agents, Chrome , Terrafor...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest Zero Trust Agentic</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="32" font-weight="300">AI Chrome Tech Support Scam Terraform Stacks</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI Zero Trust, Chrome Gemini , Terraform Stacks , Prompt</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Injection</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="241" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
+      <rect x="315" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agents</text>
+      <rect x="441" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="525" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Chrome-Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 26, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#a78bfa" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI AGENT</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI Agent</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">GEMINI AI</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Gemini AI</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="102" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="141" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI Agent</text>
-    <rect x="207" y="0" width="111" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="262" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Gemini AI</text>
-    <rect x="333" y="0" width="111" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="388" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="108" cy="69" r="3" fill="#f87171"/>
-    <circle cx="39" cy="39" r="4" fill="#fb923c"/>
-    <circle cx="131" cy="32" r="5" fill="#818cf8"/>
-    <circle cx="142" cy="80" r="6" fill="#34d399"/>
-    <circle cx="219" cy="142" r="3" fill="#fbbf24"/>
-    <circle cx="78" cy="208" r="4" fill="#f87171"/>
-    <circle cx="211" cy="224" r="5" fill="#fb923c"/>
-    <circle cx="52" cy="78" r="6" fill="#818cf8"/>
-    <circle cx="57" cy="192" r="3" fill="#34d399"/>
-    <circle cx="58" cy="120" r="4" fill="#fbbf24"/>
-    <line x1="108" y1="69" x2="39" y2="39" stroke="#475569" stroke-width="1"/>
-    <line x1="39" y1="39" x2="131" y2="32" stroke="#475569" stroke-width="1"/>
-    <line x1="131" y1="32" x2="142" y2="80" stroke="#475569" stroke-width="1"/>
-    <line x1="142" y1="80" x2="219" y2="142" stroke="#475569" stroke-width="1"/>
-    <line x1="219" y1="142" x2="78" y2="208" stroke="#475569" stroke-width="1"/>
-    <line x1="78" y1="208" x2="211" y2="224" stroke="#475569" stroke-width="1"/>
-    <line x1="211" y1="224" x2="52" y2="78" stroke="#475569" stroke-width="1"/>
-    <line x1="52" y1="78" x2="57" y2="192" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">12 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | AI Agent | Gemini AI | DevSecOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
+++ b/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
@@ -1,127 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="40" r="15" fill="url(#accent)" opacity="0.8"/>
-    <circle cx="20" cy="110" r="12" fill="url(#accent2)" opacity="0.8"/>
-    <circle cx="100" cy="110" r="12" fill="url(#accent)" opacity="0.8"/>
-    <circle cx="60" cy="140" r="10" fill="url(#accent2)" opacity="0.6"/>
-    <line x1="60" y1="55" x2="20" y2="98" stroke="#94a3b8" stroke-width="1.5"/>
-    <line x1="60" y1="55" x2="100" y2="98" stroke="#94a3b8" stroke-width="1.5"/>
-    <line x1="20" y1="122" x2="60" y2="130" stroke="#94a3b8" stroke-width="1.5"/>
-    <line x1="100" y1="122" x2="60" y2="130" stroke="#94a3b8" stroke-width="1.5"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: MS Office Zero-Day , Kimi K2.5 , Kimwolf</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest MS Office Zero</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Day Kimi K25 Kimwolf Botnet AWS G7e</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">MS Office Zero-Day , Kimi K2.5 , Kimwolf 200 IoT , AWS</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Blackwell GPU</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="232" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Day</text>
+      <rect x="297" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Microsoft-Office</text>
+      <rect x="486" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="538" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kimi-K25</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 27, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#dc2626" font-family="Arial, sans-serif" font-size="12" font-weight="bold">ZERO-DAY</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Zero-Day</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#f87171" font-family="Arial, sans-serif" font-size="12" font-weight="bold">BOTNET</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Botnet</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="102" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="51" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Zero-Day</text>
-    <rect x="117" y="0" width="84" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="159" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Botnet</text>
-    <rect x="216" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="253" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="306" y="0" width="57" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="334" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">AWS</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="83" cy="56" r="3" fill="#f87171"/>
-    <circle cx="86" cy="86" r="4" fill="#fb923c"/>
-    <circle cx="212" cy="194" r="5" fill="#818cf8"/>
-    <circle cx="102" cy="121" r="6" fill="#34d399"/>
-    <circle cx="164" cy="102" r="3" fill="#fbbf24"/>
-    <circle cx="121" cy="98" r="4" fill="#f87171"/>
-    <circle cx="66" cy="197" r="5" fill="#fb923c"/>
-    <circle cx="34" cy="121" r="6" fill="#818cf8"/>
-    <circle cx="80" cy="102" r="3" fill="#34d399"/>
-    <circle cx="61" cy="48" r="4" fill="#fbbf24"/>
-    <line x1="83" y1="56" x2="86" y2="86" stroke="#475569" stroke-width="1"/>
-    <line x1="86" y1="86" x2="212" y2="194" stroke="#475569" stroke-width="1"/>
-    <line x1="212" y1="194" x2="102" y2="121" stroke="#475569" stroke-width="1"/>
-    <line x1="102" y1="121" x2="164" y2="102" stroke="#475569" stroke-width="1"/>
-    <line x1="164" y1="102" x2="121" y2="98" stroke="#475569" stroke-width="1"/>
-    <line x1="121" y1="98" x2="66" y2="197" stroke="#475569" stroke-width="1"/>
-    <line x1="66" y1="197" x2="34" y2="121" stroke="#475569" stroke-width="1"/>
-    <line x1="34" y1="121" x2="80" y2="102" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">12 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Zero-Day | Botnet | AI/ML | AWS</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
+++ b/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
@@ -1,127 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#06b6d4"/>
-      <stop offset="100%" stop-color="#22d3ee"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#06b6d4" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <line x1="980.0" y1="230.0" x2="930.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1030.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="980.0" y1="230.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1030.0" y2="290.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="930.0" y1="290.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="955.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1030.0" y1="290.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="1005.0" y2="345.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="955.0" y1="345.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <line x1="1005.0" y1="345.0" x2="980.0" y2="300.0" stroke="#06b6d4" stroke-width="1.5" opacity="0.25"/>
-    <circle cx="980.0" cy="230.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="930.0" cy="290.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="1030.0" cy="290.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="955.0" cy="345.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="1005.0" cy="345.0" r="10" fill="#06b6d4" opacity="0.35"/>
-    <circle cx="980.0" cy="300.0" r="10" fill="#06b6d4" opacity="0.35"/>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#06b6d4"
-        letter-spacing="3" opacity="0.9">AI &amp; ML</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#06b6d4" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">AI Agent Project Security</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Design</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#06b6d4" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">Artificial Intelligence Security Guide</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">January 28, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#06b6d4" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#06b6d4">LLM</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Safety</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">Prompt</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Injection</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">RAG</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Security</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#06b6d4" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#06b6d4" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#06b6d4" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CLAUDE.md : AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI (Claude Code, Cursor, Copilot) . CLAUDE.md</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CLAUDE.md</text>
+      <rect x="126" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="270" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Claude-Code</text>
+      <rect x="414" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
+++ b/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
@@ -1,123 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft Office Zero-Day , CTEM , Grist-Co...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest MS Office</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Zero Day CTEM Grist Core RCE</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft Office Zero-Day , CTEM , - 2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 28 : Microsoft Office Zero-Day , CTEM 5</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CVE-2026-21509</text>
+      <rect x="477" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="565" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Microsoft-Office</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 28, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#dc2626" font-family="Arial, sans-serif" font-size="12" font-weight="bold">ZERO-DAY</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Zero-Day</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="102" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="51" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Zero-Day</text>
-    <rect x="117" y="0" width="111" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="172" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="243" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="280" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="333" y="0" width="111" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="388" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="153" cy="91" r="3" fill="#f87171"/>
-    <circle cx="45" cy="45" r="4" fill="#fb923c"/>
-    <circle cx="56" cy="83" r="5" fill="#818cf8"/>
-    <circle cx="183" cy="43" r="6" fill="#34d399"/>
-    <circle cx="49" cy="183" r="3" fill="#fbbf24"/>
-    <circle cx="57" cy="68" r="4" fill="#f87171"/>
-    <circle cx="133" cy="139" r="5" fill="#fb923c"/>
-    <circle cx="217" cy="57" r="6" fill="#818cf8"/>
-    <circle cx="103" cy="36" r="3" fill="#34d399"/>
-    <circle cx="39" cy="181" r="4" fill="#fbbf24"/>
-    <line x1="153" y1="91" x2="45" y2="45" stroke="#475569" stroke-width="1"/>
-    <line x1="45" y1="45" x2="56" y2="83" stroke="#475569" stroke-width="1"/>
-    <line x1="56" y1="83" x2="183" y2="43" stroke="#475569" stroke-width="1"/>
-    <line x1="183" y1="43" x2="49" y2="183" stroke="#475569" stroke-width="1"/>
-    <line x1="49" y1="183" x2="57" y2="68" stroke="#475569" stroke-width="1"/>
-    <line x1="57" y1="68" x2="133" y2="139" stroke="#475569" stroke-width="1"/>
-    <line x1="133" y1="139" x2="217" y2="57" stroke="#475569" stroke-width="1"/>
-    <line x1="217" y1="57" x2="103" y2="36" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Zero-Day | CVE Alert | Cloud | DevSecOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
+++ b/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
@@ -1,123 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: n8n Critical RCE, D-Link Zero-Day, Kubernet...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Tech Security Weekly Digest n8n RCE</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">D Link Zero Day Kubernetes AI Agent</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: n8n Critical RCE, D-Link Zero-Day, Kubernetes -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 1 29 : n8n RCE (CVE-2026-1470, CVSS 9.9), D-Link</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#n8n</text>
+      <rect x="252" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#RCE</text>
+      <rect x="324" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CVE-2026-1470</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 29, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#dc2626" font-family="Arial, sans-serif" font-size="12" font-weight="bold">ZERO-DAY</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Zero-Day</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="102" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="51" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Zero-Day</text>
-    <rect x="117" y="0" width="111" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="172" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="243" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="280" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="333" y="0" width="120" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="393" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Kubernetes</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="97" cy="163" r="3" fill="#f87171"/>
-    <circle cx="213" cy="213" r="4" fill="#fb923c"/>
-    <circle cx="127" cy="225" r="5" fill="#818cf8"/>
-    <circle cx="142" cy="78" r="6" fill="#34d399"/>
-    <circle cx="169" cy="142" r="3" fill="#fbbf24"/>
-    <circle cx="122" cy="108" r="4" fill="#f87171"/>
-    <circle cx="216" cy="199" r="5" fill="#fb923c"/>
-    <circle cx="228" cy="122" r="6" fill="#818cf8"/>
-    <circle cx="154" cy="203" r="3" fill="#34d399"/>
-    <circle cx="45" cy="223" r="4" fill="#fbbf24"/>
-    <line x1="97" y1="163" x2="213" y2="213" stroke="#475569" stroke-width="1"/>
-    <line x1="213" y1="213" x2="127" y2="225" stroke="#475569" stroke-width="1"/>
-    <line x1="127" y1="225" x2="142" y2="78" stroke="#475569" stroke-width="1"/>
-    <line x1="142" y1="78" x2="169" y2="142" stroke="#475569" stroke-width="1"/>
-    <line x1="169" y1="142" x2="122" y2="108" stroke="#475569" stroke-width="1"/>
-    <line x1="122" y1="108" x2="216" y2="199" stroke="#475569" stroke-width="1"/>
-    <line x1="216" y1="199" x2="228" y2="122" stroke="#475569" stroke-width="1"/>
-    <line x1="228" y1="122" x2="154" y2="203" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">14 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Zero-Day | CVE Alert | AI/ML | Kubernetes</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
+++ b/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
@@ -1,124 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Ollama AI 175K , SolarWinds WHD Critical RC...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Tech Security Weekly Digest Ollama</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">AI SolarWinds RCE Google IPIDEA</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Ollama AI 175K , SolarWinds WHD Critical - 2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 30 : Ollama AI 175,000 (LLMjacking), SolarWinds</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ollama</text>
+      <rect x="279" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LLMjacking</text>
+      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SolarWinds</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 30, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="111" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="55" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="126" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="163" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="216" y="0" width="57" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="244" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="288" y="0" width="111" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="343" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="141" cy="85" r="3" fill="#f87171"/>
-    <circle cx="93" cy="93" r="4" fill="#fb923c"/>
-    <circle cx="87" cy="145" r="5" fill="#818cf8"/>
-    <circle cx="137" cy="58" r="6" fill="#34d399"/>
-    <circle cx="143" cy="137" r="3" fill="#fbbf24"/>
-    <circle cx="219" cy="56" r="4" fill="#f87171"/>
-    <circle cx="53" cy="186" r="5" fill="#fb923c"/>
-    <circle cx="107" cy="219" r="6" fill="#818cf8"/>
-    <circle cx="89" cy="77" r="3" fill="#34d399"/>
-    <circle cx="37" cy="141" r="4" fill="#fbbf24"/>
-    <line x1="141" y1="85" x2="93" y2="93" stroke="#475569" stroke-width="1"/>
-    <line x1="93" y1="93" x2="87" y2="145" stroke="#475569" stroke-width="1"/>
-    <line x1="87" y1="145" x2="137" y2="58" stroke="#475569" stroke-width="1"/>
-    <line x1="137" y1="58" x2="143" y2="137" stroke="#475569" stroke-width="1"/>
-    <line x1="143" y1="137" x2="219" y2="56" stroke="#475569" stroke-width="1"/>
-    <line x1="219" y1="56" x2="53" y2="186" stroke="#475569" stroke-width="1"/>
-    <line x1="53" y1="186" x2="107" y2="219" stroke="#475569" stroke-width="1"/>
-    <line x1="107" y1="219" x2="89" y2="77" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">13 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">CVE Alert | AI/ML | LLM | DevSecOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
+++ b/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
@@ -1,121 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <rect x="25" y="0" width="70" height="130" rx="10" fill="url(#accent)" opacity="0.2" stroke="#6366f1" stroke-width="2"/>
-    <rect x="32" y="15" width="56" height="85" rx="3" fill="#1e293b"/>
-    <circle cx="60" cy="115" r="7" fill="none" stroke="#6366f1" stroke-width="1.5"/>
-    <text x="60" y="60" text-anchor="middle" fill="#fecaca" font-family="monospace" font-size="16">CALL</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M90 120 L30 120 C13 120 0 107 0 90 C0 75 10 63 24 60 C24 35 45 15 70 15 C92 15 110 30 115 50 C128 52 138 63 138 78 C138 95 125 108 108 108" fill="none" stroke="#ef4444" stroke-width="2.5"/>
-    <path d="M50 75 L65 90 L90 60" fill="none" stroke="#94a3b8" stroke-width="3"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: ShinyHunters Vishing MFA , Chrome ChatGPT , OT</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="36" font-weight="bold">Tech Security Weekly Digest ShinyHunters</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Vishing Chrome Extension OT Attack</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">ShinyHunters MFA , Chrome ChatGPT ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CERT Polska 30+ / OT</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ShinyHunters</text>
+      <rect x="459" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Vishing</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">January 31, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#f87171" font-family="Arial, sans-serif" font-size="12" font-weight="bold">VISHING</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Vishing</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#8b5cf6" font-family="Arial, sans-serif" font-size="12" font-weight="bold">DEVSECOPS</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">DevSecOps</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="93" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="46" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Vishing</text>
-    <rect x="108" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="145" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="198" y="0" width="111" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="253" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-    <rect x="324" y="0" width="102" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="375" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Security</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="38" cy="34" r="3" fill="#f87171"/>
-    <circle cx="131" cy="131" r="4" fill="#fb923c"/>
-    <circle cx="192" cy="155" r="5" fill="#818cf8"/>
-    <circle cx="75" cy="211" r="6" fill="#34d399"/>
-    <circle cx="160" cy="75" r="3" fill="#fbbf24"/>
-    <circle cx="171" cy="91" r="4" fill="#f87171"/>
-    <circle cx="72" cy="195" r="5" fill="#fb923c"/>
-    <circle cx="110" cy="171" r="6" fill="#818cf8"/>
-    <circle cx="90" cy="115" r="3" fill="#34d399"/>
-    <circle cx="37" cy="151" r="4" fill="#fbbf24"/>
-    <line x1="38" y1="34" x2="131" y2="131" stroke="#475569" stroke-width="1"/>
-    <line x1="131" y1="131" x2="192" y2="155" stroke="#475569" stroke-width="1"/>
-    <line x1="192" y1="155" x2="75" y2="211" stroke="#475569" stroke-width="1"/>
-    <line x1="75" y1="211" x2="160" y2="75" stroke="#475569" stroke-width="1"/>
-    <line x1="160" y1="75" x2="171" y2="91" stroke="#475569" stroke-width="1"/>
-    <line x1="171" y1="91" x2="72" y2="195" stroke="#475569" stroke-width="1"/>
-    <line x1="72" y1="195" x2="110" y2="171" stroke="#475569" stroke-width="1"/>
-    <line x1="110" y1="171" x2="90" y2="115" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">12 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Vishing | Cloud | DevSecOps | Security</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
+++ b/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
@@ -1,230 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#06030f"/>
-      <stop offset="50%" stop-color="#080a12"/>
-      <stop offset="100%" stop-color="#030810"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#a855f7"/>
-      <stop offset="50%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#06b6d4"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="redCard" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#1f0a0a"/>
-      <stop offset="100%" stop-color="#120505"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="greenCard" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#061a0a"/>
-      <stop offset="100%" stop-color="#030f05"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="blueCard" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0a0f1f"/>
-      <stop offset="100%" stop-color="#050812"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="redAccent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
-    </linearGradient>
-    <linearGradient id="greenAccent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#22c55e"/>
-      <stop offset="100%" stop-color="#16a34a"/>
-    </linearGradient>
-    <linearGradient id="blueAccent" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#3b82f6"/>
-      <stop offset="100%" stop-color="#06b6d4"/>
-    </linearGradient>
-    <filter id="glowPurple">
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowRed">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow">
-      <feDropShadow dx="0" dy="4" stdDeviation="10" flood-color="#000" flood-opacity="0.7"/>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
     </filter>
-    <filter id="titleGlow">
-      <feGaussianBlur stdDeviation="6" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGrad)"/>
-
-  <!-- Subtle grid -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#12102a" stroke-width="1" opacity="0.6"/>
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#12102a" stroke-width="1" opacity="0.6"/>
-  <line x1="400" y1="0" x2="400" y2="630" stroke="#12102a" stroke-width="1" opacity="0.3"/>
-  <line x1="800" y1="0" x2="800" y2="630" stroke="#12102a" stroke-width="1" opacity="0.3"/>
-
-  <!-- Background decorative circles -->
-  <circle cx="600" cy="315" r="250" fill="none" stroke="#a855f7" stroke-width="1" opacity="0.04"/>
-  <circle cx="600" cy="315" r="200" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.04"/>
-  <circle cx="1150" cy="100" r="120" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.05"/>
-  <circle cx="50" cy="530" r="100" fill="none" stroke="#a855f7" stroke-width="1" opacity="0.05"/>
-
-  <!-- Top badge -->
-  <rect x="60" y="30" width="230" height="34" rx="17" fill="url(#accentGrad)" filter="url(#shadow)"/>
-  <text x="175" y="52" fill="#fff" font-family="Arial, sans-serif" font-size="12" font-weight="700" text-anchor="middle" letter-spacing="2">AGENTIC AI SECURITY</text>
-
-  <!-- Date badge -->
-  <rect x="1030" y="30" width="120" height="34" rx="17" fill="#0d0a20" stroke="#2a1a5e" stroke-width="1"/>
-  <text x="1090" y="52" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="13" font-weight="600" text-anchor="middle">Feb 1, 2026</text>
-
-  <!-- AI brain icon -->
-  <circle cx="1130" cy="48" r="18" fill="none" stroke="#a855f7" stroke-width="1.5" opacity="0.3" filter="url(#glowPurple)"/>
-  <text x="1130" y="54" fill="#a855f7" font-family="Arial, sans-serif" font-size="16" text-anchor="middle" opacity="0.3">AI</text>
-
-  <!-- Main title -->
-  <text x="60" y="115" fill="#f5f3ff" font-family="Arial, sans-serif" font-size="46" font-weight="800" filter="url(#titleGlow)">Agentic AI Security 2026</text>
-  <text x="60" y="165" fill="url(#accentGrad)" font-family="Arial, sans-serif" font-size="28" font-weight="700" filter="url(#titleGlow)">Attack Vectors | Defense Architecture | Monitoring</text>
-
-  <!-- Subtitle pills -->
-  <rect x="60" y="185" width="140" height="26" rx="13" fill="#1f0a0a" stroke="#5a1515" stroke-width="1"/>
-  <text x="130" y="202" fill="#fca5a5" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Attack Vectors</text>
-  <rect x="212" y="185" width="170" height="26" rx="13" fill="#061a0a" stroke="#15502a" stroke-width="1"/>
-  <text x="297" y="202" fill="#86efac" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Defense Architecture</text>
-  <rect x="394" y="185" width="115" height="26" rx="13" fill="#0a0f1f" stroke="#1e3a6e" stroke-width="1"/>
-  <text x="451" y="202" fill="#93c5fd" font-family="Arial, sans-serif" font-size="12" font-weight="600" text-anchor="middle">Monitoring</text>
-
-  <!-- Accent line -->
-  <rect x="60" y="225" width="560" height="3" rx="2" fill="url(#accentGrad)" opacity="0.7"/>
-
-  <!-- Card 1: Attack Vectors (RED) -->
-  <rect x="60" y="248" width="340" height="290" rx="16" fill="url(#redCard)" stroke="#5a1515" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="60" y="248" width="340" height="4" rx="2" fill="url(#redAccent)"/>
-
-  <!-- Attack icon: target crosshair -->
-  <circle cx="110" cy="293" r="18" fill="none" stroke="#ef4444" stroke-width="2" filter="url(#glowRed)"/>
-  <circle cx="110" cy="293" r="8" fill="none" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="110" cy="293" r="2" fill="#ef4444"/>
-  <line x1="92" y1="293" x2="128" y2="293" stroke="#ef4444" stroke-width="1" opacity="0.6"/>
-  <line x1="110" y1="275" x2="110" y2="311" stroke="#ef4444" stroke-width="1" opacity="0.6"/>
-
-  <text x="140" y="288" fill="#fee2e2" font-family="Arial, sans-serif" font-size="15" font-weight="700">Attack Vectors</text>
-  <text x="140" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">AI Agent Threats</text>
-
-  <!-- Attack types -->
-  <rect x="80" y="328" width="300" height="40" rx="8" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="80" y="328" width="4" height="40" rx="2" fill="#ef4444"/>
-  <text x="95" y="345" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600">Prompt Injection</text>
-  <text x="95" y="361" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Hijack agent instructions via input</text>
-
-  <rect x="80" y="378" width="300" height="40" rx="8" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="80" y="378" width="4" height="40" rx="2" fill="#dc2626"/>
-  <text x="95" y="395" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600">Tool Misuse</text>
-  <text x="95" y="411" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Abuse agentic tool permissions</text>
-
-  <rect x="80" y="428" width="300" height="40" rx="8" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="80" y="428" width="4" height="40" rx="2" fill="#b91c1c"/>
-  <text x="95" y="445" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600">Memory Poisoning</text>
-  <text x="95" y="461" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Corrupt long-term agent memory</text>
-
-  <rect x="80" y="478" width="300" height="40" rx="8" fill="#1a0505" stroke="#5a1515" stroke-width="1"/>
-  <rect x="80" y="478" width="4" height="40" rx="2" fill="#991b1b"/>
-  <text x="95" y="495" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13" font-weight="600">Supply Chain Attack</text>
-  <text x="95" y="511" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Malicious model or plugin</text>
-
-  <!-- Card 2: Defense Architecture (GREEN) -->
-  <rect x="430" y="248" width="340" height="290" rx="16" fill="url(#greenCard)" stroke="#155a2a" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="430" y="248" width="340" height="4" rx="2" fill="url(#greenAccent)"/>
-
-  <!-- Shield icon -->
-  <path d="M468,270 L498,270 L498,298 L483,312 L468,298 Z" fill="none" stroke="#22c55e" stroke-width="2.5" filter="url(#glowRed)"/>
-  <path d="M476,284 L481,290 L492,279" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
-
-  <text x="512" y="288" fill="#dcfce7" font-family="Arial, sans-serif" font-size="15" font-weight="700">Defense Architecture</text>
-  <text x="512" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Security Controls</text>
-
-  <!-- Defense layers -->
-  <text x="450" y="338" fill="#22c55e" font-family="Arial, sans-serif" font-size="12" font-weight="700">DEFENSE LAYERS</text>
-
-  <!-- Layer 1 -->
-  <rect x="450" y="348" width="300" height="38" rx="8" fill="#061a0a" stroke="#155a2a" stroke-width="1"/>
-  <rect x="450" y="348" width="6" height="38" rx="3" fill="#22c55e"/>
-  <text x="466" y="364" fill="#86efac" font-family="Arial, sans-serif" font-size="12" font-weight="600">Input Validation Layer</text>
-  <text x="466" y="378" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Sanitize all agent inputs strictly</text>
-
-  <!-- Layer 2 -->
-  <rect x="450" y="396" width="300" height="38" rx="8" fill="#061a0a" stroke="#155a2a" stroke-width="1"/>
-  <rect x="450" y="396" width="6" height="38" rx="3" fill="#16a34a"/>
-  <text x="466" y="412" fill="#86efac" font-family="Arial, sans-serif" font-size="12" font-weight="600">Least Privilege Permissions</text>
-  <text x="466" y="426" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Scope tool access by task context</text>
-
-  <!-- Layer 3 -->
-  <rect x="450" y="444" width="300" height="38" rx="8" fill="#061a0a" stroke="#155a2a" stroke-width="1"/>
-  <rect x="450" y="444" width="6" height="38" rx="3" fill="#15803d"/>
-  <text x="466" y="460" fill="#86efac" font-family="Arial, sans-serif" font-size="12" font-weight="600">Human-in-the-Loop Approval</text>
-  <text x="466" y="474" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Require confirm for high-risk actions</text>
-
-  <!-- Layer 4 -->
-  <rect x="450" y="492" width="300" height="38" rx="8" fill="#061a0a" stroke="#155a2a" stroke-width="1"/>
-  <rect x="450" y="492" width="6" height="38" rx="3" fill="#166534"/>
-  <text x="466" y="508" fill="#86efac" font-family="Arial, sans-serif" font-size="12" font-weight="600">Memory Integrity Checks</text>
-  <text x="466" y="522" fill="#64748b" font-family="Arial, sans-serif" font-size="10">Cryptographic memory attestation</text>
-
-  <!-- Card 3: Monitoring (BLUE) -->
-  <rect x="800" y="248" width="340" height="290" rx="16" fill="url(#blueCard)" stroke="#1e3a6e" stroke-width="1.5" filter="url(#shadow)"/>
-  <rect x="800" y="248" width="340" height="4" rx="2" fill="url(#blueAccent)"/>
-
-  <!-- Eye/monitor icon -->
-  <ellipse cx="838" cy="291" rx="20" ry="13" fill="none" stroke="#3b82f6" stroke-width="2" filter="url(#glowRed)"/>
-  <circle cx="838" cy="291" r="5" fill="#3b82f6"/>
-  <circle cx="840" cy="289" r="2" fill="#1e3a6e"/>
-
-  <text x="870" y="288" fill="#dbeafe" font-family="Arial, sans-serif" font-size="15" font-weight="700">Monitoring</text>
-  <text x="870" y="306" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Observability and Detection</text>
-
-  <!-- Monitor metrics -->
-  <text x="820" y="340" fill="#3b82f6" font-family="Arial, sans-serif" font-size="12" font-weight="700">KEY METRICS</text>
-
-  <text x="820" y="364" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Tool Call Anomalies</text>
-  <rect x="820" y="372" width="295" height="10" rx="5" fill="#0a0f1f"/>
-  <rect x="820" y="372" width="230" height="10" rx="5" fill="#3b82f6"/>
-  <text x="1118" y="382" fill="#60a5fa" font-family="Arial, sans-serif" font-size="11" text-anchor="end">78%</text>
-
-  <text x="820" y="404" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Memory Access Rate</text>
-  <rect x="820" y="412" width="295" height="10" rx="5" fill="#0a0f1f"/>
-  <rect x="820" y="412" width="186" height="10" rx="5" fill="#06b6d4"/>
-  <text x="1118" y="422" fill="#60a5fa" font-family="Arial, sans-serif" font-size="11" text-anchor="end">63%</text>
-
-  <text x="820" y="444" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Prompt Injection Blocks</text>
-  <rect x="820" y="452" width="295" height="10" rx="5" fill="#0a0f1f"/>
-  <rect x="820" y="452" width="148" height="10" rx="5" fill="#0ea5e9"/>
-  <text x="1118" y="462" fill="#60a5fa" font-family="Arial, sans-serif" font-size="11" text-anchor="end">50%</text>
-
-  <text x="820" y="484" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Auth Policy Violations</text>
-  <rect x="820" y="492" width="295" height="10" rx="5" fill="#0a0f1f"/>
-  <rect x="820" y="492" width="110" height="10" rx="5" fill="#2563eb"/>
-  <text x="1118" y="502" fill="#60a5fa" font-family="Arial, sans-serif" font-size="11" text-anchor="end">37%</text>
-
-  <circle cx="825" cy="522" r="3" fill="#3b82f6"/>
-  <text x="835" y="526" fill="#94a3b8" font-family="Arial, sans-serif" font-size="11">Real-time SIEM integration</text>
-
-  <!-- Flow arrows between cards -->
-  <!-- Attack -> Defense -->
-  <text x="397" y="400" fill="#ef4444" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle" opacity="0.6">-&gt;</text>
-  <!-- Defense -> Monitor -->
-  <text x="767" y="400" fill="#22c55e" font-family="Arial, sans-serif" font-size="18" font-weight="700" text-anchor="middle" opacity="0.6">-&gt;</text>
-
-  <!-- Footer -->
-  <rect x="0" y="570" width="1200" height="60" fill="#030208" opacity="0.97"/>
-  <rect x="0" y="570" width="1200" height="2" fill="url(#accentGrad)" opacity="0.5"/>
-
-  <rect x="60" y="585" width="120" height="24" rx="12" fill="#1f0a0a" stroke="#5a1515" stroke-width="1"/>
-  <text x="120" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Agentic AI</text>
-
-  <rect x="192" y="585" width="130" height="24" rx="12" fill="#1f0a0a" stroke="#5a1515" stroke-width="1"/>
-  <text x="257" y="601" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Attack Vectors</text>
-
-  <rect x="334" y="585" width="105" height="24" rx="12" fill="#061a0a" stroke="#155a2a" stroke-width="1"/>
-  <text x="386" y="601" fill="#86efac" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Defense</text>
-
-  <rect x="451" y="585" width="115" height="24" rx="12" fill="#0a0f1f" stroke="#1e3a6e" stroke-width="1"/>
-  <text x="508" y="601" fill="#93c5fd" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">Monitoring</text>
-
-  <text x="1140" y="601" fill="#a855f7" font-family="Arial, sans-serif" font-size="13" font-weight="700" text-anchor="end">tech.2twodragon.com</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI 2026: AI Agent</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 AI (Tool Poisoning, Tool Chain Attack, Prompt</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Injection) Google Chrome CrowdStrike Falcon .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Agentic-AI</text>
+      <rect x="135" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="279" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="358" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Tool-Poisoning</text>
+      <rect x="450" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="538" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Prompt-Injection</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
+++ b/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 01, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">ZERO-DAY / OPENSSL / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Zero-Day</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">OpenSSL</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Zero-Day, OpenSSL, and AI Runtime framed for</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI OpenSSL 12 , OWASP Agentic AI , Fortinet...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ZERO-DAY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Zero-Day</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map active exploitation paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Apply emergency mitigations fast</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Document compensating controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">OPENSSL</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">OpenSSL</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize crypto library exposure</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map dependent services quickly</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare emergency update path</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI OpenSSL 12 , OWASP Agentic AI , -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 1 : AI OpenSSL 12 , OWASP</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Agentic</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="450" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="498" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OpenSSL</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ZERO</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">DAY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">OPENSSL</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">0</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="88" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="44.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Zero-Day</text>
-    <rect x="98" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="142.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">OpenSSL</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
@@ -1,124 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <rect x="25" y="60" width="70" height="80" rx="8" fill="url(#accent)" opacity="0.9"/>
-    <path d="M35 60 V40 C35 18 85 18 85 40 V60" fill="none" stroke="#fca5a5" stroke-width="3"/>
-    <circle cx="60" cy="100" r="10" fill="white"/>
-    <rect x="57" y="100" width="6" height="18" rx="2" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Notepad++ , SK , HashiCorp</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Weekly Security</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Threat Intelligence Digest</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Notepad++ , SK 11-1 (Vertical AI,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">BlackField/Sinobi/Gentlemen , , JWT ), HashiCorp</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">RDP</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Supply-Chain</text>
+      <rect x="333" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Notepad++</text>
+      <rect x="459" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 02, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">RANSOMWARE</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Ransomware</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">SECURITY</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Security</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="120" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="60" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Ransomware</text>
-    <rect x="135" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="172" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="225" y="0" width="102" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="276" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Security</text>
-    <rect x="342" y="0" width="138" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="411" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Threat Intel</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="151" cy="190" r="3" fill="#f87171"/>
-    <circle cx="170" cy="170" r="4" fill="#fb923c"/>
-    <circle cx="122" cy="215" r="5" fill="#818cf8"/>
-    <circle cx="216" cy="176" r="6" fill="#34d399"/>
-    <circle cx="103" cy="216" r="3" fill="#fbbf24"/>
-    <circle cx="164" cy="176" r="4" fill="#f87171"/>
-    <circle cx="196" cy="166" r="5" fill="#fb923c"/>
-    <circle cx="225" cy="164" r="6" fill="#818cf8"/>
-    <circle cx="129" cy="163" r="3" fill="#34d399"/>
-    <circle cx="42" cy="213" r="4" fill="#fbbf24"/>
-    <line x1="151" y1="190" x2="170" y2="170" stroke="#475569" stroke-width="1"/>
-    <line x1="170" y1="170" x2="122" y2="215" stroke="#475569" stroke-width="1"/>
-    <line x1="122" y1="215" x2="216" y2="176" stroke="#475569" stroke-width="1"/>
-    <line x1="216" y1="176" x2="103" y2="216" stroke="#475569" stroke-width="1"/>
-    <line x1="103" y1="216" x2="164" y2="176" stroke="#475569" stroke-width="1"/>
-    <line x1="164" y1="176" x2="196" y2="166" stroke="#475569" stroke-width="1"/>
-    <line x1="196" y1="166" x2="225" y2="164" stroke="#475569" stroke-width="1"/>
-    <line x1="225" y1="164" x2="129" y2="163" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">11 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Ransomware | AI/ML | Security | Threat Intel</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
@@ -1,124 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : Apple MLX , Bitcoin 74K , AI , DeFi , FO...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Weekly Tech AI Blockchain Digest</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300"></text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI : Apple MLX , Bitcoin 74K , AI - 2026 2</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2 / : Apple A18 Pro Neural Engine MLX , Bitcoin</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Apple</text>
+      <rect x="270" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="345" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Bitcoin-Crash</text>
+      <rect x="432" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Creativity</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 02, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#dc2626" font-family="Arial, sans-serif" font-size="12" font-weight="bold">EXPLOIT</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Exploit</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="93" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="46" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Exploit</text>
-    <rect x="108" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="145" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="198" y="0" width="57" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="226" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="270" y="0" width="120" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="330" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Blockchain</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="94" cy="62" r="3" fill="#f87171"/>
-    <circle cx="138" cy="138" r="4" fill="#fb923c"/>
-    <circle cx="118" cy="207" r="5" fill="#818cf8"/>
-    <circle cx="66" cy="174" r="6" fill="#34d399"/>
-    <circle cx="59" cy="66" r="3" fill="#fbbf24"/>
-    <circle cx="158" cy="89" r="4" fill="#f87171"/>
-    <circle cx="46" cy="144" r="5" fill="#fb923c"/>
-    <circle cx="132" cy="158" r="6" fill="#818cf8"/>
-    <circle cx="217" cy="62" r="3" fill="#34d399"/>
-    <circle cx="53" cy="38" r="4" fill="#fbbf24"/>
-    <line x1="94" y1="62" x2="138" y2="138" stroke="#475569" stroke-width="1"/>
-    <line x1="138" y1="138" x2="118" y2="207" stroke="#475569" stroke-width="1"/>
-    <line x1="118" y1="207" x2="66" y2="174" stroke="#475569" stroke-width="1"/>
-    <line x1="66" y1="174" x2="59" y2="66" stroke="#475569" stroke-width="1"/>
-    <line x1="59" y1="66" x2="158" y2="89" stroke="#475569" stroke-width="1"/>
-    <line x1="158" y1="89" x2="46" y2="144" stroke="#475569" stroke-width="1"/>
-    <line x1="46" y1="144" x2="132" y2="158" stroke="#475569" stroke-width="1"/>
-    <line x1="132" y1="158" x2="217" y2="62" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">11 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Exploit | AI/ML | LLM | Blockchain</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
+++ b/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
@@ -1,124 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevOps : AI Agent , MDM ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Weekly Security DevOps Digest</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300"></text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevOps : AI Agent , MDM , - 2026 2 3</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">/DevOps : AI(Clawdbot/Moltbot) CVE-2026-25253</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
+      <rect x="243" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Moltbot</text>
+      <rect x="351" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="403" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Moltbook</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 03, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#326ce5" font-family="Arial, sans-serif" font-size="12" font-weight="bold">KUBERNETES</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Kubernetes</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="111" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="55" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="126" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="163" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="216" y="0" width="120" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="276" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Kubernetes</text>
-    <rect x="351" y="0" width="84" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="393" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="183" cy="206" r="3" fill="#f87171"/>
-    <circle cx="224" cy="224" r="4" fill="#fb923c"/>
-    <circle cx="129" cy="228" r="5" fill="#818cf8"/>
-    <circle cx="92" cy="79" r="6" fill="#34d399"/>
-    <circle cx="187" cy="92" r="3" fill="#fbbf24"/>
-    <circle cx="124" cy="145" r="4" fill="#f87171"/>
-    <circle cx="216" cy="208" r="5" fill="#fb923c"/>
-    <circle cx="228" cy="124" r="6" fill="#818cf8"/>
-    <circle cx="204" cy="203" r="3" fill="#34d399"/>
-    <circle cx="51" cy="223" r="4" fill="#fbbf24"/>
-    <line x1="183" y1="206" x2="224" y2="224" stroke="#475569" stroke-width="1"/>
-    <line x1="224" y1="224" x2="129" y2="228" stroke="#475569" stroke-width="1"/>
-    <line x1="129" y1="228" x2="92" y2="79" stroke="#475569" stroke-width="1"/>
-    <line x1="92" y1="79" x2="187" y2="92" stroke="#475569" stroke-width="1"/>
-    <line x1="187" y1="92" x2="124" y2="145" stroke="#475569" stroke-width="1"/>
-    <line x1="124" y1="145" x2="216" y2="208" stroke="#475569" stroke-width="1"/>
-    <line x1="216" y1="208" x2="228" y2="124" stroke="#475569" stroke-width="1"/>
-    <line x1="228" y1="124" x2="204" y2="203" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">20 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">CVE Alert | AI/ML | Kubernetes | DevOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
+++ b/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
@@ -1,123 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background gradient -->
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0f1e"/>
-      <stop offset="50%" stop-color="#0d1b2a"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <!-- Accent gradient top bar -->
-    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#8b5cf6"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <!-- Radial glow -->
-    <radialGradient id="glow" cx="75%" cy="45%" r="45%">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.08"/>
-      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/>
-    </radialGradient>
-    <!-- Grid pattern -->
-    <pattern id="grid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="0.5"/>
-    </pattern>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  <rect width="1200" height="630" fill="url(#glow)"/>
-
-  <!-- Top accent bar -->
-  <rect x="0" y="0" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Bottom accent bar -->
-  <rect x="0" y="626" width="1200" height="4" fill="url(#accentGrad)"/>
-
-  <!-- Left vertical accent line -->
-  <rect x="0" y="4" width="3" height="622" fill="#8b5cf6" opacity="0.4"/>
-
-  <!-- Right-side visual element -->
-  <g opacity="0.85">
-    <rect x="910.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.15"/>
-    <text x="929.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Code</text>
-    <polygon points="948.0,278.0 954.0,284.0 948.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="955.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.2"/>
-    <text x="974.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Build</text>
-    <polygon points="993.0,278.0 999.0,284.0 993.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1000.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.25"/>
-    <text x="1019.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Test</text>
-    <polygon points="1038.0,278.0 1044.0,284.0 1038.0,290.0" fill="#8b5cf6" opacity="0.5"/>
-    <rect x="1045.0" y="270.0" width="38" height="28" rx="5" fill="#8b5cf6" opacity="0.30000000000000004"/>
-    <text x="1064.0" y="288.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.8">Deploy</text>
-    <rect x="925.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.1"/>
-    <text x="946.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SAST</text>
-    <rect x="980.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.14"/>
-    <text x="1001.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">DAST</text>
-    <rect x="1035.0" y="320.0" width="42" height="28" rx="5" fill="#8b5cf6" opacity="0.18"/>
-    <text x="1056.0" y="338.0" text-anchor="middle" font-size="9" font-family="Space Grotesk, Inter, system-ui, sans-serif" fill="#8b5cf6" opacity="0.7">SCA</text>
-  </g>
-
-  <!-- Category label -->
-  <text x="60" y="100"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="13" font-weight="600" fill="#8b5cf6"
-        letter-spacing="3" opacity="0.9">DEVSECOPS</text>
-
-  <!-- Accent underline under category -->
-  <rect x="60" y="108" width="50" height="2" rx="1" fill="#8b5cf6" opacity="0.5"/>
-
-  <!-- Title lines -->
-  <text x="60" y="230" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Coding Assistant Deep</text><text x="60" y="288" font-family="Space Grotesk, Inter, system-ui, sans-serif" font-size="47" font-weight="700" fill="#ffffff" opacity="0.95">Comparison Security DevSecOps</text>
-
-  <!-- Accent underline bar -->
-  <rect x="60" y="354" width="300" height="4" rx="2" fill="#8b5cf6" opacity="0.7"/>
-
-  <!-- Subtitle -->
-  <text x="60" y="386"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="21" fill="#94a3b8" opacity="0.85">DevSecOps Pipeline and Best Practices</text>
-
-  <!-- Date -->
-  <text x="60" y="420"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="16" fill="#64748b">February 4, 2026</text>
-
-  <!-- Stat cards -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
   
-    <rect x="60" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#8b5cf6" stroke-width="1.5"/>
-    <text x="125" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#8b5cf6">SAST</text>
-    <text x="125" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Scan</text>
-
-    <rect x="208" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#f59e0b" stroke-width="1.5"/>
-    <text x="273" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#f59e0b">DAST</text>
-    <text x="273" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Test</text>
-
-    <rect x="356" y="520" width="130" height="66" rx="8"
-          fill="rgba(255,255,255,0.04)" stroke="#10b981" stroke-width="1.5"/>
-    <text x="421" y="548" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="19" font-weight="700" fill="#10b981">SCA</text>
-    <text x="421" y="568" text-anchor="middle"
-          font-family="Space Grotesk, Inter, system-ui, sans-serif"
-          font-size="10" fill="#94a3b8" letter-spacing="1">Audit</text>
-
-  <!-- Branding -->
-  <text x="1140" y="600"
-        font-family="Space Grotesk, Inter, system-ui, sans-serif"
-        font-size="15" fill="#475569" text-anchor="end" opacity="0.7">Twodragon Tech Blog</text>
-
-  <!-- Corner decoration dots -->
-  <circle cx="1170" cy="30" r="4" fill="#8b5cf6" opacity="0.4"/>
-  <circle cx="1185" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
-  <circle cx="1155" cy="30" r="2.5" fill="#8b5cf6" opacity="0.25"/>
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI vs Claude Code: AI - , DevSecOps, FinOps (...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI vs Claude Code: AI - , DevSecOps, FinOps</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(2026) - AI vs Claude Code 2026: CVE-2026-25253 RCE , 400+</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="70" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Assistant</text>
+      <rect x="153" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Claude-Code</text>
+      <rect x="297" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
+      <rect x="360" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="417" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 04, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CVE ALERT / RCE ATTACK / GO ECOSYSTEM</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">CVE Alert</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">RCE Attack</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">CVE Alert, RCE Attack, and Go Ecosystem framed</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 4 : Docker AI , CVE-2025-11953, RCE</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CVE ALERT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">CVE Alert</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize exposed services first</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map patch windows against risk</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Document compensating controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RCE ATTACK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">RCE Attack</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">GO ECOSYSTEM</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Go Ecosystem</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit module provenance</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review build and release trust</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track package-risk hotspots</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 4 : Docker AI , CVE-2025-11953, RCE -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 4 : Docker AI DockerDash , React Native CLI</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Docker</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CVE</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ALERT</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RCE ATTA</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">DOCKER</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">2</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="91" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="45.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">CVE Alert</text>
-    <rect x="101" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="150.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">RCE Attack</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
+++ b/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
@@ -1,161 +1,201 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#060d1a" />
-      <stop offset="60%" stop-color="#0a1628" />
-      <stop offset="100%" stop-color="#0d2240" />
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accentGrad" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0%" stop-color="#06b6d4" />
-      <stop offset="100%" stop-color="#3b82f6" />
+    
+    <!-- Category Gradient -->
+    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#4f46e5"/>
     </linearGradient>
-    <linearGradient id="card1" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.25" />
-      <stop offset="100%" stop-color="#0369a1" stop-opacity="0.10" />
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="card2" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.25" />
-      <stop offset="100%" stop-color="#6d28d9" stop-opacity="0.10" />
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="card3" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#10b981" stop-opacity="0.25" />
-      <stop offset="100%" stop-color="#047857" stop-opacity="0.10" />
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="card4" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.25" />
-      <stop offset="100%" stop-color="#b45309" stop-opacity="0.10" />
-    </linearGradient>
-    <linearGradient id="card5" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%" stop-color="#ef4444" stop-opacity="0.25" />
-      <stop offset="100%" stop-color="#b91c1c" stop-opacity="0.10" />
-    </linearGradient>
-    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-      <feGaussianBlur stdDeviation="3" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="shadow" x="-10%" y="-10%" width="120%" height="130%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000000" flood-opacity="0.4" />
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="glowBlue" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="6" result="blur" />
-      <feMerge><feMergeNode in="blur" /><feMergeNode in="SourceGraphic" /></feMerge>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)" />
-
-  <!-- Subtle grid lines -->
-  <line x1="0" y1="210" x2="1200" y2="210" stroke="#1e3a5f" stroke-width="1" stroke-opacity="0.4" />
-  <line x1="0" y1="420" x2="1200" y2="420" stroke="#1e3a5f" stroke-width="1" stroke-opacity="0.4" />
-  <line x1="240" y1="0" x2="240" y2="630" stroke="#1e3a5f" stroke-width="1" stroke-opacity="0.3" />
-  <line x1="600" y1="0" x2="600" y2="630" stroke="#1e3a5f" stroke-width="1" stroke-opacity="0.3" />
-  <line x1="960" y1="0" x2="960" y2="630" stroke="#1e3a5f" stroke-width="1" stroke-opacity="0.3" />
-
-  <!-- Top badge -->
-  <rect x="50" y="28" width="200" height="32" rx="16" fill="#06b6d4" fill-opacity="0.18" stroke="#06b6d4" stroke-width="1.5" />
-  <circle cx="70" cy="44" r="5" fill="#06b6d4" filter="url(#glow)" />
-  <text x="84" y="49" fill="#67e8f9" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2">AI WORKFLOW 2026</text>
-
-  <!-- Accent bar -->
-  <rect x="50" y="78" width="320" height="4" rx="2" fill="url(#accentGrad)" filter="url(#glowBlue)" />
-
-  <!-- Main title -->
-  <text x="50" y="130" fill="#f0f9ff" font-family="Arial, sans-serif" font-size="42" font-weight="800" letter-spacing="-0.5">AI Content Creator Workflow 2026</text>
-
-  <!-- Subtitle -->
-  <text x="50" y="168" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="20" font-weight="400" letter-spacing="1">Blog  |  Video  |  Music  |  Animation  |  End-to-End Pipeline</text>
-
-  <!-- Pipeline arrows background -->
-  <rect x="50" y="220" width="1100" height="260" rx="16" fill="#0a1e35" fill-opacity="0.6" stroke="#1e4a6e" stroke-width="1" />
-
-  <!-- Phase label -->
-  <text x="600" y="248" fill="#475569" font-family="Arial, sans-serif" font-size="12" font-weight="600" letter-spacing="3" text-anchor="middle">5-PHASE PIPELINE</text>
-
-  <!-- Arrow connectors -->
-  <line x1="246" y1="370" x2="268" y2="370" stroke="#334155" stroke-width="2" stroke-dasharray="4 3" />
-  <polygon points="268,365 278,370 268,375" fill="#334155" />
-  <line x1="462" y1="370" x2="484" y2="370" stroke="#334155" stroke-width="2" stroke-dasharray="4 3" />
-  <polygon points="484,365 494,370 484,375" fill="#334155" />
-  <line x1="678" y1="370" x2="700" y2="370" stroke="#334155" stroke-width="2" stroke-dasharray="4 3" />
-  <polygon points="700,365 710,370 700,375" fill="#334155" />
-  <line x1="894" y1="370" x2="916" y2="370" stroke="#334155" stroke-width="2" stroke-dasharray="4 3" />
-  <polygon points="916,365 926,370 916,375" fill="#334155" />
-
-  <!-- Card 1: Blog -->
-  <rect x="60" y="265" width="186" height="190" rx="12" fill="url(#card1)" stroke="#0ea5e9" stroke-width="1.5" filter="url(#shadow)" />
-  <rect x="60" y="265" width="186" height="4" rx="2" fill="#0ea5e9" />
-  <!-- Icon circle -->
-  <circle cx="153" cy="308" r="26" fill="#0ea5e9" fill-opacity="0.15" stroke="#0ea5e9" stroke-width="1.5" />
-  <text x="153" y="316" fill="#38bdf8" font-family="Arial, sans-serif" font-size="22" font-weight="700" text-anchor="middle">B</text>
-  <text x="153" y="354" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle">Blog Post</text>
-  <text x="153" y="375" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Claude Opus 4.5</text>
-  <rect x="88" y="388" width="130" height="22" rx="11" fill="#0ea5e9" fill-opacity="0.2" />
-  <text x="153" y="404" fill="#7dd3fc" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="600">Phase 1</text>
-  <text x="153" y="440" fill="#94a3b8" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">AI Writing</text>
-
-  <!-- Card 2: Script -->
-  <rect x="276" y="265" width="186" height="190" rx="12" fill="url(#card2)" stroke="#8b5cf6" stroke-width="1.5" filter="url(#shadow)" />
-  <rect x="276" y="265" width="186" height="4" rx="2" fill="#8b5cf6" />
-  <circle cx="369" cy="308" r="26" fill="#8b5cf6" fill-opacity="0.15" stroke="#8b5cf6" stroke-width="1.5" />
-  <text x="369" y="316" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="22" font-weight="700" text-anchor="middle">S</text>
-  <text x="369" y="354" fill="#ede9fe" font-family="Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle">Video Script</text>
-  <text x="369" y="375" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Script Generation</text>
-  <rect x="304" y="388" width="130" height="22" rx="11" fill="#8b5cf6" fill-opacity="0.2" />
-  <text x="369" y="404" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="600">Phase 2</text>
-  <text x="369" y="440" fill="#94a3b8" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">NLP Processing</text>
-
-  <!-- Card 3: Video -->
-  <rect x="492" y="265" width="186" height="190" rx="12" fill="url(#card3)" stroke="#10b981" stroke-width="1.5" filter="url(#shadow)" />
-  <rect x="492" y="265" width="186" height="4" rx="2" fill="#10b981" />
-  <circle cx="585" cy="308" r="26" fill="#10b981" fill-opacity="0.15" stroke="#10b981" stroke-width="1.5" />
-  <text x="585" y="316" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="22" font-weight="700" text-anchor="middle">V</text>
-  <text x="585" y="354" fill="#d1fae5" font-family="Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle">Video Gen</text>
-  <text x="585" y="375" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Runway Gen-3</text>
-  <rect x="520" y="388" width="130" height="22" rx="11" fill="#10b981" fill-opacity="0.2" />
-  <text x="585" y="404" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="600">Phase 3</text>
-  <text x="585" y="440" fill="#94a3b8" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">Video Synthesis</text>
-
-  <!-- Card 4: Music -->
-  <rect x="708" y="265" width="186" height="190" rx="12" fill="url(#card4)" stroke="#f59e0b" stroke-width="1.5" filter="url(#shadow)" />
-  <rect x="708" y="265" width="186" height="4" rx="2" fill="#f59e0b" />
-  <circle cx="801" cy="308" r="26" fill="#f59e0b" fill-opacity="0.15" stroke="#f59e0b" stroke-width="1.5" />
-  <text x="801" y="316" fill="#fde68a" font-family="Arial, sans-serif" font-size="22" font-weight="700" text-anchor="middle">M</text>
-  <text x="801" y="354" fill="#fef9c3" font-family="Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle">Music Gen</text>
-  <text x="801" y="375" fill="#fde68a" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">Suno AI</text>
-  <rect x="736" y="388" width="130" height="22" rx="11" fill="#f59e0b" fill-opacity="0.2" />
-  <text x="801" y="404" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="600">Phase 4</text>
-  <text x="801" y="440" fill="#94a3b8" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">Audio AI</text>
-
-  <!-- Card 5: Animation -->
-  <rect x="924" y="265" width="186" height="190" rx="12" fill="url(#card5)" stroke="#ef4444" stroke-width="1.5" filter="url(#shadow)" />
-  <rect x="924" y="265" width="186" height="4" rx="2" fill="#ef4444" />
-  <circle cx="1017" cy="308" r="26" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1.5" />
-  <text x="1017" y="316" fill="#fca5a5" font-family="Arial, sans-serif" font-size="22" font-weight="700" text-anchor="middle">A</text>
-  <text x="1017" y="354" fill="#fee2e2" font-family="Arial, sans-serif" font-size="16" font-weight="700" text-anchor="middle">Animation</text>
-  <text x="1017" y="375" fill="#fca5a5" font-family="Arial, sans-serif" font-size="11" text-anchor="middle">D-ID</text>
-  <rect x="952" y="388" width="130" height="22" rx="11" fill="#ef4444" fill-opacity="0.2" />
-  <text x="1017" y="404" fill="#fca5a5" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" font-weight="600">Phase 5</text>
-  <text x="1017" y="440" fill="#94a3b8" font-family="Arial, sans-serif" font-size="10" text-anchor="middle">Avatar Sync</text>
-
-  <!-- Footer separator -->
-  <line x1="50" y1="508" x2="1150" y2="508" stroke="#1e3a5f" stroke-width="1" />
-
-  <!-- Footer left: stats -->
-  <rect x="50" y="520" width="155" height="26" rx="13" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1" />
-  <text x="127" y="537" fill="#67e8f9" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">5 Phases</text>
-
-  <rect x="215" y="520" width="195" height="26" rx="13" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1" />
-  <text x="312" y="537" fill="#c4b5fd" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">End-to-End Pipeline</text>
-
-  <rect x="420" y="520" width="160" height="26" rx="13" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1" />
-  <text x="500" y="537" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="11" font-weight="600" text-anchor="middle">ROI 4,877%</text>
-
-  <!-- Footer right: domain -->
-  <circle cx="1100" cy="533" r="5" fill="#06b6d4" fill-opacity="0.6" />
-  <text x="1112" y="537" fill="#475569" font-family="Arial, sans-serif" font-size="12" font-weight="500" text-anchor="start">tech.2twodragon.com</text>
-
-  <!-- Date label -->
-  <text x="50" y="601" fill="#334155" font-family="Arial, sans-serif" font-size="12">Feb 5, 2026</text>
-  <text x="1150" y="601" fill="#1e40af" font-family="Arial, sans-serif" font-size="12" text-anchor="end" font-weight="600">Twodragon Tech Blog</text>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
+  </g>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI 2026 - , ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Brain/Neural Network -->
+    <g transform="translate(80, 280)">
+      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
+      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
+      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
+      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+    </g>
+    
+    <!-- Robot Head -->
+    <g transform="translate(210, 285)">
+      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
+      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
+      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
+      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
+      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
+    </g>
+    
+    <!-- Chip/Processor -->
+    <g transform="translate(330, 295)">
+      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
+      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
+      <g stroke="#7c3aed" stroke-width="3">
+        <line x1="40" y1="5" x2="40" y2="15"/>
+        <line x1="40" y1="65" x2="40" y2="75"/>
+        <line x1="5" y1="40" x2="15" y2="40"/>
+        <line x1="65" y1="40" x2="75" y2="40"/>
+      </g>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI 2026 - , , - 2026 AI</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Claude Opus 4.5 , Qwen3-TTS</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="51" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#AI</text>
+      <rect x="63" y="0" width="87" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="106" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Claude</text>
+      <rect x="162" y="0" width="96" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Suno AI</text>
+      <rect x="270" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="327" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Animation</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
@@ -1,135 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#07121f"/>
-      <stop offset="48%" stop-color="#101826"/>
-      <stop offset="100%" stop-color="#1f2937"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#f59e0b"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 05, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">N8N RCE / NGINX / ASYNCRAT</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">n8n RCE</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">NGINX</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">n8n RCE, NGINX, and AsyncRAT framed for weekly</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: n8n RCE, NGINX , AsyncRAT</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#f59e0b"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">N8N RCE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">n8n RCE</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">NGINX</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">NGINX</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ASYNCRAT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AsyncRAT</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 05 : The Hacker News 28 . CVE, AI, Malware, Go</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">N8N RCE</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">NGINX</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">ASYNCRAT</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">16</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="88" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="44.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">n8n RCE</text>
-    <rect x="98" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="142.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">NGINX</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 06, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CRASHFIX RAT / DDOS / CODESPACES RCE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">CrashFix RAT</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">DDoS</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">CrashFix RAT, DDoS, and Codespaces RCE framed</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: CrashFix RAT, DDoS, Codespaces RCE</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CRASHFIX RAT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">CrashFix RAT</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">DDOS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">DDoS</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CODESPACES</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Codespaces</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">RCE</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-06 : CrashFix Python RAT, AISURU 31.4 Tbps DDoS,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Codespaces RCE, BYOVD - 2026 02 06 : CrashFix ClickFix</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Python...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CRASHFIX</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">DDOS</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CODESPAC</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">2</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="112" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="56.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">CrashFix RAT</text>
-    <rect x="122" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="166.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">DDoS</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
+++ b/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
@@ -1,135 +1,185 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#07121f"/>
-      <stop offset="48%" stop-color="#101826"/>
-      <stop offset="100%" stop-color="#1f2937"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#f59e0b"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 07, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">APT BREACH / AITM ATTACK / SUPPLY CHAIN SECURITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">APT Breach</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">AitM Attack</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">APT Breach, AitM Attack, and Supply Chain</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Security framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: APT , AitM ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#f59e0b"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">APT BREACH</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">APT Breach</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AITM ATTACK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AitM Attack</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">SUPPLY CHAIN</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Supply Chain</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 07 : The Hacker News 25 . AI, Malware, Go, Security</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">APT BREA</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">AITM ATT</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">SUPPLY C</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">APT Breach</text>
-    <rect x="108" y="0" width="105" height="28" rx="14" fill="#082f49"/>
-    <text x="160.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">AitM Attack</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 08, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">SIGNAL ATTACK / RANSOMWARE / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Signal Attack</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Ransomware</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Signal Attack, Ransomware, and AI Runtime framed</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-08 : Signal , BlackField ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">SIGNAL</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Signal</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Attack</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-08 : Signal , BlackField , - 2026</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">02 08 : BfV/BSI Signal ( / /</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SIGNAL A</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">2</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="119" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="59.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Signal Attack</text>
-    <rect x="129" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="178.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
+++ b/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
@@ -1,125 +1,195 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="35" cy="50" r="20" fill="none" stroke="#10b981" stroke-width="3"/>
-    <circle cx="85" cy="50" r="20" fill="none" stroke="#94a3b8" stroke-width="3"/>
-    <circle cx="60" cy="100" r="20" fill="none" stroke="#10b981" stroke-width="3"/>
-    <line x1="50" y1="40" x2="70" y2="40" stroke="#94a3b8" stroke-width="2"/>
-    <line x1="45" y1="65" x2="50" y2="85" stroke="#10b981" stroke-width="2"/>
-    <line x1="75" y1="65" x2="70" y2="85" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="110" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="16" font-weight="bold">B</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-09 &amp; : Bithumb , Bitcoin 71K</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Blockchain Tech</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Digest Bithumb Bitcoin</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-09 &amp; : Bithumb , Bitcoin 71K - Bithumb 44B</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, Bitcoin 71K , 3D ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="186" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="93" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Blockchain-Digest</text>
+      <rect x="198" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Tech-Digest</text>
+      <rect x="342" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Bithumb</text>
+      <rect x="450" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="498" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Bitcoin</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 09, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#f59e0b" font-family="Arial, sans-serif" font-size="12" font-weight="bold">BLOCKCHAIN</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Blockchain</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#f7931a" font-family="Arial, sans-serif" font-size="12" font-weight="bold">BITCOIN</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Bitcoin</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="120" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="150" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Blockchain</text>
-    <rect x="225" y="0" width="93" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="271" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Bitcoin</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="125" cy="77" r="3" fill="#f87171"/>
-    <circle cx="91" cy="91" r="4" fill="#fb923c"/>
-    <circle cx="162" cy="95" r="5" fill="#818cf8"/>
-    <circle cx="221" cy="196" r="6" fill="#34d399"/>
-    <circle cx="228" cy="221" r="3" fill="#fbbf24"/>
-    <circle cx="204" cy="227" r="4" fill="#f87171"/>
-    <circle cx="201" cy="129" r="5" fill="#fb923c"/>
-    <circle cx="226" cy="204" r="6" fill="#818cf8"/>
-    <circle cx="154" cy="173" r="3" fill="#34d399"/>
-    <circle cx="45" cy="215" r="4" fill="#fbbf24"/>
-    <line x1="125" y1="77" x2="91" y2="91" stroke="#475569" stroke-width="1"/>
-    <line x1="91" y1="91" x2="162" y2="95" stroke="#475569" stroke-width="1"/>
-    <line x1="162" y1="95" x2="221" y2="196" stroke="#475569" stroke-width="1"/>
-    <line x1="221" y1="196" x2="228" y2="221" stroke="#475569" stroke-width="1"/>
-    <line x1="228" y1="221" x2="204" y2="227" stroke="#475569" stroke-width="1"/>
-    <line x1="204" y1="227" x2="201" y2="129" stroke="#475569" stroke-width="1"/>
-    <line x1="201" y1="129" x2="226" y2="204" stroke="#475569" stroke-width="1"/>
-    <line x1="226" y1="204" x2="154" y2="173" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | Blockchain | Bitcoin</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
+++ b/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
@@ -1,125 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-09 &amp; : AI , AWS Agentic AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Security Cloud Digest</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">AI VirusTotal AWS Agentic</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-09 &amp; : AI , AWS Agentic AI - AI VirusTotal</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI , SK BlackField ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Digest</text>
+      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Digest</text>
+      <rect x="333" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agent-Security</text>
+      <rect x="531" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="601" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Supply-Chain</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 09, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#a78bfa" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI AGENT</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI Agent</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="102" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="141" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI Agent</text>
-    <rect x="207" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="244" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="297" y="0" width="57" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="325" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">AWS</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="119" cy="74" r="3" fill="#f87171"/>
-    <circle cx="141" cy="141" r="4" fill="#fb923c"/>
-    <circle cx="93" cy="157" r="5" fill="#818cf8"/>
-    <circle cx="37" cy="61" r="6" fill="#34d399"/>
-    <circle cx="105" cy="37" r="3" fill="#fbbf24"/>
-    <circle cx="89" cy="181" r="4" fill="#f87171"/>
-    <circle cx="37" cy="67" r="5" fill="#fb923c"/>
-    <circle cx="130" cy="89" r="6" fill="#818cf8"/>
-    <circle cx="42" cy="44" r="3" fill="#34d399"/>
-    <circle cx="31" cy="33" r="4" fill="#fbbf24"/>
-    <line x1="119" y1="74" x2="141" y2="141" stroke="#475569" stroke-width="1"/>
-    <line x1="141" y1="141" x2="93" y2="157" stroke="#475569" stroke-width="1"/>
-    <line x1="93" y1="157" x2="37" y2="61" stroke="#475569" stroke-width="1"/>
-    <line x1="37" y1="61" x2="105" y2="37" stroke="#475569" stroke-width="1"/>
-    <line x1="105" y1="37" x2="89" y2="181" stroke="#475569" stroke-width="1"/>
-    <line x1="89" y1="181" x2="37" y2="67" stroke="#475569" stroke-width="1"/>
-    <line x1="37" y1="67" x2="130" y2="89" stroke="#475569" stroke-width="1"/>
-    <line x1="130" y1="89" x2="42" y2="44" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | AI Agent | Cloud | AWS</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
+++ b/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
@@ -1,122 +1,195 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M90 120 L30 120 C13 120 0 107 0 90 C0 75 10 63 24 60 C24 35 45 15 70 15 C92 15 110 30 115 50 C128 52 138 63 138 78 C138 95 125 108 108 108" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M50 75 L65 90 L90 60" fill="none" stroke="#94a3b8" stroke-width="3"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 AI &amp; : Meta Prometheus, Google OTL...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield with Code -->
+    <g transform="translate(80, 275)">
+      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
+            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+    </g>
+    
+    <!-- Pipeline Arrow -->
+    <g transform="translate(200, 300)">
+      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
+      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
+      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
+      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
+      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
+      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
+      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    </g>
+    
+    <!-- Security Scanner -->
+    <g transform="translate(360, 290)">
+      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
+      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">AI Cloud Digest Meta</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Prometheus Google OTLP AWS</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 AI &amp; : Meta Prometheus, Google OTLP, AWS -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Meta Prometheus AI , Google Cloud OTLP , AWS Claude</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AI-Digest</text>
+      <rect x="126" y="0" width="141" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="196" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Digest</text>
+      <rect x="279" y="0" width="168" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="363" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Meta-Prometheus</text>
+      <rect x="459" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="525" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Google-OTLP</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 10, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ff9900" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AWS</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AWS</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="127" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="180" y="0" width="57" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="208" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">AWS</text>
-    <rect x="252" y="0" width="48" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="276" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Go</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="92" cy="61" r="3" fill="#f87171"/>
-    <circle cx="137" cy="137" r="4" fill="#fb923c"/>
-    <circle cx="68" cy="106" r="5" fill="#818cf8"/>
-    <circle cx="59" cy="149" r="6" fill="#34d399"/>
-    <circle cx="208" cy="59" r="3" fill="#fbbf24"/>
-    <circle cx="102" cy="187" r="4" fill="#f87171"/>
-    <circle cx="189" cy="119" r="5" fill="#fb923c"/>
-    <circle cx="199" cy="102" r="6" fill="#818cf8"/>
-    <circle cx="51" cy="148" r="3" fill="#34d399"/>
-    <circle cx="32" cy="109" r="4" fill="#fbbf24"/>
-    <line x1="92" y1="61" x2="137" y2="137" stroke="#475569" stroke-width="1"/>
-    <line x1="137" y1="137" x2="68" y2="106" stroke="#475569" stroke-width="1"/>
-    <line x1="68" y1="106" x2="59" y2="149" stroke="#475569" stroke-width="1"/>
-    <line x1="59" y1="149" x2="208" y2="59" stroke="#475569" stroke-width="1"/>
-    <line x1="208" y1="59" x2="102" y2="187" stroke="#475569" stroke-width="1"/>
-    <line x1="102" y1="187" x2="189" y2="119" stroke="#475569" stroke-width="1"/>
-    <line x1="189" y1="119" x2="199" y2="102" stroke="#475569" stroke-width="1"/>
-    <line x1="199" y1="102" x2="51" y2="148" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | Cloud | AWS | Go</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
+++ b/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
@@ -1,129 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#d97706"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <rect x="10" y="30" width="100" height="90" rx="6" fill="url(#accent)" opacity="0.2"/>
-    <rect x="10" y="30" width="100" height="90" rx="6" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <line x1="10" y1="55" x2="110" y2="55" stroke="#10b981" stroke-width="1.5"/>
-    <circle cx="25" cy="43" r="4" fill="#94a3b8"/>
-    <circle cx="38" cy="43" r="4" fill="#94a3b8"/>
-    <circle cx="51" cy="43" r="4" fill="#94a3b8"/>
-    <rect x="20" y="65" width="80" height="8" rx="3" fill="#10b981" opacity="0.4"/>
-    <rect x="20" y="80" width="60" height="8" rx="3" fill="#10b981" opacity="0.3"/>
-    <rect x="20" y="95" width="70" height="8" rx="3" fill="#10b981" opacity="0.35"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 DevOps &amp; : CNCF Velocity, Cluster ...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Infinity/DevOps Loop -->
+    <g transform="translate(80, 290)">
+      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
+            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
+    </g>
+    
+    <!-- Gear Icon -->
+    <g transform="translate(220, 290)">
+      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
+      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+    </g>
+    
+    <!-- Code Bracket -->
+    <g transform="translate(330, 295)">
+      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">DevOps Blockchain Digest</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">CNCF Chainalysis Bitcoin</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 DevOps &amp; : CNCF Velocity, Cluster API, Bitcoin -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CNCF Project Velocity 2025 , Cluster API v1.12 In-Place</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="150" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#DevOps-Digest</text>
+      <rect x="162" y="0" width="186" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="255" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Blockchain-Digest</text>
+      <rect x="360" y="0" width="69" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="394" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#CNCF</text>
+      <rect x="441" y="0" width="123" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="502" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Kubernetes</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 10, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#326ce5" font-family="Arial, sans-serif" font-size="12" font-weight="bold">KUBERNETES</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Kubernetes</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#f59e0b" font-family="Arial, sans-serif" font-size="12" font-weight="bold">BLOCKCHAIN</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Blockchain</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="120" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="150" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Kubernetes</text>
-    <rect x="225" y="0" width="120" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="285" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Blockchain</text>
-    <rect x="360" y="0" width="93" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="406" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">Bitcoin</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="47" cy="138" r="3" fill="#f87171"/>
-    <circle cx="207" cy="207" r="4" fill="#fb923c"/>
-    <circle cx="177" cy="124" r="5" fill="#818cf8"/>
-    <circle cx="223" cy="203" r="6" fill="#34d399"/>
-    <circle cx="54" cy="223" r="3" fill="#fbbf24"/>
-    <circle cx="33" cy="78" r="4" fill="#f87171"/>
-    <circle cx="55" cy="42" r="5" fill="#fb923c"/>
-    <circle cx="33" cy="33" r="6" fill="#818cf8"/>
-    <circle cx="130" cy="80" r="3" fill="#34d399"/>
-    <circle cx="42" cy="42" r="4" fill="#fbbf24"/>
-    <line x1="47" y1="138" x2="207" y2="207" stroke="#475569" stroke-width="1"/>
-    <line x1="207" y1="207" x2="177" y2="124" stroke="#475569" stroke-width="1"/>
-    <line x1="177" y1="124" x2="223" y2="203" stroke="#475569" stroke-width="1"/>
-    <line x1="223" y1="203" x2="54" y2="223" stroke="#475569" stroke-width="1"/>
-    <line x1="54" y1="223" x2="33" y2="78" stroke="#475569" stroke-width="1"/>
-    <line x1="33" y1="78" x2="55" y2="42" stroke="#475569" stroke-width="1"/>
-    <line x1="55" y1="42" x2="33" y2="33" stroke="#475569" stroke-width="1"/>
-    <line x1="33" y1="33" x2="130" y2="80" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | Kubernetes | Blockchain | Bitcoin</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
+++ b/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
@@ -1,124 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#fca5a5" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 : SolarWinds RCE, UNC3886 , LLM</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Security Digest SolarWinds</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">UNC3886 LLM Attack</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 : SolarWinds RCE, UNC3886 , LLM -</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SolarWinds WHD RCE (CVE-2025-40551), UNC3886 , LLM</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Digest</text>
+      <rect x="180" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="259" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SolarWinds-RCE</text>
+      <rect x="351" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#UNC3886</text>
+      <rect x="459" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LLM-Safety</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 10, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">SECURITY</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Security</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="111" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="55" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="126" y="0" width="57" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="154" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="198" y="0" width="102" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="249" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Security</text>
-    <rect x="315" y="0" width="120" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="375" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">SolarWinds</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="36" cy="33" r="3" fill="#f87171"/>
-    <circle cx="30" cy="30" r="4" fill="#fb923c"/>
-    <circle cx="55" cy="80" r="5" fill="#818cf8"/>
-    <circle cx="58" cy="142" r="6" fill="#34d399"/>
-    <circle cx="108" cy="58" r="3" fill="#fbbf24"/>
-    <circle cx="39" cy="187" r="4" fill="#f87171"/>
-    <circle cx="56" cy="69" r="5" fill="#fb923c"/>
-    <circle cx="83" cy="39" r="6" fill="#818cf8"/>
-    <circle cx="136" cy="82" r="3" fill="#34d399"/>
-    <circle cx="43" cy="43" r="4" fill="#fbbf24"/>
-    <line x1="36" y1="33" x2="30" y2="30" stroke="#475569" stroke-width="1"/>
-    <line x1="30" y1="30" x2="55" y2="80" stroke="#475569" stroke-width="1"/>
-    <line x1="55" y1="80" x2="58" y2="142" stroke="#475569" stroke-width="1"/>
-    <line x1="58" y1="142" x2="108" y2="58" stroke="#475569" stroke-width="1"/>
-    <line x1="108" y1="58" x2="39" y2="187" stroke="#475569" stroke-width="1"/>
-    <line x1="39" y1="187" x2="56" y2="69" stroke="#475569" stroke-width="1"/>
-    <line x1="56" y1="69" x2="83" y2="39" stroke="#475569" stroke-width="1"/>
-    <line x1="83" y1="39" x2="136" y2="82" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">CVE Alert | LLM | Security | SolarWinds</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
+++ b/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 11, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">RANSOMWARE / FORTINET PATCH / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Ransomware</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Fortinet Patch</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Ransomware, Fortinet Patch, and AI Runtime</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , Fortinet , AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">FORTINET</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Fortinet</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Patch</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 11 : The Hacker News 26 . , , , AI</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">FORTINET</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">16</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-    <rect x="108" y="0" width="126" height="28" rx="14" fill="#082f49"/>
-    <text x="171.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Fortinet Patch</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
+++ b/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 12, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">SUPPLY CHAIN BREACH / WINDOWS SECURITY / APT36 ACTIVITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Supply Chain</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Breach</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Supply Chain Breach, Windows Security, and APT36</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Activity framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , Windows , APT36</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">SUPPLY CHAIN</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Supply Chain</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Breach</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Trace package trust paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review build isolation posture</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Verify provenance coverage</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">WINDOWS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Windows</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize endpoint patch cadence</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review admin exposure routes</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Update hardening gaps</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">APT36</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">APT36</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Activity</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh intel-driven detections</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check identity and phishing paths</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice escalation workflow</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 12 : The Hacker News, Microsoft Security Blog 27 .</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI, , , DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SUPPLY</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CHAIN</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WINDOWS</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">APT36</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">ACTIVITY</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">14</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Supply Chain Bre</text>
-    <rect x="150" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="220.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Windows Security</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
+++ b/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#07121f"/>
-      <stop offset="48%" stop-color="#101826"/>
-      <stop offset="100%" stop-color="#1f2937"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#f59e0b"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 13, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">LAZARUS SUPPLY CHAIN / COPILOT STUDIO / FINOPS PRESSURE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Lazarus Supply</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Chain</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Lazarus Supply Chain, Copilot Studio, and FinOps</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Pressure framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Lazarus , Copilot Studio, FinOps</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#f59e0b"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">LAZARUS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Lazarus</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Supply Chain</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tighten developer secret handling</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review dependency approvals</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor build-system abuse</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">COPILOT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Copilot</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Studio</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Constrain tool permissions</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Validate output controls</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review approval steps</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">FINOPS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">FinOps</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Pressure</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Watch cost-to-control tradeoffs</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review usage guardrails</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep operational budgets visible</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Gemini AI , Lazarus npm PyPI , Copilot Studio ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FinOps 2026-02-13</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">LAZARUS</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CHAIN</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">COPILOT</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">FINOPS</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">COST</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">13</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Lazarus Supply C</text>
-    <rect x="150" y="0" width="126" height="28" rx="14" fill="#082f49"/>
-    <text x="213.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Copilot Studio</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
+++ b/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
@@ -1,123 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <rect x="25" y="60" width="70" height="80" rx="8" fill="url(#accent)" opacity="0.9"/>
-    <path d="M35 60 V40 C35 18 85 18 85 40 V60" fill="none" stroke="#fca5a5" stroke-width="3"/>
-    <circle cx="60" cy="100" r="10" fill="white"/>
-    <rect x="57" y="100" width="6" height="18" rx="2" fill="white"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <path d="M60 5 L115 120 L5 120 Z" fill="url(#accent)" opacity="0.9"/>
-    <path d="M60 20 L105 115 L15 115 Z" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="85" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="40" font-weight="bold">!</text>
-    <circle cx="60" cy="100" r="4" fill="white"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 2 : Microsoft 6 Zero-Day, Apple , Ivan...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Weekly Security Digest Microsoft</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Zero Day Apple Ivanti EPMM</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Microsoft Patch Tuesday 6 Zero-Day , Apple CVE-2026-20700 ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Ivanti EPMM , SAP CVSS 9.9 SQL Injection, 74B</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 ...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 14, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">RANSOMWARE</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Ransomware</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#dc2626" font-family="Arial, sans-serif" font-size="12" font-weight="bold">ZERO-DAY</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Zero-Day</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CVE ALERT</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">CVE Alert</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="120" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="60" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Ransomware</text>
-    <rect x="135" y="0" width="102" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="186" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Zero-Day</text>
-    <rect x="252" y="0" width="111" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="307" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">CVE Alert</text>
-    <rect x="378" y="0" width="75" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="415" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="203" cy="216" r="3" fill="#f87171"/>
-    <circle cx="176" cy="176" r="4" fill="#fb923c"/>
-    <circle cx="73" cy="116" r="5" fill="#818cf8"/>
-    <circle cx="135" cy="51" r="6" fill="#34d399"/>
-    <circle cx="218" cy="135" r="3" fill="#fbbf24"/>
-    <circle cx="103" cy="206" r="4" fill="#f87171"/>
-    <circle cx="139" cy="124" r="5" fill="#fb923c"/>
-    <circle cx="218" cy="103" r="6" fill="#818cf8"/>
-    <circle cx="203" cy="48" r="3" fill="#34d399"/>
-    <circle cx="51" cy="184" r="4" fill="#fbbf24"/>
-    <line x1="203" y1="216" x2="176" y2="176" stroke="#475569" stroke-width="1"/>
-    <line x1="176" y1="176" x2="73" y2="116" stroke="#475569" stroke-width="1"/>
-    <line x1="73" y1="116" x2="135" y2="51" stroke="#475569" stroke-width="1"/>
-    <line x1="135" y1="51" x2="218" y2="135" stroke="#475569" stroke-width="1"/>
-    <line x1="218" y1="135" x2="103" y2="206" stroke="#475569" stroke-width="1"/>
-    <line x1="103" y1="206" x2="139" y2="124" stroke="#475569" stroke-width="1"/>
-    <line x1="139" y1="124" x2="218" y2="103" stroke="#475569" stroke-width="1"/>
-    <line x1="218" y1="103" x2="203" y2="48" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">14 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Ransomware | Zero-Day | CVE Alert | AI/ML</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
+++ b/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
@@ -1,125 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#d97706"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 16 : LLM , Windows ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Infinity/DevOps Loop -->
+    <g transform="translate(80, 290)">
+      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
+            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
+    </g>
+    
+    <!-- Gear Icon -->
+    <g transform="translate(220, 290)">
+      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
+      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+    </g>
+    
+    <!-- Code Bracket -->
+    <g transform="translate(330, 295)">
+      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Daily Tech Digest RSS Roundup</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300"></text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">24 RSS LLM , Windows , ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="141" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="70" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Daily-Digest</text>
+      <rect x="153" y="0" width="168" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Tech-Newsletter</text>
+      <rect x="333" y="0" width="141" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="403" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#AI-Inference</text>
+      <rect x="486" y="0" width="132" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Windows-Dev</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 16, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#f59e0b" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CRYPTO</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Crypto</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="57" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="118" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="162" y="0" width="84" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="204" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Crypto</text>
-    <rect x="261" y="0" width="102" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="312" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">RSS Feed</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="139" cy="184" r="3" fill="#f87171"/>
-    <circle cx="68" cy="68" r="4" fill="#fb923c"/>
-    <circle cx="34" cy="39" r="5" fill="#818cf8"/>
-    <circle cx="205" cy="132" r="6" fill="#34d399"/>
-    <circle cx="126" cy="205" r="3" fill="#fbbf24"/>
-    <circle cx="217" cy="223" r="4" fill="#f87171"/>
-    <circle cx="53" cy="178" r="5" fill="#fb923c"/>
-    <circle cx="32" cy="217" r="6" fill="#818cf8"/>
-    <circle cx="30" cy="76" r="3" fill="#34d399"/>
-    <circle cx="55" cy="41" r="4" fill="#fbbf24"/>
-    <line x1="139" y1="184" x2="68" y2="68" stroke="#475569" stroke-width="1"/>
-    <line x1="68" y1="68" x2="34" y2="39" stroke="#475569" stroke-width="1"/>
-    <line x1="34" y1="39" x2="205" y2="132" stroke="#475569" stroke-width="1"/>
-    <line x1="205" y1="132" x2="126" y2="205" stroke="#475569" stroke-width="1"/>
-    <line x1="126" y1="205" x2="217" y2="223" stroke="#475569" stroke-width="1"/>
-    <line x1="217" y1="223" x2="53" y2="178" stroke="#475569" stroke-width="1"/>
-    <line x1="53" y1="178" x2="32" y2="217" stroke="#475569" stroke-width="1"/>
-    <line x1="32" y1="217" x2="30" y2="76" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | LLM | Crypto | RSS Feed</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
+++ b/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 17, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">AI RUNTIME / SECURITY OPERATIONS / CLOUD SECURITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">AI Runtime</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Security Operations</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">AI Runtime, Security Operations, and Cloud</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Security framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">SECURITY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Security</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Operations</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh threat monitoring rules</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Reconfirm escalation flow</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Drill recovery readiness</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CLOUD</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Cloud</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposed cloud services</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check identity and network drift</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Confirm logging coverage</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Infostealer AI / , Bitwarden/Dashlane/LastPass</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">25 , AWS AI 18 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">OPS</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CLOUD</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">8</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Runtime</text>
-    <rect x="108" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="178.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Security Operati</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
+++ b/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
@@ -1,125 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#10b981" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 3 : AI , Patch Tuesday,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Weekly Tech Security</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Digest AI Cloud Risk</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI , Microsoft Patch Tuesday, / , LLM</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2 3 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+      <rect x="162" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="342" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="486" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="556" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Threat-Intel</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 17, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">LLM</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">LLM</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="57" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="118" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">LLM</text>
-    <rect x="162" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="199" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="252" y="0" width="84" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="294" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="143" cy="186" r="3" fill="#f87171"/>
-    <circle cx="69" cy="69" r="4" fill="#fb923c"/>
-    <circle cx="159" cy="89" r="5" fill="#818cf8"/>
-    <circle cx="171" cy="194" r="6" fill="#34d399"/>
-    <circle cx="172" cy="171" r="3" fill="#fbbf24"/>
-    <circle cx="147" cy="115" r="4" fill="#f87171"/>
-    <circle cx="169" cy="101" r="5" fill="#fb923c"/>
-    <circle cx="122" cy="147" r="6" fill="#818cf8"/>
-    <circle cx="66" cy="109" r="3" fill="#34d399"/>
-    <circle cx="59" cy="199" r="4" fill="#fbbf24"/>
-    <line x1="143" y1="186" x2="69" y2="69" stroke="#475569" stroke-width="1"/>
-    <line x1="69" y1="69" x2="159" y2="89" stroke="#475569" stroke-width="1"/>
-    <line x1="159" y1="89" x2="171" y2="194" stroke="#475569" stroke-width="1"/>
-    <line x1="171" y1="194" x2="172" y2="171" stroke="#475569" stroke-width="1"/>
-    <line x1="172" y1="171" x2="147" y2="115" stroke="#475569" stroke-width="1"/>
-    <line x1="147" y1="115" x2="169" y2="101" stroke="#475569" stroke-width="1"/>
-    <line x1="169" y1="101" x2="122" y2="147" stroke="#475569" stroke-width="1"/>
-    <line x1="122" y1="147" x2="66" y2="109" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | LLM | Cloud | DevOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
+++ b/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
@@ -1,127 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#ef4444"/>
-      <stop offset="100%" stop-color="#dc2626"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <ellipse cx="60" cy="80" rx="35" ry="45" fill="url(#accent)" opacity="0.9"/>
-    <circle cx="48" cy="60" r="8" fill="white" opacity="0.8"/>
-    <circle cx="72" cy="60" r="8" fill="white" opacity="0.8"/>
-    <line x1="20" y1="60" x2="35" y2="70" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="100" y1="60" x2="85" y2="70" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="15" y1="90" x2="30" y2="85" stroke="#fca5a5" stroke-width="2"/>
-    <line x1="105" y1="90" x2="90" y2="85" stroke="#fca5a5" stroke-width="2"/>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#94a3b8" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">KrebsOnSecurity : Kimwolf 2026 2</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Tech Security Weekly Digest</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">AI Cloud Malware Update</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">KrebsOnSecurity RSS 10 Kimwolf (I2P), 2 Patch Tuesday, Badbox</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2.0 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KrebsOnSecurity</text>
+      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Threat-Intel</text>
+      <rect x="333" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Botnet</text>
+      <rect x="432" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Patch-Tuesday</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 18, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#ef4444" font-family="Arial, sans-serif" font-size="12" font-weight="bold">MALWARE</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Malware</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="93" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="46" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">Malware</text>
-    <rect x="108" y="0" width="75" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="145" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="198" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="235" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="288" y="0" width="111" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="343" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">DevSecOps</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="125" cy="177" r="3" fill="#f87171"/>
-    <circle cx="166" cy="166" r="4" fill="#fb923c"/>
-    <circle cx="97" cy="164" r="5" fill="#818cf8"/>
-    <circle cx="163" cy="163" r="6" fill="#34d399"/>
-    <circle cx="71" cy="163" r="3" fill="#fbbf24"/>
-    <circle cx="60" cy="113" r="4" fill="#f87171"/>
-    <circle cx="108" cy="150" r="5" fill="#fb923c"/>
-    <circle cx="89" cy="60" r="6" fill="#818cf8"/>
-    <circle cx="62" cy="187" r="3" fill="#34d399"/>
-    <circle cx="34" cy="69" r="4" fill="#fbbf24"/>
-    <line x1="125" y1="177" x2="166" y2="166" stroke="#475569" stroke-width="1"/>
-    <line x1="166" y1="166" x2="97" y2="164" stroke="#475569" stroke-width="1"/>
-    <line x1="97" y1="164" x2="163" y2="163" stroke="#475569" stroke-width="1"/>
-    <line x1="163" y1="163" x2="71" y2="163" stroke="#475569" stroke-width="1"/>
-    <line x1="71" y1="163" x2="60" y2="113" stroke="#475569" stroke-width="1"/>
-    <line x1="60" y1="113" x2="108" y2="150" stroke="#475569" stroke-width="1"/>
-    <line x1="108" y1="150" x2="89" y2="60" stroke="#475569" stroke-width="1"/>
-    <line x1="89" y1="60" x2="62" y2="187" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Malware | AI/ML | Cloud | DevSecOps</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
+++ b/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 18, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">ANDROID MALWARE / UPDATE RISK / CLOUD SECURITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Android Malware</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Update Risk</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Android Malware, Update Risk, and Cloud Security</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Cloud Malware ...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ANDROID</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Android</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Malware</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize mobile detection updates</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review OTA integrity signals</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit app-distribution exposure</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">UPDATE RISK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Update Risk</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Stage rollback-ready patching</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track release-induced failures</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep change ownership explicit</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CLOUD</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Cloud</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposed cloud services</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check identity and network drift</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Confirm logging coverage</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 18 : The Hacker News 20 . AI, ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ANDROID</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">MALWARE</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">UPDATE</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CLOUD</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">10</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="133" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="66.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Android Malware</text>
-    <rect x="143" y="0" width="105" height="28" rx="14" fill="#082f49"/>
-    <text x="195.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Update Risk</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
+++ b/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 19, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">AWS SECURITY / ZERO-DAY / CVE-2329</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">AWS Security</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Zero-Day</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">AWS Security, Zero-Day, and CVE-2329 framed for</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AWS , Zero-Day, CVE-2026-2329</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AWS SECURITY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AWS Security</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review identity and account posture</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check service guardrail coverage</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Validate audit logs</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ZERO-DAY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Zero-Day</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map active exploitation paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Apply emergency mitigations fast</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Document compensating controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CVE-2329</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">CVE-2329</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize exposed instances</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Patch highest-risk footprint first</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track exploit verification</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Dell RecoverPoint VM CVE-2026-22769 , VS Code 4 (1.25</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) , Cellebrite 2026 2 19</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">27 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">AWS</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">ZERO</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">DAY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CVE</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">2329</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">CVE</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">ALERT</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">15</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="112" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="56.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">AWS Security</text>
-    <rect x="122" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="166.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Zero-Day</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
+++ b/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
@@ -1,129 +1,201 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630">
-      <stop offset="0%" stop-color="#0f172a"/>
-      <stop offset="50%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#6366f1"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/>
+      <stop offset="100%" style="stop-color:#4f46e5"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#10b981"/>
-      <stop offset="100%" stop-color="#059669"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05" stroke="#94a3b8" stroke-width="1">
-    <line x1="0" y1="100" x2="1200" y2="100"/>
-    <line x1="0" y1="200" x2="1200" y2="200"/>
-    <line x1="0" y1="300" x2="1200" y2="300"/>
-    <line x1="0" y1="400" x2="1200" y2="400"/>
-    <line x1="0" y1="500" x2="1200" y2="500"/>
-    <line x1="200" y1="0" x2="200" y2="630"/>
-    <line x1="400" y1="0" x2="400" y2="630"/>
-    <line x1="600" y1="0" x2="600" y2="630"/>
-    <line x1="800" y1="0" x2="800" y2="630"/>
-    <line x1="1000" y1="0" x2="1000" y2="630"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
   </g>
-
-  <!-- Primary icon -->
-  <g transform="translate(80, 180)">
-    <circle cx="60" cy="70" r="45" fill="url(#accent)" opacity="0.15"/>
-    <circle cx="60" cy="70" r="45" fill="none" stroke="#6366f1" stroke-width="2.5"/>
-    <path d="M40 55 Q50 35 60 50 Q70 35 80 55" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <path d="M35 75 Q45 60 55 75 Q65 60 75 75 Q85 60 90 75" fill="none" stroke="#c7d2fe" stroke-width="2"/>
-    <text x="60" y="105" text-anchor="middle" fill="#6366f1" font-family="monospace" font-size="14" font-weight="bold">AI</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-
-  <!-- Secondary icon -->
-  <g transform="translate(80, 380)">
-    <rect x="10" y="30" width="100" height="90" rx="6" fill="url(#accent)" opacity="0.2"/>
-    <rect x="10" y="30" width="100" height="90" rx="6" fill="none" stroke="#10b981" stroke-width="2.5"/>
-    <line x1="10" y1="55" x2="110" y2="55" stroke="#10b981" stroke-width="1.5"/>
-    <circle cx="25" cy="43" r="4" fill="#94a3b8"/>
-    <circle cx="38" cy="43" r="4" fill="#94a3b8"/>
-    <circle cx="51" cy="43" r="4" fill="#94a3b8"/>
-    <rect x="20" y="65" width="80" height="8" rx="3" fill="#10b981" opacity="0.4"/>
-    <rect x="20" y="80" width="60" height="8" rx="3" fill="#10b981" opacity="0.3"/>
-    <rect x="20" y="95" width="70" height="8" rx="3" fill="#10b981" opacity="0.35"/>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-20 : AI EKS Flyte Docker Cloud Native</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Brain/Neural Network -->
+    <g transform="translate(80, 280)">
+      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
+      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
+      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
+      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+    </g>
+    
+    <!-- Robot Head -->
+    <g transform="translate(210, 285)">
+      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
+      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
+      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
+      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
+      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
+    </g>
+    
+    <!-- Chip/Processor -->
+    <g transform="translate(330, 295)">
+      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
+      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
+      <g stroke="#7c3aed" stroke-width="3">
+        <line x1="40" y1="5" x2="40" y2="15"/>
+        <line x1="40" y1="65" x2="40" y2="75"/>
+        <line x1="5" y1="40" x2="15" y2="40"/>
+        <line x1="65" y1="40" x2="75" y2="40"/>
+      </g>
+    </g>
+    
   </g>
-
-  <!-- Main title area -->
-  <g transform="translate(260, 100)">
-    <text x="0" y="0" fill="#f8fafc" font-family="Arial, sans-serif" font-size="18" font-weight="bold" letter-spacing="4">TECH SECURITY WEEKLY DIGEST</text>
-    <text x="0" y="60" fill="#f8fafc" font-family="Arial, sans-serif" font-size="42" font-weight="bold">Tech Blog Weekly</text>
-    <text x="0" y="110" fill="#94a3b8" font-family="Arial, sans-serif" font-size="36" font-weight="300">Digest AI Data Cloud</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 20 : OpenAI Blog, Google AI Blog, AWS Machine</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Learning Blog 15 . AI, Data, Cloud, Go .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Tech-Blog</text>
+      <rect x="126" y="0" width="150" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Weekly-Digest</text>
+      <rect x="288" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="345" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Developer</text>
+      <rect x="414" y="0" width="69" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="448" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#2026</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Date badge -->
-  <rect x="260" y="240" width="200" height="36" rx="18" fill="url(#accent)" opacity="0.9"/>
-  <text x="360" y="264" text-anchor="middle" fill="white" font-family="Arial, sans-serif" font-size="16" font-weight="bold">February 20, 2026</text>
-
-  <!-- Stats cards -->
-  <g transform="translate(260, 310)">
-    <rect x="0" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="20" y="30" fill="#818cf8" font-family="Arial, sans-serif" font-size="12" font-weight="bold">AI/ML</text>
-    <text x="20" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">AI/ML</text>
-    <text x="20" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="220" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="240" y="30" fill="#326ce5" font-family="Arial, sans-serif" font-size="12" font-weight="bold">KUBERNETES</text>
-    <text x="240" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Kubernetes</text>
-    <text x="240" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
-    <rect x="440" y="0" width="200" height="90" rx="8" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-    <text x="460" y="30" fill="#06b6d4" font-family="Arial, sans-serif" font-size="12" font-weight="bold">CLOUD</text>
-    <text x="460" y="65" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="bold">Cloud</text>
-    <text x="460" y="80" fill="#64748b" font-family="Arial, sans-serif" font-size="13">analysis</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Key topics -->
-  <g transform="translate(260, 440)">
-    <rect x="0" y="0" width="75" height="32" rx="16" fill="#991b1b" opacity="0.7"/>
-    <text x="37" y="21" text-anchor="middle" fill="#fca5a5" font-family="Arial, sans-serif" font-size="13">AI/ML</text>
-    <rect x="90" y="0" width="120" height="32" rx="16" fill="#7c2d12" opacity="0.7"/>
-    <text x="150" y="21" text-anchor="middle" fill="#fdba74" font-family="Arial, sans-serif" font-size="13">Kubernetes</text>
-    <rect x="225" y="0" width="75" height="32" rx="16" fill="#312e81" opacity="0.7"/>
-    <text x="262" y="21" text-anchor="middle" fill="#a5b4fc" font-family="Arial, sans-serif" font-size="13">Cloud</text>
-    <rect x="315" y="0" width="57" height="32" rx="16" fill="#064e3b" opacity="0.7"/>
-    <text x="343" y="21" text-anchor="middle" fill="#6ee7b7" font-family="Arial, sans-serif" font-size="13">AWS</text>
-  </g>
-
-  <!-- Network visualization -->
-  <g transform="translate(900, 180)" opacity="0.4">
-    <circle cx="116" cy="173" r="3" fill="#f87171"/>
-    <circle cx="115" cy="115" r="4" fill="#fb923c"/>
-    <circle cx="40" cy="51" r="5" fill="#818cf8"/>
-    <circle cx="131" cy="35" r="6" fill="#34d399"/>
-    <circle cx="42" cy="131" r="3" fill="#fbbf24"/>
-    <circle cx="81" cy="55" r="4" fill="#f87171"/>
-    <circle cx="61" cy="36" r="5" fill="#fb923c"/>
-    <circle cx="58" cy="81" r="6" fill="#818cf8"/>
-    <circle cx="83" cy="92" r="3" fill="#34d399"/>
-    <circle cx="61" cy="145" r="4" fill="#fbbf24"/>
-    <line x1="116" y1="173" x2="115" y2="115" stroke="#475569" stroke-width="1"/>
-    <line x1="115" y1="115" x2="40" y2="51" stroke="#475569" stroke-width="1"/>
-    <line x1="40" y1="51" x2="131" y2="35" stroke="#475569" stroke-width="1"/>
-    <line x1="131" y1="35" x2="42" y2="131" stroke="#475569" stroke-width="1"/>
-    <line x1="42" y1="131" x2="81" y2="55" stroke="#475569" stroke-width="1"/>
-    <line x1="81" y1="55" x2="61" y2="36" stroke="#475569" stroke-width="1"/>
-    <line x1="61" y1="36" x2="58" y2="81" stroke="#475569" stroke-width="1"/>
-    <line x1="58" y1="81" x2="83" y2="92" stroke="#475569" stroke-width="1"/>
-  </g>
-
-  <!-- Bottom bar -->
-  <rect x="0" y="510" width="1200" height="120" fill="#0f172a" opacity="0.8"/>
-  <rect x="0" y="510" width="1200" height="2" fill="url(#accent)" opacity="0.5"/>
-
-  <!-- Bottom text -->
-  <text x="80" y="560" fill="#94a3b8" font-family="Arial, sans-serif" font-size="16">tech.2twodragon.com</text>
-  <text x="80" y="590" fill="#64748b" font-family="Arial, sans-serif" font-size="13">DevSecOps Weekly Security Intelligence</text>
-
-  <!-- Bottom right -->
-  <text x="1120" y="560" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="14">10 curated articles</text>
-  <text x="1120" y="590" text-anchor="end" fill="#64748b" font-family="Arial, sans-serif" font-size="13">AI/ML | Kubernetes | Cloud | AWS</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
+++ b/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 20, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">GEMINI 3.1 PRO / AI SUPPLY CHAIN / KUBERNETES</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Gemini 3.1 Pro</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">AI Supply Chain</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Gemini 3.1 Pro, AI Supply Chain, and Kubernetes</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Gemini 3.1 Pro, AI , Kubernetes</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">GEMINI 3.1</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Gemini 3.1</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Pro</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review model rollout controls</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check prompt and data boundaries</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Measure production performance drift</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI SUPPLY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Supply</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Chain</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit agent/plugin dependencies</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Validate package provenance</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck CI trust boundaries</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">KUBERNETES</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Kubernetes</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review cluster exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check ingress and policy drift</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep response runbooks current</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 20 : The Hacker News, Google Cloud, Snyk 29 . Gemini</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">3.1 Pro, AI , Kubernetes Ingress NGINX DevSecOps</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">GEMINI</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">3.1</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SUPPLY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">K8S</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">22</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="126" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="63.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Gemini 3.1 Pro</text>
-    <rect x="136" y="0" width="133" height="28" rx="14" fill="#082f49"/>
-    <text x="202.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Supply Chain</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
+++ b/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 21, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CVE-49113 / RANSOMWARE / RUST SUPPLY CHAIN</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">CVE-49113</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Ransomware</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">CVE-49113, Ransomware, and Rust Supply Chain</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: CVE-2025-49113, , Rust</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CVE-49113</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">CVE-49113</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Sort exposure by business impact</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck vulnerable dependencies</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit patch exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RUST SUPPLY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Rust Supply</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Chain</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit crate provenance</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check build reproducibility</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Verify SBOM freshness</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 21 : The Hacker News, SK 15 .</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Vulnerability, AI, Security, AWS DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CVE</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">49113</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUST</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CHAIN</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="91" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="45.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">CVE-49113</text>
-    <rect x="101" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="150.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
+++ b/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 22, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">AI THREAT ACTORS / ROUNDCUBE KEV / CLAUDE CODE SECURITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">AI Threat Actors</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Roundcube KEV</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">AI Threat Actors, Roundcube KEV, and Claude Code</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Security framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , Roundcube KEV, Claude Code</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI THREAT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Threat</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Actors</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh adversary detections</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tighten AI workflow guardrails</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map attacker automation paths</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ROUNDCUBE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Roundcube</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">KEV</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Patch internet-facing mail assets</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposed auth flows</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Confirm isolation controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CLAUDE CODE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Claude Code</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Limit tool and secret scope</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review code-scanning guardrails</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track prompt abuse risks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 22 : AI 55 FortiGate , CISA</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Roundcube 2 KEV , Anthropic Claude Code Security</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps ...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">THREATS</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">ROUND</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">KEV</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CLAUDE</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">CODE</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Threat Actors</text>
-    <rect x="150" y="0" width="119" height="28" rx="14" fill="#082f49"/>
-    <text x="209.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Roundcube KEV</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
+++ b/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 23, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">VERTICAL AI SECURITY / RANSOMWARE / DATA STRATEGY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Vertical AI</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Vertical AI Security, Ransomware, and Data</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Strategy framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Vertical AI , BlackField ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">VERTICAL AI</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Vertical AI</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tie domain data to controls</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review customer-boundary leakage</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Measure rollout exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">DATA</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Data</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Strategy</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check access review coverage</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Align retention with response plans</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track governance drift</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SK 5 Vertical AI , BlackField ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, OT</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">VERTICAL</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">DATA</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">STRATEGY</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">2</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Vertical AI Secu</text>
-    <rect x="150" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="199.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
+++ b/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 24, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">APT28 MALWARE / DOCKER SECURITY / LLM OPERATIONS</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">APT28 Malware</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Docker Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">APT28 Malware, Docker Security, and LLM</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Operations framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: APT28 , Docker , LLM</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">APT28</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">APT28</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Malware</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh threat hunting playbooks</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check phishing-resistant auth</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tighten admin hygiene</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">DOCKER</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Docker</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review image provenance checks</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Constrain registry trust</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit runtime hardening</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">LLM</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">LLM</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Operations</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep model changes observable</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review data boundary controls</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare controlled rollback</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">APT28 MacroMaze , XMRig BYOVD , OpenAI SWE-bench ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Docker Gordon AI , KubeCon Europe SecurityCon</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">APT28</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">MALWARE</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">DOCKER</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">LLM</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">OPS</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">12</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="119" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="59.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">APT28 Malware</text>
-    <rect x="129" y="0" width="133" height="28" rx="14" fill="#082f49"/>
-    <text x="195.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Docker Security</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
+++ b/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
@@ -1,101 +1,190 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" font-family="'Segoe UI', 'Apple SD Gothic Neo', sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0c29"/>
-      <stop offset="50%" style="stop-color:#302b63"/>
-      <stop offset="100%" style="stop-color:#24243e"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <linearGradient id="accent1" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#667eea"/>
-      <stop offset="100%" style="stop-color:#764ba2"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#d97706"/>
     </linearGradient>
-    <linearGradient id="accent2" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#f093fb"/>
-      <stop offset="100%" style="stop-color:#f5576c"/>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
     </linearGradient>
-    <linearGradient id="accent3" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#4facfe"/>
-      <stop offset="100%" style="stop-color:#00f2fe"/>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
       <feMerge>
         <feMergeNode in="blur"/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bg)"/>
-
-  <!-- Grid pattern -->
-  <g opacity="0.05">
-    <line x1="0" y1="0" x2="1200" y2="630" stroke="#fff" stroke-width="0.5"/>
-    <line x1="200" y1="0" x2="1200" y2="500" stroke="#fff" stroke-width="0.5"/>
-    <line x1="400" y1="0" x2="1200" y2="400" stroke="#fff" stroke-width="0.5"/>
-    <line x1="0" y1="200" x2="1000" y2="630" stroke="#fff" stroke-width="0.5"/>
-    <line x1="0" y1="400" x2="800" y2="630" stroke="#fff" stroke-width="0.5"/>
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
   </g>
-
-  <!-- Decorative circles -->
-  <circle cx="100" cy="100" r="180" fill="none" stroke="url(#accent1)" stroke-width="1" opacity="0.15"/>
-  <circle cx="1100" cy="530" r="200" fill="none" stroke="url(#accent3)" stroke-width="1" opacity="0.15"/>
-  <circle cx="900" cy="150" r="100" fill="none" stroke="url(#accent2)" stroke-width="1" opacity="0.1"/>
-
-  <!-- Top badge -->
-  <rect x="440" y="60" width="320" height="36" rx="18" fill="url(#accent1)" opacity="0.8"/>
-  <text x="600" y="84" text-anchor="middle" fill="#fff" font-size="15" font-weight="600">Best Practices 2026</text>
-
-  <!-- Title -->
-  <text x="600" y="160" text-anchor="middle" fill="#fff" font-size="48" font-weight="800" filter="url(#glow)">Claude Code</text>
-  <text x="600" y="215" text-anchor="middle" fill="#fff" font-size="40" font-weight="300" opacity="0.9">&amp; OpenCode</text>
-  <text x="600" y="265" text-anchor="middle" fill="url(#accent3)" font-size="28" font-weight="600">38 Best Practices Guide</text>
-
-  <!-- Divider -->
-  <line x1="350" y1="295" x2="850" y2="295" stroke="url(#accent1)" stroke-width="2" opacity="0.6"/>
-
-  <!-- Feature cards -->
-  <!-- Card 1: Agent -->
-  <rect x="80" y="330" width="220" height="90" rx="12" fill="#fff" fill-opacity="0.06" stroke="url(#accent1)" stroke-width="1"/>
-  <text x="190" y="365" text-anchor="middle" fill="url(#accent1)" font-size="26">&#x1f916;</text>
-  <text x="190" y="393" text-anchor="middle" fill="#fff" font-size="15" font-weight="600">Agent Teams</text>
-  <text x="190" y="412" text-anchor="middle" fill="#aaa" font-size="12">Multi-Agent Orchestration</text>
-
-  <!-- Card 2: Context -->
-  <rect x="330" y="330" width="220" height="90" rx="12" fill="#fff" fill-opacity="0.06" stroke="url(#accent2)" stroke-width="1"/>
-  <text x="440" y="365" text-anchor="middle" fill="url(#accent2)" font-size="26">&#x1f4a1;</text>
-  <text x="440" y="393" text-anchor="middle" fill="#fff" font-size="15" font-weight="600">Context Window</text>
-  <text x="440" y="412" text-anchor="middle" fill="#aaa" font-size="12">Smart Management</text>
-
-  <!-- Card 3: CLAUDE.md -->
-  <rect x="580" y="330" width="220" height="90" rx="12" fill="#fff" fill-opacity="0.06" stroke="url(#accent3)" stroke-width="1"/>
-  <text x="690" y="365" text-anchor="middle" fill="url(#accent3)" font-size="26">&#x1f4dd;</text>
-  <text x="690" y="393" text-anchor="middle" fill="#fff" font-size="15" font-weight="600">CLAUDE.md</text>
-  <text x="690" y="412" text-anchor="middle" fill="#aaa" font-size="12">Project Instructions</text>
-
-  <!-- Card 4: Workflow -->
-  <rect x="830" y="330" width="220" height="90" rx="12" fill="#fff" fill-opacity="0.06" stroke="#ffd700" stroke-width="1"/>
-  <text x="940" y="365" text-anchor="middle" fill="#ffd700" font-size="26">&#x26a1;</text>
-  <text x="940" y="393" text-anchor="middle" fill="#fff" font-size="15" font-weight="600">Workflow</text>
-  <text x="940" y="412" text-anchor="middle" fill="#aaa" font-size="12">Explore Plan Build Commit</text>
-
-  <!-- Bottom section -->
-  <rect x="80" y="460" width="500" height="55" rx="10" fill="#fff" fill-opacity="0.04"/>
-  <text x="100" y="492" fill="#aaa" font-size="13">Prompting | Session Mgmt | Hook &amp; Skills | Scaling | Anti-Patterns</text>
-  <text x="100" y="508" fill="#666" font-size="11">Anthropic Official Docs + Real-World Experience</text>
-
-  <!-- Tech badges -->
-  <rect x="620" y="460" width="120" height="30" rx="15" fill="url(#accent1)" opacity="0.7"/>
-  <text x="680" y="480" text-anchor="middle" fill="#fff" font-size="12" font-weight="600">Opus 4.6</text>
-
-  <rect x="750" y="460" width="120" height="30" rx="15" fill="url(#accent3)" opacity="0.7"/>
-  <text x="810" y="480" text-anchor="middle" fill="#fff" font-size="12" font-weight="600">MCP Server</text>
-
-  <rect x="880" y="460" width="120" height="30" rx="15" fill="url(#accent2)" opacity="0.7"/>
-  <text x="940" y="480" text-anchor="middle" fill="#fff" font-size="12" font-weight="600">Subagents</text>
-
-  <!-- Footer -->
-  <text x="600" y="575" text-anchor="middle" fill="#666" font-size="14">tech.2twodragon.com</text>
-  <text x="600" y="600" text-anchor="middle" fill="#555" font-size="12">2026-02-25 | DevSecOps</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Claude Code &amp; OpenCode : 38</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Infinity/DevOps Loop -->
+    <g transform="translate(80, 290)">
+      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
+            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
+    </g>
+    
+    <!-- Gear Icon -->
+    <g transform="translate(220, 290)">
+      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
+      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
+      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
+    </g>
+    
+    <!-- Code Bracket -->
+    <g transform="translate(330, 295)">
+      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Claude Code OpenCode 38 Best Practice . ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CLAUDE.md , ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="132" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="66" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Claude-Code</text>
+      <rect x="144" y="0" width="105" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="196" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#OpenCode</text>
+      <rect x="261" y="0" width="159" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Best-Practices</text>
+      <rect x="432" y="0" width="105" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="484" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#AI-Agent</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
+++ b/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 25, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">MALWARE PRESSURE / RANSOMWARE / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Malware Pressure</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Ransomware</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Malware Pressure, Ransomware, and AI Runtime</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Malware Ransom...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">MALWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Malware</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Pressure</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Improve endpoint triage speed</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check payload detection freshness</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Reconfirm sandbox workflow</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 25 : The Hacker News, Microsoft Security Blog 14 .</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GitHub Codespaces RoguePilot RCE, UAC-0050 , Next.js C2</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">MALWARE</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">PRESSURE</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">12</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Malware Pressure</text>
-    <rect x="150" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="199.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
+++ b/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 26, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">GO ECOSYSTEM / AWS / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Go Ecosystem</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">AWS</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Go Ecosystem, AWS, and AI Runtime framed for</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI, Go, AWS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">GO ECOSYSTEM</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Go Ecosystem</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit module provenance</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review build and release trust</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track package-risk hotspots</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AWS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AWS</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 26 : The Hacker News 23 . AI, Go, AWS, API</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">AWS</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">12</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="112" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="56.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Go Ecosystem</text>
-    <rect x="122" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="166.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">AWS</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
+++ b/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 27, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">BOTNET ACTIVITY / BLOCKCHAIN / GO ECOSYSTEM</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Botnet Activity</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Blockchain</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Botnet Activity, Blockchain, and Go Ecosystem</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Botnet Blockch...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">BOTNET</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Botnet</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Activity</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh network anomaly rules</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map C2-like traffic paths</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review egress restrictions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">BLOCKCHAIN</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Blockchain</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">GO ECOSYSTEM</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Go Ecosystem</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit module provenance</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review build and release trust</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track package-risk hotspots</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 27 : The Hacker News, AWS Security Blog 30 . AI,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Botnet, Blockchain, Go DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">BOTNET</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ACTIVITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">BLOCKCHA</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">15</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="133" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="66.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Botnet Activity</text>
-    <rect x="143" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="192.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Blockchain</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
+++ b/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
@@ -1,138 +1,193 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
+    <!-- Background Gradients -->
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23"/>
-      <stop offset="50%" style="stop-color:#1a1a3e"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
       <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
     <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#1e293b"/>
       <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="purpleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    <linearGradient id="blueGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    <linearGradient id="redGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
       <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="greenGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10b981"/>
-      <stop offset="100%" style="stop-color:#059669"/>
-    </linearGradient>
-    <linearGradient id="orangeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    <linearGradient id="indigoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1"/>
-      <stop offset="100%" style="stop-color:#4f46e5"/>
-    </linearGradient>
+    
+    <!-- Glow Effects -->
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
   <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-    <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#ffffff" stroke-opacity="0.03" stroke-width="1"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
   </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Decorative -->
-  <circle cx="150" cy="150" r="250" fill="#8b5cf6" fill-opacity="0.06"/>
-  <circle cx="1050" cy="480" r="200" fill="#3b82f6" fill-opacity="0.05"/>
-  <circle cx="600" cy="315" r="300" fill="#dc2626" fill-opacity="0.03"/>
-
-  <!-- Header Badge -->
-  <rect x="40" y="30" width="240" height="36" rx="18" fill="url(#purpleGradient)" filter="url(#shadow)"/>
-  <text x="160" y="54" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">AI AGENT SECURITY</text>
-
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
   <!-- Date Badge -->
-  <rect x="960" y="30" width="200" height="36" rx="18" fill="url(#blueGradient)" filter="url(#shadow)"/>
-  <text x="1060" y="54" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">February 28, 2026</text>
-
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
   <!-- Main Title -->
-  <text x="600" y="115" font-family="Arial, sans-serif" font-size="38" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Security Architecture</text>
-  <text x="600" y="155" font-family="Arial, sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle">Stateful Runtime | Continuous Evaluation | Defense Patterns</text>
-
-  <!-- Central Architecture Diagram -->
-  <!-- Agent Core -->
-  <rect x="450" y="195" width="300" height="60" rx="12" fill="url(#cardGradient)" filter="url(#shadow)"/>
-  <rect x="450" y="195" width="300" height="5" rx="2" fill="url(#purpleGradient)"/>
-  <text x="600" y="232" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">AI Agent Runtime</text>
-
-  <!-- Arrows down -->
-  <line x1="500" y1="255" x2="200" y2="310" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4" opacity="0.6"/>
-  <line x1="600" y1="255" x2="600" y2="310" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4" opacity="0.6"/>
-  <line x1="700" y1="255" x2="1000" y2="310" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="6,4" opacity="0.6"/>
-
-  <!-- Left Column: Attack Vectors -->
-  <rect x="50" y="310" width="300" height="240" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-  <rect x="50" y="310" width="300" height="6" rx="3" fill="url(#redGradient)"/>
-  <circle cx="90" cy="355" r="20" fill="url(#redGradient)" fill-opacity="0.2"/>
-  <text x="90" y="362" font-family="Arial, sans-serif" font-size="14" fill="#dc2626" text-anchor="middle">!</text>
-  <text x="125" y="350" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#dc2626">ATTACK VECTORS</text>
-  <text x="125" y="368" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">Threats to AI Agents</text>
-  <text x="75" y="400" font-family="Arial, sans-serif" font-size="12" fill="#f87171">1. Prompt Injection</text>
-  <text x="75" y="422" font-family="Arial, sans-serif" font-size="12" fill="#f87171">2. Tool Abuse / Escalation</text>
-  <text x="75" y="444" font-family="Arial, sans-serif" font-size="12" fill="#f87171">3. Memory Poisoning</text>
-  <text x="75" y="466" font-family="Arial, sans-serif" font-size="12" fill="#f87171">4. Data Exfiltration</text>
-  <text x="75" y="488" font-family="Arial, sans-serif" font-size="12" fill="#f87171">5. Supply Chain (Plugins)</text>
-  <text x="75" y="510" font-family="Arial, sans-serif" font-size="12" fill="#f87171">6. Indirect Injection via Data</text>
-
-  <!-- Center Column: Security Controls -->
-  <rect x="400" y="310" width="400" height="240" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-  <rect x="400" y="310" width="400" height="6" rx="3" fill="url(#greenGradient)"/>
-  <circle cx="440" cy="355" r="20" fill="url(#greenGradient)" fill-opacity="0.2"/>
-  <text x="440" y="362" font-family="Arial, sans-serif" font-size="14" fill="#10b981" text-anchor="middle">S</text>
-  <text x="475" y="350" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#10b981">DEFENSE ARCHITECTURE</text>
-  <text x="475" y="368" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">Security Controls</text>
-
-  <!-- Defense items in 2 columns -->
-  <text x="425" y="400" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Sandboxed Execution</text>
-  <text x="425" y="420" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Least Privilege Tools</text>
-  <text x="425" y="440" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Input Sanitization</text>
-  <text x="425" y="460" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Output Validation</text>
-  <text x="425" y="480" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Human-in-the-Loop</text>
-  <text x="425" y="500" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Circuit Breakers</text>
-
-  <text x="610" y="400" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Audit Logging</text>
-  <text x="610" y="420" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Rate Limiting</text>
-  <text x="610" y="440" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Memory Isolation</text>
-  <text x="610" y="460" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Session Management</text>
-  <text x="610" y="480" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Guardrails / Policies</text>
-  <text x="610" y="500" font-family="Arial, sans-serif" font-size="11" fill="#6ee7b7">Continuous Evaluation</text>
-
-  <!-- Right Column: Frameworks -->
-  <rect x="850" y="310" width="300" height="240" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-  <rect x="850" y="310" width="300" height="6" rx="3" fill="url(#indigoGradient)"/>
-  <circle cx="890" cy="355" r="20" fill="url(#indigoGradient)" fill-opacity="0.2"/>
-  <text x="890" y="362" font-family="Arial, sans-serif" font-size="14" fill="#6366f1" text-anchor="middle">F</text>
-  <text x="925" y="350" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#6366f1">FRAMEWORKS</text>
-  <text x="925" y="368" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">Standards and Tools</text>
-  <text x="875" y="400" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">OWASP LLM Top 10</text>
-  <text x="875" y="422" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">NIST AI RMF</text>
-  <text x="875" y="444" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">AWS Bedrock Guardrails</text>
-  <text x="875" y="466" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">Google Vertex AI Safety</text>
-  <text x="875" y="488" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">OpenAI Stateful Runtime</text>
-  <text x="875" y="510" font-family="Arial, sans-serif" font-size="12" fill="#a5b4fc">Zero Trust for Agents</text>
-
-  <!-- Footer -->
-  <line x1="50" y1="575" x2="1150" y2="575" stroke="#334155" stroke-width="1"/>
-  <text x="50" y="600" font-family="Arial, sans-serif" font-size="13" fill="#dc2626">6 Attack Vectors</text>
-  <text x="210" y="600" font-family="Arial, sans-serif" font-size="13" fill="#10b981">12 Defense Controls</text>
-  <text x="420" y="600" font-family="Arial, sans-serif" font-size="13" fill="#6366f1">6 Frameworks</text>
-  <text x="600" y="600" font-family="Arial, sans-serif" font-size="13" fill="#f59e0b">Python Code Examples</text>
-  <text x="1150" y="600" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent : Stateful Runtime Continuous Evalua...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI Agent : Stateful Runtime Continuous Evaluation</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">- AI Agent - OpenAI Stateful Runtime, Amazon Bedrock</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AgentCore,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agent</text>
+      <rect x="117" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="183" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
+      <rect x="261" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Stateful-Runtime</text>
+      <rect x="450" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="547" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Continuous-Eval...</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
+++ b/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">FEBRUARY 28, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">GO ECOSYSTEM / MALWARE PRESSURE / AI RUNTIME</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Go Ecosystem</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Malware Pressure</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Go Ecosystem, Malware Pressure, and AI Runtime</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Go, AI,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">GO ECOSYSTEM</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Go Ecosystem</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit module provenance</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review build and release trust</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track package-risk hotspots</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">MALWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Malware</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Pressure</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Improve endpoint triage speed</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check payload detection freshness</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Reconfirm sandbox workflow</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI RUNTIME</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Runtime</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor live AI performance drift</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review prompt and tool boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track deployment exceptions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 28 : The Hacker News 26 . Go, AI, Malware</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">MALWARE</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">PRESSURE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">14</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="112" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="56.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Go Ecosystem</text>
-    <rect x="122" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="192.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Malware Pressure</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.svg
+++ b/assets/images/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 01, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">AI AGENT SECURITY / RANSOMWARE / OPERATOR RESPONSE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">AI Agent</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">AI Agent Security, Ransomware, and Operator</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Response framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , Gentlemen ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI AGENT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Agent</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Limit tools and memory scope</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review action approvals</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track unsafe fallback paths</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">OPERATOR</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Operator</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Response</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep runbooks concise</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tie actions to KPIs</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice communication flow</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">NVIDIA Agentic AI , SK Gentlemen , AWS MCP</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Registry 7</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI AGENT</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">TEAM</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RESPONSE</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Agent Securit</text>
-    <rect x="150" y="0" width="98" height="28" rx="14" fill="#082f49"/>
-    <text x="199.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Ransomware</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.svg
+++ b/assets/images/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 02, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">ZERO TRUST / CRYPTO REGULATION / RANSOMWARE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Zero Trust</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Crypto Regulation</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Zero Trust, Crypto Regulation, and Ransomware</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ransomware Ai Agent</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ZERO TRUST</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Zero Trust</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map trust boundaries explicitly</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review identity telemetry gaps</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep asset context current</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CRYPTO</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Crypto</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Regulation</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Watch policy-to-product impact</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review compliance dependencies</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare control updates</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RANSOMWARE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Ransomware</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Recheck backup recovery readiness</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review privilege escalation paths</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Practice incident ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SK , Trump Media , X , Anthropic</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI 6 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="367" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
+      <rect x="441" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="534" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Crypto-Regulation</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ZERO</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">TRUST</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">CRYPTO</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RULES</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RANSOM</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">WARE</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Zero Trust</text>
-    <rect x="108" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="178.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Crypto Regulatio</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.svg
+++ b/assets/images/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 04, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">JWT IDENTITY RISK / CRYPTO OUTFLOW RISK / AI GOVERNANCE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">JWT Identity</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Risk</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">JWT Identity Risk, Crypto Outflow Risk, and AI</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Governance framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: JWT , , AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">JWT IDENTITY</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">JWT Identity</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Risk</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review token lifecycle controls</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tighten signing-key handling</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit auth boundary drift</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CRYPTO</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Crypto</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Outflow Risk</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor suspicious transfer spikes</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check withdrawal controls</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Escalate treasury anomalies</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Governance</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review model approval gates</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check customer-impact controls</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Align risk and compliance</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">JWT , - 1,030 ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI 7 .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">JWT</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">IDENTITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">CRYPTO</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">OUTFLOW</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">FINANCE</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">5</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">JWT Identity Ris</text>
-    <rect x="150" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="220.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Crypto Outflow R</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.svg
+++ b/assets/images/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.svg
@@ -1,135 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#140f1b"/>
-      <stop offset="48%" stop-color="#26172d"/>
-      <stop offset="100%" stop-color="#111827"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#f59e0b"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#a78bfa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 05, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CORUNA IOS / HACKTIVIST DDOS / RESPONSE PRIORITY</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Coruna iOS</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Hacktivist DDoS</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Coruna iOS, Hacktivist DDoS, and Response</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Priority framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Coruna iOS , DDoS,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#f59e0b"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CORUNA IOS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Coruna iOS</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize mobile patch response</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track exploit chain exposure</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare customer advisories</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#a78bfa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">HACKTIVIST</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Hacktivist</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">DDoS</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review edge protection posture</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Refresh scrubbing playbooks</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Test comms under pressure</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">RESPONSE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Response</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Priority</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Sort actions by blast radius</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep owner assignments explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Reduce decision latency</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Google Coruna iOS (23 , 5 ), 16 110</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DDoS 149 , AI RFP 17 DevSecOps .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#a78bfa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CORUNA</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">IOS</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">HACK</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">DDOS</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RESPONSE</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">PRIORITY</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">11</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">6</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Coruna iOS</text>
-    <rect x="108" y="0" width="133" height="28" rx="14" fill="#082f49"/>
-    <text x="174.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Hacktivist DDoS</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.svg
+++ b/assets/images/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#071421"/>
-      <stop offset="48%" stop-color="#10253b"/>
-      <stop offset="100%" stop-color="#1e293b"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#22c55e" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#22c55e" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#c084fc" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#c084fc" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#22c55e"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#c084fc"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 06, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CVE-2026-20122 / CISCO SECURITY / AWS OPERATIONS</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">CVE-2026-20122</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Cisco Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">CVE-2026-20122, Cisco Security, and AWS</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Operations framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: CVE-2026-20122, Cisco , AWS</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#22c55e"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CVE-2026-20122</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">CVE-2026-20122</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#c084fc"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CISCO</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Cisco</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Patch exposed network managers</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review auth-bypass exposure</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Confirm segmentation controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#38bdf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AWS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AWS</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Operations</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Link product changes to runbooks</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review account drift weekly</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tie ops metrics to risk</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Cisco Catalyst SD-WAN Manager CVE-2026-20122 , Europol Tycoon</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2FA PhaaS (64,000 ), APT28 , GPT-5.4</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Google...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#c084fc" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CVE-2026</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">CISCO</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AWS</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">OPS</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">19</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">9</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="126" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="63.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">CVE-2026-20122</text>
-    <rect x="136" y="0" width="126" height="28" rx="14" fill="#082f49"/>
-    <text x="199.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Cisco Security</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-07-LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP.svg
+++ b/assets/images/2026-03-07-LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP.svg
@@ -1,150 +1,189 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
+    <!-- Background Gradients -->
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23"/>
-      <stop offset="50%" style="stop-color:#1a1a3e"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
       <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
     <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#1e293b"/>
       <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-    <linearGradient id="redGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
       <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="orangeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    <linearGradient id="greenGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10b981"/>
-      <stop offset="100%" style="stop-color:#059669"/>
-    </linearGradient>
-    <linearGradient id="blueGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    <linearGradient id="purpleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    <linearGradient id="cyanGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#06b6d4"/>
-      <stop offset="100%" style="stop-color:#0891b2"/>
-    </linearGradient>
+    
+    <!-- Glow Effects -->
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
 
   <!-- Background -->
   <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-    <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#ffffff" stroke-opacity="0.03" stroke-width="1"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
   </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Decorative Circles -->
-  <circle cx="150" cy="180" r="260" fill="#8b5cf6" fill-opacity="0.05"/>
-  <circle cx="1050" cy="480" r="220" fill="#3b82f6" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="300" fill="#dc2626" fill-opacity="0.02"/>
-
-  <!-- Header Badge -->
-  <rect x="35" y="24" width="240" height="38" rx="19" fill="url(#purpleGradient)" filter="url(#shadow)"/>
-  <text x="155" y="48" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">LLM SECURITY 2026</text>
-
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
   <!-- Date Badge -->
-  <rect x="925" y="24" width="240" height="38" rx="19" fill="url(#cyanGradient)" filter="url(#shadow)"/>
-  <text x="1045" y="48" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">March 7, 2026</text>
-
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
   <!-- Main Title -->
-  <text x="600" y="115" font-family="Arial, sans-serif" font-size="46" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">LLM Security Practical Guide 2026</text>
-  <text x="600" y="155" font-family="Arial, sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle">Prompt Injection | RAG Security | MCP Threats | Supply Chain</text>
-
-  <!-- Left Card: Defense -->
-  <g filter="url(#shadow)">
-    <rect x="55" y="200" width="320" height="320" rx="16" fill="url(#cardGradient)"/>
-    <rect x="55" y="200" width="320" height="6" rx="3" fill="url(#greenGradient)"/>
-
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">LLM 2026: , RAG , MCP</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
     <!-- Shield Icon -->
-    <g transform="translate(215, 300)">
-      <path d="M 0 -48 L 38 -28 L 38 8 Q 0 48 -38 8 L -38 -28 Z" fill="url(#greenGradient)" stroke="#10b981" stroke-width="2.5"/>
-      <circle cx="0" cy="-8" r="12" fill="#6ee7b7" fill-opacity="0.4"/>
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-
-    <text x="215" y="400" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#10b981" text-anchor="middle">DEFENSE</text>
-    <text x="215" y="428" font-family="Arial, sans-serif" font-size="15" fill="#94a3b8" text-anchor="middle">Guardrails</text>
-    <text x="215" y="452" font-family="Arial, sans-serif" font-size="15" fill="#6ee7b7" text-anchor="middle">Input Sanitization</text>
-    <text x="215" y="476" font-family="Arial, sans-serif" font-size="14" fill="#34d399" text-anchor="middle">Output Validation</text>
-    <text x="215" y="498" font-family="Arial, sans-serif" font-size="14" fill="#6ee7b7" text-anchor="middle">Access Control</text>
-  </g>
-
-  <!-- Center Card: Threats -->
-  <g filter="url(#shadow)">
-    <rect x="440" y="200" width="320" height="320" rx="16" fill="url(#cardGradient)"/>
-    <rect x="440" y="200" width="320" height="6" rx="3" fill="url(#blueGradient)"/>
-
-    <!-- Brain/AI Icon -->
-    <g transform="translate(600, 300)">
-      <circle cx="0" cy="-20" r="22" fill="none" stroke="#3b82f6" stroke-width="3"/>
-      <circle cx="-18" cy="4" r="15" fill="none" stroke="#3b82f6" stroke-width="3"/>
-      <circle cx="18" cy="4" r="15" fill="none" stroke="#3b82f6" stroke-width="3"/>
-      <circle cx="0" cy="20" r="15" fill="none" stroke="#3b82f6" stroke-width="3"/>
-      <circle cx="0" cy="0" r="6" fill="#3b82f6"/>
-    </g>
-
-    <text x="600" y="400" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#3b82f6" text-anchor="middle">THREATS</text>
-    <text x="600" y="428" font-family="Arial, sans-serif" font-size="15" fill="#94a3b8" text-anchor="middle">Attack Vectors</text>
-    <text x="600" y="452" font-family="Arial, sans-serif" font-size="15" fill="#93c5fd" text-anchor="middle">Injection | RAG Poisoning</text>
-    <text x="600" y="476" font-family="Arial, sans-serif" font-size="14" fill="#60a5fa" text-anchor="middle">Jailbreaking</text>
-    <text x="600" y="498" font-family="Arial, sans-serif" font-size="14" fill="#93c5fd" text-anchor="middle">Model Extraction</text>
-  </g>
-
-  <!-- Right Card: Risks -->
-  <g filter="url(#shadow)">
-    <rect x="825" y="200" width="320" height="320" rx="16" fill="url(#cardGradient)"/>
-    <rect x="825" y="200" width="320" height="6" rx="3" fill="url(#redGradient)"/>
-
+    
     <!-- Lock Icon -->
-    <g transform="translate(985, 300)">
-      <rect x="-22" y="-4" width="44" height="36" rx="4" fill="none" stroke="#dc2626" stroke-width="3"/>
-      <path d="M -14 -4 L -14 -18 Q 0 -30 14 -18 L 14 -4" fill="none" stroke="#dc2626" stroke-width="3"/>
-      <circle cx="0" cy="16" r="5" fill="#dc2626"/>
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-
-    <text x="985" y="400" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#dc2626" text-anchor="middle">RISKS</text>
-    <text x="985" y="428" font-family="Arial, sans-serif" font-size="15" fill="#94a3b8" text-anchor="middle">Supply Chain</text>
-    <text x="985" y="452" font-family="Arial, sans-serif" font-size="15" fill="#f87171" text-anchor="middle">MCP Vulnerabilities</text>
-    <text x="985" y="476" font-family="Arial, sans-serif" font-size="14" fill="#fca5a5" text-anchor="middle">Data Poisoning</text>
-    <text x="985" y="498" font-family="Arial, sans-serif" font-size="14" fill="#f87171" text-anchor="middle">Third-party Plugins</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Footer Stats Bar -->
-  <rect x="35" y="548" width="1130" height="58" rx="10" fill="url(#cardGradient)" filter="url(#shadow)"/>
-  <text x="55" y="572" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#f59e0b">LLM Security</text>
-  <text x="180" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">|</text>
-  <text x="200" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">4 Topics</text>
-  <text x="290" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">|</text>
-  <text x="310" y="572" font-family="Arial, sans-serif" font-size="13" fill="#fca5a5">Prompt Injection</text>
-  <text x="460" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">|</text>
-  <text x="480" y="572" font-family="Arial, sans-serif" font-size="13" fill="#6ee7b7">RAG</text>
-  <text x="530" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">|</text>
-  <text x="550" y="572" font-family="Arial, sans-serif" font-size="13" fill="#93c5fd">MCP</text>
-  <text x="600" y="572" font-family="Arial, sans-serif" font-size="13" fill="#94a3b8">|</text>
-  <text x="620" y="572" font-family="Arial, sans-serif" font-size="13" fill="#f87171">Supply Chain</text>
-
-  <!-- Practical Topics Row -->
-  <text x="55" y="594" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#f59e0b">PRACTICAL TOPICS:</text>
-  <text x="200" y="594" font-family="Arial, sans-serif" font-size="12" fill="#fca5a5">Prompt Injection Detection</text>
-  <text x="430" y="594" font-family="Arial, sans-serif" font-size="12" fill="#6ee7b7">RAG Pipeline Security</text>
-  <text x="640" y="594" font-family="Arial, sans-serif" font-size="12" fill="#93c5fd">MCP Framework Hardening</text>
-  <text x="880" y="594" font-family="Arial, sans-serif" font-size="12" fill="#f87171">Defense Strategies</text>
-
-  <!-- Footer URL -->
-  <text x="1160" y="594" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">LLM - , RAG , MCP</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, .</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="70" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LLM-Security</text>
+      <rect x="153" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="241" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Prompt-Injection</text>
+      <rect x="342" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="412" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#RAG-Security</text>
+      <rect x="495" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="565" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#MCP-Security</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
+  </g>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
+  </g>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
+++ b/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
@@ -1,135 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#140f1b"/>
-      <stop offset="48%" stop-color="#26172d"/>
-      <stop offset="100%" stop-color="#111827"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#f59e0b" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#f59e0b"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#a78bfa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 07, 2026</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">ANDROID 129 / DEVSECOPS SECURITY / K8S ATTACK</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Android 129</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">DevSecOps Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Android 129, DevSecOps Security, and K8s Attack</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Android 129 , DevSecOps , K8s</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#f59e0b"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ANDROID 129</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Android 129</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#a78bfa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">DEVSECOPS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">DevSecOps</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">K8S ATTACK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">K8s Attack</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Google Android 129 (Qualcomm CVE-2026-21385 ), VMware</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Aria Operations CVE-2026-22719 KEV , Datadog DevSecOps (87</text>
+    </g>
+    <g transform="translate(30, 160)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">),...</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#a78bfa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ANDROID</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">DEVSECOP</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">K8S ATTA</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">20</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">9</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="105" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="52.5" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Android 129</text>
-    <rect x="115" y="0" width="140" height="28" rx="14" fill="#082f49"/>
-    <text x="185.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">DevSecOps Securi</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.svg
+++ b/assets/images/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.svg
@@ -1,137 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 08, 2026</text>
-  <rect x="340" y="34" width="120" height="38" rx="19" fill="#f97316"/>
-  <text x="400" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">HIGH RISK</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CODEX SCAN / FIREFOX BUGS / USDC FLOW</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Codex Scan</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Firefox Bugs</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Codex Scan, Firefox Bugs, and USDC Flow framed</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: OpenAI Codex , Claude Firefox , USDC</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CODEX SCAN</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Codex Scan</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Compare AI findings with SAST</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Triage high-risk repos first</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track false-positive ownership</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">FIREFOX BUGS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Firefox Bugs</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize browser patch windows</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review client hardening baselines</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Update exposure inventory</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">USDC FLOW</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">USDC Flow</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Watch token-linked abuse patterns</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tie market signals to fraud alerts</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check custody workflows</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">High OpenAI Codex 120 10,561 . High Claude Firefox</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">22 (14 High). USDC 1.8T , Go UUID</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CODEX</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SCAN</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">FIREFOX</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">BUGS</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">USDC</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">FLOW</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">8</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">7</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Codex Scan</text>
-    <rect x="108" y="0" width="112" height="28" rx="14" fill="#082f49"/>
-    <text x="164.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Firefox Bugs</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
+++ b/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
@@ -1,137 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="48%" stop-color="#181c3a"/>
-      <stop offset="100%" stop-color="#261c48"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#34d399" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#34d399" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#67e8f9" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#67e8f9" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#818cf8" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#818cf8" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#34d399"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#67e8f9"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 09, 2026</text>
-  <rect x="340" y="34" width="120" height="38" rx="19" fill="#f97316"/>
-  <text x="400" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">HIGH RISK</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">AI AGENT SECURITY / SAYLOR / AGENT SAFEHOUSE</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">AI Agent</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Security</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">AI Agent Security, Saylor, and Agent Safehouse</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , Saylor , Agent Safehouse</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#34d399"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI AGENT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Agent</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Security</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Limit tools and memory scope</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review action approvals</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track unsafe fallback paths</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#67e8f9"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">SAYLOR</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Saylor</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#818cf8"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AGENT</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Agent</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Safehouse</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review exposure paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep ownership explicit</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare response playbooks</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">High AI - , , . Saylor BTC</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, Agent Safehouse , LINE LLM</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#67e8f9" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI AGENT</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SECURITY</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">SAYLOR</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AGENT SA</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">GO</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">ECOSYSTEM</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">7</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">2</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">AI Agent Securit</text>
-    <rect x="150" y="0" width="88" height="28" rx="14" fill="#082f49"/>
-    <text x="194.0" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Saylor</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
+++ b/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
@@ -1,137 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 10, 2026</text>
-  <rect x="340" y="34" width="142" height="38" rx="19" fill="#ef4444"/>
-  <text x="411" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">CRITICAL RISK</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">CRYPTO BREACH RISK / MOBILE ZERO-DAY / AI OPS RISK</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Crypto Breach</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Risk</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Crypto Breach Risk, Mobile Zero-Day, and AI Ops</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Risk framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , , AI</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">CRYPTO</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Crypto</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Breach Risk</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track exchange and wallet exposure</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Reconfirm account recovery policy</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map incident escalation lines</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">MOBILE</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Mobile</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Zero-Day</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Stage mobile patch rollout</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Audit device exposure clusters</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare rapid comms templates</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">AI OPS RISK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">AI Ops Risk</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Gate releases with fallback criteria</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Monitor drift in production workflows</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review tool permission boundaries</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Critical Qualcomm 0-Day, iOS Exploit Chain, AirSnitch . High</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. 2026 03 10 / 27</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">CRYPTO</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">MOBILE</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">ZERO-DAY</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI OPS</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">15</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">13</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="140" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="70.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Crypto Breach Ri</text>
-    <rect x="150" y="0" width="133" height="28" rx="14" fill="#082f49"/>
-    <text x="216.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Mobile Zero-Day</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
+++ b/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
@@ -1,137 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 11, 2026</text>
-  <rect x="340" y="34" width="142" height="38" rx="19" fill="#ef4444"/>
-  <text x="411" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">CRITICAL RISK</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">ATTACK SURFACE / BLOCKCHAIN RISK / TECH SIGNALS</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Attack Surface</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Blockchain Risk</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Attack Surface, Blockchain Risk, and Tech</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Signals framed for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Agent Data Mal...</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">ATTACK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Attack</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Surface</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Map exposed services and stale assets</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prioritize internet-facing gaps</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Assign owners for risky nodes</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">BLOCKCHAIN</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Blockchain</text>
-      <text x="20" y="98" fill="#f8fafc" font-family="Arial, sans-serif" font-size="20" font-weight="800">Risk</text>
-      <text x="20" y="118" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review wallet and custody paths</text>
-      <text x="20" y="142" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Track fraud pressure after price moves</text>
-      <text x="20" y="166" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Tie market events to alerting</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">TECH SIGNALS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Tech Signals</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Translate news into control impact</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Watch platform operating shifts</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep governance docs current</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Critical Cloudflare . High , / .</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 03 11 / 11</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">ATTACK</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">SURFACE</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">CHAIN</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">TECH</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">SIGNALS</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">4</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">7</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="126" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="63.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Attack Surface</text>
-    <rect x="136" y="0" width="133" height="28" rx="14" fill="#082f49"/>
-    <text x="202.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Blockchain Risk</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.svg
+++ b/assets/images/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.svg
@@ -1,137 +1,189 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#120f19"/>
-      <stop offset="48%" stop-color="#1f2937"/>
-      <stop offset="100%" stop-color="#312116"/>
+    <!-- Background Gradients -->
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
+      <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-    <radialGradient id="glowA" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(160 108) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fb7185" stop-opacity="0.30"/>
-      <stop offset="100%" stop-color="#fb7185" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowB" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1020 110) rotate(90) scale(260)">
-      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.28"/>
-      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/>
-    </radialGradient>
-    <radialGradient id="glowC" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(980 472) rotate(90) scale(220)">
-      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.24"/>
-      <stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/>
-    </radialGradient>
-    <filter id="softShadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#020617" flood-opacity="0.42"/>
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
+    <!-- Card Gradient -->
+    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
+    </linearGradient>
+    
+    <!-- Glow Effects -->
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feDropShadow dx="0" dy="12" stdDeviation="14" flood-color="#020617" flood-opacity="0.34"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
     </filter>
   </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="#020617" opacity="0.18"/>
-  <circle cx="160" cy="108" r="220" fill="url(#glowA)"/>
-  <circle cx="1020" cy="110" r="260" fill="url(#glowB)"/>
-  <circle cx="980" cy="472" r="220" fill="url(#glowC)"/>
-  <g opacity="0.07" stroke="#cbd5e1" stroke-width="1">
-    <line x1="0" y1="84" x2="1200" y2="84"/>
-    <line x1="0" y1="168" x2="1200" y2="168"/>
-    <line x1="0" y1="252" x2="1200" y2="252"/>
-    <line x1="0" y1="336" x2="1200" y2="336"/>
-    <line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="504" x2="1200" y2="504"/>
-    <line x1="120" y1="0" x2="120" y2="630"/>
-    <line x1="300" y1="0" x2="300" y2="630"/>
-    <line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="660" y1="0" x2="660" y2="630"/>
-    <line x1="840" y1="0" x2="840" y2="630"/>
-    <line x1="1020" y1="0" x2="1020" y2="630"/>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bgGradient)"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
+  </pattern>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
   </g>
-  <rect x="54" y="34" width="258" height="38" rx="19" fill="#fb7185"/>
-  <text x="183" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.6">TECH SECURITY WEEKLY DIGEST</text>
-  <rect x="932" y="34" width="214" height="38" rx="19" fill="#60a5fa"/>
-  <text x="1039" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">MARCH 12, 2026</text>
-  <rect x="340" y="34" width="120" height="38" rx="19" fill="#f97316"/>
-  <text x="400" y="58" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif" font-size="14" font-weight="700" letter-spacing="1.3">HIGH RISK</text>
-  <g transform="translate(62 96)">
-    <text x="0" y="0" fill="#e2e8f0" font-family="Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="4">TRUST RISK / VERTICAL AI / TECH SIGNALS</text>
-    <text x="0" y="58" fill="#f8fafc" font-family="Arial, sans-serif" font-size="44" font-weight="800">Trust Risk</text>
-    <text x="0" y="102" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="28" font-weight="700">Vertical AI</text>
-    <text x="0" y="138" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">Trust Risk, Vertical AI, and Tech Signals framed</text>
-    <text x="0" y="170" fill="#94a3b8" font-family="Arial, sans-serif" font-size="22">for weekly operator decisions</text>
+  
+  <!-- Date Badge -->
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
   </g>
-  <g transform="translate(58 198)" filter="url(#softShadow)">
-    <rect width="728" height="264" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5"/>
-    <rect x="0" y="0" width="728" height="264" rx="28" fill="url(#glowB)" opacity="0.16"/>
-    <text x="34" y="42" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.8">EDITORIAL SIGNAL BOARD</text>
+  
+  <!-- Main Title -->
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , Vertical AI ,</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
     
-    <g transform="translate(34 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fb7185"/>
-      <text x="20" y="34" fill="#fde68a" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">TRUST RISK</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Trust Risk</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review poisoning and phishing paths</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Validate custody dependencies</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Prepare trust-restoration actions</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
     </g>
-    <g transform="translate(261 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#60a5fa"/>
-      <text x="20" y="34" fill="#bae6fd" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">VERTICAL AI</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Vertical AI</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Check margin and pricing pressure</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Review governance boundaries</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Align product growth with controls</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
     </g>
-    <g transform="translate(488 66)">
-      <rect width="206" height="190" rx="20" fill="#0f172a" stroke="#334155" filter="url(#cardShadow)"/>
-      <rect width="206" height="8" rx="4" fill="#fbbf24"/>
-      <text x="20" y="34" fill="#fecdd3" font-family="Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="1.5">TECH SIGNALS</text>
-      <text x="20" y="72" fill="#f8fafc" font-family="Arial, sans-serif" font-size="26" font-weight="800">Tech Signals</text>
-      
-      <text x="20" y="92" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Translate news into control impact</text>
-      <text x="20" y="116" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Watch platform operating shifts</text>
-      <text x="20" y="140" fill="#cbd5e1" font-family="Arial, sans-serif" font-size="14">- Keep governance docs current</text>
-      <text x="20" y="184" fill="#64748b" font-family="Arial, sans-serif" font-size="11">Priority: article-specific operator guidance</text>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
+  </g>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">High / . 2026 03 12 / 10 - ,</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Vertical AI ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
     </g>
   </g>
-  <g transform="translate(820 182)">
-    <rect width="322" height="290" rx="28" fill="#09111d" stroke="#1e293b" stroke-width="1.5" filter="url(#softShadow)"/>
-    <text x="28" y="40" fill="#f8fafc" font-family="Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="2.4">THREAT RELATION MAP</text>
-    <circle cx="160" cy="146" r="44" fill="#111827" stroke="#60a5fa" stroke-width="2.5"/>
-    <circle cx="160" cy="146" r="24" fill="#0f172a" stroke="#93c5fd" stroke-width="1.5"/>
-    <text x="160" y="141" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">RISK</text>
-    <text x="160" y="157" text-anchor="middle" fill="#e0f2fe" font-family="Arial, sans-serif" font-size="11" font-weight="700">CORE</text>
-    <circle cx="72" cy="86" r="30" fill="#1f2937" stroke="#f59e0b" stroke-width="2"/><text x="72" y="82" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">TRUST</text><text x="72" y="96" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="10" font-weight="700">RISK</text><circle cx="252" cy="82" r="30" fill="#1f2937" stroke="#38bdf8" stroke-width="2"/><text x="252" y="78" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">VERTICAL</text><text x="252" y="92" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><circle cx="88" cy="228" r="30" fill="#1f2937" stroke="#fb7185" stroke-width="2"/><text x="88" y="224" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">TECH</text><text x="88" y="238" text-anchor="middle" fill="#fecdd3" font-family="Arial, sans-serif" font-size="10" font-weight="700">SIGNALS</text><circle cx="244" cy="232" r="30" fill="#1f2937" stroke="#67e8f9" stroke-width="2"/><text x="244" y="228" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">AI</text><text x="244" y="242" text-anchor="middle" fill="#cffafe" font-family="Arial, sans-serif" font-size="10" font-weight="700">RUNTIME</text>
-    <line x1="96" y1="102" x2="126" y2="123" stroke="#f59e0b" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="225" y1="100" x2="194" y2="123" stroke="#38bdf8" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="110" y1="211" x2="133" y2="179" stroke="#fb7185" stroke-width="2" stroke-dasharray="5 4"/>
-    <line x1="218" y1="213" x2="188" y2="179" stroke="#67e8f9" stroke-width="2" stroke-dasharray="5 4"/>
-    <rect x="28" y="246" width="266" height="22" rx="11" fill="#0f172a" stroke="#334155"/>
-    <text x="161" y="261" text-anchor="middle" fill="#94a3b8" font-family="Arial, sans-serif" font-size="12">Article-specific cover tuned to the weekly operator story</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-  <g transform="translate(58 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">CURATED ITEMS</text>
-    <text x="22" y="48" fill="#f8fafc" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(230 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">SECURITY</text>
-    <text x="22" y="48" fill="#fde68a" font-family="Arial, sans-serif" font-size="28" font-weight="800">1</text>
-  </g>
-  <g transform="translate(402 494)">
-    <rect width="154" height="60" rx="18" fill="#101827" stroke="#334155"/>
-    <text x="22" y="24" fill="#64748b" font-family="Arial, sans-serif" font-size="12" font-weight="700" letter-spacing="1.2">THEMES</text>
-    <text x="22" y="48" fill="#bae6fd" font-family="Arial, sans-serif" font-size="28" font-weight="800">3</text>
-  </g>
-  <g transform="translate(602 500)">
-    <rect x="0" y="0" width="98" height="28" rx="14" fill="#3f2a0a"/>
-    <text x="49.0" y="19" text-anchor="middle" fill="#fde68a" font-family="Arial, sans-serif" font-size="12" font-weight="700">Trust Risk</text>
-    <rect x="108" y="0" width="105" height="28" rx="14" fill="#082f49"/>
-    <text x="160.5" y="19" text-anchor="middle" fill="#bae6fd" font-family="Arial, sans-serif" font-size="12" font-weight="700">Vertical AI</text>
-  </g>
-  <line x1="58" y1="584" x2="1142" y2="584" stroke="#334155" stroke-width="1"/>
-  <text x="58" y="610" fill="#64748b" font-family="Arial, sans-serif" font-size="13">Each weekly digest cover now reflects its specific article themes instead of a generic template.</text>
-  <text x="1142" y="610" text-anchor="end" fill="#94a3b8" font-family="Arial, sans-serif" font-size="13" font-weight="700">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.svg
+++ b/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.svg
@@ -1,219 +1,189 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradient -->
+    <!-- Background Gradients -->
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23"/>
-      <stop offset="50%" style="stop-color:#1a1a3e"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="30%" style="stop-color:#0f1629"/>
+      <stop offset="70%" style="stop-color:#1a1f3a"/>
       <stop offset="100%" style="stop-color:#0d1117"/>
     </linearGradient>
-
+    
+    <!-- Category Gradient -->
+    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#991b1b"/>
+    </linearGradient>
+    
+    <!-- Accent Gradient -->
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="33%" style="stop-color:#8b5cf6"/>
+      <stop offset="66%" style="stop-color:#ec4899"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    
     <!-- Card Gradient -->
     <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#1e293b"/>
       <stop offset="100%" style="stop-color:#0f172a"/>
     </linearGradient>
-
-    <!-- Category Gradients -->
-    <linearGradient id="redGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    
+    <!-- Fire Gradient for Incident -->
+    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
       <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#fbbf24"/>
     </linearGradient>
-    <linearGradient id="blueGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    <linearGradient id="purpleGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    <linearGradient id="greenGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#10b981"/>
-      <stop offset="100%" style="stop-color:#059669"/>
-    </linearGradient>
-    <linearGradient id="orangeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    <linearGradient id="indigoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1"/>
-      <stop offset="100%" style="stop-color:#4f46e5"/>
-    </linearGradient>
-
-    <!-- Glow Filter -->
+    
+    <!-- Glow Effects -->
     <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feGaussianBlur stdDeviation="4" result="blur"/>
       <feMerge>
         <feMergeNode in="blur"/>
         <feMergeNode in="SourceGraphic"/>
       </feMerge>
     </filter>
-
-    <!-- Shadow Filter -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    
+    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
-    <pattern id="grid" width="30" height="30" patternUnits="userSpaceOnUse">
-      <path d="M 30 0 L 0 0 0 30" fill="none" stroke="#334155" stroke-width="0.3" opacity="0.4"/>
-    </pattern>
-    <pattern id="dots" width="20" height="20" patternUnits="userSpaceOnUse">
-      <circle cx="2" cy="2" r="0.8" fill="#475569" opacity="0.3"/>
-    </pattern>
+    
+    <!-- Shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
+    </filter>
+    
+    <!-- Inner Glow -->
+    <filter id="innerGlow">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
+      <feOffset in="blur" dx="0" dy="0"/>
+      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
+      <feBlend in2="SourceGraphic"/>
+    </filter>
   </defs>
 
   <!-- Background -->
   <rect width="1200" height="630" fill="url(#bgGradient)"/>
-
-  <!-- Grid Pattern -->
-  <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-    <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#ffffff" stroke-opacity="0.03" stroke-width="1"/>
+  
+  <!-- Animated Grid Pattern -->
+  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
+    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
   </pattern>
   <rect width="1200" height="630" fill="url(#grid)"/>
-
-  <!-- Decorative Circles -->
-  <circle cx="100" cy="100" r="200" fill="#3b82f6" fill-opacity="0.05"/>
-  <circle cx="1100" cy="530" r="250" fill="#8b5cf6" fill-opacity="0.05"/>
-  <circle cx="600" cy="315" r="300" fill="#dc2626" fill-opacity="0.03"/>
-
-  <!-- Header Section -->
-  <rect x="40" y="30" width="200" height="36" rx="18" fill="url(#redGradient)" filter="url(#shadow)"/>
-  <text x="140" y="54" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
-
+  
+  <!-- Background Decorative Elements -->
+  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
+  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
+  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
+  
+  <!-- Decorative Lines -->
+  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+  
+  <!-- Top Header Bar -->
+  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
+  
+  <!-- Category Badge -->
+  <g filter="url(#shadow)">
+    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
+    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  </g>
+  
   <!-- Date Badge -->
-  <rect x="960" y="30" width="200" height="36" rx="18" fill="url(#blueGradient)" filter="url(#shadow)"/>
-  <text x="1060" y="54" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-
+  <g filter="url(#shadow)">
+    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
+    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  </g>
+  
   <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="42" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech &amp; Security Weekly Digest</text>
-  <text x="600" y="155" font-family="Arial, sans-serif" font-size="20" fill="#94a3b8" text-anchor="middle">AWS | AI | Bitcoin</text>
-
-  <!-- Card 1: SECURITY -->
-  <g transform="translate(50, 190)">
-    <rect width="340" height="180" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#redGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#redGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#dc2626" text-anchor="middle">!</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#dc2626">SECURITY</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Deploy AWS applications and access</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">If your organization relies on AWS IAM</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">Identity Center for workforce access,</text>
-
-    <rect x="20" y="155" width="120" height="18" rx="9" fill="url(#redGradient)" fill-opacity="0.2"/>
-    <text x="80" y="168" font-family="Arial, sans-serif" font-size="10" fill="#dc2626" text-anchor="middle">AWS Security Blog</text>
+  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: GlassWorm , AI , AWS IAM</text>
+  
+  <!-- Subtitle Line -->
+  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
+  
+  <!-- Icon Section - Left Side -->
+  <g opacity="0.95">
+    
+    <!-- Shield Icon -->
+    <g transform="translate(80, 280)">
+      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
+            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    </g>
+    
+    <!-- Lock Icon -->
+    <g transform="translate(200, 300)">
+      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
+      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
+      <circle cx="40" cy="55" r="6" fill="white"/>
+    </g>
+    
+    <!-- Alert Triangle -->
+    <g transform="translate(320, 290)">
+      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
+      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    </g>
+    
   </g>
-
-  <!-- Card 2: SECURITY -->
-  <g transform="translate(430, 190)">
-    <rect width="340" height="180" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#redGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#redGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#dc2626" text-anchor="middle">!</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#dc2626">SECURITY</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">GlassWorm Supply-Chain Attack Abuse</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">Cybersecurity researchers have flagged a</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">new iteration of the GlassWorm campaign</text>
-
-    <rect x="20" y="155" width="120" height="18" rx="9" fill="url(#redGradient)" fill-opacity="0.2"/>
-    <text x="80" y="168" font-family="Arial, sans-serif" font-size="10" fill="#dc2626" text-anchor="middle">The Hacker News</text>
+  
+  <!-- Main Content Card -->
+  <g transform="translate(450, 180)" filter="url(#shadow)">
+    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
+    
+    <!-- Card Header Accent -->
+    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
+    
+    <!-- Card Title -->
+    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
+    
+    <!-- Summary Content -->
+    <g transform="translate(30, 90)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Critical GlassWorm AI . 2026 03 15</text>
+    </g>
+    <g transform="translate(30, 125)">
+      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
+      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">/ 9 - VS Code , AI , AWS IAM ,</text>
+    </g>
+    
+    <!-- Tags Section -->
+    <g transform="translate(30, 230)">
+      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
+      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
+      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
+      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
+      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
+    </g>
+    
+    <!-- CTA Button -->
+    <g transform="translate(540, 280)">
+      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
+      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    </g>
   </g>
-
-  <!-- Card 3: BLOCKCHAIN -->
-  <g transform="translate(810, 190)">
-    <rect width="340" height="180" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#orangeGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#f97316" text-anchor="middle">BC</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#f97316">BLOCKCHAIN</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Changing Basel rules could unlock &#39;</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">Banks seek to deploy capital in the most</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">efficient way possible, but capital</text>
-
-    <rect x="20" y="155" width="120" height="18" rx="9" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="80" y="168" font-family="Arial, sans-serif" font-size="10" fill="#f97316" text-anchor="middle">Cointelegraph</text>
+  
+  <!-- Bottom Section -->
+  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
+  
+  <!-- Blog Branding -->
+  <g transform="translate(50, 575)">
+    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
+    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
   </g>
-
-  <!-- Card 4: BLOCKCHAIN -->
-  <g transform="translate(50, 400)">
-    <rect width="340" height="160" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#orangeGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#f97316" text-anchor="middle">BC</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#f97316">BLOCKCHAIN</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Former UK Prime Minister Boris John</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">Johnson said that he could understand</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">why gold and Pokmon cards have</text>
-
-    <rect x="20" y="140" width="120" height="18" rx="9" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="80" y="153" font-family="Arial, sans-serif" font-size="10" fill="#f97316" text-anchor="middle">Cointelegraph</text>
-  </g>
-
-  <!-- Card 5: BLOCKCHAIN -->
-  <g transform="translate(430, 400)">
-    <rect width="340" height="160" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#orangeGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#f97316" text-anchor="middle">BC</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#f97316">BLOCKCHAIN</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Bitcoin beats stocks as Strategy&#39;s</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">BTC faces bull trap risks due to the</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">formation of a bear flag pattern, with a</text>
-
-    <rect x="20" y="140" width="120" height="18" rx="9" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="80" y="153" font-family="Arial, sans-serif" font-size="10" fill="#f97316" text-anchor="middle">Cointelegraph</text>
-  </g>
-
-  <!-- Card 6: BLOCKCHAIN -->
-  <g transform="translate(810, 400)">
-    <rect width="340" height="160" rx="16" fill="url(#cardGradient)" filter="url(#shadow)"/>
-    <rect x="0" y="0" width="340" height="6" rx="3" fill="url(#orangeGradient)"/>
-
-    <!-- Icon -->
-    <circle cx="40" cy="50" r="24" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="40" y="58" font-family="Arial, sans-serif" font-size="16" fill="#f97316" text-anchor="middle">BC</text>
-
-    <text x="80" y="45" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#f97316">BLOCKCHAIN</text>
-    <text x="80" y="65" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white">Balaji calls for more crypto tools</text>
-    <text x="20" y="95" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">Former Coinbase CTO says the crypto</text>
-    <text x="20" y="113" font-family="Arial, sans-serif" font-size="12" fill="#94a3b8">industry should build more financial</text>
-
-    <rect x="20" y="140" width="120" height="18" rx="9" fill="url(#orangeGradient)" fill-opacity="0.2"/>
-    <text x="80" y="153" font-family="Arial, sans-serif" font-size="10" fill="#f97316" text-anchor="middle">Cointelegraph</text>
-  </g>
-
-  <!-- Footer -->
-  <line x1="50" y1="585" x2="1150" y2="585" stroke="#334155" stroke-width="1"/>
-
-  <!-- Stats -->
-  <g transform="translate(50, 600)">
-    <text font-family="Arial, sans-serif" font-size="13" fill="#64748b">12 News Collected</text>
-  </g>
-  <g transform="translate(250, 600)">
-    <text font-family="Arial, sans-serif" font-size="13" fill="#64748b">2 Security</text>
-  </g>
-  <g transform="translate(400, 600)">
-    <text font-family="Arial, sans-serif" font-size="13" fill="#64748b">0 Cloud</text>
-  </g>
-  <g transform="translate(520, 600)">
-    <text font-family="Arial, sans-serif" font-size="13" fill="#64748b">0 DevOps</text>
-  </g>
-  <g transform="translate(650, 600)">
-    <text font-family="Arial, sans-serif" font-size="13" fill="#64748b">0 AI/ML</text>
-  </g>
-
-  <!-- Blog Info -->
-  <text x="1150" y="612" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  
+  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
+  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
+  
+  <!-- Tech Stack -->
+  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
+  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
 </svg>

--- a/scripts/generate_high_quality_images.py
+++ b/scripts/generate_high_quality_images.py
@@ -49,6 +49,34 @@ def _truncate_title(title: str, max_len: int = 50) -> str:
     return title[: max_len - 3] + "..."
 
 
+def _normalize_english_text(text: str) -> str:
+    """Keep only English-friendly characters for SVG text."""
+    if not text:
+        return ""
+
+    normalized = re.sub(r"[^\x00-\x7F]+", " ", text)
+    normalized = re.sub(r"[^A-Za-z0-9&:/+.,()\-\s]", " ", normalized)
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def _derive_english_title(raw_title: str, filename: str) -> str:
+    """Derive an English-only display title for SVG output."""
+    normalized_title = _normalize_english_text(raw_title)
+    if len(normalized_title) >= 8:
+        return normalized_title
+
+    stem = Path(filename).stem
+    stem = re.sub(r"^\d{4}-\d{2}-\d{2}-", "", stem)
+    stem = stem.replace("ampquot", " ").replace("amp", " ")
+    stem = re.sub(r"[_\-]+", " ", stem)
+    stem = _normalize_english_text(stem)
+    if stem:
+        return stem.title()
+
+    return "Tech Blog Post"
+
+
 def extract_post_info(post_file: Path) -> Dict:
     """포스팅 파일에서 정보 추출"""
     try:
@@ -336,6 +364,7 @@ def generate_high_quality_svg(post_info: Dict, output_path: Path) -> bool:
     """고퀄리티 SVG 이미지 생성"""
     try:
         title = post_info.get("title", "Tech Blog Post")
+        filename = post_info.get("filename", "")
         category = post_info.get("category", "tech").lower()
         tags = post_info.get("tags", [])
         excerpt = post_info.get("excerpt", "")
@@ -427,16 +456,28 @@ def generate_high_quality_svg(post_info: Dict, output_path: Path) -> bool:
 
         config = category_config.get(category, category_config["tech"])
 
-        display_title = _escape_svg_text(_truncate_title(title, 48))
+        english_title = _derive_english_title(str(title), str(filename))
+        display_title = _escape_svg_text(_truncate_title(english_title, 48))
 
         # 태그 처리
-        display_tags = tags[:4] if tags else ["Tech", "Blog", "Update"]
+        raw_tags = tags[:4] if tags else ["Tech", "Blog", "Update"]
+        display_tags = []
+        for raw_tag in raw_tags:
+            normalized_tag = _normalize_english_text(str(raw_tag))
+            if normalized_tag:
+                display_tags.append(_truncate_title(normalized_tag, 18))
+
+        if not display_tags:
+            display_tags = [config["label"], "Architecture", "Overview"]
 
         # 요약 라인 처리
         summary_lines = []
         if highlights:
             for h in highlights[:3]:
                 clean_h = re.sub(r"<[^>]+>", "", h)
+                clean_h = _normalize_english_text(clean_h)
+                if not clean_h:
+                    continue
                 if len(clean_h) > 70:
                     clean_h = clean_h[:67] + "..."
                 summary_lines.append(_escape_svg_text(clean_h))
@@ -446,14 +487,25 @@ def generate_high_quality_svg(post_info: Dict, output_path: Path) -> bool:
             for word in words:
                 test_line = f"{line} {word}".strip()
                 if len(test_line) > 70:
-                    summary_lines.append(_escape_svg_text(line))
+                    safe_line = _normalize_english_text(line)
+                    if safe_line:
+                        summary_lines.append(_escape_svg_text(safe_line))
                     line = word
                     if len(summary_lines) >= 3:
                         break
                 else:
                     line = test_line
             if line and len(summary_lines) < 3:
-                summary_lines.append(_escape_svg_text(line))
+                safe_line = _normalize_english_text(line)
+                if safe_line:
+                    summary_lines.append(_escape_svg_text(safe_line))
+
+        if not summary_lines:
+            summary_lines = [
+                "Practical implementation guidance",
+                "Architecture and operational checklist",
+                "Security and reliability focus",
+            ]
 
         date_str = datetime.now().strftime("%B %d, %Y")
         icons_svg = config["icons_func"]()


### PR DESCRIPTION
## Summary
- Improve `scripts/generate_high_quality_images.py` to normalize SVG text into English-safe output and stronger fallbacks.
- Regenerate all post cover SVGs (`assets/images/*.svg`) using the high-quality generator.
- Restore consistent, glanceable visual hierarchy for post thumbnails across the site.

## Verification
- `.venv/bin/python scripts/generate_high_quality_images.py --all --force`
- `.venv/bin/python scripts/verify_images_unified.py --all`
- `bundle exec jekyll build --destination _site`