### PR TITLE
feat: 2025-2026 전체 SVG 이미지 비주얼 업그레이드 (98개)

### DIFF
--- a/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
+++ b/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
@@ -1,189 +1,38 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a20"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SKT : IMEI , USIM/eSIM , MFA</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#ef4444" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <path d="M-60,-120 L60,-120 L80,-100 L80,120 L-80,120 L-80,-100 Z" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+    <rect x="-30" y="-40" width="60" height="50" rx="6" fill="#f59e0b" opacity="0.3" stroke="#f59e0b" stroke-width="1.5"/>
+    <line x1="-30" y1="-15" x2="30" y2="-15" stroke="#f59e0b" stroke-width="0.8" opacity="0.5"/>
+    <line x1="-30" y1="0" x2="30" y2="0" stroke="#f59e0b" stroke-width="0.8" opacity="0.5"/>
+    <line x1="0" y1="-40" x2="0" y2="10" stroke="#f59e0b" stroke-width="0.8" opacity="0.5"/>
+    <path d="M-20,-120 L-5,-80 L10,-60 L-5,-20 L15,30 L0,80" fill="none" stroke="#ef4444" stroke-width="2.5" opacity="0.7"/>
+    <circle cx="0" cy="75" r="20" fill="#ef4444" opacity="0.15"/>
+    <text x="0" y="81" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="#ef4444" text-anchor="middle">!</text>
+    <g transform="translate(160,0)">
+      <path d="M0,-50 L40,-35 L40,10 C40,35 20,50 0,58 C-20,50 -40,35 -40,10 L-40,-35 Z" fill="#1e293b" stroke="#22c55e" stroke-width="2.5"/>
+      <text x="0" y="-10" font-family="Courier New" font-size="11" fill="#86efac" text-anchor="middle">MFA</text>
+      <path d="M-10,10 L-4,18 L12,0" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SKT : IMEI , USIM/eSIM , MFA - SK USIM</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. USIM/eSIM , IMEI , MFA , SIM ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SKT</text>
-      <rect x="72" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#MFA</text>
-      <rect x="144" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="178" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#USIM</text>
-      <rect x="225" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Incident</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g transform="translate(-160,-20)" opacity="0.6">
+      <rect x="-45" y="-25" width="90" height="50" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+      <text x="0" y="-5" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">IMEI</text>
+      <text x="0" y="10" font-family="Courier New" font-size="8" fill="#60a5fa" text-anchor="middle">*06#</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SIM Security Breach</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">IMEI Check | USIM/eSIM Replace | MFA Defense</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">INCIDENT GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">April 29, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
+++ b/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
@@ -1,185 +1,40 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a20"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">PC , OTP,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#10b981" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <circle cx="-80" cy="0" r="50" fill="#1e293b" stroke="#10b981" stroke-width="3"/>
+    <circle cx="-80" cy="0" r="20" fill="none" stroke="#10b981" stroke-width="2" opacity="0.5"/>
+    <rect x="-30" y="-8" width="180" height="16" rx="4" fill="#1e293b" stroke="#10b981" stroke-width="2"/>
+    <rect x="110" y="8" width="12" height="20" rx="2" fill="#10b981" opacity="0.6"/>
+    <rect x="130" y="8" width="12" height="28" rx="2" fill="#10b981" opacity="0.5"/>
+    <rect x="150" y="8" width="12" height="15" rx="2" fill="#10b981" opacity="0.7"/>
+    <g transform="translate(-80,0)" opacity="0.4">
+      <path d="M-12,0 C-12,-8 -6,-14 0,-14 C6,-14 12,-8 12,0" fill="none" stroke="#34d399" stroke-width="1.5"/>
+      <path d="M-8,0 C-8,-5 -4,-10 0,-10 C4,-10 8,-5 8,0" fill="none" stroke="#34d399" stroke-width="1.5"/>
+      <path d="M-4,0 C-4,-3 -2,-6 0,-6 C2,-6 4,-3 4,0" fill="none" stroke="#34d399" stroke-width="1.5"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <g transform="translate(0,-100)" opacity="0.6">
+      <rect x="-60" y="-18" width="120" height="36" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <text x="0" y="6" font-family="Courier New" font-size="22" fill="#60a5fa" text-anchor="middle" letter-spacing="8">847291</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">PC . (Passkey) WebAuthn , OTP 2FA , ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Passkey</text>
-      <rect x="108" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OTP</text>
-      <rect x="180" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Password-Manager</text>
-      <rect x="369" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="448" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Authentication</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g transform="translate(0,90)" opacity="0.5">
+      <rect x="-20" y="0" width="40" height="30" rx="5" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <path d="M-10,0 L-10,-10 C-10,-20 10,-20 10,-10 L10,0" fill="none" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="0" cy="15" r="4" fill="#f59e0b" opacity="0.7"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Passkey Authentication</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Passkey | OTP | Strong Password Management</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#10b981" opacity="0.2" stroke="#10b981" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#6ee7b7" text-anchor="middle">SECURITY GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">April 30, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
+++ b/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
@@ -1,194 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1520"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 3 : AWS FinOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <path d="M-120,20 C-140,20 -160,0 -150,-25 C-145,-55 -115,-70 -85,-65 C-75,-100 -40,-115 0,-105 C40,-115 75,-100 85,-65 C115,-70 145,-55 150,-25 C160,0 140,20 120,20 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+    <text x="-50" y="-20" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#f97316" opacity="0.8">AWS</text>
+    <g transform="translate(50,-30)">
+      <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <text x="0" y="10" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#22c55e" text-anchor="middle">$</text>
     </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 3 . AWS (IAM, Organizations, CloudTrail,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GuardDuty,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="87" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="115" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#FinOps</text>
-      <rect x="171" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
-      <rect x="342" y="0" width="186" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="435" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cost-Optimization</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g transform="translate(0,60)">
+      <path d="M0,-30 L30,-20 L30,5 C30,20 15,30 0,35 C-15,30 -30,20 -30,5 L-30,-20 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="1.5"/>
+      <path d="M-8,5 L-3,12 L10,-2" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Security and FinOps</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 3 | Cost Optimization</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 2, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
+++ b/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
@@ -1,189 +1,83 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#6366f1" opacity="0.04" filter="url(#sg)"/>
+  <!-- MacBook laptop -->
+  <g transform="translate(600,260)">
+    <!-- Screen -->
+    <rect x="-150" y="-140" width="300" height="195" rx="10" fill="#1e293b" stroke="#475569" stroke-width="2.5"/>
+    <rect x="-138" y="-130" width="276" height="175" rx="4" fill="#0f172a"/>
+    <!-- Camera dot -->
+    <circle cx="0" cy="-135" r="3" fill="#334155"/>
+    <!-- Screen content: Kandji dashboard -->
+    <!-- Shield logo center -->
+    <path d="M0,-80 L35,-65 L35,-30 C35,-5 18,10 0,18 C-18,10 -35,-5 -35,-30 L-35,-65 Z" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="2"/>
+    <text x="0" y="-40" font-family="Courier New" font-size="14" fill="#a5b4fc" text-anchor="middle">MDM</text>
+    <!-- Compliance checkmarks around shield -->
+    <g transform="translate(-100,-90)" opacity="0.7">
+      <rect x="0" y="0" width="50" height="18" rx="4" fill="#22c55e" opacity="0.15"/>
+      <circle cx="12" cy="9" r="5" fill="#22c55e" opacity="0.8"/>
+      <path d="M9,9 L11,12 L15,7" fill="none" stroke="white" stroke-width="1.5"/>
+      <text x="32" y="13" font-family="Courier New" font-size="7" fill="#86efac">CIS</text>
+    </g>
+    <g transform="translate(50,-90)" opacity="0.7">
+      <rect x="0" y="0" width="55" height="18" rx="4" fill="#22c55e" opacity="0.15"/>
+      <circle cx="12" cy="9" r="5" fill="#22c55e" opacity="0.8"/>
+      <path d="M9,9 L11,12 L15,7" fill="none" stroke="white" stroke-width="1.5"/>
+      <text x="35" y="13" font-family="Courier New" font-size="7" fill="#86efac">SOC2</text>
+    </g>
+    <g transform="translate(-100,-5)" opacity="0.7">
+      <rect x="0" y="0" width="55" height="18" rx="4" fill="#22c55e" opacity="0.15"/>
+      <circle cx="12" cy="9" r="5" fill="#22c55e" opacity="0.8"/>
+      <path d="M9,9 L11,12 L15,7" fill="none" stroke="white" stroke-width="1.5"/>
+      <text x="35" y="13" font-family="Courier New" font-size="7" fill="#86efac">NIST</text>
+    </g>
+    <g transform="translate(50,-5)" opacity="0.7">
+      <rect x="0" y="0" width="60" height="18" rx="4" fill="#f59e0b" opacity="0.15"/>
+      <circle cx="12" cy="9" r="5" fill="#f59e0b" opacity="0.8"/>
+      <text x="10" y="12" font-family="Courier New" font-size="8" fill="white" text-anchor="middle">~</text>
+      <text x="38" y="13" font-family="Courier New" font-size="7" fill="#fde68a">FIDO2</text>
+    </g>
+    <!-- Status bar at bottom of screen -->
+    <rect x="-130" y="20" width="260" height="18" rx="3" fill="#334155" opacity="0.5"/>
+    <circle cx="-115" cy="29" r="4" fill="#22c55e"/>
+    <text x="-105" y="33" font-family="Courier New" font-size="8" fill="#94a3b8">128 devices managed</text>
+    <!-- Laptop base -->
+    <path d="M-180,55 L-150,55 L-138,60 L138,60 L150,55 L180,55 L170,70 L-170,70 Z" fill="#334155" stroke="#475569" stroke-width="1.5"/>
+    <rect x="-40" y="55" width="80" height="4" rx="2" fill="#475569"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  <!-- Floating device icons managed by Kandji -->
+  <g opacity="0.4">
+    <!-- iPhone -->
+    <g transform="translate(200,180)">
+      <rect x="-12" y="-20" width="24" height="40" rx="5" fill="none" stroke="#6366f1" stroke-width="1.5"/>
+      <circle cx="0" cy="14" r="3" fill="none" stroke="#6366f1" stroke-width="1"/>
+    </g>
+    <path d="M212,180 L450,230" fill="none" stroke="#6366f1" stroke-width="1" stroke-dasharray="4,4" opacity="0.3"/>
+    <!-- iPad -->
+    <g transform="translate(200,340)">
+      <rect x="-18" y="-24" width="36" height="48" rx="5" fill="none" stroke="#6366f1" stroke-width="1.5"/>
+      <circle cx="0" cy="18" r="3" fill="none" stroke="#6366f1" stroke-width="1"/>
+    </g>
+    <path d="M218,340 L460,300" fill="none" stroke="#6366f1" stroke-width="1" stroke-dasharray="4,4" opacity="0.3"/>
+    <!-- Another Mac -->
+    <g transform="translate(1000,200)">
+      <rect x="-20" y="-15" width="40" height="28" rx="3" fill="none" stroke="#6366f1" stroke-width="1.5"/>
+      <path d="M-25,13 L25,13 L20,18 L-20,18 Z" fill="none" stroke="#6366f1" stroke-width="1"/>
+    </g>
+    <path d="M980,200 L750,240" fill="none" stroke="#6366f1" stroke-width="1" stroke-dasharray="4,4" opacity="0.3"/>
   </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kandji macOS ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Kandji macOS . MDM , , ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FIDO2/WebAuthn</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kandji</text>
-      <rect x="99" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#macOS</text>
-      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#MDM</text>
-      <rect x="261" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Endpoint-Security</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kandji macOS MDM</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Endpoint Security | Compliance | Device Management</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#a5b4fc" text-anchor="middle">SECURITY GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 2, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
+++ b/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
@@ -1,194 +1,37 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a15"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 4 AWS ISMS</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
-    </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 - 4 AWS ISMS - 7 4 . AWS</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Inspector, Security Hub, GuardDuty), ISMS-P</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="69" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="106" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#ISMS</text>
-      <rect x="153" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="228" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Vulnerability</text>
-      <rect x="315" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Compliance</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#dc2626" opacity="0.04" filter="url(#sg)"/>
+  <!-- Magnifying glass scanning vulnerability -->
+  <g transform="translate(600,250)">
+    <circle cx="-30" cy="-20" r="80" fill="none" stroke="#dc2626" stroke-width="3" opacity="0.6"/>
+    <circle cx="-30" cy="-20" r="70" fill="#1e293b" opacity="0.8"/>
+    <line x1="30" y1="40" x2="100" y2="110" stroke="#dc2626" stroke-width="8" stroke-linecap="round"/>
+    <!-- Bug inside magnifier -->
+    <circle cx="-30" cy="-30" r="18" fill="#ef4444" opacity="0.15"/>
+    <text x="-30" y="-20" font-family="Courier New" font-size="20" fill="#ef4444" text-anchor="middle">BUG</text>
+    <!-- Scan lines -->
+    <line x1="-80" y1="-50" x2="20" y2="-50" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
+    <line x1="-80" y1="-30" x2="20" y2="-30" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
+    <line x1="-80" y1="-10" x2="20" y2="-10" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
+    <line x1="-80" y1="10" x2="20" y2="10" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
+    <!-- ISMS badge -->
+    <g transform="translate(140,-60)">
+      <rect x="-40" y="-20" width="80" height="40" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <text x="0" y="5" font-family="Courier New" font-size="14" fill="#60a5fa" text-anchor="middle">ISMS</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Vulnerability Scan</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 4 | ISMS Response</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#dc2626" opacity="0.2" stroke="#dc2626" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 9, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
+++ b/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
@@ -1,190 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 5 AWS Control Tower ZTNA</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#8b5cf6" opacity="0.04" filter="url(#sg)"/>
+  <!-- Control Tower -->
+  <g transform="translate(600,250)">
+    <rect x="-30" y="-130" width="60" height="200" rx="4" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+    <rect x="-80" y="-130" width="160" height="40" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
+    <rect x="-70" y="-120" width="140" height="20" rx="3" fill="#8b5cf6" opacity="0.15"/>
+    <circle cx="-40" cy="-110" r="4" fill="#22d3ee" opacity="0.8"/>
+    <circle cx="0" cy="-110" r="4" fill="#22c55e" opacity="0.8"/>
+    <circle cx="40" cy="-110" r="4" fill="#f59e0b" opacity="0.8"/>
+    <!-- Antenna -->
+    <line x1="0" y1="-130" x2="0" y2="-160" stroke="#8b5cf6" stroke-width="2"/>
+    <circle cx="0" cy="-165" r="6" fill="#8b5cf6" opacity="0.6"/>
+    <!-- Signal waves -->
+    <path d="M-20,-165 C-20,-185 20,-185 20,-165" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.3"/>
+    <path d="M-35,-165 C-35,-195 35,-195 35,-165" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.2"/>
+    <!-- ZTNA rings at base -->
+    <ellipse cx="0" cy="80" rx="160" ry="30" fill="none" stroke="#22d3ee" stroke-width="1.5" opacity="0.3" stroke-dasharray="6,4"/>
+    <ellipse cx="0" cy="80" rx="110" ry="20" fill="none" stroke="#22d3ee" stroke-width="1.5" opacity="0.4" stroke-dasharray="4,3"/>
+    <ellipse cx="0" cy="80" rx="60" ry="12" fill="none" stroke="#22d3ee" stroke-width="2" opacity="0.5"/>
+    <text x="0" y="85" font-family="Courier New" font-size="10" fill="#67e8f9" text-anchor="middle">ZTNA</text>
+    <!-- SCP policy documents -->
+    <g transform="translate(-140,-40)" opacity="0.5">
+      <rect x="0" y="0" width="50" height="60" rx="4" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="25" y="35" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">SCP</text>
     </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 5 . AWS Control Tower (Landing Zone, Guardrails,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Control-Tower</text>
-      <rect x="234" y="0" width="69" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#ZTNA</text>
-      <rect x="315" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Zero-Trust</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g transform="translate(90,-40)" opacity="0.5">
+      <rect x="0" y="0" width="50" height="60" rx="4" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="25" y="35" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">OU</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Control Tower</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 5 | ZTNA Architecture</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 16, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
+++ b/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
@@ -1,189 +1,42 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a28"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#sg)"/>
+  <!-- Cloudflare shield -->
+  <g transform="translate(420,250)">
+    <path d="M0,-90 L70,-65 L70,20 C70,60 35,85 0,95 C-35,85 -70,60 -70,20 L-70,-65 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+    <text x="0" y="-15" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#f97316" text-anchor="middle">CF</text>
+    <!-- Cloud inside shield -->
+    <path d="M-30,15 C-38,15 -45,8 -42,-2 C-40,-12 -30,-18 -20,-16 C-16,-28 -5,-32 5,-28 C15,-32 26,-28 28,-16 C38,-18 48,-12 50,-2 C53,8 46,15 38,15 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="1"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 6 Cloudflare GitHub</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">7 6 . AWS WAF, Cloudflare (DDoS, SSL/TLS), GitHub</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Dependabot, CodeQL) .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CDN</text>
-      <rect x="144" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloudflare</text>
-      <rect x="279" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#GitHub</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <!-- GitHub octocat simplified -->
+  <g transform="translate(780,250)">
+    <circle cx="0" cy="-20" r="60" fill="#1e293b" stroke="#e2e8f0" stroke-width="2.5"/>
+    <!-- Octocat face -->
+    <circle cx="-18" cy="-30" r="10" fill="#0f172a" stroke="#e2e8f0" stroke-width="1.5"/>
+    <circle cx="18" cy="-30" r="10" fill="#0f172a" stroke="#e2e8f0" stroke-width="1.5"/>
+    <circle cx="-18" cy="-30" r="5" fill="#e2e8f0"/>
+    <circle cx="18" cy="-30" r="5" fill="#e2e8f0"/>
+    <path d="M-10,-8 C-5,2 5,2 10,-8" fill="none" stroke="#e2e8f0" stroke-width="1.5"/>
+    <!-- Lock on GitHub -->
+    <g transform="translate(40,-50)">
+      <rect x="-10" y="0" width="20" height="16" rx="3" fill="#22c55e" opacity="0.8"/>
+      <path d="M-5,0 L-5,-6 C-5,-12 5,-12 5,-6 L5,0" fill="none" stroke="#22c55e" stroke-width="2"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <!-- Connection between them -->
+  <path d="M490,250 L690,250" fill="none" stroke="#475569" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.4"/>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloudflare and GitHub</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 6 | Edge Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 23, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
+++ b/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
@@ -1,191 +1,45 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0f1a2e"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Amazon Q Developer GitHub Advanced Security AWS</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#22d3ee" opacity="0.04" filter="url(#sg)"/>
+  <!-- Amazon Q AI assistant -->
+  <g transform="translate(600,250)">
+    <!-- Q letter as main visual -->
+    <circle cx="0" cy="-10" r="80" fill="#1e293b" stroke="#22d3ee" stroke-width="3"/>
+    <text x="0" y="20" font-family="Arial,sans-serif" font-size="90" font-weight="bold" fill="#22d3ee" text-anchor="middle" opacity="0.3">Q</text>
+    <!-- AI sparkle dots -->
+    <circle cx="50" cy="-70" r="4" fill="#22d3ee" opacity="0.6"/>
+    <circle cx="70" cy="-40" r="3" fill="#22d3ee" opacity="0.4"/>
+    <circle cx="-55" cy="-65" r="3" fill="#22d3ee" opacity="0.5"/>
+    <!-- Code scanning lines -->
+    <g transform="translate(-180,-60)" opacity="0.5">
+      <rect x="0" y="0" width="80" height="8" rx="2" fill="#3b82f6" opacity="0.3"/>
+      <rect x="0" y="15" width="60" height="8" rx="2" fill="#3b82f6" opacity="0.2"/>
+      <rect x="0" y="30" width="70" height="8" rx="2" fill="#ef4444" opacity="0.3"/>
+      <rect x="0" y="45" width="50" height="8" rx="2" fill="#3b82f6" opacity="0.2"/>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    <!-- GitHub security shield -->
+    <g transform="translate(160,-40)" opacity="0.5">
+      <path d="M0,-30 L25,-20 L25,5 C25,18 12,25 0,30 C-12,25 -25,18 -25,5 L-25,-20 Z" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <path d="M-6,2 L-2,8 L8,-4" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
     </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Amazon Q Developer GitHub Advanced Security AWS</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="105" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Amazon-Q</text>
-      <rect x="117" y="0" width="195" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#GitHub-Advanced...</text>
-      <rect x="324" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Code-Security</text>
-      <rect x="486" y="0" width="60" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="516" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AWS</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- AWS label -->
+    <g transform="translate(0,100)" opacity="0.5">
+      <rect x="-40" y="-12" width="80" height="24" rx="6" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="0" y="4" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#f97316" text-anchor="middle">AWS</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Amazon Q Developer</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Code Security | GitHub Advanced Security | AWS</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22d3ee" opacity="0.2" stroke="#22d3ee" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#67e8f9" text-anchor="middle">AI SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 24, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
+++ b/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
@@ -1,194 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1528"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#3b82f6" opacity="0.04" filter="url(#sg)"/>
+  <!-- Docker whale -->
+  <g transform="translate(420,240)">
+    <!-- Whale body -->
+    <path d="M-60,20 C-80,20 -90,0 -80,-20 C-70,-40 -40,-50 0,-45 C40,-50 70,-40 80,-20 C90,0 80,20 60,20 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+    <!-- Containers on whale -->
+    <rect x="-40" y="-40" width="18" height="14" rx="2" fill="#3b82f6" opacity="0.4" stroke="#3b82f6" stroke-width="1"/>
+    <rect x="-18" y="-40" width="18" height="14" rx="2" fill="#3b82f6" opacity="0.5" stroke="#3b82f6" stroke-width="1"/>
+    <rect x="4" y="-40" width="18" height="14" rx="2" fill="#3b82f6" opacity="0.6" stroke="#3b82f6" stroke-width="1"/>
+    <rect x="-18" y="-55" width="18" height="14" rx="2" fill="#3b82f6" opacity="0.3" stroke="#3b82f6" stroke-width="1"/>
+    <!-- Eye -->
+    <circle cx="-50" cy="-5" r="4" fill="#60a5fa"/>
+    <!-- Tail -->
+    <path d="M60,10 C80,0 90,-15 85,-30" fill="none" stroke="#3b82f6" stroke-width="2"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
+  <!-- Kubernetes helm -->
+  <g transform="translate(780,240)">
+    <!-- Helm wheel -->
+    <circle cx="0" cy="0" r="55" fill="#1e293b" stroke="#326ce5" stroke-width="2.5"/>
+    <circle cx="0" cy="0" r="20" fill="#326ce5" opacity="0.15"/>
+    <!-- 7 spokes -->
+    <line x1="0" y1="-55" x2="0" y2="-25" stroke="#326ce5" stroke-width="3"/>
+    <line x1="52" y1="-17" x2="24" y2="-8" stroke="#326ce5" stroke-width="3"/>
+    <line x1="32" y1="45" x2="15" y2="20" stroke="#326ce5" stroke-width="3"/>
+    <line x1="-32" y1="45" x2="-15" y2="20" stroke="#326ce5" stroke-width="3"/>
+    <line x1="-52" y1="-17" x2="-24" y2="-8" stroke="#326ce5" stroke-width="3"/>
+    <!-- Spoke endpoints -->
+    <circle cx="0" cy="-55" r="6" fill="#326ce5"/>
+    <circle cx="52" cy="-17" r="6" fill="#326ce5"/>
+    <circle cx="32" cy="45" r="6" fill="#326ce5"/>
+    <circle cx="-32" cy="45" r="6" fill="#326ce5"/>
+    <circle cx="-52" cy="-17" r="6" fill="#326ce5"/>
   </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 7 : Docker Kubernetes</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Kubernetes Wheel -->
-    <g transform="translate(100, 290)">
-      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
-      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
-      <g stroke="#326ce5" stroke-width="4">
-        <line x1="50" y1="10" x2="50" y2="35"/>
-        <line x1="50" y1="65" x2="50" y2="90"/>
-        <line x1="10" y1="50" x2="35" y2="50"/>
-        <line x1="65" y1="50" x2="90" y2="50"/>
-        <line x1="22" y1="22" x2="39" y2="39"/>
-        <line x1="61" y1="61" x2="78" y2="78"/>
-        <line x1="22" y1="78" x2="39" y2="61"/>
-        <line x1="61" y1="39" x2="78" y2="22"/>
-      </g>
-    </g>
-    
-    <!-- Container Box -->
-    <g transform="translate(230, 300)">
-      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
-      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
-      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
-    </g>
-    
-    <!-- Pod Circle -->
-    <g transform="translate(340, 310)">
-      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
-      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Docker ( , , Dockerfile), Kubernetes (Control Plane, Node,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="87" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Docker</text>
-      <rect x="99" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
-      <rect x="234" y="0" width="114" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Container</text>
-      <rect x="360" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K8s</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <!-- Connection -->
+  <path d="M500,240 L700,240" fill="none" stroke="#475569" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.4"/>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Docker and Kubernetes</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 7 | Container Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 30, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
+++ b/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
@@ -1,198 +1,49 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1828"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kubernetes Minikube &amp; K9s :</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Kubernetes Wheel -->
-    <g transform="translate(100, 290)">
-      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
-      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
-      <g stroke="#326ce5" stroke-width="4">
-        <line x1="50" y1="10" x2="50" y2="35"/>
-        <line x1="50" y1="65" x2="50" y2="90"/>
-        <line x1="10" y1="50" x2="35" y2="50"/>
-        <line x1="65" y1="50" x2="90" y2="50"/>
-        <line x1="22" y1="22" x2="39" y2="39"/>
-        <line x1="61" y1="61" x2="78" y2="78"/>
-        <line x1="22" y1="78" x2="39" y2="61"/>
-        <line x1="61" y1="39" x2="78" y2="22"/>
-      </g>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#326ce5" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- K9s terminal window -->
+    <rect x="-180" y="-130" width="360" height="240" rx="12" fill="#1e293b" stroke="#326ce5" stroke-width="2"/>
+    <rect x="-180" y="-130" width="360" height="30" rx="12" fill="#334155"/>
+    <rect x="-180" y="-110" width="360" height="10" fill="#334155"/>
+    <circle cx="-155" cy="-115" r="6" fill="#ef4444" opacity="0.8"/>
+    <circle cx="-135" cy="-115" r="6" fill="#f59e0b" opacity="0.8"/>
+    <circle cx="-115" cy="-115" r="6" fill="#22c55e" opacity="0.8"/>
+    <text x="0" y="-110" font-family="Courier New" font-size="10" fill="#94a3b8" text-anchor="middle">K9s - Cluster Overview</text>
+    <!-- K9s content rows -->
+    <g font-family="Courier New" font-size="10">
+      <text x="-160" y="-75" fill="#326ce5">NAMESPACE</text>
+      <text x="-60" y="-75" fill="#326ce5">POD</text>
+      <text x="80" y="-75" fill="#326ce5">STATUS</text>
+      <rect x="-165" y="-65" width="320" height="1" fill="#334155"/>
+      <text x="-160" y="-50" fill="#94a3b8">default</text>
+      <text x="-60" y="-50" fill="#e2e8f0">nginx-pod</text>
+      <text x="80" y="-50" fill="#22c55e">Running</text>
+      <text x="-160" y="-35" fill="#94a3b8">kube-sys</text>
+      <text x="-60" y="-35" fill="#e2e8f0">coredns</text>
+      <text x="80" y="-35" fill="#22c55e">Running</text>
+      <text x="-160" y="-20" fill="#94a3b8">default</text>
+      <text x="-60" y="-20" fill="#e2e8f0">api-srv</text>
+      <text x="80" y="-20" fill="#f59e0b">Pending</text>
     </g>
-    
-    <!-- Container Box -->
-    <g transform="translate(230, 300)">
-      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
-      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
-      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
-    </g>
-    
-    <!-- Pod Circle -->
-    <g transform="translate(340, 310)">
-      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
-      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Minikube 1.37.0+ , K9s UI , Kubernetes 2024-2025</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(User</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
-      <rect x="135" y="0" width="105" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="187" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Minikube</text>
-      <rect x="252" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K9s</text>
-      <rect x="324" y="0" width="60" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#K8s</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Minikube icon -->
+    <g transform="translate(0,60)">
+      <circle cx="0" cy="0" r="30" fill="#326ce5" opacity="0.15" stroke="#326ce5" stroke-width="2"/>
+      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#93c5fd" text-anchor="middle">mini</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Minikube and K9s</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Kubernetes Practical Guide | Local Development | Cluster Management</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">K8S GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 30, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
+++ b/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
@@ -1,185 +1,43 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a201a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: SendGrid SPF, DKIM, DMARC</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#3b82f6" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- Email envelope -->
+    <path d="M-120,-60 L120,-60 L120,70 L-120,70 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+    <path d="M-120,-60 L0,20 L120,-60" fill="none" stroke="#3b82f6" stroke-width="2.5"/>
+    <path d="M-120,70 L-20,10" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+    <path d="M120,70 L20,10" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+    <!-- Trust shield on envelope -->
+    <g transform="translate(0,-20)">
+      <path d="M0,-25 L20,-18 L20,0 C20,12 10,20 0,24 C-10,20 -20,12 -20,0 L-20,-18 Z" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="2"/>
+      <path d="M-6,-2 L-2,4 L8,-6" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- SPF / DKIM / DMARC labels -->
+    <g transform="translate(-160,-30)" opacity="0.6">
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <text x="0" y="4" font-family="Courier New" font-size="10" fill="#86efac" text-anchor="middle">SPF</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    <g transform="translate(-160,20)" opacity="0.6">
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="4" font-family="Courier New" font-size="10" fill="#c4b5fd" text-anchor="middle">DKIM</text>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SendGrid . SPF, DKIM, DMARC , ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SendGrid</text>
-      <rect x="117" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SPF</text>
-      <rect x="189" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DKIM</text>
-      <rect x="270" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="309" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DMARC</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g transform="translate(160,-5)" opacity="0.6">
+      <rect x="-35" y="-12" width="70" height="24" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="0" y="4" font-family="Courier New" font-size="10" fill="#fde68a" text-anchor="middle">DMARC</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Email Trust Setup</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">SendGrid | SPF | DKIM | DMARC Configuration</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">EMAIL GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">June 5, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
@@ -1,194 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a25"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="k8sGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="100%" style="stop-color:#1d4ed8"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#60a5fa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#3b82f6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#1d4ed8" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#3b82f6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#60a5fa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#k8sGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">KUBERNETES</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 8 : CI/CD Kubernetes</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Kubernetes Wheel -->
-    <g transform="translate(100, 290)">
-      <circle cx="50" cy="50" r="40" fill="none" stroke="#326ce5" stroke-width="4"/>
-      <circle cx="50" cy="50" r="15" fill="#326ce5"/>
-      <g stroke="#326ce5" stroke-width="4">
-        <line x1="50" y1="10" x2="50" y2="35"/>
-        <line x1="50" y1="65" x2="50" y2="90"/>
-        <line x1="10" y1="50" x2="35" y2="50"/>
-        <line x1="65" y1="50" x2="90" y2="50"/>
-        <line x1="22" y1="22" x2="39" y2="39"/>
-        <line x1="61" y1="61" x2="78" y2="78"/>
-        <line x1="22" y1="78" x2="39" y2="61"/>
-        <line x1="61" y1="39" x2="78" y2="22"/>
-      </g>
-    </g>
-    
-    <!-- Container Box -->
-    <g transform="translate(230, 300)">
-      <rect x="10" y="20" width="60" height="50" rx="5" fill="#3b82f6" stroke="#1d4ed8" stroke-width="2"/>
-      <rect x="10" y="10" width="60" height="15" rx="3" fill="#60a5fa"/>
-      <rect x="20" y="35" width="40" height="25" rx="3" fill="#1e3a8a"/>
-    </g>
-    
-    <!-- Pod Circle -->
-    <g transform="translate(340, 310)">
-      <circle cx="30" cy="30" r="25" fill="#8b5cf6" stroke="#7c3aed" stroke-width="2"/>
-      <text x="30" y="38" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">Pod</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#k8sGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#60a5fa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#60a5fa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CI/CD (GitHub Actions, SAST/DAST, Secret ), Kubernetes</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="78" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#CI/CD</text>
-      <rect x="90" y="0" width="123" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="151" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Kubernetes</text>
-      <rect x="225" y="0" width="105" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="277" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#Security</text>
-      <rect x="342" y="0" width="114" height="30" rx="15" fill="#60a5fa" fill-opacity="0.15" stroke="#60a5fa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">#DevSecOps</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#22c55e" opacity="0.04" filter="url(#sg)"/>
+  <!-- CI/CD Pipeline infinity loop -->
+  <g transform="translate(600,250)">
+    <!-- Infinity / pipeline loop -->
+    <path d="M-80,0 C-80,-60 -20,-60 0,0 C20,60 80,60 80,0 C80,-60 20,-60 0,0 C-20,60 -80,60 -80,0 Z" fill="none" stroke="#22c55e" stroke-width="3" opacity="0.6"/>
+    <!-- Pipeline stages on the loop -->
+    <circle cx="-80" cy="0" r="18" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+    <text x="-80" y="5" font-family="Courier New" font-size="8" fill="#60a5fa" text-anchor="middle">CODE</text>
+    <circle cx="-40" cy="-35" r="18" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+    <text x="-40" y="-30" font-family="Courier New" font-size="8" fill="#c4b5fd" text-anchor="middle">BUILD</text>
+    <circle cx="0" cy="0" r="22" fill="#1e293b" stroke="#22c55e" stroke-width="2.5"/>
+    <text x="0" y="5" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">TEST</text>
+    <circle cx="40" cy="35" r="18" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+    <text x="40" y="40" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">DEPLOY</text>
+    <circle cx="80" cy="0" r="18" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+    <text x="80" y="5" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">SCAN</text>
+    <!-- K8s helm at center bottom -->
+    <g transform="translate(0,90)" opacity="0.5">
+      <circle cx="0" cy="0" r="25" fill="#1e293b" stroke="#326ce5" stroke-width="2"/>
+      <line x1="0" y1="-25" x2="0" y2="-12" stroke="#326ce5" stroke-width="2"/>
+      <line x1="24" y1="-8" x2="12" y2="-4" stroke="#326ce5" stroke-width="2"/>
+      <line x1="24" y1="8" x2="12" y2="4" stroke="#326ce5" stroke-width="2"/>
+      <line x1="0" y1="25" x2="0" y2="12" stroke="#326ce5" stroke-width="2"/>
+      <line x1="-24" y1="8" x2="-12" y2="4" stroke="#326ce5" stroke-width="2"/>
+      <line x1="-24" y1="-8" x2="-12" y2="-4" stroke="#326ce5" stroke-width="2"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#k8sGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CI/CD Pipeline Security</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 8 | Kubernetes Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">June 6, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
+++ b/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
@@ -1,191 +1,32 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#8b5cf6" opacity="0.04" filter="url(#sg)"/>
+  <!-- DevSecOps Venn diagram -->
+  <g transform="translate(600,240)">
+    <circle cx="-60" cy="-30" r="90" fill="#3b82f6" opacity="0.08" stroke="#3b82f6" stroke-width="2"/>
+    <circle cx="60" cy="-30" r="90" fill="#22c55e" opacity="0.08" stroke="#22c55e" stroke-width="2"/>
+    <circle cx="0" cy="50" r="90" fill="#ef4444" opacity="0.08" stroke="#ef4444" stroke-width="2"/>
+    <!-- Labels -->
+    <text x="-100" y="-50" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#60a5fa" text-anchor="middle">Dev</text>
+    <text x="100" y="-50" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#86efac" text-anchor="middle">Ops</text>
+    <text x="0" y="110" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#fca5a5" text-anchor="middle">Sec</text>
+    <!-- Center intersection -->
+    <circle cx="0" cy="5" r="25" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="2"/>
+    <path d="M0,-12 L10,-2 L10,5 C10,12 5,16 0,18 C-5,16 -10,12 -10,5 L-10,-2 Z" fill="#8b5cf6" opacity="0.4"/>
+    <path d="M-4,5 L-1,9 L6,1" fill="none" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">7 - 9 : DevSecOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
-    </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
-    </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps , , AWS , DevSecOps ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
-      <rect x="126" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Integration</text>
-      <rect x="270" y="0" width="159" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Security</text>
-      <rect x="441" y="0" width="69" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#SDLC</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevSecOps Integration</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 9 | Security Pipeline</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">June 13, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
+++ b/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
@@ -1,189 +1,39 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ef4444"/>
-      <stop offset="100%" style="stop-color:#b91c1c"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">npm : 20</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Warning Bell -->
-    <g transform="translate(80, 280)">
-      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
-            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
-      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
-      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#cb3837" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- npm box -->
+    <rect x="-80" y="-80" width="160" height="120" rx="12" fill="#1e293b" stroke="#cb3837" stroke-width="3"/>
+    <text x="0" y="-10" font-family="Arial,sans-serif" font-size="50" font-weight="bold" fill="#cb3837" text-anchor="middle" opacity="0.8">npm</text>
+    <!-- Warning badge -->
+    <circle cx="70" cy="-70" r="25" fill="#ef4444" opacity="0.9"/>
+    <text x="70" y="-64" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="white" text-anchor="middle">20</text>
+    <text x="70" y="-52" font-family="Courier New" font-size="7" fill="white" text-anchor="middle">CVEs</text>
+    <!-- Malicious packages -->
+    <g opacity="0.4">
+      <rect x="-160" y="-40" width="55" height="35" rx="4" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="-133" y="-18" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">pkg_1</text>
+      <rect x="105" y="-40" width="55" height="35" rx="4" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="133" y="-18" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">pkg_2</text>
     </g>
-    
-    <!-- Timeline -->
-    <g transform="translate(200, 310)">
-      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
-      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
-      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
-      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
-      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
-    </g>
-    
-    <!-- Fire Icon -->
-    <g transform="translate(370, 285)">
-      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
-            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 9 npm 18 . debug, chalk, lodash 20</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#npm</text>
-      <rect x="72" y="0" width="141" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Supply-Chain</text>
-      <rect x="225" y="0" width="96" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="273" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Malware</text>
-      <rect x="333" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Security-Incident</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Shield scan -->
+    <g transform="translate(0,70)" opacity="0.5">
+      <path d="M0,-20 L25,-12 L25,8 C25,18 12,25 0,28 C-12,25 -25,18 -25,8 L-25,-12 Z" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <text x="0" y="8" font-family="Courier New" font-size="10" fill="#86efac" text-anchor="middle">SCAN</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">npm Security Audit</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Large-scale Package Analysis | 20 Critical Vulnerabilities</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#cb3837" opacity="0.2" stroke="#cb3837" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">NPM SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Sep 10, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
@@ -1,190 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2e"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS re:Inforce 2025:</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- Conference stage -->
+    <rect x="-200" y="40" width="400" height="8" rx="4" fill="#f97316" opacity="0.3"/>
+    <!-- Large AWS re:Inforce logo area -->
+    <rect x="-120" y="-100" width="240" height="120" rx="16" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+    <text x="0" y="-45" font-family="Arial,sans-serif" font-size="16" fill="#f97316" text-anchor="middle">re:Inforce</text>
+    <text x="0" y="-20" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="#f97316" text-anchor="middle" opacity="0.8">2025</text>
+    <!-- Shield with cloud -->
+    <g transform="translate(0,80)">
+      <path d="M0,-25 L30,-18 L30,5 C30,18 15,28 0,32 C-15,28 -30,18 -30,5 L-30,-18 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="2"/>
+      <path d="M-10,-5 C-14,-5 -16,-8 -15,-12 C-14,-16 -10,-18 -6,-17 C-5,-22 0,-24 5,-22 C10,-24 15,-22 16,-17 C20,-18 24,-16 25,-12 C26,-8 24,-5 20,-5 Z" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.6"/>
     </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS re:Inforce 2025 Zero Trust , AI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="114" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#reInforce</text>
-      <rect x="198" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="277" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
-      <rect x="369" y="0" width="123" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="430" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Conference</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Spotlight beams -->
+    <g opacity="0.15">
+      <path d="M-200,-150 L-50,-60" fill="none" stroke="#f97316" stroke-width="2"/>
+      <path d="M200,-150 L50,-60" fill="none" stroke="#f97316" stroke-width="2"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS re:Inforce 2025</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Conference | Future of Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CONFERENCE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Sep 16, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
+++ b/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
@@ -1,193 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a100a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ef4444"/>
-      <stop offset="100%" style="stop-color:#b91c1c"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">NPM Shai-Hulud : 180</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Warning Bell -->
-    <g transform="translate(80, 280)">
-      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
-            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
-      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
-      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
-    </g>
-    
-    <!-- Timeline -->
-    <g transform="translate(200, 310)">
-      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
-      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
-      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
-      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
-      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
-    </g>
-    
-    <!-- Fire Icon -->
-    <g transform="translate(370, 285)">
-      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
-            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">NPM Shai-Hulud . SBOM</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2FA</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#npm</text>
-      <rect x="72" y="0" width="195" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="169" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Supply-Chain-At...</text>
-      <rect x="279" y="0" width="69" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="313" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Worm</text>
-      <rect x="360" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="453" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Security-Incident</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#f59e0b" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- Sandworm / snake shape representing Shai-Hulud -->
+    <path d="M-180,0 C-150,-60 -100,-80 -50,-40 C0,0 50,-40 100,-80 C150,-120 180,-60 160,0 C140,60 100,40 50,0 C0,-40 -50,0 -100,40 C-150,80 -180,60 -180,0 Z" fill="none" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+    <!-- Worm eye -->
+    <circle cx="-170" cy="0" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+    <circle cx="-170" cy="0" r="5" fill="#f59e0b" opacity="0.8"/>
+    <!-- 180 packages count -->
+    <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+    <text x="0" y="-5" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#ef4444" text-anchor="middle">180</text>
+    <text x="0" y="15" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">packages</text>
+    <!-- Scattered malicious package boxes -->
+    <g opacity="0.3">
+      <rect x="-140" y="50" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
+      <rect x="60" y="60" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
+      <rect x="120" y="30" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
+      <rect x="-80" y="70" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Shai-Hulud Campaign</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">180 Malicious npm Packages | Large-scale Analysis</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">THREAT INTEL</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Sep 17, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
+++ b/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
@@ -1,189 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a15"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ef4444"/>
-      <stop offset="100%" style="stop-color:#b91c1c"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="270" r="260" fill="#ef4444" opacity="0.04" filter="url(#sg)"/>
+  <g transform="translate(600,250)">
+    <!-- Karpenter node scaling visual -->
+    <!-- Failed nodes -->
+    <rect x="-160" y="-80" width="70" height="70" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+    <text x="-125" y="-40" font-family="Courier New" font-size="10" fill="#fca5a5" text-anchor="middle">NODE</text>
+    <line x1="-155" y1="-75" x2="-95" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.5"/>
+    <line x1="-95" y1="-75" x2="-155" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.5"/>
+    <!-- Working node -->
+    <rect x="-35" y="-80" width="70" height="70" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+    <text x="0" y="-40" font-family="Courier New" font-size="10" fill="#86efac" text-anchor="middle">NODE</text>
+    <circle cx="0" cy="-30" r="4" fill="#22c55e" opacity="0.6"/>
+    <!-- Scaling arrow -->
+    <path d="M50,-45 L80,-45" fill="none" stroke="#f59e0b" stroke-width="2"/>
+    <polygon points="80,-50 95,-45 80,-40" fill="#f59e0b"/>
+    <!-- New node being provisioned -->
+    <rect x="100" y="-80" width="70" height="70" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,4"/>
+    <text x="135" y="-40" font-family="Courier New" font-size="10" fill="#fde68a" text-anchor="middle">NEW</text>
+    <!-- Karpenter logo area -->
+    <g transform="translate(0,50)">
+      <rect x="-60" y="-18" width="120" height="36" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#c4b5fd" text-anchor="middle">Karpenter</text>
+    </g>
+    <!-- Version badge -->
+    <rect x="50" y="40" width="60" height="22" rx="6" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+    <text x="80" y="55" font-family="Courier New" font-size="9" fill="#c4b5fd" text-anchor="middle">v1.5.3</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Karpenter v1.5.3</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Warning Bell -->
-    <g transform="translate(80, 280)">
-      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
-            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
-      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
-      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
-    </g>
-    
-    <!-- Timeline -->
-    <g transform="translate(200, 310)">
-      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
-      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
-      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
-      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
-      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
-    </g>
-    
-    <!-- Fire Icon -->
-    <g transform="translate(370, 285)">
-      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
-            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Karpenter v1.5.3 PodDisruptionBudget</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Karpenter</text>
-      <rect x="126" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="187" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Kubernetes</text>
-      <rect x="261" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#AWS</text>
-      <rect x="333" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Karpenter Incident</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">v1.5.3 Node Integration | Large-scale Analysis | Resolution</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">POST-MORTEM</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Oct 2, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
+++ b/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
@@ -1,190 +1,115 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
+    <linearGradient id="nlb" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#f97316"/><stop offset="100%" style="stop-color:#ea580c"/>
     </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
+    <linearGradient id="db" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/><stop offset="100%" style="stop-color:#1d4ed8"/>
     </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <!-- Ambient glow -->
+  <circle cx="400" cy="260" r="200" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <circle cx="800" cy="260" r="200" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <!-- Grid pattern -->
+  <g opacity="0.03">
+    <line x1="0" y1="100" x2="1200" y2="100" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="200" x2="1200" y2="200" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="300" x2="1200" y2="300" stroke="#fff" stroke-width="1"/>
+    <line x1="0" y1="400" x2="1200" y2="400" stroke="#fff" stroke-width="1"/>
+    <line x1="200" y1="0" x2="200" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="400" y1="0" x2="400" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="600" y1="0" x2="600" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="800" y1="0" x2="800" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1000" y1="0" x2="1000" y2="630" stroke="#fff" stroke-width="1"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS : NLB + Security Group</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+  <g transform="translate(600,240)">
+    <!-- NLB (Network Load Balancer) - central hub -->
+    <g filter="url(#shadow)">
+      <rect x="-60" y="-70" width="120" height="140" rx="16" fill="#1e293b" stroke="#f97316" stroke-width="3"/>
+      <rect x="-50" y="-60" width="100" height="30" rx="6" fill="url(#nlb)" opacity="0.8"/>
+      <text x="0" y="-40" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">NLB</text>
+      <!-- Port indicators -->
+      <circle cx="-20" cy="-10" r="8" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="-20" y="-6" font-family="Courier New" font-size="7" fill="#fdba74" text-anchor="middle">443</text>
+      <circle cx="20" cy="-10" r="8" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="20" y="-6" font-family="Courier New" font-size="7" fill="#fdba74" text-anchor="middle">3306</text>
+      <!-- Health check indicator -->
+      <g transform="translate(0,25)">
+        <rect x="-35" y="-10" width="70" height="20" rx="4" fill="#22c55e" opacity="0.15"/>
+        <circle cx="-20" cy="0" r="4" fill="#22c55e" opacity="0.8"/>
+        <text x="5" y="4" font-family="Courier New" font-size="9" fill="#86efac" text-anchor="middle">HEALTHY</text>
+      </g>
+      <!-- Traffic arrows -->
+      <g transform="translate(0,50)">
+        <rect x="-8" y="-4" width="4" height="8" rx="1" fill="#f97316" opacity="0.6"/>
+        <rect x="-2" y="-6" width="4" height="12" rx="1" fill="#f97316" opacity="0.8"/>
+        <rect x="4" y="-3" width="4" height="6" rx="1" fill="#f97316" opacity="0.5"/>
+      </g>
     </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    <!-- Left: Client/VPC -->
+    <g transform="translate(-250,0)">
+      <rect x="-70" y="-50" width="140" height="100" rx="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="2" filter="url(#shadow)"/>
+      <text x="0" y="-20" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">VPC</text>
+      <!-- Subnet boxes -->
+      <rect x="-50" y="-5" width="45" height="30" rx="4" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1"/>
+      <text x="-28" y="15" font-family="Courier New" font-size="7" fill="#a78bfa" text-anchor="middle">Private</text>
+      <rect x="5" y="-5" width="45" height="30" rx="4" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1"/>
+      <text x="28" y="15" font-family="Courier New" font-size="7" fill="#a78bfa" text-anchor="middle">Public</text>
+      <!-- Security Group shield -->
+      <g transform="translate(0,40)">
+        <path d="M0,-12 L15,-6 L15,4 C15,10 8,14 0,16 C-8,14 -15,10 -15,4 L-15,-6 Z" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1.5"/>
+        <text x="0" y="6" font-family="Courier New" font-size="6" fill="#c4b5fd" text-anchor="middle">SG</text>
+      </g>
     </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    <!-- Connection lines VPC -> NLB -->
+    <line x1="-110" y1="0" x2="-65" y2="0" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="8,4" opacity="0.5"/>
+    <polygon points="-70,5 -60,0 -70,-5" fill="#8b5cf6" opacity="0.5"/>
+    <!-- Right: Database cluster -->
+    <g transform="translate(250,0)">
+      <g filter="url(#shadow)">
+        <!-- DB cylinder shape -->
+        <ellipse cx="0" cy="-50" rx="60" ry="15" fill="url(#db)" opacity="0.3" stroke="#3b82f6" stroke-width="2"/>
+        <rect x="-60" y="-50" width="120" height="80" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+        <ellipse cx="0" cy="30" rx="60" ry="15" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+        <ellipse cx="0" cy="-50" rx="60" ry="15" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+        <!-- Data rows -->
+        <g opacity="0.4">
+          <line x1="-40" y1="-30" x2="40" y2="-30" stroke="#60a5fa" stroke-width="1"/>
+          <line x1="-40" y1="-15" x2="40" y2="-15" stroke="#60a5fa" stroke-width="1"/>
+          <line x1="-40" y1="0" x2="40" y2="0" stroke="#60a5fa" stroke-width="1"/>
+          <line x1="-40" y1="15" x2="40" y2="15" stroke="#60a5fa" stroke-width="1"/>
+        </g>
+        <text x="0" y="-5" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#93c5fd" text-anchor="middle">RDS</text>
+      </g>
+      <!-- Replica indicator -->
+      <g transform="translate(55,-20)" opacity="0.4">
+        <ellipse cx="0" cy="0" rx="20" ry="8" fill="#1e293b" stroke="#3b82f6" stroke-width="1"/>
+        <text x="0" y="4" font-family="Courier New" font-size="7" fill="#60a5fa" text-anchor="middle">R</text>
+      </g>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS Network Load Balancer Security Group Zero Trust</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#NLB</text>
-      <rect x="144" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Security-Group</text>
-      <rect x="315" y="0" width="105" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="367" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Database</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Connection lines NLB -> DB -->
+    <line x1="65" y1="0" x2="185" y2="0" stroke="#f97316" stroke-width="2" opacity="0.5"/>
+    <polygon points="180,5 190,0 180,-5" fill="#f97316" opacity="0.5"/>
+    <!-- Encrypted traffic indicator -->
+    <g transform="translate(125,-20)">
+      <rect x="-20" y="-8" width="40" height="16" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="7" fill="#86efac" text-anchor="middle">TLS</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <!-- Title -->
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Database Gateway</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">NLB + Security Group | RDS Access Architecture</text>
+  <!-- Badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">AWS GUIDE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Oct 3, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
+++ b/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
@@ -1,185 +1,79 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
+    <linearGradient id="brain" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/><stop offset="100%" style="stop-color:#6d28d9"/>
     </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI , : AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <circle cx="600" cy="250" r="180" fill="#ef4444" opacity="0.02" filter="url(#sg)"/>
+  <g transform="translate(600,240)">
+    <!-- AI Brain shape -->
+    <g filter="url(#shadow)">
+      <!-- Brain outline -->
+      <path d="M0,-100 C55,-100 100,-75 100,-30 C100,0 85,20 70,30 C80,45 75,70 55,80 C35,90 10,85 0,75 C-10,85 -35,90 -55,80 C-75,70 -80,45 -70,30 C-85,20 -100,0 -100,-30 C-100,-75 -55,-100 0,-100 Z" fill="#1e293b" stroke="url(#brain)" stroke-width="3"/>
+      <!-- Brain folds -->
+      <path d="M0,-85 C0,-50 -30,-30 -30,0" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.3"/>
+      <path d="M-20,-80 C-20,-45 10,-25 10,5" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.3"/>
+      <path d="M20,-80 C20,-50 -10,-30 -10,5" fill="none" stroke="#8b5cf6" stroke-width="1.5" opacity="0.3"/>
+      <!-- Neural network nodes -->
+      <circle cx="-30" cy="-50" r="6" fill="#8b5cf6" opacity="0.6"/>
+      <circle cx="25" cy="-55" r="6" fill="#8b5cf6" opacity="0.6"/>
+      <circle cx="0" cy="-25" r="8" fill="#8b5cf6" opacity="0.8"/>
+      <circle cx="-40" cy="-10" r="5" fill="#8b5cf6" opacity="0.5"/>
+      <circle cx="35" cy="-15" r="5" fill="#8b5cf6" opacity="0.5"/>
+      <circle cx="-15" cy="15" r="6" fill="#8b5cf6" opacity="0.6"/>
+      <circle cx="20" cy="20" r="6" fill="#8b5cf6" opacity="0.6"/>
+      <!-- Neural connections -->
+      <line x1="-30" y1="-50" x2="0" y2="-25" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <line x1="25" y1="-55" x2="0" y2="-25" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="-25" x2="-15" y2="15" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="-25" x2="20" y2="20" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <line x1="-40" y1="-10" x2="-15" y2="15" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <line x1="35" y1="-15" x2="20" y2="20" stroke="#c4b5fd" stroke-width="1" opacity="0.3"/>
+      <!-- AI text in center -->
+      <text x="0" y="-20" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#c4b5fd" text-anchor="middle" opacity="0.9">AI</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Security shield overlay -->
+    <g transform="translate(0,10)">
+      <path d="M0,-45 L55,-30 L55,15 C55,40 30,55 0,65 C-30,55 -55,40 -55,15 L-55,-30 Z" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-dasharray="8,4" opacity="0.6"/>
+      <!-- Lock icon in shield -->
+      <g transform="translate(0,35)">
+        <rect x="-10" y="-5" width="20" height="16" rx="3" fill="#ef4444" opacity="0.3"/>
+        <path d="M-6,-5 L-6,-10 C-6,-14 -3,-17 0,-17 C3,-17 6,-14 6,-10 L6,-5" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.6"/>
+        <circle cx="0" cy="3" r="2" fill="#fca5a5"/>
+      </g>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    <!-- Orbiting threat indicators -->
+    <g opacity="0.4">
+      <circle cx="-130" cy="-40" r="18" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="-130" y="-36" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">XSS</text>
+      <circle cx="130" cy="-40" r="18" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="130" y="-36" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">SQLI</text>
+      <circle cx="-120" cy="50" r="18" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="-120" y="54" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">LLM</text>
+      <circle cx="120" cy="50" r="18" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="120" y="54" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">RAG</text>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 AI AI . Shadow AI, , Rogue AI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
-      <rect x="63" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Enterprise-Secu...</text>
-      <rect x="270" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Governance</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Connecting dashed lines to threats -->
+    <g stroke-dasharray="4,4" opacity="0.2">
+      <line x1="-100" y1="-30" x2="-112" y2="-35" stroke="#ef4444" stroke-width="1"/>
+      <line x1="100" y1="-30" x2="112" y2="-35" stroke="#ef4444" stroke-width="1"/>
+      <line x1="-90" y1="40" x2="-102" y2="45" stroke="#f59e0b" stroke-width="1"/>
+      <line x1="90" y1="40" x2="102" y2="45" stroke="#f59e0b" stroke-width="1"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Security Guide</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Threats + Defense | LLM Security | Batch Analysis</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">AI SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Oct 31, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
+++ b/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
@@ -1,185 +1,82 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
+    <linearGradient id="zs" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0099d5"/><stop offset="100%" style="stop-color:#006eb8"/>
     </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zscaler : SSL , , AI, ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#0099d5" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,235)">
+    <!-- Cloud proxy shape -->
+    <g filter="url(#shadow)">
+      <path d="M-60,-90 C-90,-90 -120,-70 -120,-45 C-150,-45 -170,-25 -170,0 C-170,30 -150,50 -120,50 L120,50 C150,50 170,30 170,0 C170,-25 150,-45 120,-45 C120,-70 90,-90 60,-90 C35,-90 15,-75 0,-65 C-15,-75 -35,-90 -60,-90 Z" fill="#1e293b" stroke="url(#zs)" stroke-width="3"/>
+      <!-- Zscaler Z logo -->
+      <g transform="translate(0,-20)">
+        <rect x="-35" y="-25" width="70" height="50" rx="8" fill="#0099d5" opacity="0.15"/>
+        <text x="0" y="10" font-family="Arial,sans-serif" font-size="42" font-weight="bold" fill="#0099d5" text-anchor="middle">Z</text>
+      </g>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- SSL inspection tunnel -->
+    <g transform="translate(0,80)">
+      <!-- Tunnel shape -->
+      <path d="M-200,0 C-150,-30 -80,-35 0,-35 C80,-35 150,-30 200,0" fill="none" stroke="#22c55e" stroke-width="2" opacity="0.4"/>
+      <path d="M-200,0 C-150,30 -80,35 0,35 C80,35 150,30 200,0" fill="none" stroke="#22c55e" stroke-width="2" opacity="0.4"/>
+      <!-- SSL lock icons along tunnel -->
+      <g transform="translate(-120,0)">
+        <rect x="-8" y="-4" width="16" height="12" rx="2" fill="#22c55e" opacity="0.3"/>
+        <path d="M-4,-4 L-4,-8 C-4,-11 -2,-13 0,-13 C2,-13 4,-11 4,-8 L4,-4" fill="none" stroke="#22c55e" stroke-width="1.5" opacity="0.5"/>
+      </g>
+      <g transform="translate(0,0)">
+        <rect x="-8" y="-4" width="16" height="12" rx="2" fill="#22c55e" opacity="0.3"/>
+        <path d="M-4,-4 L-4,-8 C-4,-11 -2,-13 0,-13 C2,-13 4,-11 4,-8 L4,-4" fill="none" stroke="#22c55e" stroke-width="1.5" opacity="0.5"/>
+      </g>
+      <g transform="translate(120,0)">
+        <rect x="-8" y="-4" width="16" height="12" rx="2" fill="#22c55e" opacity="0.3"/>
+        <path d="M-4,-4 L-4,-8 C-4,-11 -2,-13 0,-13 C2,-13 4,-11 4,-8 L4,-4" fill="none" stroke="#22c55e" stroke-width="1.5" opacity="0.5"/>
+      </g>
+      <!-- Traffic flow arrows -->
+      <g opacity="0.3">
+        <polygon points="-160,-15 -150,-20 -150,-10" fill="#0099d5"/>
+        <polygon points="-60,-25 -50,-30 -50,-20" fill="#0099d5"/>
+        <polygon points="50,-25 60,-30 60,-20" fill="#0099d5"/>
+        <polygon points="150,-15 160,-20 160,-10" fill="#0099d5"/>
+      </g>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    <!-- Left: Users -->
+    <g transform="translate(-220,-30)" opacity="0.5">
+      <circle cx="0" cy="-12" r="10" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+      <path d="M-15,15 C-15,5 -8,0 0,0 C8,0 15,5 15,15" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+      <circle cx="25" cy="-8" r="8" fill="none" stroke="#94a3b8" stroke-width="1"/>
+      <path d="M13,12 C13,5 18,0 25,0 C32,0 37,5 37,12" fill="none" stroke="#94a3b8" stroke-width="1"/>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Zscaler . SSL , (ATP), AI/ / Zero Trust</text>
+    <!-- Right: Internet/Apps -->
+    <g transform="translate(220,-30)" opacity="0.5">
+      <circle cx="0" cy="0" r="25" fill="none" stroke="#94a3b8" stroke-width="1.5"/>
+      <circle cx="0" cy="0" r="15" fill="none" stroke="#94a3b8" stroke-width="1"/>
+      <line x1="-25" y1="0" x2="25" y2="0" stroke="#94a3b8" stroke-width="1"/>
+      <line x1="0" y1="-25" x2="0" y2="25" stroke="#94a3b8" stroke-width="1"/>
+      <path d="M-10,-25 C-10,-10 -10,10 -10,25" fill="none" stroke="#94a3b8" stroke-width="0.8"/>
+      <path d="M10,-25 C10,-10 10,10 10,25" fill="none" stroke="#94a3b8" stroke-width="0.8"/>
     </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zscaler</text>
-      <rect x="108" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ZTNA</text>
-      <rect x="189" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="268" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SSL-Inspection</text>
-      <rect x="360" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="421" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Blocked threats -->
+    <g opacity="0.3">
+      <line x1="-140" y1="60" x2="-130" y2="70" stroke="#ef4444" stroke-width="2"/>
+      <line x1="-130" y1="60" x2="-140" y2="70" stroke="#ef4444" stroke-width="2"/>
+      <line x1="130" y1="60" x2="140" y2="70" stroke="#ef4444" stroke-width="2"/>
+      <line x1="140" y1="60" x2="130" y2="70" stroke="#ef4444" stroke-width="2"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zscaler Complete Guide</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">SSL Inspection | AI-Powered Security | Zero Trust Proxy</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0099d5" opacity="0.2" stroke="#0099d5" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#67d4ff" text-anchor="middle">ZERO TRUST</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Nov 4, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
+++ b/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
@@ -1,189 +1,59 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ef4444"/>
-      <stop offset="100%" style="stop-color:#b91c1c"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Post-Mortem 2025 11 18 Cloudflare</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Warning Bell -->
-    <g transform="translate(80, 280)">
-      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
-            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
-      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
-      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Cloudflare logo shape -->
+    <g filter="url(#shadow)">
+      <!-- CF cloud -->
+      <path d="M-30,-70 C-60,-70 -90,-50 -90,-25 C-120,-25 -140,-5 -140,20 C-140,50 -120,65 -90,65 L90,65 C120,65 140,50 140,20 C140,-5 120,-25 90,-25 C90,-50 60,-70 30,-70 C10,-70 -5,-60 -10,-50 C-15,-60 -20,-70 -30,-70 Z" fill="#1e293b" stroke="#f97316" stroke-width="3"/>
+      <!-- CF text -->
+      <text x="0" y="10" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#f97316" text-anchor="middle" opacity="0.8">CF</text>
     </g>
-    
-    <!-- Timeline -->
-    <g transform="translate(200, 310)">
-      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
-      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
-      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
-      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
-      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
+    <!-- Incident crack/lightning bolt -->
+    <g transform="translate(0,0)">
+      <path d="M10,-65 L-5,-20 L10,-25 L-10,30 L5,-10 L-10,-5 Z" fill="#ef4444" opacity="0.6"/>
     </g>
-    
-    <!-- Fire Icon -->
-    <g transform="translate(370, 285)">
-      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
-            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
+    <!-- Status timeline bar -->
+    <g transform="translate(0,100)">
+      <line x1="-200" y1="0" x2="200" y2="0" stroke="#334155" stroke-width="3" stroke-linecap="round"/>
+      <!-- Incident start -->
+      <circle cx="-160" cy="0" r="8" fill="#ef4444" opacity="0.8"/>
+      <text x="-160" y="20" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">DOWN</text>
+      <!-- Detection -->
+      <circle cx="-60" cy="0" r="8" fill="#f59e0b" opacity="0.8"/>
+      <text x="-60" y="20" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">DETECT</text>
+      <!-- Mitigation -->
+      <circle cx="60" cy="0" r="8" fill="#3b82f6" opacity="0.8"/>
+      <text x="60" y="20" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">MITIGATE</text>
+      <!-- Recovery -->
+      <circle cx="160" cy="0" r="8" fill="#22c55e" opacity="0.8"/>
+      <text x="160" y="20" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">RESOLVE</text>
+      <!-- Progress fill -->
+      <line x1="-160" y1="0" x2="160" y2="0" stroke="#22c55e" stroke-width="3" stroke-linecap="round" opacity="0.3"/>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 11 18 Cloudflare . Multi-CDN Failover</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Cloudflare</text>
-      <rect x="135" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
-      <rect x="279" y="0" width="186" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Incident-Response</text>
-      <rect x="477" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#CDN</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Global network nodes affected -->
+    <g opacity="0.3">
+      <circle cx="-180" cy="-40" r="4" fill="#ef4444"/>
+      <circle cx="-160" cy="-70" r="3" fill="#ef4444"/>
+      <circle cx="170" cy="-50" r="4" fill="#ef4444"/>
+      <circle cx="190" cy="-20" r="3" fill="#ef4444"/>
+      <circle cx="-190" cy="20" r="3" fill="#f59e0b"/>
+      <circle cx="180" cy="30" r="3" fill="#f59e0b"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloudflare Post-Mortem</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2025.11.18 Global Incident | Response Log | Lessons Learned</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">POST-MORTEM</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Nov 19, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
+++ b/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
@@ -1,191 +1,66 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
+    <linearGradient id="ot" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#10b981"/><stop offset="100%" style="stop-color:#059669"/>
     </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 OT : DevSecOps FinOps ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#10b981" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,235)">
+    <!-- OT/Industrial control system -->
+    <g filter="url(#shadow)">
+      <!-- Factory/industrial shape -->
+      <rect x="-100" y="-80" width="200" height="140" rx="12" fill="#1e293b" stroke="#10b981" stroke-width="2.5"/>
+      <!-- Smokestacks -->
+      <rect x="-80" y="-110" width="20" height="35" rx="3" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+      <rect x="-45" y="-100" width="20" height="25" rx="3" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+      <!-- Control panel -->
+      <rect x="-75" y="-55" width="150" height="80" rx="6" fill="#0f172a" stroke="#10b981" stroke-width="1.5"/>
+      <!-- Gauges -->
+      <circle cx="-40" cy="-30" r="18" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+      <line x1="-40" y1="-30" x2="-32" y2="-40" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <circle cx="20" cy="-30" r="18" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <line x1="20" y1="-30" x2="30" y2="-38" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+      <!-- Status lights -->
+      <circle cx="-50" cy="5" r="5" fill="#22c55e" opacity="0.8"/>
+      <circle cx="-30" cy="5" r="5" fill="#22c55e" opacity="0.8"/>
+      <circle cx="-10" cy="5" r="5" fill="#f59e0b" opacity="0.8"/>
+      <circle cx="10" cy="5" r="5" fill="#22c55e" opacity="0.6"/>
+      <circle cx="30" cy="5" r="5" fill="#ef4444" opacity="0.6"/>
+      <circle cx="50" cy="5" r="5" fill="#22c55e" opacity="0.8"/>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    <!-- DevSecOps + FinOps bridge -->
+    <g transform="translate(0,95)">
+      <rect x="-140" y="-15" width="100" height="30" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="-90" y="5" font-family="Arial,sans-serif" font-size="11" font-weight="bold" fill="#c4b5fd" text-anchor="middle">DevSecOps</text>
+      <rect x="40" y="-15" width="100" height="30" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <text x="90" y="5" font-family="Arial,sans-serif" font-size="11" font-weight="bold" fill="#86efac" text-anchor="middle">FinOps</text>
+      <!-- Arrow bridge -->
+      <path d="M-35,0 L35,0" fill="none" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <polygon points="30,-4 38,0 30,4" fill="#94a3b8" opacity="0.5"/>
+      <polygon points="-30,4 -38,0 -30,-4" fill="#94a3b8" opacity="0.5"/>
     </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 9 DevSecOps FinOps , 2025 AI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="159" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="79" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Security</text>
-      <rect x="171" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="228" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
-      <rect x="297" y="0" width="87" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#FinOps</text>
-      <rect x="396" y="0" width="87" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Course</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Network connections -->
+    <g opacity="0.25">
+      <line x1="-140" y1="-20" x2="-180" y2="-60" stroke="#10b981" stroke-width="1" stroke-dasharray="3,3"/>
+      <line x1="140" y1="-20" x2="180" y2="-60" stroke="#10b981" stroke-width="1" stroke-dasharray="3,3"/>
+      <circle cx="-180" cy="-60" r="10" fill="#1e293b" stroke="#10b981" stroke-width="1"/>
+      <text x="-180" y="-56" font-family="Courier New" font-size="6" fill="#86efac" text-anchor="middle">PLC</text>
+      <circle cx="180" cy="-60" r="10" fill="#1e293b" stroke="#10b981" stroke-width="1"/>
+      <text x="180" y="-56" font-family="Courier New" font-size="6" fill="#86efac" text-anchor="middle">HMI</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OT Security Guide</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th Batch | DevSecOps + FinOps | OT/ICS</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#10b981" opacity="0.2" stroke="#10b981" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#6ee7b7" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Nov 21, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
+++ b/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
@@ -1,188 +1,83 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
+    <linearGradient id="infra" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#6366f1"/><stop offset="100%" style="stop-color:#4f46e5"/>
     </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#6366f1" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Server rack -->
+    <g filter="url(#shadow)">
+      <rect x="-70" y="-100" width="140" height="200" rx="10" fill="#1e293b" stroke="#6366f1" stroke-width="2.5"/>
+      <!-- Server units -->
+      <g transform="translate(0,-75)">
+        <rect x="-55" y="-12" width="110" height="28" rx="4" fill="#0f172a" stroke="#6366f1" stroke-width="1"/>
+        <circle cx="-38" cy="2" r="3" fill="#22c55e" opacity="0.8"/>
+        <rect x="-25" y="-2" width="50" height="4" rx="1" fill="#6366f1" opacity="0.2"/>
+        <rect x="-25" y="4" width="35" height="4" rx="1" fill="#6366f1" opacity="0.15"/>
+        <circle cx="42" cy="2" r="4" fill="#1e293b" stroke="#6366f1" stroke-width="0.8"/>
+      </g>
+      <g transform="translate(0,-40)">
+        <rect x="-55" y="-12" width="110" height="28" rx="4" fill="#0f172a" stroke="#6366f1" stroke-width="1"/>
+        <circle cx="-38" cy="2" r="3" fill="#22c55e" opacity="0.8"/>
+        <rect x="-25" y="-2" width="50" height="4" rx="1" fill="#6366f1" opacity="0.2"/>
+        <rect x="-25" y="4" width="45" height="4" rx="1" fill="#6366f1" opacity="0.15"/>
+        <circle cx="42" cy="2" r="4" fill="#1e293b" stroke="#6366f1" stroke-width="0.8"/>
+      </g>
+      <g transform="translate(0,-5)">
+        <rect x="-55" y="-12" width="110" height="28" rx="4" fill="#0f172a" stroke="#f59e0b" stroke-width="1"/>
+        <circle cx="-38" cy="2" r="3" fill="#f59e0b" opacity="0.8"/>
+        <rect x="-25" y="-2" width="50" height="4" rx="1" fill="#f59e0b" opacity="0.2"/>
+        <rect x="-25" y="4" width="25" height="4" rx="1" fill="#f59e0b" opacity="0.15"/>
+        <circle cx="42" cy="2" r="4" fill="#1e293b" stroke="#f59e0b" stroke-width="0.8"/>
+      </g>
+      <g transform="translate(0,30)">
+        <rect x="-55" y="-12" width="110" height="28" rx="4" fill="#0f172a" stroke="#6366f1" stroke-width="1"/>
+        <circle cx="-38" cy="2" r="3" fill="#22c55e" opacity="0.8"/>
+        <rect x="-25" y="-2" width="50" height="4" rx="1" fill="#6366f1" opacity="0.2"/>
+        <rect x="-25" y="4" width="40" height="4" rx="1" fill="#6366f1" opacity="0.15"/>
+        <circle cx="42" cy="2" r="4" fill="#1e293b" stroke="#6366f1" stroke-width="0.8"/>
+      </g>
+      <g transform="translate(0,65)">
+        <rect x="-55" y="-12" width="110" height="28" rx="4" fill="#0f172a" stroke="#6366f1" stroke-width="1"/>
+        <circle cx="-38" cy="2" r="3" fill="#22c55e" opacity="0.8"/>
+        <rect x="-25" y="-2" width="50" height="4" rx="1" fill="#6366f1" opacity="0.2"/>
+        <rect x="-25" y="4" width="48" height="4" rx="1" fill="#6366f1" opacity="0.15"/>
+        <circle cx="42" cy="2" r="4" fill="#1e293b" stroke="#6366f1" stroke-width="0.8"/>
+      </g>
+    </g>
+    <!-- Security shield overlay -->
+    <g transform="translate(0,0)">
+      <path d="M0,-120 L90,-90 L90,30 C90,70 50,100 0,115 C-50,100 -90,70 -90,30 L-90,-90 Z" fill="none" stroke="#22c55e" stroke-width="2" stroke-dasharray="8,4" opacity="0.3"/>
+    </g>
+    <!-- Network connections -->
+    <g opacity="0.3">
+      <line x1="-75" y1="-50" x2="-150" y2="-80" stroke="#6366f1" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <line x1="75" y1="-50" x2="150" y2="-80" stroke="#6366f1" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <line x1="-75" y1="30" x2="-150" y2="60" stroke="#6366f1" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <line x1="75" y1="30" x2="150" y2="60" stroke="#6366f1" stroke-width="1.5" stroke-dasharray="4,3"/>
+      <!-- Endpoint nodes -->
+      <circle cx="-155" cy="-83" r="12" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+      <circle cx="155" cy="-83" r="12" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+      <circle cx="-155" cy="63" r="12" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+      <circle cx="155" cy="63" r="12" fill="#1e293b" stroke="#6366f1" stroke-width="1"/>
+    </g>
+    <!-- Week 1 badge -->
+    <rect x="80" y="-110" width="50" height="22" rx="6" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="1"/>
+    <text x="105" y="-95" font-family="Courier New" font-size="9" fill="#a5b4fc" text-anchor="middle">W1</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security 8Batch 1Week Infrastructure Es...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
-    </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 . AI , Zero Trust, Post-quantum</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="79" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Infrastructure</text>
-      <rect x="171" y="0" width="159" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Cloud-Security</text>
-      <rect x="342" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Infrastructure Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th Batch | Week 1 | Security Foundations</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#a5b4fc" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Nov 26, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
+++ b/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
@@ -1,190 +1,65 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- VPC boundary -->
+    <g filter="url(#shadow)">
+      <rect x="-180" y="-100" width="360" height="200" rx="16" fill="#1e293b" stroke="#f97316" stroke-width="2.5" stroke-dasharray="12,4"/>
+      <text x="-160" y="-78" font-family="Courier New" font-size="11" fill="#fdba74" opacity="0.6">VPC</text>
+    </g>
+    <!-- Public subnet -->
+    <rect x="-160" y="-65" width="150" height="140" rx="8" fill="#0f172a" stroke="#22c55e" stroke-width="1.5" opacity="0.8"/>
+    <text x="-85" y="-48" font-family="Courier New" font-size="9" fill="#86efac" text-anchor="middle">Public Subnet</text>
+    <!-- ALB -->
+    <rect x="-145" y="-35" width="120" height="35" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="-85" y="-12" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#86efac" text-anchor="middle">ALB</text>
+    <!-- NAT GW -->
+    <rect x="-145" y="10" width="120" height="35" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="-85" y="33" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#86efac" text-anchor="middle">NAT GW</text>
+    <!-- Private subnet -->
+    <rect x="10" y="-65" width="150" height="140" rx="8" fill="#0f172a" stroke="#3b82f6" stroke-width="1.5" opacity="0.8"/>
+    <text x="85" y="-48" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">Private Subnet</text>
+    <!-- EC2 instances -->
+    <rect x="25" y="-35" width="50" height="35" rx="6" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+    <text x="50" y="-12" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">EC2</text>
+    <rect x="85" y="-35" width="50" height="35" rx="6" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+    <text x="110" y="-12" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">EC2</text>
+    <!-- RDS -->
+    <rect x="25" y="10" width="120" height="35" rx="6" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+    <text x="85" y="33" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#c4b5fd" text-anchor="middle">RDS</text>
+    <!-- Connection arrows -->
+    <line x1="-25" y1="-17" x2="20" y2="-17" stroke="#94a3b8" stroke-width="1.5" opacity="0.4"/>
+    <polygon points="17,-21 25,-17 17,-13" fill="#94a3b8" opacity="0.4"/>
+    <!-- GuardDuty eye -->
+    <g transform="translate(0,120)">
+      <g filter="url(#shadow)">
+        <ellipse cx="0" cy="0" rx="60" ry="25" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+        <!-- Eye shape -->
+        <ellipse cx="0" cy="0" rx="40" ry="18" fill="#ef4444" opacity="0.1"/>
+        <circle cx="0" cy="0" r="12" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.5"/>
+        <circle cx="0" cy="0" r="5" fill="#ef4444" opacity="0.6"/>
+        <text x="0" y="38" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#fca5a5" text-anchor="middle">GuardDuty</text>
+      </g>
+      <!-- Scan lines -->
+      <line x1="0" y1="-30" x2="0" y2="-50" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,3" opacity="0.3"/>
+    </g>
+    <!-- Week 2 badge -->
+    <rect x="140" y="-100" width="50" height="22" rx="6" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+    <text x="165" y="-85" font-family="Courier New" font-size="9" fill="#fdba74" text-anchor="middle">W2</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 2 : AWS , VPC GuardDuty</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
-    </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">VPC, IAM, S3, GuardDuty AWS 2025 re:Invent</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#VPC</text>
-      <rect x="144" y="0" width="114" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#GuardDuty</text>
-      <rect x="270" y="0" width="195" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="367" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Security-Archit...</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS VPC + GuardDuty</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th Batch | Week 2 | Security Architecture</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Dec 5, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
+++ b/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
@@ -1,189 +1,63 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a1a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="finopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#14b8a6"/>
-      <stop offset="100%" style="stop-color:#0d9488"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#2dd4bf" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#14b8a6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0d9488" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#14b8a6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#2dd4bf" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#2dd4bf" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#finopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">FINOPS</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Giant dollar/FinOps coin -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="-10" r="90" fill="#1e293b" stroke="#f59e0b" stroke-width="3"/>
+      <circle cx="0" cy="-10" r="75" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="6,3"/>
+      <!-- Dollar sign -->
+      <text x="0" y="15" font-family="Arial,sans-serif" font-size="70" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.7">$</text>
+      <!-- Cost trend line -->
+      <g transform="translate(0,-10)">
+        <polyline points="-50,20 -30,15 -10,25 10,5 30,-10 50,-25" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" opacity="0.6"/>
+        <polygon points="48,-30 55,-25 48,-20" fill="#22c55e" opacity="0.6"/>
+      </g>
+    </g>
+    <!-- ISMS-P certification badge -->
+    <g transform="translate(-150,30)">
+      <rect x="-45" y="-20" width="90" height="40" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2" filter="url(#shadow)"/>
+      <text x="0" y="-2" font-family="Arial,sans-serif" font-size="11" font-weight="bold" fill="#c4b5fd" text-anchor="middle">ISMS-P</text>
+      <text x="0" y="12" font-family="Courier New" font-size="8" fill="#a78bfa" text-anchor="middle">Certified</text>
+    </g>
+    <!-- AWS Cost Explorer chart -->
+    <g transform="translate(150,30)">
+      <rect x="-45" y="-20" width="90" height="40" rx="8" fill="#1e293b" stroke="#f97316" stroke-width="2" filter="url(#shadow)"/>
+      <!-- Mini bar chart -->
+      <rect x="-30" y="-5" width="10" height="15" rx="1" fill="#f97316" opacity="0.4"/>
+      <rect x="-15" y="-10" width="10" height="20" rx="1" fill="#f97316" opacity="0.5"/>
+      <rect x="0" y="-2" width="10" height="12" rx="1" fill="#22c55e" opacity="0.5"/>
+      <rect x="15" y="-8" width="10" height="18" rx="1" fill="#22c55e" opacity="0.4"/>
+      <text x="0" y="15" font-family="Courier New" font-size="7" fill="#fdba74" text-anchor="middle">CUR</text>
+    </g>
+    <!-- Audit checklist -->
+    <g transform="translate(0,110)">
+      <rect x="-80" y="-15" width="160" height="30" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <!-- Check marks -->
+      <path d="M-55,-2 L-52,2 L-48,-4" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-30,-2 L-27,2 L-23,-4" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-5,-2 L-2,2 L2,-4" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M20,-2 L23,2 L27,-4" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round"/>
+      <rect x="42" y="-4" width="20" height="8" rx="2" fill="#334155"/>
+      <text x="0" y="25" font-family="Courier New" font-size="8" fill="#94a3b8" text-anchor="middle">Security Audit Progress</text>
+    </g>
+    <!-- Week 3 badge -->
+    <rect x="70" y="-105" width="50" height="22" rx="6" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+    <text x="95" y="-90" font-family="Courier New" font-size="9" fill="#fde68a" text-anchor="middle">W3</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 3 : AWS FinOps ISMS-P</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Dollar Chart -->
-    <g transform="translate(80, 280)">
-      <rect x="5" y="5" width="90" height="70" rx="5" fill="#0f172a" stroke="#14b8a6" stroke-width="2"/>
-      <polyline points="15,60 30,45 50,55 70,30 85,40" fill="none" stroke="#22d3ee" stroke-width="3"/>
-      <text x="50" y="55" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#14b8a6" text-anchor="middle">$</text>
-    </g>
-    
-    <!-- Cloud Cost -->
-    <g transform="translate(210, 290)">
-      <path d="M20 50 Q5 50 5 35 Q5 20 20 20 Q20 5 40 5 Q60 5 60 25 Q75 25 75 40 Q75 50 60 50 Z" 
-            fill="#14b8a6" stroke="#0d9488" stroke-width="2" opacity="0.8"/>
-      <text x="40" y="38" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">$</text>
-    </g>
-    
-    <!-- Savings Piggy -->
-    <g transform="translate(330, 295)">
-      <ellipse cx="40" cy="40" rx="35" ry="25" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <ellipse cx="65" cy="35" rx="8" ry="5" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="60" cy="30" r="3" fill="#0f172a"/>
-      <rect x="30" y="10" width="20" height="8" rx="2" fill="#0d9488"/>
-      <ellipse cx="25" cy="55" rx="8" ry="5" fill="#0d9488"/>
-      <ellipse cx="55" cy="55" rx="8" ry="5" fill="#0d9488"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#finopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#2dd4bf">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#2dd4bf"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 FinOps AWS , ISMS-P</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="87" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="115" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#FinOps</text>
-      <rect x="171" y="0" width="87" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#ISMS-P</text>
-      <rect x="270" y="0" width="78" height="30" rx="15" fill="#2dd4bf" fill-opacity="0.15" stroke="#2dd4bf" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="309" y="20" font-family="Arial, sans-serif" font-size="12" fill="#2dd4bf" text-anchor="middle">#Audit</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#finopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">FinOps + ISMS-P Audit</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th Batch | Week 3 | Cost + Compliance Strategy</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Dec 12, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
+++ b/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
@@ -1,194 +1,74 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ec4899" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Conference stage/podium -->
+    <g filter="url(#shadow)">
+      <!-- Stage platform -->
+      <path d="M-200,80 L-220,100 L220,100 L200,80 Z" fill="#1e293b" stroke="#ec4899" stroke-width="1.5"/>
+      <rect x="-200" y="-20" width="400" height="100" rx="12" fill="#1e293b" stroke="#ec4899" stroke-width="2"/>
+      <!-- Screen/presentation -->
+      <rect x="-180" y="-10" width="360" height="70" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+      <!-- Presentation content - AI + Security -->
+      <g transform="translate(0,25)">
+        <!-- AI icon -->
+        <circle cx="-80" cy="0" r="20" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1.5"/>
+        <text x="-80" y="5" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#c4b5fd" text-anchor="middle">AI</text>
+        <!-- Plus sign -->
+        <text x="0" y="8" font-family="Arial,sans-serif" font-size="24" fill="#94a3b8" text-anchor="middle">+</text>
+        <!-- Security shield -->
+        <path d="M80,-15 L100,-8 L100,8 C100,18 92,24 80,28 C68,24 60,18 60,8 L60,-8 Z" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="1.5"/>
+        <text x="80" y="8" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">SEC</text>
+      </g>
+    </g>
+    <!-- Conference logos -->
+    <g transform="translate(0,130)">
+      <!-- AWSKRUG -->
+      <rect x="-170" y="-15" width="90" height="30" rx="6" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="-125" y="5" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#fdba74" text-anchor="middle">AWSKRUG</text>
+      <!-- OWASP -->
+      <rect x="-55" y="-15" width="90" height="30" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <text x="-10" y="5" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#86efac" text-anchor="middle">OWASP</text>
+      <!-- Datadog -->
+      <rect x="60" y="-15" width="90" height="30" rx="6" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="105" y="5" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#c4b5fd" text-anchor="middle">Datadog</text>
+    </g>
+    <!-- Audience silhouettes -->
+    <g transform="translate(0,100)" opacity="0.15">
+      <circle cx="-150" cy="30" r="8" fill="#94a3b8"/>
+      <circle cx="-120" cy="35" r="8" fill="#94a3b8"/>
+      <circle cx="-90" cy="30" r="8" fill="#94a3b8"/>
+      <circle cx="-60" cy="35" r="8" fill="#94a3b8"/>
+      <circle cx="-30" cy="30" r="8" fill="#94a3b8"/>
+      <circle cx="0" cy="35" r="8" fill="#94a3b8"/>
+      <circle cx="30" cy="30" r="8" fill="#94a3b8"/>
+      <circle cx="60" cy="35" r="8" fill="#94a3b8"/>
+      <circle cx="90" cy="30" r="8" fill="#94a3b8"/>
+      <circle cx="120" cy="35" r="8" fill="#94a3b8"/>
+      <circle cx="150" cy="30" r="8" fill="#94a3b8"/>
+    </g>
+    <!-- Spotlight beams -->
+    <g opacity="0.08">
+      <path d="M-250,-150 L-100,-20" stroke="#ec4899" stroke-width="3"/>
+      <path d="M250,-150 L100,-20" stroke="#ec4899" stroke-width="3"/>
+    </g>
+    <!-- 2025 badge -->
+    <rect x="-30" y="-70" width="60" height="28" rx="8" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1.5"/>
+    <text x="0" y="-51" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#f9a8d4" text-anchor="middle">2025</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">12 AWSKRUG, OWASP, Datadog 2025 : AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
-    </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWSKRUG, OWASP, Datadog 2025 AI , AWS re:Invent</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="48" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWSKRUG</text>
-      <rect x="108" y="0" width="78" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#OWASP</text>
-      <rect x="198" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Datadog</text>
-      <rect x="306" y="0" width="51" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="331" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AI</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Conference Review 2025</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AWSKRUG + OWASP + Datadog | AI and Security Coexistence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ec4899" opacity="0.2" stroke="#ec4899" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f9a8d4" text-anchor="middle">CONFERENCE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Dec 17, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
+++ b/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
@@ -1,185 +1,73 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Giant magnifying glass scanning for vulnerabilities -->
+    <g filter="url(#shadow)">
+      <!-- Lens -->
+      <circle cx="-30" cy="-20" r="80" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
+      <circle cx="-30" cy="-20" r="70" fill="#0f172a" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.5"/>
+      <!-- Handle -->
+      <line x1="30" y1="40" x2="90" y2="100" stroke="#ef4444" stroke-width="8" stroke-linecap="round"/>
+      <line x1="30" y1="40" x2="90" y2="100" stroke="#7f1d1d" stroke-width="4" stroke-linecap="round"/>
+      <!-- Scan content inside lens -->
+      <g transform="translate(-30,-20)">
+        <!-- Code lines being scanned -->
+        <rect x="-45" y="-40" width="90" height="8" rx="2" fill="#ef4444" opacity="0.15"/>
+        <rect x="-45" y="-28" width="70" height="8" rx="2" fill="#334155" opacity="0.3"/>
+        <rect x="-45" y="-16" width="80" height="8" rx="2" fill="#ef4444" opacity="0.2"/>
+        <rect x="-45" y="-4" width="60" height="8" rx="2" fill="#334155" opacity="0.3"/>
+        <rect x="-45" y="8" width="85" height="8" rx="2" fill="#f59e0b" opacity="0.2"/>
+        <rect x="-45" y="20" width="50" height="8" rx="2" fill="#334155" opacity="0.3"/>
+        <rect x="-45" y="32" width="75" height="8" rx="2" fill="#334155" opacity="0.3"/>
+        <!-- Bug icons -->
+        <circle cx="30" cy="-36" r="6" fill="#ef4444" opacity="0.6"/>
+        <text x="30" y="-33" font-family="Courier New" font-size="7" fill="white" text-anchor="middle">!</text>
+        <circle cx="25" cy="12" r="6" fill="#f59e0b" opacity="0.6"/>
+        <text x="25" y="15" font-family="Courier New" font-size="7" fill="white" text-anchor="middle">?</text>
+      </g>
+      <!-- Scan beam effect -->
+      <rect x="-110" y="-25" width="160" height="3" rx="1" fill="#ef4444" opacity="0.3">
+        <animate attributeName="y" values="-90;50;-90" dur="3s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- ISMS-P certification stamp -->
+    <g transform="translate(140,10)">
+      <circle cx="0" cy="0" r="45" fill="#1e293b" stroke="#22c55e" stroke-width="2.5" filter="url(#shadow)"/>
+      <circle cx="0" cy="0" r="38" fill="none" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,2"/>
+      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">ISMS-P</text>
+      <path d="M-8,8 L-3,14 L10,0" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round"/>
+    </g>
+    <!-- Vulnerability count badges -->
+    <g transform="translate(-160,80)" opacity="0.6">
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">HIGH: 3</text>
+    </g>
+    <g transform="translate(-80,80)" opacity="0.6">
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#fde68a" text-anchor="middle">MED: 7</text>
+    </g>
+    <g transform="translate(0,80)" opacity="0.6">
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">LOW: 12</text>
+    </g>
+    <!-- Week 4 badge -->
+    <rect x="100" y="-100" width="50" height="22" rx="6" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+    <text x="125" y="-85" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">W4</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 4 : ISMS-P</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">ISMS-P .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Vulnerability</text>
-      <rect x="162" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ISMS-P</text>
-      <rect x="261" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Compliance</text>
-      <rect x="396" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Audit</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Vulnerability + ISMS-P</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th Batch | Week 4 | Security Inspection + Certification</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Dec 19, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
+++ b/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
@@ -1,190 +1,78 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Control Tower - tall tower structure -->
+    <g filter="url(#shadow)">
+      <!-- Tower base -->
+      <rect x="-40" y="-100" width="80" height="180" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+      <!-- Tower antenna -->
+      <line x1="0" y1="-100" x2="0" y2="-130" stroke="#3b82f6" stroke-width="3" stroke-linecap="round"/>
+      <circle cx="0" cy="-135" r="6" fill="#3b82f6" opacity="0.6"/>
+      <!-- Signal waves -->
+      <path d="M-20,-140 C-20,-155 20,-155 20,-140" fill="none" stroke="#3b82f6" stroke-width="1.5" opacity="0.3"/>
+      <path d="M-35,-145 C-35,-165 35,-165 35,-145" fill="none" stroke="#3b82f6" stroke-width="1.5" opacity="0.2"/>
+      <!-- Tower windows/levels -->
+      <rect x="-28" y="-85" width="56" height="25" rx="4" fill="#0f172a" stroke="#3b82f6" stroke-width="1"/>
+      <text x="0" y="-68" font-family="Courier New" font-size="9" fill="#60a5fa" text-anchor="middle">SCP</text>
+      <rect x="-28" y="-50" width="56" height="25" rx="4" fill="#0f172a" stroke="#3b82f6" stroke-width="1"/>
+      <text x="0" y="-33" font-family="Courier New" font-size="9" fill="#60a5fa" text-anchor="middle">OU</text>
+      <rect x="-28" y="-15" width="56" height="25" rx="4" fill="#0f172a" stroke="#3b82f6" stroke-width="1"/>
+      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#60a5fa" text-anchor="middle">SSO</text>
+      <rect x="-28" y="20" width="56" height="25" rx="4" fill="#0f172a" stroke="#3b82f6" stroke-width="1"/>
+      <text x="0" y="37" font-family="Courier New" font-size="9" fill="#60a5fa" text-anchor="middle">Guard</text>
+      <rect x="-28" y="55" width="56" height="20" rx="4" fill="#3b82f6" opacity="0.15"/>
+      <text x="0" y="69" font-family="Arial,sans-serif" font-size="8" font-weight="bold" fill="#93c5fd" text-anchor="middle">TOWER</text>
+    </g>
+    <!-- Left: Datadog SIEM -->
+    <g transform="translate(-170,0)">
+      <rect x="-60" y="-40" width="120" height="80" rx="10" fill="#1e293b" stroke="#8b5cf6" stroke-width="2" filter="url(#shadow)"/>
+      <!-- Datadog dog silhouette (simplified) -->
+      <circle cx="0" cy="-10" r="18" fill="#8b5cf6" opacity="0.15"/>
+      <text x="0" y="-5" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#c4b5fd" text-anchor="middle">DD</text>
+      <text x="0" y="15" font-family="Courier New" font-size="9" fill="#a78bfa" text-anchor="middle">SIEM</text>
+      <!-- Log lines -->
+      <g transform="translate(0,28)" opacity="0.3">
+        <rect x="-40" y="0" width="80" height="3" rx="1" fill="#8b5cf6"/>
+        <rect x="-40" y="5" width="60" height="3" rx="1" fill="#8b5cf6"/>
+      </g>
+    </g>
+    <!-- Right: Cloudflare -->
+    <g transform="translate(170,0)">
+      <rect x="-60" y="-40" width="120" height="80" rx="10" fill="#1e293b" stroke="#f97316" stroke-width="2" filter="url(#shadow)"/>
+      <!-- CF cloud -->
+      <path d="M-15,-18 C-25,-18 -30,-12 -30,-5 C-35,-5 -38,0 -38,5 C-38,12 -33,15 -28,15 L28,15 C33,15 38,12 38,5 C38,0 35,-5 30,-5 C30,-12 25,-18 15,-18 C8,-18 2,-14 0,-10 C-2,-14 -8,-18 -15,-18 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="1.5"/>
+      <text x="0" y="30" font-family="Courier New" font-size="9" fill="#fdba74" text-anchor="middle">WAF</text>
+    </g>
+    <!-- Connection lines -->
+    <g stroke-dasharray="6,3" opacity="0.3">
+      <line x1="-45" y1="0" x2="-110" y2="0" stroke="#8b5cf6" stroke-width="1.5"/>
+      <line x1="45" y1="0" x2="110" y2="0" stroke="#f97316" stroke-width="1.5"/>
+    </g>
+    <!-- Governance flow arrows -->
+    <g transform="translate(0,105)" opacity="0.4">
+      <path d="M-120,0 L120,0" fill="none" stroke="#22c55e" stroke-width="1.5"/>
+      <polygon points="115,-4 125,0 115,4" fill="#22c55e"/>
+      <polygon points="-115,4 -125,0 -115,-4" fill="#22c55e"/>
+      <text x="0" y="15" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Governance Flow</text>
+    </g>
+    <!-- Week 5 badge -->
+    <rect x="50" y="-140" width="50" height="22" rx="6" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+    <text x="75" y="-125" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">W5</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 5 : AWS Control Tower/SCP Datadog SIEM, Clo...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
-    </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
-    </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS Control Tower/SCP , Datadog SIEM Cloudflare</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="150" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Control-Tower</text>
-      <rect x="234" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#SCP</text>
-      <rect x="306" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#Datadog</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Control Tower + SIEM</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th | Week 5 | SCP Governance + Datadog + Cloudflare</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Dec 24, 2025</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
+++ b/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
@@ -1,195 +1,59 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">FSD 2026 : Model Y Juniper , , DevSecOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <g filter="url(#shadow)">
+      <!-- Car silhouette (Model Y) -->
+      <path d="M-150,20 C-150,20 -140,-10 -120,-25 C-100,-40 -60,-50 -30,-52 L30,-52 C60,-50 100,-40 120,-25 C140,-10 150,20 150,20 Z" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <!-- Windshield -->
+      <path d="M-80,-25 C-60,-45 60,-45 80,-25" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+      <!-- Wheels -->
+      <circle cx="-90" cy="25" r="20" fill="#0f172a" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="-90" cy="25" r="10" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.4"/>
+      <circle cx="90" cy="25" r="20" fill="#0f172a" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="90" cy="25" r="10" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.4"/>
+      <!-- Tesla T logo -->
+      <g transform="translate(0,-30)">
+        <line x1="-12" y1="0" x2="12" y2="0" stroke="#ef4444" stroke-width="2.5"/>
+        <line x1="0" y1="0" x2="0" y2="18" stroke="#ef4444" stroke-width="2.5"/>
+      </g>
+      <!-- FSD sensor beams -->
+      <g opacity="0.2">
+        <path d="M-30,-52 L-80,-100 L80,-100 L30,-52" fill="#3b82f6" stroke="#3b82f6" stroke-width="1"/>
+        <path d="M150,10 L200,-30 L200,50 L150,30" fill="#3b82f6" stroke="#3b82f6" stroke-width="1"/>
+        <path d="M-150,10 L-200,-30 L-200,50 L-150,30" fill="#3b82f6" stroke="#3b82f6" stroke-width="1"/>
+      </g>
+      <!-- Detection dots -->
+      <g opacity="0.4">
+        <circle cx="-60" cy="-85" r="3" fill="#3b82f6"/>
+        <circle cx="0" cy="-95" r="3" fill="#3b82f6"/>
+        <circle cx="60" cy="-85" r="3" fill="#3b82f6"/>
+        <circle cx="185" cy="0" r="3" fill="#22c55e"/>
+        <circle cx="-185" cy="0" r="3" fill="#22c55e"/>
+      </g>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
-    </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FSD 2026 . FSD v14.2.1 ( , ), Model Y</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Juniper( 49,990 ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="78" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Tesla</text>
-      <rect x="90" y="0" width="60" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="120" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#FSD</text>
-      <rect x="162" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Model Y</text>
-      <rect x="270" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Juniper</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- FSD badge -->
+    <rect x="-30" y="55" width="60" height="24" rx="6" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="1.5"/>
+    <text x="0" y="72" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#fca5a5" text-anchor="middle">FSD</text>
+    <!-- Security shield -->
+    <g transform="translate(140,60)" opacity="0.5">
+      <path d="M0,-15 L18,-8 L18,8 C18,16 10,22 0,25 C-10,22 -18,16 -18,8 L-18,-8 Z" fill="#22c55e" opacity="0.15" stroke="#22c55e" stroke-width="1.5"/>
+      <path d="M-4,3 L-1,7 L7,-2" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tesla FSD 2026</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Model Y Juniper | Full Self-Driving | Security + DevSecOps</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">AUTOMOTIVE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 1, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
+++ b/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
@@ -1,189 +1,53 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OWASP 2025 : Top 10 AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#22c55e" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- OWASP wasp/bee icon -->
+    <g filter="url(#shadow)">
+      <ellipse cx="0" cy="-10" rx="70" ry="85" fill="#1e293b" stroke="#22c55e" stroke-width="3"/>
+      <!-- Wasp stripes -->
+      <rect x="-55" y="-50" width="110" height="14" rx="4" fill="#22c55e" opacity="0.15"/>
+      <rect x="-60" y="-30" width="120" height="14" rx="4" fill="#f59e0b" opacity="0.1"/>
+      <rect x="-55" y="-10" width="110" height="14" rx="4" fill="#22c55e" opacity="0.15"/>
+      <rect x="-50" y="10" width="100" height="14" rx="4" fill="#f59e0b" opacity="0.1"/>
+      <rect x="-40" y="30" width="80" height="14" rx="4" fill="#22c55e" opacity="0.15"/>
+      <!-- Eyes -->
+      <circle cx="-20" cy="-60" r="10" fill="#22c55e" opacity="0.3"/>
+      <circle cx="20" cy="-60" r="10" fill="#22c55e" opacity="0.3"/>
+      <circle cx="-20" cy="-60" r="4" fill="#22c55e" opacity="0.8"/>
+      <circle cx="20" cy="-60" r="4" fill="#22c55e" opacity="0.8"/>
+      <!-- Wings -->
+      <ellipse cx="-80" cy="-30" rx="30" ry="45" fill="none" stroke="#22c55e" stroke-width="1.5" opacity="0.2" transform="rotate(-15,-80,-30)"/>
+      <ellipse cx="80" cy="-30" rx="30" ry="45" fill="none" stroke="#22c55e" stroke-width="1.5" opacity="0.2" transform="rotate(15,80,-30)"/>
+      <!-- Top 10 badge -->
+      <circle cx="0" cy="0" r="25" fill="#0f172a" stroke="#22c55e" stroke-width="2"/>
+      <text x="0" y="-3" font-family="Arial,sans-serif" font-size="10" fill="#86efac" text-anchor="middle">TOP</text>
+      <text x="0" y="12" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#22c55e" text-anchor="middle">10</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- AI badge -->
+    <g transform="translate(120,20)">
+      <rect x="-30" y="-15" width="60" height="30" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#c4b5fd" text-anchor="middle">AI</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">OWASP 2025 . OWASP Top 10 2025 Software Supply Chain</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Failures,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OWASP</text>
-      <rect x="90" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
-      <rect x="207" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Top10</text>
-      <rect x="297" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Agentic badge -->
+    <g transform="translate(-120,20)">
+      <rect x="-35" y="-15" width="70" height="30" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#fde68a" text-anchor="middle">Agentic</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OWASP Top 10 2025</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Security + Agentic Threats | Complete Guide</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">OWASP</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 3, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
+++ b/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
@@ -1,191 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a1a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevSecOps :</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Car with circuit board pattern -->
+    <g filter="url(#shadow)">
+      <path d="M-140,15 C-140,15 -130,-15 -110,-30 C-90,-45 -50,-50 -20,-52 L20,-52 C50,-50 90,-45 110,-30 C130,-15 140,15 140,15 Z" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <circle cx="-85" cy="20" r="18" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="85" cy="20" r="18" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
+      <!-- Circuit patterns on car -->
+      <g opacity="0.3">
+        <line x1="-60" y1="-20" x2="-20" y2="-20" stroke="#f59e0b" stroke-width="1"/>
+        <line x1="-20" y1="-20" x2="-20" y2="-5" stroke="#f59e0b" stroke-width="1"/>
+        <line x1="20" y1="-30" x2="60" y2="-30" stroke="#f59e0b" stroke-width="1"/>
+        <line x1="60" y1="-30" x2="60" y2="-10" stroke="#f59e0b" stroke-width="1"/>
+        <circle cx="-60" cy="-20" r="2" fill="#f59e0b"/>
+        <circle cx="-20" cy="-5" r="2" fill="#f59e0b"/>
+        <circle cx="20" cy="-30" r="2" fill="#f59e0b"/>
+        <circle cx="60" cy="-10" r="2" fill="#f59e0b"/>
+      </g>
+      <!-- ECU chip -->
+      <rect x="-20" y="-25" width="40" height="30" rx="4" fill="#0f172a" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="0" y="-6" font-family="Courier New" font-size="9" fill="#fde68a" text-anchor="middle">ECU</text>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    <!-- Security shield around car -->
+    <path d="M0,-80 L170,-50 L170,30 C170,60 90,80 0,90 C-90,80 -170,60 -170,30 L-170,-50 Z" fill="none" stroke="#22c55e" stroke-width="2" stroke-dasharray="8,4" opacity="0.3"/>
+    <!-- CAN bus label -->
+    <g transform="translate(0,60)">
+      <rect x="-40" y="-12" width="80" height="24" rx="6" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="0" y="4" font-family="Courier New" font-size="10" fill="#fca5a5" text-anchor="middle">CAN Bus</text>
     </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps . SDV(Software Defined Vehicle) ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
-      <rect x="126" y="0" width="195" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Automotive-Secu...</text>
-      <rect x="333" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Connected-Car</text>
-      <rect x="495" y="0" width="69" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="529" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#SAST</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- V2X antenna signals -->
+    <g transform="translate(0,-70)" opacity="0.3">
+      <path d="M-15,-5 C-15,-15 15,-15 15,-5" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+      <path d="M-25,-10 C-25,-25 25,-25 25,-10" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+      <text x="0" y="8" font-family="Courier New" font-size="7" fill="#93c5fd" text-anchor="middle">V2X</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Automotive Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">DevSecOps Perspective | ECU + CAN Bus + V2X Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">AUTOMOTIVE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 6, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
+++ b/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
@@ -1,189 +1,57 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a1a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: DevSecOps GitHub</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Blockchain chain -->
+    <g filter="url(#shadow)">
+      <!-- Block 1 -->
+      <rect x="-170" y="-40" width="80" height="80" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <text x="-130" y="-10" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">BLOCK</text>
+      <text x="-130" y="8" font-family="Courier New" font-size="16" font-weight="bold" fill="#f59e0b" text-anchor="middle">#1</text>
+      <rect x="-160" y="18" width="60" height="4" rx="1" fill="#f59e0b" opacity="0.2"/>
+      <!-- Chain link -->
+      <line x1="-85" y1="0" x2="-55" y2="0" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+      <circle cx="-70" cy="0" r="5" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <!-- Block 2 (Bitcoin) -->
+      <rect x="-50" y="-40" width="80" height="80" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <text x="-10" y="8" font-family="Arial,sans-serif" font-size="30" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.7">B</text>
+      <line x1="-10" y1="-15" x2="-10" y2="25" stroke="#f59e0b" stroke-width="1.5" opacity="0.3"/>
+      <!-- Chain link -->
+      <line x1="35" y1="0" x2="65" y2="0" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+      <circle cx="50" cy="0" r="5" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <!-- Block 3 -->
+      <rect x="70" y="-40" width="80" height="80" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <text x="110" y="-10" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">BLOCK</text>
+      <text x="110" y="8" font-family="Courier New" font-size="16" font-weight="bold" fill="#f59e0b" text-anchor="middle">#N</text>
+      <rect x="80" y="18" width="60" height="4" rx="1" fill="#f59e0b" opacity="0.2"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Security shield over chain -->
+    <path d="M0,-70 L190,-45 L190,40 C190,65 100,85 0,95 C-100,85 -190,65 -190,40 L-190,-45 Z" fill="none" stroke="#22c55e" stroke-width="2" stroke-dasharray="8,4" opacity="0.25"/>
+    <!-- Lock -->
+    <g transform="translate(0,70)">
+      <rect x="-12" y="-5" width="24" height="18" rx="3" fill="#22c55e" opacity="0.3"/>
+      <path d="M-7,-5 L-7,-12 C-7,-17 -4,-20 0,-20 C4,-20 7,-17 7,-12 L7,-5" fill="none" stroke="#22c55e" stroke-width="2"/>
+      <circle cx="0" cy="4" r="2.5" fill="#86efac"/>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. 2024-2025 34 ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(Slither/Mythril), CI/CD , DevSecOps .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Blockchain</text>
-      <rect x="135" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cryptocurrency</text>
-      <rect x="306" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="354" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Bitcoin</text>
-      <rect x="414" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="466" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ethereum</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Hash values floating -->
+    <g opacity="0.2">
+      <text x="-160" y="-60" font-family="Courier New" font-size="7" fill="#94a3b8">0x3f2a...</text>
+      <text x="100" y="-60" font-family="Courier New" font-size="7" fill="#94a3b8">0x8b1c...</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Blockchain Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cryptocurrency + DevSecOps | GitHub Security Tools</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">BLOCKCHAIN</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 8, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
+++ b/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
@@ -1,189 +1,73 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- WAF firewall wall -->
+    <g filter="url(#shadow)">
+      <rect x="-30" y="-90" width="60" height="180" rx="8" fill="#1e293b" stroke="#f97316" stroke-width="3"/>
+      <!-- Brick pattern -->
+      <g opacity="0.15">
+        <rect x="-25" y="-82" width="50" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="-58" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="3" y="-58" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="-34" width="50" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="-10" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="3" y="-10" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="14" width="50" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="38" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="3" y="38" width="22" height="18" rx="2" fill="#f97316"/>
+        <rect x="-25" y="62" width="50" height="18" rx="2" fill="#f97316"/>
+      </g>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#fdba74" text-anchor="middle">WAF</text>
+    </g>
+    <!-- Left: Threats -->
+    <g transform="translate(-130,0)" opacity="0.5">
+      <polygon points="-40,-15 -25,0 -40,15" fill="#ef4444" opacity="0.4"/>
+      <polygon points="-55,-10 -40,0 -55,10" fill="#ef4444" opacity="0.3"/>
+      <polygon points="-70,-8 -58,0 -70,8" fill="#ef4444" opacity="0.2"/>
+      <text x="-55" y="35" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">SQLi/XSS</text>
+    </g>
+    <!-- Blocked X marks -->
+    <g transform="translate(-55,0)" opacity="0.5">
+      <line x1="-8" y1="-8" x2="8" y2="8" stroke="#ef4444" stroke-width="2"/>
+      <line x1="8" y1="-8" x2="-8" y2="8" stroke="#ef4444" stroke-width="2"/>
+    </g>
+    <!-- Right: CloudFront CDN -->
+    <g transform="translate(130,0)">
+      <g filter="url(#shadow)">
+        <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+        <!-- Globe lines -->
+        <ellipse cx="0" cy="0" rx="50" ry="20" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+        <ellipse cx="0" cy="0" rx="20" ry="50" fill="none" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+        <line x1="-50" y1="0" x2="50" y2="0" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+        <line x1="0" y1="-50" x2="0" y2="50" stroke="#3b82f6" stroke-width="1" opacity="0.3"/>
+        <text x="0" y="5" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">CDN</text>
+      </g>
+      <!-- Edge locations -->
+      <circle cx="35" cy="-35" r="4" fill="#22c55e" opacity="0.5"/>
+      <circle cx="-30" cy="-40" r="4" fill="#22c55e" opacity="0.5"/>
+      <circle cx="40" cy="25" r="4" fill="#22c55e" opacity="0.5"/>
+    </g>
+    <!-- Arrow WAF -> CDN -->
+    <line x1="35" y1="0" x2="75" y2="0" stroke="#22c55e" stroke-width="2" opacity="0.4"/>
+    <polygon points="72,-4 80,0 72,4" fill="#22c55e" opacity="0.4"/>
+    <!-- W6 badge -->
+    <rect x="160" y="-90" width="40" height="20" rx="5" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+    <text x="180" y="-76" font-family="Courier New" font-size="9" fill="#fdba74" text-anchor="middle">W6</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 6 : AWS WAF/CloudFront GitHub DevSecOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 6 . AWS WAF/CloudFront (OAI/OAC, WAF ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Geo-blocking),</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="133" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CloudFront</text>
-      <rect x="207" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#cloudsecurity</text>
-      <rect x="369" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="444" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cybersecurity</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS WAF + CloudFront</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th | Week 6 | WAF + CDN + GitHub DevSecOps</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 8, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
+++ b/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
@@ -1,191 +1,61 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 DevSecOps : roadmap.sh</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#10b981" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Roadmap path -->
+    <g filter="url(#shadow)">
+      <path d="M-200,40 C-150,40 -130,-20 -80,-20 C-30,-20 -10,40 40,40 C90,40 110,-20 160,-20 C210,-20 230,40 230,40" fill="none" stroke="#10b981" stroke-width="4" stroke-linecap="round"/>
+      <!-- Road dashes -->
+      <path d="M-200,40 C-150,40 -130,-20 -80,-20 C-30,-20 -10,40 40,40 C90,40 110,-20 160,-20 C210,-20 230,40 230,40" fill="none" stroke="#86efac" stroke-width="1.5" stroke-dasharray="8,12" opacity="0.4"/>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    <!-- Milestone nodes -->
+    <g>
+      <!-- Plan -->
+      <circle cx="-180" cy="40" r="16" fill="#1e293b" stroke="#3b82f6" stroke-width="2" filter="url(#shadow)"/>
+      <text x="-180" y="44" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">Plan</text>
+      <!-- Code -->
+      <circle cx="-80" cy="-20" r="16" fill="#1e293b" stroke="#8b5cf6" stroke-width="2" filter="url(#shadow)"/>
+      <text x="-80" y="-16" font-family="Courier New" font-size="8" fill="#c4b5fd" text-anchor="middle">Code</text>
+      <!-- Build -->
+      <circle cx="40" cy="40" r="16" fill="#1e293b" stroke="#f59e0b" stroke-width="2" filter="url(#shadow)"/>
+      <text x="40" y="44" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">Build</text>
+      <!-- Test -->
+      <circle cx="160" cy="-20" r="16" fill="#1e293b" stroke="#ef4444" stroke-width="2" filter="url(#shadow)"/>
+      <text x="160" y="-16" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">Test</text>
+      <!-- Deploy -->
+      <circle cx="230" cy="40" r="16" fill="#1e293b" stroke="#22c55e" stroke-width="2" filter="url(#shadow)"/>
+      <text x="230" y="44" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Deploy</text>
     </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- Security checkpoints above path -->
+    <g opacity="0.4">
+      <path d="M-130,-55 L-130,-35" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="3,2"/>
+      <path d="M-130,-62 L-125,-55 L-135,-55 Z" fill="#ef4444"/>
+      <path d="M-10,-5 L-10,15" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="3,2"/>
+      <path d="M-10,-12 L-5,-5 L-15,-5 Z" fill="#ef4444"/>
+      <path d="M100,-55 L100,-35" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="3,2"/>
+      <path d="M100,-62 L105,-55 L95,-55 Z" fill="#ef4444"/>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">roadmap.sh 2026 DevSecOps . 93 , OWASP Top 10:2025,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">NIST</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
-      <rect x="126" y="0" width="42" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="147" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#-</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- 2026 year -->
+    <text x="0" y="-70" font-family="Arial,sans-serif" font-size="48" font-weight="bold" fill="#10b981" text-anchor="middle" opacity="0.15">2026</text>
+    <!-- Terminal prompt -->
+    <g transform="translate(0,90)">
+      <rect x="-80" y="-12" width="160" height="24" rx="4" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+      <text x="-70" y="4" font-family="Courier New" font-size="10" fill="#86efac">$ roadmap.sh</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevSecOps Roadmap 2026</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">roadmap.sh Analysis | Complete Learning Path</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#10b981" opacity="0.2" stroke="#10b981" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#6ee7b7" text-anchor="middle">ROADMAP</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 10, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
+++ b/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
@@ -1,199 +1,66 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : DevSecOps AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- Music note + AI brain -->
+    <g filter="url(#shadow)">
+      <!-- Giant music note -->
+      <circle cx="-40" cy="40" r="25" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="2.5"/>
+      <line x1="-15" y1="40" x2="-15" y2="-60" stroke="#8b5cf6" stroke-width="3"/>
+      <path d="M-15,-60 C-15,-60 30,-70 30,-45 C30,-20 -15,-30 -15,-30" fill="#8b5cf6" opacity="0.4"/>
+      <!-- Second note -->
+      <circle cx="40" cy="50" r="20" fill="#ec4899" opacity="0.2" stroke="#ec4899" stroke-width="2"/>
+      <line x1="60" y1="50" x2="60" y2="-40" stroke="#ec4899" stroke-width="2.5"/>
+      <!-- Beam connecting notes -->
+      <line x1="-15" y1="-55" x2="60" y2="-40" stroke="#c4b5fd" stroke-width="3"/>
     </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
+    <!-- Sound wave visualization -->
+    <g transform="translate(0,90)" opacity="0.4">
+      <rect x="-100" y="-12" width="4" height="24" rx="2" fill="#8b5cf6"/>
+      <rect x="-90" y="-18" width="4" height="36" rx="2" fill="#8b5cf6"/>
+      <rect x="-80" y="-8" width="4" height="16" rx="2" fill="#8b5cf6"/>
+      <rect x="-70" y="-22" width="4" height="44" rx="2" fill="#c4b5fd"/>
+      <rect x="-60" y="-15" width="4" height="30" rx="2" fill="#8b5cf6"/>
+      <rect x="-50" y="-10" width="4" height="20" rx="2" fill="#8b5cf6"/>
+      <rect x="-40" y="-25" width="4" height="50" rx="2" fill="#ec4899"/>
+      <rect x="-30" y="-12" width="4" height="24" rx="2" fill="#8b5cf6"/>
+      <rect x="-20" y="-18" width="4" height="36" rx="2" fill="#8b5cf6"/>
+      <rect x="-10" y="-8" width="4" height="16" rx="2" fill="#c4b5fd"/>
+      <rect x="0" y="-20" width="4" height="40" rx="2" fill="#8b5cf6"/>
+      <rect x="10" y="-14" width="4" height="28" rx="2" fill="#8b5cf6"/>
+      <rect x="20" y="-22" width="4" height="44" rx="2" fill="#ec4899"/>
+      <rect x="30" y="-10" width="4" height="20" rx="2" fill="#8b5cf6"/>
+      <rect x="40" y="-16" width="4" height="32" rx="2" fill="#8b5cf6"/>
+      <rect x="50" y="-8" width="4" height="16" rx="2" fill="#c4b5fd"/>
+      <rect x="60" y="-20" width="4" height="40" rx="2" fill="#8b5cf6"/>
+      <rect x="70" y="-12" width="4" height="24" rx="2" fill="#8b5cf6"/>
+      <rect x="80" y="-18" width="4" height="36" rx="2" fill="#ec4899"/>
+      <rect x="90" y="-8" width="4" height="16" rx="2" fill="#8b5cf6"/>
     </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <!-- AI sparkles -->
+    <g opacity="0.4">
+      <path d="M100,-40 L105,-30 L115,-30 L107,-23 L110,-13 L100,-20 L90,-13 L93,-23 L85,-30 L95,-30 Z" fill="#c4b5fd"/>
+      <path d="M-100,-50 L-97,-43 L-90,-43 L-96,-38 L-94,-31 L-100,-36 L-106,-31 L-104,-38 L-110,-43 L-103,-43 Z" fill="#f9a8d4" transform="scale(0.7) translate(-40,-30)"/>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI . Suno V5 MIDI Export, Veo 3 1080p ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Midjourney Video V1 DevSecOps (API , Zero-Trust)</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="51" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AI</text>
-      <rect x="63" y="0" width="150" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="138" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Generative-AI</text>
-      <rect x="225" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Music-Video</text>
-      <rect x="369" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#DevSecOps</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Video frame -->
+    <g transform="translate(130,-20)" opacity="0.4">
+      <rect x="-25" y="-18" width="50" height="36" rx="4" fill="#1e293b" stroke="#ec4899" stroke-width="1.5"/>
+      <polygon points="-5,-8 10,0 -5,8" fill="#ec4899" opacity="0.6"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Music + Video</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Generation Complete Guide | DevSecOps Perspective</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">AI CREATIVE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 11, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
+++ b/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
@@ -1,189 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2025 ISMS-P : AWS</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#22c55e" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- ISMS-P certification seal -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#22c55e" stroke-width="3"/>
+      <circle cx="0" cy="0" r="78" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="6,3"/>
+      <circle cx="0" cy="0" r="65" fill="#0f172a" stroke="#22c55e" stroke-width="1"/>
+      <!-- Star pattern -->
+      <g opacity="0.2">
+        <polygon points="0,-55 5,-45 15,-45 7,-38 10,-28 0,-35 -10,-28 -7,-38 -15,-45 -5,-45" fill="#22c55e"/>
+      </g>
+      <!-- ISMS-P text -->
+      <text x="0" y="-10" font-family="Arial,sans-serif" font-size="26" font-weight="bold" fill="#22c55e" text-anchor="middle">ISMS-P</text>
+      <!-- Checkmark -->
+      <path d="M-15,15 L-5,28 L20,2" fill="none" stroke="#86efac" stroke-width="4" stroke-linecap="round"/>
+      <!-- Ribbon tails -->
+      <path d="M-60,75 L-40,85 L-60,95" fill="#22c55e" opacity="0.2"/>
+      <path d="M60,75 L40,85 L60,95" fill="#22c55e" opacity="0.2"/>
+      <rect x="-60" y="70" width="120" height="20" rx="3" fill="#22c55e" opacity="0.15"/>
+      <text x="0" y="84" font-family="Courier New" font-size="9" fill="#86efac" text-anchor="middle">CERTIFIED 2025</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- AWS cloud connection -->
+    <g transform="translate(-170,0)" opacity="0.5">
+      <path d="M-15,-20 C-30,-20 -40,-12 -40,0 C-50,0 -55,8 -55,15 C-55,25 -48,30 -38,30 L20,30 C30,30 35,25 35,15 C35,8 30,0 20,0 C20,-12 10,-20 -5,-20 Z" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="-10" y="12" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#fdba74" text-anchor="middle">AWS</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2025 ISMS-P (101 ) . AWS , , NIST</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CSF 2.0 , AI .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ISMS-P</text>
-      <rect x="99" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
-      <rect x="171" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
-      <rect x="288" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Compliance</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <line x1="-100" y1="0" x2="-95" y2="0" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.3"/>
+    <!-- Protection measures -->
+    <g transform="translate(170,0)" opacity="0.5">
+      <path d="M0,-30 L30,-18 L30,12 C30,25 16,33 0,38 C-16,33 -30,25 -30,12 L-30,-18 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <rect x="-12" y="-5" width="24" height="16" rx="3" fill="#3b82f6" opacity="0.3"/>
+      <path d="M-7,-5 L-7,-10 C-7,-15 -4,-18 0,-18 C4,-18 7,-15 7,-10 L7,-5" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">ISMS-P Certification</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AWS Environment | Management System | Protection Measures</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">COMPLIANCE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 14, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
@@ -1,189 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- AWS cloud shape -->
+    <g filter="url(#shadow)">
+      <path d="M-40,-80 C-80,-80 -110,-55 -110,-25 C-145,-25 -165,0 -165,30 C-165,65 -140,80 -110,80 L110,80 C140,80 165,65 165,30 C165,0 145,-25 110,-25 C110,-55 80,-80 40,-80 C15,-80 -5,-68 -10,-55 C-15,-68 -25,-80 -40,-80 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+      <text x="0" y="-25" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#f97316" text-anchor="middle" opacity="0.7">AWS</text>
+    </g>
+    <!-- IAM key -->
+    <g transform="translate(-80,15)">
+      <circle cx="0" cy="0" r="18" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+      <line x1="10" y1="0" x2="30" y2="0" stroke="#f59e0b" stroke-width="2"/>
+      <line x1="25" y1="0" x2="25" y2="6" stroke="#f59e0b" stroke-width="2"/>
+      <text x="0" y="30" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">IAM</text>
+    </g>
+    <!-- Arrow -->
+    <path d="M-40,15 L-10,15" fill="none" stroke="#94a3b8" stroke-width="1.5" opacity="0.4"/>
+    <polygon points="-15,11 -5,15 -15,19" fill="#94a3b8" opacity="0.4"/>
+    <!-- EKS helm wheel -->
+    <g transform="translate(50,15)">
+      <circle cx="0" cy="0" r="22" fill="#1e293b" stroke="#326ce5" stroke-width="2"/>
+      <circle cx="0" cy="0" r="8" fill="none" stroke="#326ce5" stroke-width="1.5"/>
+      <!-- Helm spokes -->
+      <line x1="0" y1="-22" x2="0" y2="-8" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="0" y1="8" x2="0" y2="22" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="-22" y1="0" x2="-8" y2="0" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="8" y1="0" x2="22" y2="0" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="-15" y1="-15" x2="-6" y2="-6" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="6" y1="6" x2="15" y2="15" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="15" y1="-15" x2="6" y2="-6" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="-6" y1="6" x2="-15" y2="15" stroke="#326ce5" stroke-width="1.5"/>
+      <text x="0" y="35" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">EKS</text>
+    </g>
+    <!-- Security shield wrapping -->
+    <path d="M0,-100 L180,-70 L180,60 C180,90 100,110 0,120 C-100,110 -180,90 -180,60 L-180,-70 Z" fill="none" stroke="#22c55e" stroke-width="2" stroke-dasharray="8,4" opacity="0.2"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS : IAM EKS</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS : IAM EKS - AWS</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">. IAM, VPC, S3, RDS, EKS</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="124" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
-      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#IAM</text>
-      <rect x="261" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VPC</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Cloud Security</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">IAM to EKS | Complete Security Architecture Guide</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">AWS SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 14, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
+++ b/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
@@ -1,189 +1,63 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CSPM(DataDog) AWS :</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#632ca6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Datadog dashboard -->
+    <g filter="url(#shadow)">
+      <rect x="-160" y="-90" width="320" height="190" rx="12" fill="#1e293b" stroke="#632ca6" stroke-width="2.5"/>
+      <!-- Title bar -->
+      <rect x="-160" y="-90" width="320" height="30" rx="12" fill="#632ca6" opacity="0.15"/>
+      <circle cx="-140" cy="-75" r="5" fill="#ef4444" opacity="0.5"/>
+      <circle cx="-125" cy="-75" r="5" fill="#f59e0b" opacity="0.5"/>
+      <circle cx="-110" cy="-75" r="5" fill="#22c55e" opacity="0.5"/>
+      <text x="0" y="-71" font-family="Arial,sans-serif" font-size="11" font-weight="bold" fill="#c4b5fd" text-anchor="middle">CSPM Dashboard</text>
+      <!-- Compliance score gauge -->
+      <g transform="translate(-80,-15)">
+        <circle cx="0" cy="0" r="35" fill="#0f172a" stroke="#632ca6" stroke-width="1.5"/>
+        <path d="M0,-30 A30,30 0 1,1 -25,15" fill="none" stroke="#22c55e" stroke-width="5" stroke-linecap="round"/>
+        <text x="0" y="0" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#86efac" text-anchor="middle">92%</text>
+        <text x="0" y="14" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="middle">Score</text>
+      </g>
+      <!-- Findings list -->
+      <g transform="translate(60,-30)">
+        <rect x="-55" y="0" width="110" height="16" rx="3" fill="#22c55e" opacity="0.1"/>
+        <circle cx="-42" cy="8" r="3" fill="#22c55e"/>
+        <text x="-30" y="12" font-family="Courier New" font-size="7" fill="#86efac">PASS: 142</text>
+        <rect x="-55" y="20" width="110" height="16" rx="3" fill="#ef4444" opacity="0.1"/>
+        <circle cx="-42" cy="28" r="3" fill="#ef4444"/>
+        <text x="-30" y="32" font-family="Courier New" font-size="7" fill="#fca5a5">FAIL: 12</text>
+        <rect x="-55" y="40" width="110" height="16" rx="3" fill="#f59e0b" opacity="0.1"/>
+        <circle cx="-42" cy="48" r="3" fill="#f59e0b"/>
+        <text x="-30" y="52" font-family="Courier New" font-size="7" fill="#fde68a">WARN: 8</text>
+      </g>
+      <!-- Mini bar chart -->
+      <g transform="translate(-80,50)">
+        <rect x="-5" y="-20" width="8" height="20" rx="1" fill="#22c55e" opacity="0.4"/>
+        <rect x="8" y="-30" width="8" height="30" rx="1" fill="#22c55e" opacity="0.5"/>
+        <rect x="21" y="-15" width="8" height="15" rx="1" fill="#f59e0b" opacity="0.4"/>
+        <rect x="34" y="-25" width="8" height="25" rx="1" fill="#22c55e" opacity="0.5"/>
+        <rect x="47" y="-8" width="8" height="8" rx="1" fill="#ef4444" opacity="0.4"/>
+      </g>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DataDog CSPM AWS .</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Misconfiguration , CIS Benchmark, ISMS-P .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="34" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CSPM</text>
-      <rect x="81" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="129" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DataDog</text>
-      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AWS</text>
-      <rect x="261" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="313" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Datadog logo -->
+    <g transform="translate(0,125)">
+      <rect x="-25" y="-12" width="50" height="24" rx="6" fill="#632ca6" opacity="0.2" stroke="#632ca6" stroke-width="1"/>
+      <text x="0" y="4" font-family="Arial,sans-serif" font-size="11" font-weight="bold" fill="#c4b5fd" text-anchor="middle">DD</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CSPM + Datadog</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AWS Security Posture | Automated Compliance Monitoring</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#632ca6" opacity="0.2" stroke="#632ca6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">CSPM</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 14, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
@@ -1,189 +1,58 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#4285f4" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- GCP hexagon -->
+    <g filter="url(#shadow)">
+      <polygon points="0,-100 87,-50 87,50 0,100 -87,50 -87,-50" fill="#1e293b" stroke="#4285f4" stroke-width="3"/>
+      <polygon points="0,-80 70,-40 70,40 0,80 -70,40 -70,-40" fill="none" stroke="#4285f4" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <!-- Google colors dots -->
+      <circle cx="0" cy="-40" r="8" fill="#4285f4" opacity="0.6"/>
+      <circle cx="35" cy="-20" r="8" fill="#ea4335" opacity="0.6"/>
+      <circle cx="35" cy="20" r="8" fill="#fbbc05" opacity="0.6"/>
+      <circle cx="0" cy="40" r="8" fill="#34a853" opacity="0.6"/>
+      <circle cx="-35" cy="20" r="8" fill="#4285f4" opacity="0.6"/>
+      <circle cx="-35" cy="-20" r="8" fill="#ea4335" opacity="0.6"/>
+      <!-- Center -->
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="#4285f4" text-anchor="middle">GCP</text>
+    </g>
+    <!-- IAM key icon (left) -->
+    <g transform="translate(-150,0)" opacity="0.5">
+      <circle cx="0" cy="0" r="16" fill="#1e293b" stroke="#fbbc05" stroke-width="2"/>
+      <circle cx="0" cy="0" r="5" fill="none" stroke="#fbbc05" stroke-width="1.5"/>
+      <line x1="8" y1="0" x2="22" y2="0" stroke="#fbbc05" stroke-width="2"/>
+      <line x1="18" y1="0" x2="18" y2="5" stroke="#fbbc05" stroke-width="1.5"/>
+      <text x="0" y="28" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">IAM</text>
+    </g>
+    <!-- GKE icon (right) -->
+    <g transform="translate(150,0)" opacity="0.5">
+      <circle cx="0" cy="0" r="20" fill="#1e293b" stroke="#326ce5" stroke-width="2"/>
+      <circle cx="0" cy="0" r="7" fill="none" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="0" y1="-20" x2="0" y2="-7" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="0" y1="7" x2="0" y2="20" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="-20" y1="0" x2="-7" y2="0" stroke="#326ce5" stroke-width="1.5"/>
+      <line x1="7" y1="0" x2="20" y2="0" stroke="#326ce5" stroke-width="1.5"/>
+      <text x="0" y="32" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">GKE</text>
+    </g>
+    <!-- Connection arrows -->
+    <line x1="-130" y1="0" x2="-92" y2="0" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.3"/>
+    <line x1="92" y1="0" x2="125" y2="0" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.3"/>
+    <!-- Security shield -->
+    <path d="M0,-115 L100,-85 L100,50 C100,80 55,100 0,110 C-55,100 -100,80 -100,50 L-100,-85 Z" fill="none" stroke="#34a853" stroke-width="2" stroke-dasharray="8,4" opacity="0.2"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">GCP : IAM GKE</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GCP : IAM , VPC , Cloud SQL , Cloud</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Storage</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#GCP</text>
-      <rect x="72" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="124" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security</text>
-      <rect x="189" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#IAM</text>
-      <rect x="261" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="318" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-SQL</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">GCP Cloud Security</text>
+  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">IAM to GKE | Complete Security Architecture Guide</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#4285f4" opacity="0.2" stroke="#4285f4" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">GCP SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#34a853" opacity="0.2" stroke="#34a853" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Jan 14, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
@@ -1,189 +1,61 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#0db7ed" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Docker whale -->
+    <g transform="translate(-100,-10)" filter="url(#shadow)">
+      <path d="M-60,10 L80,10 C85,10 90,5 90,-5 L90,-30 C90,-35 85,-40 80,-40 L-40,-40 C-45,-40 -50,-38 -52,-35 L-70,-10 C-75,-5 -70,5 -60,10 Z" fill="#1e293b" stroke="#0db7ed" stroke-width="2.5"/>
+      <!-- Containers on whale -->
+      <rect x="-30" y="-35" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-8" y="-35" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="14" y="-35" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-8" y="-53" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="36" y="-35" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.4" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="58" y="-35" width="18" height="14" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <!-- Eye -->
+      <circle cx="-55" cy="-5" r="3" fill="#0db7ed"/>
+    </g>
+    <!-- K8s wheel -->
+    <g transform="translate(110,-10)" filter="url(#shadow)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#326ce5" stroke-width="2.5"/>
+      <circle cx="0" cy="0" r="18" fill="none" stroke="#326ce5" stroke-width="2"/>
+      <!-- 7 spokes -->
+      <line x1="0" y1="-50" x2="0" y2="-18" stroke="#326ce5" stroke-width="2"/>
+      <line x1="0" y1="18" x2="0" y2="50" stroke="#326ce5" stroke-width="2"/>
+      <line x1="-43" y1="-25" x2="-16" y2="-9" stroke="#326ce5" stroke-width="2"/>
+      <line x1="16" y1="9" x2="43" y2="25" stroke="#326ce5" stroke-width="2"/>
+      <line x1="43" y1="-25" x2="16" y2="-9" stroke="#326ce5" stroke-width="2"/>
+      <line x1="-16" y1="9" x2="-43" y2="25" stroke="#326ce5" stroke-width="2"/>
+      <line x1="-50" y1="0" x2="-18" y2="0" stroke="#326ce5" stroke-width="2"/>
+      <line x1="18" y1="0" x2="50" y2="0" stroke="#326ce5" stroke-width="2"/>
+    </g>
+    <!-- Security overlay -->
+    <g transform="translate(0,80)">
+      <rect x="-120" y="-12" width="240" height="24" rx="6" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <path d="M-95,-2 L-92,2 L-88,-4" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+      <text x="-75" y="4" font-family="Courier New" font-size="9" fill="#86efac">Trivy</text>
+      <path d="M-35,-2 L-32,2 L-28,-4" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+      <text x="-15" y="4" font-family="Courier New" font-size="9" fill="#86efac">OPA</text>
+      <path d="M25,-2 L28,2 L32,-4" fill="none" stroke="#22c55e" stroke-width="1.5" stroke-linecap="round"/>
+      <text x="50" y="4" font-family="Courier New" font-size="9" fill="#86efac">Falco</text>
+    </g>
+    <!-- W7 badge -->
+    <rect x="145" y="-75" width="40" height="20" rx="5" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+    <text x="165" y="-61" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">W7</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 7 : Docker &amp; Kubernetes -</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 7 : Docker &amp; Kubernetes - -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 7 : Docker ( , Secret , ),...</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="43" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Docker</text>
-      <rect x="99" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="160" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
-      <rect x="234" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="331" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Container-Security</text>
-      <rect x="441" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#K8s</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Docker + K8s Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th | Week 7 | Container Security Practical</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0db7ed" opacity="0.2" stroke="#0db7ed" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#67e8f9" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 15, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
+++ b/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
@@ -1,189 +1,45 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="incidentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#ef4444"/>
-      <stop offset="100%" style="stop-color:#b91c1c"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#f87171" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#ef4444" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#f87171" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#incidentGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">INCIDENT</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Post-Mortem Next.js SSR Cloudflare ALB 5XX</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Warning Bell -->
-    <g transform="translate(80, 280)">
-      <path d="M50 15 Q30 15 30 40 L30 65 L20 75 L80 75 L70 65 L70 40 Q70 15 50 15" 
-            fill="#ef4444" stroke="#dc2626" stroke-width="2"/>
-      <circle cx="50" cy="85" r="8" fill="#ef4444"/>
-      <line x1="50" y1="5" x2="50" y2="15" stroke="#ef4444" stroke-width="3"/>
-      <circle cx="50" cy="3" r="3" fill="#ef4444"/>
-    </g>
-    
-    <!-- Timeline -->
-    <g transform="translate(200, 310)">
-      <line x1="0" y1="30" x2="140" y2="30" stroke="#64748b" stroke-width="3"/>
-      <circle cx="0" cy="30" r="8" fill="#ef4444"/>
-      <circle cx="50" cy="30" r="8" fill="#f59e0b"/>
-      <circle cx="100" cy="30" r="8" fill="#22c55e"/>
-      <circle cx="140" cy="30" r="8" fill="#3b82f6"/>
-    </g>
-    
-    <!-- Fire Icon -->
-    <g transform="translate(370, 285)">
-      <path d="M30 70 Q10 50 20 30 Q25 40 35 35 Q30 20 40 5 Q50 25 55 20 Q65 35 60 50 Q70 55 65 70 Z" 
-            fill="url(#fireGradient)" stroke="#dc2626" stroke-width="2"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#f87171" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#incidentGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#f87171">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#f87171"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Post-Mortem: Next.js SSR location ReferenceError, Cloudflare</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="132" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="66" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Post-Mortem</text>
-      <rect x="144" y="0" width="96" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Next.js</text>
-      <rect x="252" y="0" width="60" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#SSR</text>
-      <rect x="324" y="0" width="123" height="30" rx="15" fill="#f87171" fill-opacity="0.15" stroke="#f87171" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#f87171" text-anchor="middle">#Cloudflare</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Error terminal -->
+    <g filter="url(#shadow)">
+      <rect x="-180" y="-90" width="360" height="200" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <rect x="-180" y="-90" width="360" height="28" rx="12" fill="#ef4444" opacity="0.1"/>
+      <circle cx="-160" cy="-76" r="5" fill="#ef4444" opacity="0.6"/>
+      <circle cx="-145" cy="-76" r="5" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-130" cy="-76" r="5" fill="#22c55e" opacity="0.6"/>
+      <text x="0" y="-72" font-family="Courier New" font-size="10" fill="#fca5a5" text-anchor="middle">500 INTERNAL SERVER ERROR</text>
+      <!-- Error log lines -->
+      <text x="-160" y="-45" font-family="Courier New" font-size="9" fill="#ef4444" opacity="0.8">ERROR: SSR render failed</text>
+      <text x="-160" y="-30" font-family="Courier New" font-size="9" fill="#f59e0b" opacity="0.6">WARN: CF blocked request</text>
+      <text x="-160" y="-15" font-family="Courier New" font-size="9" fill="#ef4444" opacity="0.8">ERROR: ALB 502 Bad Gateway</text>
+      <text x="-160" y="0" font-family="Courier New" font-size="9" fill="#94a3b8" opacity="0.5">INFO: Retry attempt 3/5</text>
+      <text x="-160" y="15" font-family="Courier New" font-size="9" fill="#ef4444" opacity="0.8">FATAL: Connection timeout</text>
+      <text x="-160" y="30" font-family="Courier New" font-size="9" fill="#94a3b8" opacity="0.5">---</text>
+      <text x="-160" y="45" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.8">FIX: Update SSR config</text>
+      <text x="-160" y="60" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.8">FIX: Whitelist CF headers</text>
+      <!-- Blinking cursor -->
+      <rect x="-160" y="70" width="8" height="12" rx="1" fill="#22c55e" opacity="0.6">
+        <animate attributeName="opacity" values="0.6;0;0.6" dur="1s" repeatCount="indefinite"/>
+      </rect>
+      <!-- 5XX big overlay -->
+      <text x="100" y="30" font-family="Arial,sans-serif" font-size="80" font-weight="bold" fill="#ef4444" text-anchor="middle" opacity="0.08">5XX</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#incidentGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Next.js SSR Post-Mortem</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloudflare Blocking | ALB 5XX | Incident Analysis</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">POST-MORTEM</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 16, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
+++ b/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
@@ -1,205 +1,65 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1"/>
-      <stop offset="100%" style="stop-color:#4f46e5"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : Gemini, Claude Code, ChatGPT, OpenCode -...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Brain/Neural Network -->
-    <g transform="translate(80, 280)">
-      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
-      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
-      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
-      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,220)">
+    <!-- Four AI assistants in a row -->
+    <!-- Gemini -->
+    <g transform="translate(-135,-10)" filter="url(#shadow)">
+      <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#4285f4" stroke-width="2.5"/>
+      <circle cx="-10" cy="-8" r="12" fill="#4285f4" opacity="0.2"/>
+      <circle cx="10" cy="8" r="12" fill="#ea4335" opacity="0.2"/>
+      <text x="0" y="55" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">Gemini</text>
     </g>
-    
-    <!-- Robot Head -->
-    <g transform="translate(210, 285)">
-      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
-      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
-      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
-      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
-      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
+    <!-- Claude -->
+    <g transform="translate(-45,-10)" filter="url(#shadow)">
+      <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#d97706" stroke-width="2.5"/>
+      <circle cx="0" cy="-5" r="15" fill="#d97706" opacity="0.15"/>
+      <text x="0" y="0" font-family="Arial,sans-serif" font-size="16" font-weight="bold" fill="#fbbf24" text-anchor="middle">C</text>
+      <text x="0" y="55" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#fde68a" text-anchor="middle">Claude</text>
     </g>
-    
-    <!-- Chip/Processor -->
-    <g transform="translate(330, 295)">
-      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
-      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
-      <g stroke="#7c3aed" stroke-width="3">
-        <line x1="40" y1="5" x2="40" y2="15"/>
-        <line x1="40" y1="65" x2="40" y2="75"/>
-        <line x1="5" y1="40" x2="15" y2="40"/>
-        <line x1="65" y1="40" x2="75" y2="40"/>
-      </g>
+    <!-- ChatGPT -->
+    <g transform="translate(45,-10)" filter="url(#shadow)">
+      <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#10b981" stroke-width="2.5"/>
+      <circle cx="0" cy="-3" r="14" fill="#10b981" opacity="0.15"/>
+      <path d="M-8,-8 C-8,-15 8,-15 8,-8 L8,5 C8,12 -8,12 -8,5 Z" fill="none" stroke="#10b981" stroke-width="1.5" opacity="0.5"/>
+      <text x="0" y="55" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#86efac" text-anchor="middle">ChatGPT</text>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI : Gemini, Claude Code, ChatGPT, OpenCode - 2025-2026</text>
+    <!-- OpenCode -->
+    <g transform="translate(135,-10)" filter="url(#shadow)">
+      <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#ec4899" stroke-width="2.5"/>
+      <text x="0" y="2" font-family="Courier New" font-size="12" font-weight="bold" fill="#f9a8d4" text-anchor="middle">&gt;_</text>
+      <text x="0" y="55" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#f9a8d4" text-anchor="middle">OpenCode</text>
     </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">- 2025-2026 AI . Gemini,</text>
+    <!-- VS arrows between -->
+    <g opacity="0.3">
+      <text x="-90" y="-5" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">vs</text>
+      <text x="0" y="-5" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">vs</text>
+      <text x="90" y="-5" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">vs</text>
     </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Claude</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="51" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#AI</text>
-      <rect x="63" y="0" width="186" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="156" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Coding-Assistants</text>
-      <rect x="261" y="0" width="87" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="304" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Gemini</text>
-      <rect x="360" y="0" width="132" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Claude-Code</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Comparison chart bars -->
+    <g transform="translate(0,100)">
+      <rect x="-150" y="-5" width="300" height="40" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1"/>
+      <rect x="-140" y="0" width="60" height="8" rx="2" fill="#4285f4" opacity="0.5"/>
+      <rect x="-140" y="12" width="75" height="8" rx="2" fill="#d97706" opacity="0.5"/>
+      <rect x="-140" y="24" width="55" height="8" rx="2" fill="#10b981" opacity="0.5"/>
+      <text x="140" y="8" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">Speed</text>
+      <text x="140" y="20" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">Quality</text>
+      <text x="140" y="32" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">Cost</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="505" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Coding Assistants</text>
+  <text x="600" y="543" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Gemini vs Claude vs ChatGPT vs OpenCode | 2025-2026</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">AI COMPARE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 17, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
+++ b/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
@@ -1,198 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="cloudGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0ea5e9"/>
-      <stop offset="100%" style="stop-color:#0284c7"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#38bdf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#0ea5e9" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#0284c7" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#0ea5e9" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#38bdf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#cloudGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">CLOUD</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS/GCP 2026 1 : EC2 G7e/X8i , Bangkok , Euro...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Cloud Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M30 80 Q10 80 10 60 Q10 40 30 40 Q30 20 55 20 Q80 20 80 45 Q100 45 100 65 Q100 80 80 80 Z" 
-            fill="url(#cloudGradient)" stroke="#0ea5e9" stroke-width="2" opacity="0.9"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="400" cy="250" r="200" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <circle cx="800" cy="250" r="200" fill="#4285f4" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,230)">
+    <!-- AWS cloud -->
+    <g transform="translate(-100,0)" filter="url(#shadow)">
+      <path d="M-20,-55 C-45,-55 -60,-38 -60,-18 C-75,-18 -85,-5 -85,12 C-85,32 -72,42 -55,42 L55,42 C72,42 85,32 85,12 C85,-5 75,-18 60,-18 C60,-38 45,-55 20,-55 C5,-55 -5,-48 -10,-40 C-12,-48 -15,-55 -20,-55 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="#f97316" text-anchor="middle">AWS</text>
     </g>
-    
-    <!-- Server Stack -->
-    <g transform="translate(200, 290)">
-      <rect x="10" y="10" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="35" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <rect x="10" y="60" width="60" height="20" rx="3" fill="#14b8a6" stroke="#0d9488" stroke-width="2"/>
-      <circle cx="55" cy="20" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="45" r="4" fill="#22d3ee"/>
-      <circle cx="55" cy="70" r="4" fill="#22d3ee"/>
+    <!-- GCP hexagon -->
+    <g transform="translate(100,0)" filter="url(#shadow)">
+      <polygon points="0,-55 48,-28 48,28 0,55 -48,28 -48,-28" fill="#1e293b" stroke="#4285f4" stroke-width="2.5"/>
+      <text x="0" y="8" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="#4285f4" text-anchor="middle">GCP</text>
     </g>
-    
-    <!-- Network Node -->
-    <g transform="translate(330, 300)">
-      <circle cx="30" cy="30" r="20" fill="#0284c7" stroke="#0369a1" stroke-width="2"/>
-      <circle cx="30" cy="30" r="8" fill="white"/>
-      <line x1="10" y1="30" x2="-10" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="50" y1="30" x2="70" y2="30" stroke="#0284c7" stroke-width="2"/>
-      <line x1="30" y1="10" x2="30" y2="-10" stroke="#0284c7" stroke-width="2"/>
+    <!-- Update arrows -->
+    <g transform="translate(0,0)" opacity="0.4">
+      <path d="M-15,-15 C-15,-30 15,-30 15,-15" fill="none" stroke="#22c55e" stroke-width="2"/>
+      <polygon points="13,-20 18,-12 10,-14" fill="#22c55e"/>
+      <path d="M15,15 C15,30 -15,30 -15,15" fill="none" stroke="#22c55e" stroke-width="2"/>
+      <polygon points="-13,20 -18,12 -10,14" fill="#22c55e"/>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#cloudGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#38bdf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AWS/GCP 2026 1 : EC2 G7e/X8i , Bangkok , European</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Sovereign - 2026 1 AWS GCP : AWS EC2 G7e NVIDIA Blackwell</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#38bdf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">GPU, EC2 X8i</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="30" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#AWS</text>
-      <rect x="72" y="0" width="60" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="102" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#GCP</text>
-      <rect x="144" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#EC2-G7e</text>
-      <rect x="252" y="0" width="96" height="30" rx="15" fill="#38bdf8" fill-opacity="0.15" stroke="#38bdf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="300" y="20" font-family="Arial, sans-serif" font-size="12" fill="#38bdf8" text-anchor="middle">#EC2-X8i</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Update items -->
+    <g transform="translate(0,80)">
+      <rect x="-140" y="-12" width="100" height="24" rx="6" fill="#f97316" opacity="0.1" stroke="#f97316" stroke-width="1"/>
+      <text x="-90" y="4" font-family="Courier New" font-size="8" fill="#fdba74" text-anchor="middle">EC2 G7e</text>
+      <rect x="-30" y="-12" width="60" height="24" rx="6" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">NEW</text>
+      <rect x="40" y="-12" width="100" height="24" rx="6" fill="#4285f4" opacity="0.1" stroke="#4285f4" stroke-width="1"/>
+      <text x="90" y="4" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">EU Cloud</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#cloudGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Updates Jan 2026</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AWS + GCP | New Instances + Regions + Services</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD UPDATE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
@@ -1,185 +1,56 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#22c55e" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- CI/CD infinity loop -->
+    <g filter="url(#shadow)">
+      <path d="M-80,0 C-80,-50 -30,-50 0,-25 C30,-50 80,-50 80,0 C80,50 30,50 0,25 C-30,50 -80,50 -80,0 Z" fill="none" stroke="#22c55e" stroke-width="4"/>
+      <!-- Pipeline stages on loop -->
+      <circle cx="-60" cy="-20" r="12" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <text x="-60" y="-16" font-family="Courier New" font-size="6" fill="#93c5fd" text-anchor="middle">Code</text>
+      <circle cx="-20" cy="-35" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <text x="-20" y="-31" font-family="Courier New" font-size="6" fill="#c4b5fd" text-anchor="middle">Build</text>
+      <circle cx="20" cy="-35" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="20" y="-31" font-family="Courier New" font-size="6" fill="#fde68a" text-anchor="middle">Test</text>
+      <circle cx="60" cy="-20" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <text x="60" y="-16" font-family="Courier New" font-size="6" fill="#fca5a5" text-anchor="middle">Scan</text>
+      <circle cx="60" cy="20" r="12" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <text x="60" y="24" font-family="Courier New" font-size="6" fill="#86efac" text-anchor="middle">Deploy</text>
+      <circle cx="20" cy="35" r="12" fill="#1e293b" stroke="#0db7ed" stroke-width="2"/>
+      <text x="20" y="39" font-family="Courier New" font-size="6" fill="#67e8f9" text-anchor="middle">K8s</text>
+      <circle cx="-20" cy="35" r="12" fill="#1e293b" stroke="#ec4899" stroke-width="2"/>
+      <text x="-20" y="39" font-family="Courier New" font-size="6" fill="#f9a8d4" text-anchor="middle">Mon</text>
+      <circle cx="-60" cy="20" r="12" fill="#1e293b" stroke="#94a3b8" stroke-width="2"/>
+      <text x="-60" y="24" font-family="Courier New" font-size="6" fill="#cbd5e1" text-anchor="middle">Plan</text>
+    </g>
+    <!-- K8s cluster below -->
+    <g transform="translate(0,90)">
+      <rect x="-100" y="-15" width="200" height="30" rx="6" fill="#1e293b" stroke="#326ce5" stroke-width="1.5"/>
+      <!-- Pod boxes -->
+      <rect x="-85" y="-8" width="25" height="16" rx="3" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+      <rect x="-55" y="-8" width="25" height="16" rx="3" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+      <rect x="-25" y="-8" width="25" height="16" rx="3" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+      <rect x="5" y="-8" width="25" height="16" rx="3" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+      <rect x="35" y="-8" width="25" height="16" rx="3" fill="#326ce5" opacity="0.2" stroke="#326ce5" stroke-width="1"/>
+      <rect x="65" y="-8" width="25" height="16" rx="3" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+    </g>
+    <!-- W8 badge -->
+    <rect x="100" y="-55" width="40" height="20" rx="5" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+    <text x="120" y="-41" font-family="Courier New" font-size="9" fill="#86efac" text-anchor="middle">W8</text>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">8 8 : CI/CD Kubernetes - DevSecOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">8 8 : CI/CD (Trivy, Snyk, Vault), Kubernetes</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="39" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CI/CD</text>
-      <rect x="90" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="151" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
-      <rect x="225" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="351" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="421" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#K8s-Security</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CI/CD + K8s Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security 8th | Week 8 | Pipeline Security Practical</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">CLOUD COURSE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
@@ -1,185 +1,48 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 1 : Kubernetes 82 , VS Code , CNCF</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Trend chart -->
+    <g filter="url(#shadow)">
+      <rect x="-180" y="-80" width="360" height="170" rx="12" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <!-- Grid lines -->
+      <g opacity="0.1">
+        <line x1="-160" y1="-40" x2="160" y2="-40" stroke="#fff"/>
+        <line x1="-160" y1="0" x2="160" y2="0" stroke="#fff"/>
+        <line x1="-160" y1="40" x2="160" y2="40" stroke="#fff"/>
+      </g>
+      <!-- K8s trend line (82%) -->
+      <polyline points="-150,30 -100,20 -50,0 0,-10 50,-30 100,-40 150,-50" fill="none" stroke="#326ce5" stroke-width="3" stroke-linecap="round"/>
+      <text x="155" y="-55" font-family="Courier New" font-size="8" fill="#93c5fd">K8s 82%</text>
+      <!-- VS Code threat line -->
+      <polyline points="-150,40 -100,35 -50,25 0,10 50,0 100,-10 150,-15" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-dasharray="6,3"/>
+      <text x="155" y="-20" font-family="Courier New" font-size="8" fill="#fca5a5">Threats</text>
+      <!-- Cloud adoption -->
+      <polyline points="-150,50 -100,40 -50,25 0,15 50,5 100,-5 150,-10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <text x="155" y="-5" font-family="Courier New" font-size="8" fill="#86efac">Cloud</text>
+      <!-- Y-axis label -->
+      <text x="-170" y="-55" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">100%</text>
+      <text x="-170" y="55" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">0%</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 1 . CNCF Kubernetes 82 , VS Code</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kubernetes</text>
-      <rect x="135" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="214" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="306" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CNCF</text>
-      <rect x="387" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VS-Code-Security</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- CNCF badge -->
+    <g transform="translate(0,115)">
+      <rect x="-35" y="-12" width="70" height="24" rx="6" fill="#326ce5" opacity="0.15" stroke="#326ce5" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">CNCF</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Trends</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">January 2026 | K8s 82% Production | CNCF Survey</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">TRENDS</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
+++ b/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
@@ -1,189 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2025 3 : KARA</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Giant padlock (locked/ransomed) -->
+    <g filter="url(#shadow)">
+      <rect x="-50" y="-10" width="100" height="80" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
+      <path d="M-30,-10 L-30,-40 C-30,-65 -15,-80 0,-80 C15,-80 30,-65 30,-40 L30,-10" fill="none" stroke="#ef4444" stroke-width="4"/>
+      <!-- Keyhole -->
+      <circle cx="0" cy="30" r="12" fill="#ef4444" opacity="0.3"/>
+      <rect x="-4" y="35" width="8" height="18" rx="2" fill="#ef4444" opacity="0.3"/>
+      <!-- Ransomware $ overlay -->
+      <text x="0" y="35" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="#ef4444" text-anchor="middle" opacity="0.6">$</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Q3 2025 badge -->
+    <g transform="translate(110,-30)">
+      <rect x="-30" y="-15" width="60" height="30" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <text x="0" y="-2" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#fde68a" text-anchor="middle">Q3</text>
+      <text x="0" y="10" font-family="Courier New" font-size="8" fill="#fde68a" text-anchor="middle">2025</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    <!-- Trend bar chart -->
+    <g transform="translate(0,105)">
+      <rect x="-80" y="-30" width="20" height="30" rx="2" fill="#ef4444" opacity="0.3"/>
+      <rect x="-50" y="-45" width="20" height="45" rx="2" fill="#ef4444" opacity="0.4"/>
+      <rect x="-20" y="-55" width="20" height="55" rx="2" fill="#ef4444" opacity="0.5"/>
+      <rect x="10" y="-40" width="20" height="40" rx="2" fill="#f59e0b" opacity="0.4"/>
+      <rect x="40" y="-60" width="20" height="60" rx="2" fill="#ef4444" opacity="0.6"/>
+      <rect x="70" y="-50" width="20" height="50" rx="2" fill="#ef4444" opacity="0.5"/>
+      <text x="0" y="15" font-family="Courier New" font-size="8" fill="#94a3b8" text-anchor="middle">Monthly Incidents</text>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SK EQST insight 2025 3 . KARA (LockBit</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">5.0,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
-      <rect x="135" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="169" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KARA</text>
-      <rect x="216" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SK-Shieldus</text>
-      <rect x="360" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LockBit</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- KARA label -->
+    <g transform="translate(-110,-30)">
+      <rect x="-35" y="-15" width="70" height="30" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#fca5a5" text-anchor="middle">KARA</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="505" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ransomware Trends</text>
+  <text x="600" y="543" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">KARA Report | 2025 Q3 | SK Shieldus EQST Analysis</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">RANSOMWARE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
+++ b/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
@@ -1,185 +1,55 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Kisa Security Advisory Ransomware Prevention ...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Linux penguin silhouette with warning -->
+    <g filter="url(#shadow)">
+      <!-- Penguin body -->
+      <ellipse cx="0" cy="10" rx="55" ry="70" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <!-- Belly -->
+      <ellipse cx="0" cy="25" rx="35" ry="45" fill="#0f172a" stroke="#f59e0b" stroke-width="1" opacity="0.5"/>
+      <!-- Head -->
+      <circle cx="0" cy="-55" r="30" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <!-- Eyes -->
+      <circle cx="-10" cy="-60" r="5" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="10" cy="-60" r="5" fill="#f59e0b" opacity="0.6"/>
+      <!-- Beak -->
+      <polygon points="0,-48 -6,-42 6,-42" fill="#f97316" opacity="0.6"/>
+      <!-- Rootkit warning overlay -->
+      <g transform="translate(0,10)">
+        <path d="M0,-25 L25,-25 L25,25 L-25,25 L-25,-25 Z" fill="#ef4444" opacity="0.1" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="4,3"/>
+        <text x="0" y="0" font-family="Courier New" font-size="10" fill="#ef4444" text-anchor="middle" opacity="0.8">ROOT</text>
+        <text x="0" y="12" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle" opacity="0.6">KIT</text>
+      </g>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Terminal showing rootkit detection -->
+    <g transform="translate(140,10)">
+      <rect x="-55" y="-30" width="110" height="60" rx="6" fill="#0f172a" stroke="#334155" stroke-width="1.5"/>
+      <text x="-45" y="-12" font-family="Courier New" font-size="7" fill="#22c55e">$ rkhunter</text>
+      <text x="-45" y="0" font-family="Courier New" font-size="7" fill="#ef4444">WARN: found</text>
+      <text x="-45" y="12" font-family="Courier New" font-size="7" fill="#f59e0b">rootkit.so</text>
+      <rect x="-45" y="18" width="6" height="8" rx="1" fill="#22c55e" opacity="0.6"/>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">KISA : 3-2-1 , (chkrootkit,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="69" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="34" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KISA</text>
-      <rect x="81" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="142" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
-      <rect x="216" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Linux-Rootkit</text>
-      <rect x="378" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Advisory</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- KISA badge -->
+    <g transform="translate(-130,10)">
+      <rect x="-35" y="-20" width="70" height="40" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <text x="0" y="-2" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">KISA</text>
+      <text x="0" y="12" font-family="Courier New" font-size="7" fill="#60a5fa" text-anchor="middle">Advisory</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Linux Rootkit Advisory</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">KISA Security Advisory | Ransomware + Linux Rootkit Detection</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">ADVISORY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
+++ b/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
@@ -1,185 +1,57 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">(2026 01 22 )</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#6366f1" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Open book/blog shape -->
+    <g filter="url(#shadow)">
+      <path d="M0,-60 L-150,-40 L-150,60 L0,80 Z" fill="#1e293b" stroke="#6366f1" stroke-width="2"/>
+      <path d="M0,-60 L150,-40 L150,60 L0,80 Z" fill="#1e293b" stroke="#6366f1" stroke-width="2"/>
+      <!-- Spine -->
+      <line x1="0" y1="-60" x2="0" y2="80" stroke="#6366f1" stroke-width="2"/>
+      <!-- Text lines (left page) -->
+      <g opacity="0.3">
+        <rect x="-130" y="-25" width="100" height="4" rx="1" fill="#6366f1"/>
+        <rect x="-130" y="-15" width="80" height="4" rx="1" fill="#6366f1"/>
+        <rect x="-130" y="-5" width="90" height="4" rx="1" fill="#ef4444"/>
+        <rect x="-130" y="5" width="70" height="4" rx="1" fill="#6366f1"/>
+        <rect x="-130" y="15" width="85" height="4" rx="1" fill="#6366f1"/>
+        <rect x="-130" y="25" width="60" height="4" rx="1" fill="#f59e0b"/>
+        <rect x="-130" y="35" width="95" height="4" rx="1" fill="#6366f1"/>
+        <rect x="-130" y="45" width="75" height="4" rx="1" fill="#6366f1"/>
+      </g>
+      <!-- Text lines (right page) -->
+      <g opacity="0.3">
+        <rect x="30" y="-25" width="95" height="4" rx="1" fill="#6366f1"/>
+        <rect x="30" y="-15" width="70" height="4" rx="1" fill="#22c55e"/>
+        <rect x="30" y="-5" width="85" height="4" rx="1" fill="#6366f1"/>
+        <rect x="30" y="5" width="100" height="4" rx="1" fill="#6366f1"/>
+        <rect x="30" y="15" width="65" height="4" rx="1" fill="#ef4444"/>
+        <rect x="30" y="25" width="80" height="4" rx="1" fill="#6366f1"/>
+        <rect x="30" y="35" width="90" height="4" rx="1" fill="#6366f1"/>
+        <rect x="30" y="45" width="55" height="4" rx="1" fill="#f59e0b"/>
+      </g>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: VS Code , ACME , AI Zero Trust NHI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="97" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Vendor...</text>
-      <rect x="207" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="333" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="412" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="504" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="561" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Hashicorp</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Vendor logos floating -->
+    <g transform="translate(0,-85)" opacity="0.4">
+      <circle cx="-60" cy="0" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <circle cx="-20" cy="0" r="12" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <circle cx="20" cy="0" r="12" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+      <circle cx="60" cy="0" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="505" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Vendor Blog Review</text>
+  <text x="600" y="543" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security Vendor Weekly | Threat Intelligence Roundup</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#a5b4fc" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
@@ -1,189 +1,41 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft AitM , Agentic AI Zero Trust, Ope...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft AitM , Agentic AI Zero Trust, - 2026</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 23 / : Microsoft AitM , HashiCorp Agentic AI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="255" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AitM-Phishing</text>
-      <rect x="342" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#BEC</text>
-      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Radar/scanning circle -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="100" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <circle cx="0" cy="0" r="70" fill="none" stroke="#22c55e" stroke-width="1" opacity="0.3"/>
+      <circle cx="0" cy="0" r="40" fill="none" stroke="#22c55e" stroke-width="1" opacity="0.2"/>
+      <!-- Cross hairs -->
+      <line x1="-100" y1="0" x2="100" y2="0" stroke="#22c55e" stroke-width="0.5" opacity="0.2"/>
+      <line x1="0" y1="-100" x2="0" y2="100" stroke="#22c55e" stroke-width="0.5" opacity="0.2"/>
+      <!-- Radar sweep -->
+      <path d="M0,0 L0,-100 A100,100 0 0,1 70,-70 Z" fill="#22c55e" opacity="0.08"/>
+      <!-- Threat dots -->
+      <circle cx="-40" cy="-55" r="5" fill="#ef4444" opacity="0.7"/>
+      <circle cx="60" cy="-20" r="4" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-20" cy="45" r="5" fill="#ef4444" opacity="0.7"/>
+      <circle cx="50" cy="40" r="3" fill="#22c55e" opacity="0.5"/>
+      <circle cx="-60" cy="10" r="4" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="30" cy="-60" r="3" fill="#22c55e" opacity="0.5"/>
+      <!-- Center -->
+      <circle cx="0" cy="0" r="6" fill="#22c55e" opacity="0.8"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security Weekly Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Threat Radar | Weekly Intelligence Roundup</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 23, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
@@ -1,189 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft BitLocker FBI , Cloudflare Route ...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Shield with scanning lines -->
+    <g filter="url(#shadow)">
+      <path d="M0,-100 L110,-70 L110,30 C110,70 60,95 0,110 C-60,95 -110,70 -110,30 L-110,-70 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="3"/>
+      <!-- Scan lines -->
+      <g opacity="0.15">
+        <line x1="-90" y1="-40" x2="90" y2="-40" stroke="#3b82f6" stroke-width="1"/>
+        <line x1="-95" y1="-20" x2="95" y2="-20" stroke="#3b82f6" stroke-width="1"/>
+        <line x1="-100" y1="0" x2="100" y2="0" stroke="#3b82f6" stroke-width="1"/>
+        <line x1="-95" y1="20" x2="95" y2="20" stroke="#3b82f6" stroke-width="1"/>
+        <line x1="-85" y1="40" x2="85" y2="40" stroke="#3b82f6" stroke-width="1"/>
+        <line x1="-70" y1="60" x2="70" y2="60" stroke="#3b82f6" stroke-width="1"/>
+      </g>
+      <!-- Central lock -->
+      <rect x="-18" y="-10" width="36" height="28" rx="4" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="2"/>
+      <path d="M-10,-10 L-10,-22 C-10,-30 -5,-35 0,-35 C5,-35 10,-30 10,-22 L10,-10" fill="none" stroke="#3b82f6" stroke-width="2.5"/>
+      <circle cx="0" cy="5" r="4" fill="#93c5fd"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft BitLocker FBI , Cloudflare Route - 2026</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 24 / : Microsoft FBI BitLocker</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#BitLocker</text>
-      <rect x="306" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#FBI</text>
-      <rect x="378" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Encryption</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Alert indicators -->
+    <g opacity="0.5">
+      <circle cx="-60" cy="-50" r="6" fill="#ef4444"/>
+      <circle cx="55" cy="-30" r="5" fill="#f59e0b"/>
+      <circle cx="-50" cy="30" r="4" fill="#22c55e"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security Weekly Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Tech Security Shield | Threat Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Jan 24, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
@@ -1,189 +1,38 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: VMware vCenter KEV , Fortinet SSO , Sandwor...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: VMware vCenter KEV , Fortinet SSO , - 2026 1</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">25 / : CISA KEV VMware vCenter CVE-2024-37079</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#VMware</text>
-      <rect x="279" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="327" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#vCenter</text>
-      <rect x="387" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="439" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CISA-KEV</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Fingerprint scan -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <!-- Fingerprint lines -->
+      <path d="M-50,0 C-50,-30 -25,-50 0,-50" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.3"/>
+      <path d="M-40,10 C-40,-20 -18,-40 10,-40 C38,-40 50,-20 50,10" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.35"/>
+      <path d="M-30,20 C-30,-10 -10,-30 15,-30 C40,-30 45,-5 45,20" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.4"/>
+      <path d="M-20,25 C-20,0 -5,-20 15,-20 C35,-20 38,5 38,25" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.45"/>
+      <path d="M-10,30 C-10,10 0,-10 15,-10 C30,-10 32,15 30,30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.5"/>
+      <!-- Scan line -->
+      <rect x="-80" y="-2" width="160" height="4" rx="2" fill="#8b5cf6" opacity="0.3">
+        <animate attributeName="y" values="-80;80;-80" dur="3s" repeatCount="indefinite"/>
+      </rect>
+      <!-- Alert at center -->
+      <circle cx="5" cy="5" r="8" fill="#ef4444" opacity="0.5"/>
+      <text x="5" y="9" font-family="Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">!</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security Weekly Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Identity Threat Analysis | Weekly Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 25, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
+++ b/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
@@ -1,189 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#7c3aed" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Zero Trust concentric rings -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="95" fill="none" stroke="#ef4444" stroke-width="2" stroke-dasharray="8,4" opacity="0.3"/>
+      <circle cx="0" cy="0" r="70" fill="none" stroke="#f59e0b" stroke-width="2" stroke-dasharray="6,3" opacity="0.4"/>
+      <circle cx="0" cy="0" r="45" fill="none" stroke="#22c55e" stroke-width="2" opacity="0.5"/>
+      <circle cx="0" cy="0" r="25" fill="#1e293b" stroke="#7c3aed" stroke-width="3"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#c4b5fd" text-anchor="middle">ZT</text>
+      <!-- Labels on rings -->
+      <text x="75" y="-60" font-family="Courier New" font-size="7" fill="#fca5a5" transform="rotate(20,75,-60)">Untrusted</text>
+      <text x="55" y="-40" font-family="Courier New" font-size="7" fill="#fde68a" transform="rotate(15,55,-40)">Verify</text>
+      <text x="38" y="-22" font-family="Courier New" font-size="7" fill="#86efac">Trust</text>
+    </g>
+    <!-- Agentic AI node -->
+    <g transform="translate(-120,40)" opacity="0.6">
+      <rect x="-30" y="-15" width="60" height="30" rx="6" fill="#1e293b" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="0" font-family="Courier New" font-size="8" fill="#c4b5fd" text-anchor="middle">AI</text>
+      <text x="0" y="10" font-family="Courier New" font-size="6" fill="#a78bfa" text-anchor="middle">Agentic</text>
+    </g>
+    <!-- Terraform node -->
+    <g transform="translate(120,40)" opacity="0.6">
+      <rect x="-30" y="-15" width="60" height="30" rx="6" fill="#1e293b" stroke="#7c3aed" stroke-width="1.5"/>
+      <text x="0" y="5" font-family="Courier New" font-size="8" fill="#c4b5fd" text-anchor="middle">TF</text>
+    </g>
+    <!-- Connection lines -->
+    <line x1="-85" y1="35" x2="-30" y2="10" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
+    <line x1="85" y1="35" x2="30" y2="10" stroke="#7c3aed" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Zero Trust for AI Agents, Chrome , Terrafor...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI Zero Trust, Chrome Gemini , Terraform Stacks , Prompt</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Injection</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="241" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Trust</text>
-      <rect x="315" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agents</text>
-      <rect x="441" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="525" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Chrome-Security</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zero Trust + Agentic AI</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Zero Trust + AI Agents + Terraform Stacks</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#7c3aed" opacity="0.2" stroke="#7c3aed" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 26, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
+++ b/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
@@ -1,189 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: MS Office Zero-Day , Kimi K2.5 , Kimwolf</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- MS Office document with zero-day crack -->
+    <g filter="url(#shadow)">
+      <rect x="-60" y="-80" width="120" height="160" rx="8" fill="#1e293b" stroke="#0078d4" stroke-width="2.5"/>
+      <!-- Doc corner fold -->
+      <path d="M30,-80 L60,-80 L60,-50 Z" fill="#0f172a" stroke="#0078d4" stroke-width="1"/>
+      <!-- Doc lines -->
+      <g opacity="0.2">
+        <rect x="-40" y="-55" width="80" height="5" rx="1" fill="#0078d4"/>
+        <rect x="-40" y="-45" width="60" height="5" rx="1" fill="#0078d4"/>
+        <rect x="-40" y="-35" width="70" height="5" rx="1" fill="#0078d4"/>
+        <rect x="-40" y="-20" width="80" height="5" rx="1" fill="#0078d4"/>
+        <rect x="-40" y="-10" width="50" height="5" rx="1" fill="#0078d4"/>
+      </g>
+      <!-- Zero-day lightning crack -->
+      <path d="M5,-70 L-10,-25 L5,-30 L-15,30 L10,-15 L-5,-10 Z" fill="#ef4444" opacity="0.5"/>
+      <!-- 0-day label -->
+      <rect x="-25" y="35" width="50" height="22" rx="4" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="0" y="50" font-family="Courier New" font-size="10" fill="#fca5a5" text-anchor="middle">0-day</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Kimwolf botnet -->
+    <g transform="translate(130,0)" opacity="0.5">
+      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <!-- Wolf silhouette simplified -->
+      <polygon points="-10,-15 -15,-5 -5,-10 0,-20 5,-10 15,-5 10,-15" fill="#f59e0b" opacity="0.3"/>
+      <text x="0" y="10" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">Kimwolf</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">MS Office Zero-Day , Kimi K2.5 , Kimwolf 200 IoT , AWS</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Blackwell GPU</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="232" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Zero-Day</text>
-      <rect x="297" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Microsoft-Office</text>
-      <rect x="486" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="538" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Kimi-K25</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- AWS node -->
+    <g transform="translate(-130,0)" opacity="0.5">
+      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
+      <text x="0" y="5" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#fdba74" text-anchor="middle">AWS</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">MS Office Zero-Day</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Kimi K25 + Kimwolf Botnet + AWS G7e</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 27, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
+++ b/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
@@ -1,185 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CLAUDE.md : AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#d97706" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- CLAUDE.md file -->
+    <g filter="url(#shadow)">
+      <rect x="-80" y="-90" width="160" height="190" rx="10" fill="#1e293b" stroke="#d97706" stroke-width="2.5"/>
+      <!-- File tab -->
+      <rect x="-80" y="-90" width="100" height="25" rx="10" fill="#d97706" opacity="0.15"/>
+      <text x="-30" y="-73" font-family="Courier New" font-size="10" fill="#fbbf24" text-anchor="middle">CLAUDE.md</text>
+      <!-- Markdown content -->
+      <text x="-60" y="-48" font-family="Courier New" font-size="9" fill="#d97706" opacity="0.7"># Security</text>
+      <rect x="-60" y="-38" width="100" height="4" rx="1" fill="#334155" opacity="0.4"/>
+      <rect x="-60" y="-28" width="80" height="4" rx="1" fill="#334155" opacity="0.3"/>
+      <text x="-60" y="-12" font-family="Courier New" font-size="9" fill="#d97706" opacity="0.7">## Rules</text>
+      <rect x="-60" y="-2" width="90" height="4" rx="1" fill="#334155" opacity="0.4"/>
+      <rect x="-60" y="8" width="70" height="4" rx="1" fill="#ef4444" opacity="0.3"/>
+      <rect x="-60" y="18" width="85" height="4" rx="1" fill="#334155" opacity="0.3"/>
+      <text x="-60" y="38" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- No secrets</text>
+      <text x="-60" y="52" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- Validate input</text>
+      <text x="-60" y="66" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- Mask logs</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI (Claude Code, Cursor, Copilot) . CLAUDE.md</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CLAUDE.md</text>
-      <rect x="126" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="192" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="270" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="336" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Claude-Code</text>
-      <rect x="414" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="471" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Security shield beside -->
+    <g transform="translate(130,0)" opacity="0.5">
+      <path d="M0,-40 L45,-25 L45,15 C45,35 25,48 0,55 C-25,48 -45,35 -45,15 L-45,-25 Z" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <path d="M-10,5 L-4,12 L12,-5" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CLAUDE.md Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Agent Security Guide | Safe Configuration Rules</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#d97706" opacity="0.2" stroke="#d97706" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fbbf24" text-anchor="middle">AI SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 28, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
+++ b/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
@@ -1,189 +1,44 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Microsoft Office Zero-Day , CTEM , Grist-Co...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Vulnerability target -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
+      <!-- CVE markers -->
+      <text x="0" y="-2" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">CVE</text>
+      <text x="0" y="10" font-family="Courier New" font-size="7" fill="#ef4444" text-anchor="middle">0-Day</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- RCE exploit arrow -->
+    <g transform="translate(0,0)">
+      <line x1="-180" y1="-60" x2="-20" y2="-5" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444" opacity="0.4"/>
+      <text x="-160" y="-65" font-family="Courier New" font-size="9" fill="#fca5a5" opacity="0.6">RCE</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Microsoft Office Zero-Day , CTEM , - 2026</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 28 : Microsoft Office Zero-Day , CTEM 5</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CVE-2026-21509</text>
-      <rect x="477" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="565" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Microsoft-Office</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- CTEM cycle -->
+    <g transform="translate(140,30)" opacity="0.5">
+      <circle cx="0" cy="0" r="35" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+      <path d="M0,-25 A25,25 0 1,1 -18,18" fill="none" stroke="#3b82f6" stroke-width="2"/>
+      <polygon points="-22,14 -14,22 -20,10" fill="#3b82f6"/>
+      <text x="0" y="5" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">CTEM</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zero-Day + CTEM + RCE</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | MS Office 0-Day + Grist Core RCE</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 28, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
+++ b/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
@@ -1,189 +1,52 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: n8n Critical RCE, D-Link Zero-Day, Kubernet...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- n8n workflow nodes with exploit -->
+    <g filter="url(#shadow)">
+      <!-- Workflow nodes -->
+      <circle cx="-100" cy="-30" r="25" fill="#1e293b" stroke="#ea580c" stroke-width="2"/>
+      <text x="-100" y="-26" font-family="Courier New" font-size="9" fill="#fdba74" text-anchor="middle">n8n</text>
+      <line x1="-72" y1="-30" x2="-28" y2="-30" stroke="#ea580c" stroke-width="2" opacity="0.4"/>
+      <circle cx="0" cy="-30" r="25" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <text x="0" y="-33" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">RCE</text>
+      <text x="0" y="-22" font-family="Courier New" font-size="7" fill="#ef4444" text-anchor="middle">VULN</text>
+      <line x1="28" y1="-30" x2="72" y2="-30" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <circle cx="100" cy="-30" r="25" fill="#1e293b" stroke="#ea580c" stroke-width="2"/>
+      <text x="100" y="-26" font-family="Courier New" font-size="8" fill="#fdba74" text-anchor="middle">EXEC</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- D-Link router -->
+    <g transform="translate(-80,60)" opacity="0.5">
+      <rect x="-35" y="-18" width="70" height="36" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <circle cx="-15" cy="0" r="3" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-5" cy="0" r="3" fill="#ef4444" opacity="0.6"/>
+      <circle cx="5" cy="0" r="3" fill="#22c55e" opacity="0.6"/>
+      <text x="0" y="25" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">D-Link 0-Day</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: n8n Critical RCE, D-Link Zero-Day, Kubernetes -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 1 29 : n8n RCE (CVE-2026-1470, CVSS 9.9), D-Link</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#n8n</text>
-      <rect x="252" y="0" width="60" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="282" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#RCE</text>
-      <rect x="324" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#CVE-2026-1470</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- K8s + AI Agent -->
+    <g transform="translate(80,60)" opacity="0.5">
+      <circle cx="0" cy="0" r="25" fill="#1e293b" stroke="#326ce5" stroke-width="1.5"/>
+      <circle cx="0" cy="0" r="10" fill="none" stroke="#326ce5" stroke-width="1"/>
+      <line x1="0" y1="-25" x2="0" y2="-10" stroke="#326ce5" stroke-width="1"/>
+      <line x1="0" y1="10" x2="0" y2="25" stroke="#326ce5" stroke-width="1"/>
+      <line x1="-25" y1="0" x2="-10" y2="0" stroke="#326ce5" stroke-width="1"/>
+      <line x1="10" y1="0" x2="25" y2="0" stroke="#326ce5" stroke-width="1"/>
+      <text x="0" y="35" font-family="Courier New" font-size="7" fill="#93c5fd" text-anchor="middle">K8s + AI</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">n8n RCE + Zero-Day</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | D-Link 0-Day + Kubernetes AI Agent</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 29, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
+++ b/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
@@ -1,189 +1,50 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Ollama AI 175K , SolarWinds WHD Critical RC...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Ollama llama silhouette -->
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
+      <!-- Simple llama shape -->
+      <path d="M-20,-40 C-20,-55 -10,-60 -5,-55 L-5,-30 M20,-40 C20,-55 10,-60 5,-55 L5,-30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.5"/>
+      <ellipse cx="0" cy="0" rx="35" ry="30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.3"/>
+      <text x="0" y="8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#c4b5fd" text-anchor="middle">Ollama</text>
+      <!-- AI sparkle -->
+      <circle cx="30" cy="-25" r="4" fill="#c4b5fd" opacity="0.5"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- SolarWinds breach -->
+    <g transform="translate(-130,30)" opacity="0.5">
+      <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <!-- Sun rays -->
+      <g opacity="0.3">
+        <line x1="0" y1="-28" x2="0" y2="-20" stroke="#ef4444" stroke-width="2"/>
+        <line x1="20" y1="-20" x2="14" y2="-14" stroke="#ef4444" stroke-width="2"/>
+        <line x1="28" y1="0" x2="20" y2="0" stroke="#ef4444" stroke-width="2"/>
+        <line x1="-28" y1="0" x2="-20" y2="0" stroke="#ef4444" stroke-width="2"/>
+      </g>
+      <text x="0" y="4" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">SOLAR</text>
+      <text x="0" y="44" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">RCE</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Ollama AI 175K , SolarWinds WHD Critical - 2026</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">1 30 : Ollama AI 175,000 (LLMjacking), SolarWinds</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="223" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ollama</text>
-      <rect x="279" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LLMjacking</text>
-      <rect x="414" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="475" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SolarWinds</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- Google/IPIDEA -->
+    <g transform="translate(130,30)" opacity="0.5">
+      <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#4285f4" stroke-width="1.5"/>
+      <text x="0" y="-2" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">G</text>
+      <text x="0" y="10" font-family="Courier New" font-size="6" fill="#60a5fa" text-anchor="middle">IPIDEA</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ollama AI + SolarWinds</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Security + RCE + Google IPIDEA</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 30, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
+++ b/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
@@ -1,189 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: ShinyHunters Vishing MFA , Chrome ChatGPT , OT</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <!-- Phishing hook (vishing) -->
+    <g filter="url(#shadow)">
+      <path d="M0,-90 L0,-20 C0,10 -20,25 -20,25 C-20,25 0,40 20,25 C20,25 40,10 40,-20 L40,-30" fill="none" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <!-- Hook point -->
+      <circle cx="-20" cy="30" r="5" fill="#ef4444" opacity="0.6"/>
+      <!-- Fishing line -->
+      <line x1="0" y1="-90" x2="0" y2="-120" stroke="#ef4444" stroke-width="1.5" opacity="0.3"/>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
+    <!-- Chrome extension icon -->
+    <g transform="translate(-120,0)">
+      <circle cx="0" cy="0" r="35" fill="#1e293b" stroke="#4285f4" stroke-width="2" filter="url(#shadow)"/>
+      <!-- Chrome colors -->
+      <circle cx="0" cy="0" r="12" fill="#fff" opacity="0.1"/>
+      <path d="M0,-12 A12,12 0 0,1 10,6 L0,0 Z" fill="#ea4335" opacity="0.4"/>
+      <path d="M10,6 A12,12 0 0,1 -10,6 L0,0 Z" fill="#34a853" opacity="0.4"/>
+      <path d="M-10,6 A12,12 0 0,1 0,-12 L0,0 Z" fill="#fbbc05" opacity="0.4"/>
+      <circle cx="0" cy="0" r="6" fill="#4285f4" opacity="0.5"/>
+      <text x="0" y="48" font-family="Courier New" font-size="7" fill="#93c5fd" text-anchor="middle">Extension</text>
     </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
+    <!-- OT attack indicator -->
+    <g transform="translate(120,0)" opacity="0.6">
+      <rect x="-35" y="-25" width="70" height="50" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <!-- Industrial gauge -->
+      <circle cx="0" cy="-5" r="14" fill="none" stroke="#f59e0b" stroke-width="1.5"/>
+      <line x1="0" y1="-5" x2="8" y2="-14" stroke="#ef4444" stroke-width="2" stroke-linecap="round"/>
+      <text x="0" y="20" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">OT</text>
+      <text x="0" y="38" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">Attack</text>
     </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">ShinyHunters MFA , Chrome ChatGPT ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CERT Polska 30+ / OT</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#ShinyHunters</text>
-      <rect x="459" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Vishing</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <!-- ShinyHunters tag -->
+    <g transform="translate(0,80)">
+      <rect x="-50" y="-12" width="100" height="24" rx="6" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="1"/>
+      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">ShinyHunters</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Vishing + OT Attack</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | ShinyHunters + Chrome Extension + OT</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 31, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
+++ b/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
@@ -1,189 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
+      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
+      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+    </g>
+    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI 2026: AI Agent</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 AI (Tool Poisoning, Tool Chain Attack, Prompt</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Injection) Google Chrome CrowdStrike Falcon .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="61" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Agentic-AI</text>
-      <rect x="135" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="279" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="358" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Tool-Poisoning</text>
-      <rect x="450" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="538" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Prompt-Injection</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Agentic AI Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2026 Attack Vectors + Defense Architecture</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">AI SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 1, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
+++ b/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
@@ -1,193 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
+      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">0-DAY</text>
+    </g>
+    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#ef4444" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI OpenSSL 12 , OWASP Agentic AI , Fortinet...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI OpenSSL 12 , OWASP Agentic AI , -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 1 : AI OpenSSL 12 , OWASP</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Agentic</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="372" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="450" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="498" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#OpenSSL</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OpenSSL Zero-Day</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly | AI + OWASP Agentic + Fortinet</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 1, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
@@ -1,193 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Notepad++ , SK , HashiCorp</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Notepad++ , SK 11-1 (Vertical AI,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">BlackField/Sinobi/Gentlemen , , JWT ), HashiCorp</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">RDP</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Supply-Chain</text>
-      <rect x="333" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Notepad++</text>
-      <rect x="459" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Ransomware</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#22c55e" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <circle cx="0" cy="0" r="60" fill="none" stroke="#22c55e" stroke-width="1" opacity="0.3"/>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="#22c55e" stroke-width="1" opacity="0.2"/>
+      <line x1="-90" y1="0" x2="90" y2="0" stroke="#22c55e" stroke-width="0.5" opacity="0.2"/>
+      <line x1="0" y1="-90" x2="0" y2="90" stroke="#22c55e" stroke-width="0.5" opacity="0.2"/>
+      <path d="M0,0 L0,-90 A90,90 0 0,1 64,-64 Z" fill="#22c55e" opacity="0.06"/>
+      <circle cx="-35" cy="-50" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="50" cy="-15" r="3" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-15" cy="40" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="40" cy="35" r="3" fill="#22c55e" opacity="0.5"/>
+      <circle cx="0" cy="0" r="5" fill="#22c55e" opacity="0.8"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Threat Intelligence</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Security Digest | Global Threats</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#22c55e" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 2, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
@@ -1,189 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI : Apple MLX , Bitcoin 74K , AI , DeFi , FO...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI : Apple MLX , Bitcoin 74K , AI - 2026 2</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2 / : Apple A18 Pro Neural Engine MLX , Bitcoin</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="78" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Apple</text>
-      <rect x="270" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="345" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Bitcoin-Crash</text>
-      <rect x="432" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Creativity</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-140" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="-108" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#f59e0b" text-anchor="middle">#1</text>
+      <line x1="-72" y1="0" x2="-42" y2="0" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+      <circle cx="-57" cy="0" r="4" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <rect x="-38" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <text x="-6" y="8" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.7">B</text>
+      <line x1="30" y1="0" x2="60" y2="0" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+      <circle cx="45" cy="0" r="4" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
+      <rect x="64" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <text x="96" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#f59e0b" text-anchor="middle">#N</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech + AI + Blockchain</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cross-Domain Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 2, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
+++ b/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
@@ -1,189 +1,30 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevOps : AI Agent , MDM ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevOps : AI Agent , MDM , - 2026 2 3</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">/DevOps : AI(Clawdbot/Moltbot) CVE-2026-25253</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="205" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
-      <rect x="243" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="291" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Moltbot</text>
-      <rect x="351" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="403" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Moltbook</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#10b981" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M-70,0 C-70,-45 -25,-45 0,-20 C25,-45 70,-45 70,0 C70,45 25,45 0,20 C-25,45 -70,45 -70,0 Z" fill="none" stroke="#10b981" stroke-width="4"/>
+      <circle cx="-50" cy="-18" r="10" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
+      <text x="-50" y="-14" font-family="Courier New" font-size="6" fill="#93c5fd" text-anchor="middle">Dev</text>
+      <circle cx="0" cy="-30" r="10" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
+      <text x="0" y="-26" font-family="Courier New" font-size="6" fill="#fca5a5" text-anchor="middle">Sec</text>
+      <circle cx="50" cy="-18" r="10" fill="#1e293b" stroke="#10b981" stroke-width="1.5"/>
+      <text x="50" y="-14" font-family="Courier New" font-size="6" fill="#86efac" text-anchor="middle">Ops</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security DevOps</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | DevSecOps Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#10b981" opacity="0.2" stroke="#10b981" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#10b981" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 3, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
+++ b/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
@@ -1,189 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI vs Claude Code: AI - , DevSecOps, FinOps (...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI vs Claude Code: AI - , DevSecOps, FinOps</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">(2026) - AI vs Claude Code 2026: CVE-2026-25253 RCE , 400+</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="70" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Assistant</text>
-      <rect x="153" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="219" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Claude-Code</text>
-      <rect x="297" y="0" width="51" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="322" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI</text>
-      <rect x="360" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="417" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#d97706" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#d97706" stroke-width="2"/>
+      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
+      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
+      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Coding Battle</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Claude Code vs AI Assistants | Head-to-Head</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#d97706" opacity="0.2" stroke="#d97706" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#d97706" text-anchor="middle">AI COMPARE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
@@ -1,189 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 4 : Docker AI , CVE-2025-11953, RCE</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 4 : Docker AI , CVE-2025-11953, RCE -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 2 4 : Docker AI DockerDash , React Native CLI</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Docker</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#0db7ed" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M-55,8 L75,8 C80,8 85,3 85,-7 L85,-28 C85,-33 80,-38 75,-38 L-35,-38 C-40,-38 -45,-36 -47,-33 L-65,-8 C-70,-3 -65,3 -55,8 Z" fill="#1e293b" stroke="#0db7ed" stroke-width="2.5"/>
+      <rect x="-25" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-5" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="15" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="35" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.4" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="55" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-5" y="-48" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <circle cx="-50" cy="-3" r="3" fill="#0db7ed"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Docker + Go</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Container + Language Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0db7ed" opacity="0.2" stroke="#0db7ed" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#0db7ed" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
+++ b/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
@@ -1,201 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1"/>
-      <stop offset="100%" style="stop-color:#4f46e5"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ec4899" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#ec4899" stroke-width="2.5"/>
+      <circle cx="0" cy="-15" r="25" fill="#ec4899" opacity="0.1" stroke="#ec4899" stroke-width="1.5"/>
+      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#ec4899" text-anchor="middle" opacity="0.8">AI</text>
+      <circle cx="-30" cy="25" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
+      <circle cx="0" cy="35" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
+      <circle cx="30" cy="25" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
+      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="12" x2="0" y2="25" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
+      <line x1="15" y1="10" x2="25" y2="20" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
+    </g>
+    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#ec4899" stroke-width="1"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI 2026 - , ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Brain/Neural Network -->
-    <g transform="translate(80, 280)">
-      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
-      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
-      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
-      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
-    </g>
-    
-    <!-- Robot Head -->
-    <g transform="translate(210, 285)">
-      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
-      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
-      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
-      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
-      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
-    </g>
-    
-    <!-- Chip/Processor -->
-    <g transform="translate(330, 295)">
-      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
-      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
-      <g stroke="#7c3aed" stroke-width="3">
-        <line x1="40" y1="5" x2="40" y2="15"/>
-        <line x1="40" y1="65" x2="40" y2="75"/>
-        <line x1="5" y1="40" x2="15" y2="40"/>
-        <line x1="65" y1="40" x2="75" y2="40"/>
-      </g>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI 2026 - , , - 2026 AI</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Claude Opus 4.5 , Qwen3-TTS</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="51" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="25" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#AI</text>
-      <rect x="63" y="0" width="87" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="106" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Claude</text>
-      <rect x="162" y="0" width="96" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="210" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Suno AI</text>
-      <rect x="270" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="327" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Animation</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Content Creator</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2026 Workflow | Blog + Video + Music + Animation</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ec4899" opacity="0.2" stroke="#ec4899" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ec4899" text-anchor="middle">AI CREATIVE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 5, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
@@ -1,185 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: n8n RCE, NGINX , AsyncRAT</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 05 : The Hacker News 28 . CVE, AI, Malware, Go</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <line x1="60" y1="0" x2="40" y2="0" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="30" x2="35" y2="15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
+      <circle cx="-15" cy="-25" r="8" fill="#ef4444" opacity="0.3"/>
+      <circle cx="15" cy="-25" r="8" fill="#ef4444" opacity="0.3"/>
+      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#ef4444" text-anchor="middle" opacity="0.6">CVE</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CVE + AI Malware</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Security Threats</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 5, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
@@ -1,193 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: CrashFix RAT, DDoS, Codespaces RCE</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#ef4444" text-anchor="middle">C2</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-06 : CrashFix Python RAT, AISURU 31.4 Tbps DDoS,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Codespaces RCE, BYOVD - 2026 02 06 : CrashFix ClickFix</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Python...</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g opacity="0.4">
+      <circle cx="-80" cy="-50" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="-65" y1="-40" x2="-25" y2="-15" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="80" cy="-50" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="65" y1="-40" x2="25" y2="-15" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="-90" cy="30" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="-75" y1="25" x2="-28" y2="10" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="90" cy="30" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="75" y1="25" x2="28" y2="10" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="-40" cy="70" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="-35" y1="58" x2="-15" y2="25" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="40" cy="70" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="35" y1="58" x2="15" y2="25" stroke="#ef4444" stroke-width="1"/>
+      <circle cx="0" cy="-80" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="0" y1="-68" x2="0" y2="-30" stroke="#ef4444" stroke-width="1"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Botnet Threat</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cloud + Botnet Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 6, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
+++ b/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
@@ -1,185 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: APT , AitM ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 07 : The Hacker News 25 . AI, Malware, Go, Security</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-80" y="-70" width="160" height="140" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="-40" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.6">00101101 10110</text>
+      <text x="-60" y="-25" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11010010 01101</text>
+      <text x="-60" y="-10" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.8">MALWARE FOUND</text>
+      <text x="-60" y="5" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">10101100 11010</text>
+      <text x="-60" y="20" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.5">01110101 10011</text>
+      <text x="-60" y="35" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11001010 01110</text>
+      <text x="-60" y="50" font-family="Courier New" font-size="8" fill="#22c55e" opacity="0.6">QUARANTINED...</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Malware + Go</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Malware Analysis + Go Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 7, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
@@ -1,189 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-08 : Signal , BlackField ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-08 : Signal , BlackField , - 2026</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">02 08 : BfV/BSI Signal ( / /</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-45" y="-5" width="90" height="70" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
+      <path d="M-25,-5 L-25,-35 C-25,-55 -12,-68 0,-68 C12,-68 25,-55 25,-35 L25,-5" fill="none" stroke="#ef4444" stroke-width="4"/>
+      <circle cx="0" cy="28" r="10" fill="#ef4444" opacity="0.3"/>
+      <rect x="-3" y="32" width="6" height="15" rx="2" fill="#ef4444" opacity="0.3"/>
+      <text x="0" y="32" font-family="Arial,sans-serif" font-size="16" fill="#ef4444" text-anchor="middle" opacity="0.6">$</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Ransomware</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Data Breach + Ransomware</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 8, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
+++ b/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
@@ -1,195 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-09 &amp; : Bithumb , Bitcoin 71K</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
-    </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
-    </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-09 &amp; : Bithumb , Bitcoin 71K - Bithumb 44B</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, Bitcoin 71K , 3D ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="186" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="93" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Blockchain-Digest</text>
-      <rect x="198" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="264" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Tech-Digest</text>
-      <rect x="342" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="390" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Bithumb</text>
-      <rect x="450" y="0" width="96" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="498" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Bitcoin</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#f59e0b" stroke-width="3"/>
+      <circle cx="0" cy="0" r="65" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <text x="0" y="18" font-family="Arial,sans-serif" font-size="60" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.6">B</text>
+      <line x1="-5" y1="-30" x2="-5" y2="35" stroke="#f59e0b" stroke-width="2" opacity="0.3"/>
+      <line x1="5" y1="-30" x2="5" y2="35" stroke="#f59e0b" stroke-width="2" opacity="0.3"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Blockchain Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Bithumb + Bitcoin | Crypto Intelligence</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">BLOCKCHAIN</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
+++ b/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
@@ -1,189 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-09 &amp; : AI , AWS Agentic AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-09 &amp; : AI , AWS Agentic AI - AI VirusTotal</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI , SK BlackField ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Digest</text>
-      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Digest</text>
-      <rect x="333" y="0" width="186" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="426" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agent-Security</text>
-      <rect x="531" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="601" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Supply-Chain</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M-30,-60 C-55,-60 -75,-42 -75,-20 C-95,-20 -110,-2 -110,15 C-110,40 -90,52 -70,52 L70,52 C90,52 110,40 110,15 C110,-2 95,-20 75,-20 C75,-42 55,-60 30,-60 C12,-60 0,-50 -5,-42 C-10,-50 -18,-60 -30,-60 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+      <path d="M0,-35 L25,-22 L25,10 C25,22 14,30 0,35 C-14,30 -25,22 -25,10 L-25,-22 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="1.5"/>
+      <path d="M-6,5 L-2,10 L10,-2" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI + VirusTotal + AWS Agentic</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">CLOUD</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
+++ b/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
@@ -1,195 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devsecopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#8b5cf6"/>
-      <stop offset="100%" style="stop-color:#6d28d9"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#a78bfa" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#8b5cf6" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#7c3aed" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#8b5cf6" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devsecopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVSECOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 AI &amp; : Meta Prometheus, Google OTL...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield with Code -->
-    <g transform="translate(80, 275)">
-      <path d="M50 5 L95 25 L95 65 Q95 100 50 120 Q5 100 5 65 L5 25 Z" 
-            fill="url(#devsecopsGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <text x="50" y="75" font-family="monospace" font-size="28" font-weight="bold" fill="white" text-anchor="middle">&lt;/&gt;</text>
-    </g>
-    
-    <!-- Pipeline Arrow -->
-    <g transform="translate(200, 300)">
-      <rect x="0" y="20" width="30" height="30" rx="5" fill="#3b82f6"/>
-      <text x="15" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">D</text>
-      <path d="M35 35 L50 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="55" y="20" width="30" height="30" rx="5" fill="#8b5cf6"/>
-      <text x="70" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">S</text>
-      <path d="M90 35 L105 35" stroke="#64748b" stroke-width="3"/>
-      <rect x="110" y="20" width="30" height="30" rx="5" fill="#22c55e"/>
-      <text x="125" y="42" font-family="Arial" font-size="16" fill="white" text-anchor="middle">O</text>
-    </g>
-    
-    <!-- Security Scanner -->
-    <g transform="translate(360, 290)">
-      <circle cx="30" cy="35" r="25" fill="none" stroke="#ef4444" stroke-width="3"/>
-      <line x1="48" y1="53" x2="65" y2="70" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
-      <path d="M20 35 L25 40 L40 25" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devsecopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#a78bfa">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 AI &amp; : Meta Prometheus, Google OTLP, AWS -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#a78bfa"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Meta Prometheus AI , Google Cloud OTLP , AWS Claude</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#AI-Digest</text>
-      <rect x="126" y="0" width="141" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="196" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Cloud-Digest</text>
-      <rect x="279" y="0" width="168" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="363" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Meta-Prometheus</text>
-      <rect x="459" y="0" width="132" height="30" rx="15" fill="#a78bfa" fill-opacity="0.15" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="525" y="20" font-family="Arial, sans-serif" font-size="12" fill="#a78bfa" text-anchor="middle">#Google-OTLP</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
+      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
+      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
+      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devsecopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Cloud Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Meta Prometheus + Google OTLP + AWS</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">CLOUD</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
+++ b/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
@@ -1,190 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 DevOps &amp; : CNCF Velocity, Cluster ...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Infinity/DevOps Loop -->
-    <g transform="translate(80, 290)">
-      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
-            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
-    </g>
-    
-    <!-- Gear Icon -->
-    <g transform="translate(220, 290)">
-      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
-      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-    </g>
-    
-    <!-- Code Bracket -->
-    <g transform="translate(330, 295)">
-      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 DevOps &amp; : CNCF Velocity, Cluster API, Bitcoin -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CNCF Project Velocity 2025 , Cluster API v1.12 In-Place</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="150" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#DevOps-Digest</text>
-      <rect x="162" y="0" width="186" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="255" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Blockchain-Digest</text>
-      <rect x="360" y="0" width="69" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="394" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#CNCF</text>
-      <rect x="441" y="0" width="123" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="502" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Kubernetes</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#22c55e" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-140" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <text x="-108" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#22c55e" text-anchor="middle">#1</text>
+      <line x1="-72" y1="0" x2="-42" y2="0" stroke="#22c55e" stroke-width="3" opacity="0.5"/>
+      <circle cx="-57" cy="0" r="4" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <rect x="-38" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="2.5"/>
+      <text x="-6" y="8" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#22c55e" text-anchor="middle" opacity="0.7">B</text>
+      <line x1="30" y1="0" x2="60" y2="0" stroke="#22c55e" stroke-width="3" opacity="0.5"/>
+      <circle cx="45" cy="0" r="4" fill="#1e293b" stroke="#22c55e" stroke-width="1.5"/>
+      <rect x="64" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <text x="96" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#22c55e" text-anchor="middle">#N</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">DevOps + Blockchain</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">CNCF + Chainalysis + Bitcoin</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#22c55e" text-anchor="middle">DEVOPS</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
+++ b/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
@@ -1,189 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <circle cx="0" cy="0" r="55" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
+      <text x="0" y="-10" font-family="Courier New" font-size="14" fill="#ef4444" text-anchor="middle" opacity="0.8">APT</text>
+      <text x="0" y="10" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle" opacity="0.5">UNC3886</text>
+    </g>
+    <g opacity="0.3"><line x1="-100" y1="-50" x2="-60" y2="-30" stroke="#ef4444" stroke-width="1.5"/><line x1="100" y1="-50" x2="60" y2="-30" stroke="#ef4444" stroke-width="1.5"/><line x1="-100" y1="50" x2="-60" y2="30" stroke="#ef4444" stroke-width="1.5"/><line x1="100" y1="50" x2="60" y2="30" stroke="#ef4444" stroke-width="1.5"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-10 : SolarWinds RCE, UNC3886 , LLM</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-10 : SolarWinds RCE, UNC3886 , LLM -</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">SolarWinds WHD RCE (CVE-2025-40551), UNC3886 , LLM</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Digest</text>
-      <rect x="180" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="259" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#SolarWinds-RCE</text>
-      <rect x="351" y="0" width="96" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="399" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#UNC3886</text>
-      <rect x="459" y="0" width="123" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="520" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#LLM-Safety</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SolarWinds + LLM</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">UNC3886 APT + LLM Attack Vectors</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">THREAT</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
+++ b/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
@@ -1,189 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , Fortinet , AI</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 11 : The Hacker News 26 . , , , AI</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-70" y="-70" width="140" height="140" rx="12" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <rect x="-50" y="-50" width="100" height="25" rx="4" fill="#f59e0b" opacity="0.1" stroke="#f59e0b" stroke-width="1"/>
+      <rect x="-50" y="-18" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <rect x="-50" y="14" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <rect x="-50" y="46" width="100" height="12" rx="4" fill="#334155" opacity="0.3"/>
+      <path d="M-35,-42 L-32,-38 L-28,-44" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-35,-10 L-32,-6 L-28,-12" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-35,22 L-32,26 L-28,20" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <text x="0" y="-34" font-family="Courier New" font-size="8" fill="#f59e0b" text-anchor="middle">CVE-2026-XXX</text>
+      <text x="0" y="-2" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
+      <text x="0" y="30" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ransomware + Patch</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Security Patches + AI</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 11, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
+++ b/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
@@ -1,189 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: , Windows , APT36</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 12 : The Hacker News, Microsoft Security Blog 27 .</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI, , , DevSecOps .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="3"/>
+      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#3b82f6" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#3b82f6" stroke-width="4" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Agent</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Agent + Cloud Defense</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 12, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
+++ b/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
@@ -1,189 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Lazarus , Copilot Studio, FinOps</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Gemini AI , Lazarus npm PyPI , Copilot Studio ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">FinOps 2026-02-13</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#00add8" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#00add8" stroke-width="3"/>
+      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#00add8" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#00add8" stroke-width="4" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Go Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Agent Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#00add8" opacity="0.2" stroke="#00add8" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#00add8" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 13, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
+++ b/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
@@ -1,193 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
+      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">0-DAY</text>
+    </g>
+    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#ef4444" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 2 : Microsoft 6 Zero-Day, Apple , Ivan...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Microsoft Patch Tuesday 6 Zero-Day , Apple CVE-2026-20700 ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Ivanti EPMM , SAP CVSS 9.9 SQL Injection, 74B</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 ...</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">MS + Apple Zero-Day</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly | Microsoft + Apple + Ivanti EPMM</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 14, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
+++ b/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
@@ -1,190 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 16 : LLM , Windows ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Infinity/DevOps Loop -->
-    <g transform="translate(80, 290)">
-      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
-            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
-    </g>
-    
-    <!-- Gear Icon -->
-    <g transform="translate(220, 290)">
-      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
-      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-    </g>
-    
-    <!-- Code Bracket -->
-    <g transform="translate(330, 295)">
-      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">24 RSS LLM , Windows , ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">, .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="141" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="70" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Daily-Digest</text>
-      <rect x="153" y="0" width="168" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Tech-Newsletter</text>
-      <rect x="333" y="0" width="141" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="403" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#AI-Inference</text>
-      <rect x="486" y="0" width="132" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Windows-Dev</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#f97316" stroke-width="2"/>
+      <circle cx="0" cy="0" r="60" fill="none" stroke="#f97316" stroke-width="1" opacity="0.3"/>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="#f97316" stroke-width="1" opacity="0.2"/>
+      <line x1="-90" y1="0" x2="90" y2="0" stroke="#f97316" stroke-width="0.5" opacity="0.2"/>
+      <line x1="0" y1="-90" x2="0" y2="90" stroke="#f97316" stroke-width="0.5" opacity="0.2"/>
+      <path d="M0,0 L0,-90 A90,90 0 0,1 64,-64 Z" fill="#f97316" opacity="0.06"/>
+      <circle cx="-35" cy="-50" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="50" cy="-15" r="3" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-15" cy="40" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="40" cy="35" r="3" fill="#f97316" opacity="0.5"/>
+      <circle cx="0" cy="0" r="5" fill="#f97316" opacity="0.8"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Daily Tech Digest</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">RSS Roundup | Tech News Aggregation</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">DAILY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 16, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
+++ b/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
@@ -1,189 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
+      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
+      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+    </g>
+    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Infostealer AI / , Bitwarden/Dashlane/LastPass</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">25 , AWS AI 18 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Security</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cloud + Agent Defense</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 17, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
+++ b/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
@@ -1,189 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026 2 3 : AI , Patch Tuesday,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI , Microsoft Patch Tuesday, / , LLM</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2 3 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="75" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-      <rect x="162" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="246" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="342" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="408" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="486" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="556" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Threat-Intel</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round"/>
+      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
+      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Risk Analysis</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI + Cloud Risk Assessment</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 17, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
+++ b/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
@@ -1,189 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">KrebsOnSecurity : Kimwolf 2026 2</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">KrebsOnSecurity RSS 10 Kimwolf (I2P), 2 Patch Tuesday, Badbox</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2.0 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#KrebsOnSecurity</text>
-      <rect x="180" y="0" width="141" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="250" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Threat-Intel</text>
-      <rect x="333" y="0" width="87" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="376" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Botnet</text>
-      <rect x="432" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="507" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Patch-Tuesday</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-70" y="-70" width="140" height="140" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <rect x="-50" y="-50" width="100" height="25" rx="4" fill="#ef4444" opacity="0.1" stroke="#ef4444" stroke-width="1"/>
+      <rect x="-50" y="-18" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <rect x="-50" y="14" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
+      <rect x="-50" y="46" width="100" height="12" rx="4" fill="#334155" opacity="0.3"/>
+      <path d="M-35,-42 L-32,-38 L-28,-44" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-35,-10 L-32,-6 L-28,-12" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <path d="M-35,22 L-32,26 L-28,20" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
+      <text x="0" y="-34" font-family="Courier New" font-size="8" fill="#ef4444" text-anchor="middle">CVE-2026-XXX</text>
+      <text x="0" y="-2" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
+      <text x="0" y="30" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Krebs + Patch Tuesday</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Kimwolf Botnet + Microsoft Patch Tuesday</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">SECURITY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 18, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
+++ b/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
@@ -1,189 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Cloud Malware ...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026 02 18 : The Hacker News 20 . AI, ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">DevSecOps .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-80" y="-70" width="160" height="140" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="-40" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.6">00101101 10110</text>
+      <text x="-60" y="-25" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11010010 01101</text>
+      <text x="-60" y="-10" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.8">MALWARE FOUND</text>
+      <text x="-60" y="5" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">10101100 11010</text>
+      <text x="-60" y="20" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.5">01110101 10011</text>
+      <text x="-60" y="35" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11001010 01110</text>
+      <text x="-60" y="50" font-family="Courier New" font-size="8" fill="#22c55e" opacity="0.6">QUARANTINED...</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Malware Update</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI + Cloud Malware</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 18, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
+++ b/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
@@ -1,193 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#f97316" stroke-width="2"/>
+      <circle cx="0" cy="0" r="65" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="0" cy="0" r="40" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="0" cy="0" r="15" fill="#f97316" opacity="0.3"/>
+      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#f97316" text-anchor="middle">0-DAY</text>
+    </g>
+    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#f97316" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#f97316"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AWS , Zero-Day, CVE-2026-2329</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Dell RecoverPoint VM CVE-2026-22769 , VS Code 4 (1.25</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) , Cellebrite 2026 2 19</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">27 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Zero-Day CVE</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AWS Security Vulnerabilities</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 19, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
+++ b/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
@@ -1,205 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="aiGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1"/>
-      <stop offset="100%" style="stop-color:#4f46e5"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#818cf8" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#6366f1" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#4f46e5" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#6366f1" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#818cf8" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#aiGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">TECH</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">2026-02-20 : AI EKS Flyte Docker Cloud Native</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Brain/Neural Network -->
-    <g transform="translate(80, 280)">
-      <ellipse cx="50" cy="50" rx="45" ry="35" fill="url(#aiGradient)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
-      <circle cx="30" cy="40" r="8" fill="white" opacity="0.8"/>
-      <circle cx="50" cy="55" r="8" fill="white" opacity="0.8"/>
-      <circle cx="70" cy="40" r="8" fill="white" opacity="0.8"/>
-      <line x1="30" y1="40" x2="50" y2="55" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="50" y1="55" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
-      <line x1="30" y1="40" x2="70" y2="40" stroke="white" stroke-width="2" opacity="0.8"/>
-    </g>
-    
-    <!-- Robot Head -->
-    <g transform="translate(210, 285)">
-      <rect x="10" y="20" width="60" height="50" rx="10" fill="#6366f1" stroke="#4f46e5" stroke-width="2"/>
-      <rect x="25" y="5" width="30" height="20" rx="5" fill="#818cf8"/>
-      <circle cx="30" cy="40" r="8" fill="#22d3ee"/>
-      <circle cx="50" cy="40" r="8" fill="#22d3ee"/>
-      <rect x="25" y="55" width="30" height="8" rx="2" fill="#c7d2fe"/>
-    </g>
-    
-    <!-- Chip/Processor -->
-    <g transform="translate(330, 295)">
-      <rect x="15" y="15" width="50" height="50" rx="5" fill="#7c3aed" stroke="#6d28d9" stroke-width="2"/>
-      <rect x="25" y="25" width="30" height="30" rx="3" fill="#a78bfa"/>
-      <g stroke="#7c3aed" stroke-width="3">
-        <line x1="40" y1="5" x2="40" y2="15"/>
-        <line x1="40" y1="65" x2="40" y2="75"/>
-        <line x1="5" y1="40" x2="15" y2="40"/>
-        <line x1="65" y1="40" x2="75" y2="40"/>
-      </g>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#818cf8" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#aiGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#818cf8">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2026-02-20 : AI EKS Flyte Docker Cloud Native</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) ( )</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#818cf8"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="57" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Tech-Blog</text>
-      <rect x="126" y="0" width="150" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="201" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Weekly-Digest</text>
-      <rect x="288" y="0" width="114" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="345" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#Developer</text>
-      <rect x="414" y="0" width="69" height="30" rx="15" fill="#818cf8" fill-opacity="0.15" stroke="#818cf8" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="448" y="20" font-family="Arial, sans-serif" font-size="12" fill="#818cf8" text-anchor="middle">#2026</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M-30,-60 C-55,-60 -75,-42 -75,-20 C-95,-20 -110,-2 -110,15 C-110,40 -90,52 -70,52 L70,52 C90,52 110,40 110,15 C110,-2 95,-20 75,-20 C75,-42 55,-60 30,-60 C12,-60 0,-50 -5,-42 C-10,-50 -18,-60 -30,-60 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+      <path d="M0,-35 L25,-22 L25,10 C25,22 14,30 0,35 C-14,30 -25,22 -25,10 L-25,-22 Z" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" stroke-width="1.5"/>
+      <path d="M-6,5 L-2,10 L10,-2" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#aiGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Data + Cloud</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Tech Blog Digest</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 20, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
+++ b/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
@@ -1,193 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Gemini 3.1 Pro, AI , Kubernetes</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Gemini 3.1 Pro, AI , Kubernetes (</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) ( ) 2</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#4285f4" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-140" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#4285f4" stroke-width="2"/>
+      <text x="-108" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#4285f4" text-anchor="middle">#1</text>
+      <line x1="-72" y1="0" x2="-42" y2="0" stroke="#4285f4" stroke-width="3" opacity="0.5"/>
+      <circle cx="-57" cy="0" r="4" fill="#1e293b" stroke="#4285f4" stroke-width="1.5"/>
+      <rect x="-38" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#4285f4" stroke-width="2.5"/>
+      <text x="-6" y="8" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#4285f4" text-anchor="middle" opacity="0.7">B</text>
+      <line x1="30" y1="0" x2="60" y2="0" stroke="#4285f4" stroke-width="3" opacity="0.5"/>
+      <circle cx="45" cy="0" r="4" fill="#1e293b" stroke="#4285f4" stroke-width="1.5"/>
+      <rect x="64" y="-30" width="65" height="60" rx="8" fill="#1e293b" stroke="#4285f4" stroke-width="2"/>
+      <text x="96" y="5" font-family="Courier New" font-size="12" font-weight="bold" fill="#4285f4" text-anchor="middle">#N</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Gemini + Supply Chain</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly | AI Supply Chain + Kubernetes</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#4285f4" opacity="0.2" stroke="#4285f4" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#4285f4" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 20, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
+++ b/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
@@ -1,189 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: CVE-2025-49113, , Rust</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: CVE-2025-49113, , Rust (</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) ( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ce422b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#ce422b" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <line x1="60" y1="0" x2="40" y2="0" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="30" x2="35" y2="15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
+      <circle cx="-15" cy="-25" r="8" fill="#ce422b" opacity="0.3"/>
+      <circle cx="15" cy="-25" r="8" fill="#ce422b" opacity="0.3"/>
+      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#ce422b" text-anchor="middle" opacity="0.6">CVE</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Data + Rust + AI</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Rust Security + AI Threats</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ce422b" opacity="0.2" stroke="#ce422b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ce422b" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 21, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
+++ b/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
@@ -1,193 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI , Roundcube KEV, Claude Code</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI , Roundcube KEV, Claude Code</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) ( ) 2</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="60" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
+      <circle cx="0" cy="0" r="30" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.2"/>
+      <line x1="-90" y1="0" x2="90" y2="0" stroke="#ef4444" stroke-width="0.5" opacity="0.2"/>
+      <line x1="0" y1="-90" x2="0" y2="90" stroke="#ef4444" stroke-width="0.5" opacity="0.2"/>
+      <path d="M0,0 L0,-90 A90,90 0 0,1 64,-64 Z" fill="#ef4444" opacity="0.06"/>
+      <circle cx="-35" cy="-50" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="50" cy="-15" r="3" fill="#f59e0b" opacity="0.6"/>
+      <circle cx="-15" cy="40" r="4" fill="#ef4444" opacity="0.7"/>
+      <circle cx="40" cy="35" r="3" fill="#ef4444" opacity="0.5"/>
+      <circle cx="0" cy="0" r="5" fill="#ef4444" opacity="0.8"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Threat Landscape</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Vulnerability Analysis</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 22, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
+++ b/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
@@ -1,193 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Vertical AI , BlackField ,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Vertical AI , BlackField , (</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) ( ) 2</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">.</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-45" y="-5" width="90" height="70" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
+      <path d="M-25,-5 L-25,-35 C-25,-55 -12,-68 0,-68 C12,-68 25,-55 25,-35 L25,-5" fill="none" stroke="#ef4444" stroke-width="4"/>
+      <circle cx="0" cy="28" r="10" fill="#ef4444" opacity="0.3"/>
+      <rect x="-3" y="32" width="6" height="15" rx="2" fill="#ef4444" opacity="0.3"/>
+      <text x="0" y="32" font-family="Arial,sans-serif" font-size="16" fill="#ef4444" text-anchor="middle" opacity="0.6">$</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ransomware + Bitcoin</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Ransomware + Crypto</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 23, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
+++ b/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
@@ -1,189 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: APT28 , Docker , LLM</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: APT28 , Docker , LLM (</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">) ( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#0db7ed" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M-55,8 L75,8 C80,8 85,3 85,-7 L85,-28 C85,-33 80,-38 75,-38 L-35,-38 C-40,-38 -45,-36 -47,-33 L-65,-8 C-70,-3 -65,3 -55,8 Z" fill="#1e293b" stroke="#0db7ed" stroke-width="2.5"/>
+      <rect x="-25" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-5" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="15" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="35" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.4" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="55" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <rect x="-5" y="-48" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
+      <circle cx="-50" cy="-3" r="3" fill="#0db7ed"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Malware + Docker LLM</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Malware + Container</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0db7ed" opacity="0.2" stroke="#0db7ed" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#0db7ed" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 24, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
+++ b/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
@@ -1,190 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="devopsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#d97706"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#fbbf24" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#f59e0b" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#d97706" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#f59e0b" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#fbbf24" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#devopsGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">DEVOPS</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Claude Code &amp; OpenCode : 38</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Infinity/DevOps Loop -->
-    <g transform="translate(80, 290)">
-      <path d="M10 40 Q10 10 40 10 Q70 10 70 40 Q70 70 100 70 Q130 70 130 40 Q130 10 100 10 Q70 10 70 40 Q70 70 40 70 Q10 70 10 40" 
-            fill="none" stroke="url(#devopsGradient)" stroke-width="6" stroke-linecap="round"/>
-    </g>
-    
-    <!-- Gear Icon -->
-    <g transform="translate(220, 290)">
-      <circle cx="35" cy="35" r="25" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <circle cx="35" cy="35" r="10" fill="#0f172a"/>
-      <rect x="30" y="2" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="30" y="53" width="10" height="15" rx="2" fill="#f59e0b"/>
-      <rect x="2" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-      <rect x="53" y="30" width="15" height="10" rx="2" fill="#f59e0b"/>
-    </g>
-    
-    <!-- Code Bracket -->
-    <g transform="translate(330, 295)">
-      <text x="0" y="45" font-family="monospace" font-size="50" font-weight="bold" fill="#a855f7">&lt;/&gt;</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#devopsGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#fbbf24">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">Claude Code OpenCode 38 Best Practice . ,</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#fbbf24"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">CLAUDE.md , ,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="132" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="66" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Claude-Code</text>
-      <rect x="144" y="0" width="105" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="196" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#OpenCode</text>
-      <rect x="261" y="0" width="159" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="340" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#Best-Practices</text>
-      <rect x="432" y="0" width="105" height="30" rx="15" fill="#fbbf24" fill-opacity="0.15" stroke="#fbbf24" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="484" y="20" font-family="Arial, sans-serif" font-size="12" fill="#fbbf24" text-anchor="middle">#AI-Agent</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#d97706" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-80" y="-70" width="160" height="140" rx="10" fill="#1e293b" stroke="#d97706" stroke-width="2"/>
+      <text x="-60" y="-40" font-family="Courier New" font-size="8" fill="#d97706" opacity="0.6">00101101 10110</text>
+      <text x="-60" y="-25" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11010010 01101</text>
+      <text x="-60" y="-10" font-family="Courier New" font-size="8" fill="#d97706" opacity="0.8">MALWARE FOUND</text>
+      <text x="-60" y="5" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">10101100 11010</text>
+      <text x="-60" y="20" font-family="Courier New" font-size="8" fill="#d97706" opacity="0.5">01110101 10011</text>
+      <text x="-60" y="35" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11001010 01110</text>
+      <text x="-60" y="50" font-family="Courier New" font-size="8" fill="#22c55e" opacity="0.6">QUARANTINED...</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#devopsGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Claude Code Practices</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">OpenCode Best Practices Guide</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#d97706" opacity="0.2" stroke="#d97706" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#d97706" text-anchor="middle">BEST PRACTICE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 25, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
+++ b/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
@@ -1,189 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Malware Ransom...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI, , ( )</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <rect x="-80" y="-70" width="160" height="140" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="-40" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.6">00101101 10110</text>
+      <text x="-60" y="-25" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11010010 01101</text>
+      <text x="-60" y="-10" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.8">MALWARE FOUND</text>
+      <text x="-60" y="5" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">10101100 11010</text>
+      <text x="-60" y="20" font-family="Courier New" font-size="8" fill="#ef4444" opacity="0.5">01110101 10011</text>
+      <text x="-60" y="35" font-family="Courier New" font-size="8" fill="#94a3b8" opacity="0.3">11001010 01110</text>
+      <text x="-60" y="50" font-family="Courier New" font-size="8" fill="#22c55e" opacity="0.6">QUARANTINED...</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Malware + LLM</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Ransomware + LLM Threats</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 25, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
+++ b/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
@@ -1,189 +1,26 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: AI, Go, AWS</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI, Go, AWS ( )</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#f97316" stroke-width="3"/>
+      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#f97316" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#f97316" stroke-width="4" stroke-linecap="round"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Go + AWS API</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | API Security</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 26, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
+++ b/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
@@ -1,189 +1,34 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Tech Security Weekly Digest Ai Botnet Blockch...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
+      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#f59e0b" text-anchor="middle">C2</text>
     </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: AI, , ( )</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+    <g opacity="0.4">
+      <circle cx="-80" cy="-50" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="-65" y1="-40" x2="-25" y2="-15" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="80" cy="-50" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="65" y1="-40" x2="25" y2="-15" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="-90" cy="30" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="-75" y1="25" x2="-28" y2="10" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="90" cy="30" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="75" y1="25" x2="28" y2="10" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="-40" cy="70" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="-35" y1="58" x2="-15" y2="25" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="40" cy="70" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="35" y1="58" x2="15" y2="25" stroke="#f59e0b" stroke-width="1"/>
+      <circle cx="0" cy="-80" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="0" y1="-68" x2="0" y2="-30" stroke="#f59e0b" stroke-width="1"/>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Botnet + Blockchain</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go + Botnet + Chain</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 27, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
+++ b/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
@@ -1,193 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
+      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
+      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
+      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
+    </g>
+    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
   </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 15, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent : Stateful Runtime Continuous Evalua...</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AI Agent : Stateful Runtime Continuous Evaluation</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">- AI Agent - OpenAI Stateful Runtime, Amazon Bedrock</text>
-    </g>
-    <g transform="translate(30, 160)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">AgentCore,</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="105" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="52" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Agent</text>
-      <rect x="117" y="0" width="132" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="183" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#AI-Security</text>
-      <rect x="261" y="0" width="177" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="349" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Stateful-Runtime</text>
-      <rect x="450" y="0" width="195" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="547" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Continuous-Eval...</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
-    </g>
-  </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Architecture</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security Design Guide | Agent Framework</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">ARCHITECTURE</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 28, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
+++ b/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
@@ -1,189 +1,33 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
-    <!-- Background Gradients -->
-    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/>
-      <stop offset="30%" style="stop-color:#0f1629"/>
-      <stop offset="70%" style="stop-color:#1a1f3a"/>
-      <stop offset="100%" style="stop-color:#0d1117"/>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
     </linearGradient>
-    
-    <!-- Category Gradient -->
-    <linearGradient id="securityGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="100%" style="stop-color:#991b1b"/>
-    </linearGradient>
-    
-    <!-- Accent Gradient -->
-    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#3b82f6"/>
-      <stop offset="33%" style="stop-color:#8b5cf6"/>
-      <stop offset="66%" style="stop-color:#ec4899"/>
-      <stop offset="100%" style="stop-color:#f59e0b"/>
-    </linearGradient>
-    
-    <!-- Card Gradient -->
-    <linearGradient id="cardGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1e293b"/>
-      <stop offset="100%" style="stop-color:#0f172a"/>
-    </linearGradient>
-    
-    <!-- Fire Gradient for Incident -->
-    <linearGradient id="fireGradient" x1="0%" y1="100%" x2="0%" y2="0%">
-      <stop offset="0%" style="stop-color:#dc2626"/>
-      <stop offset="50%" style="stop-color:#f59e0b"/>
-      <stop offset="100%" style="stop-color:#fbbf24"/>
-    </linearGradient>
-    
-    <!-- Glow Effects -->
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="4" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <filter id="strongGlow" x="-100%" y="-100%" width="300%" height="300%">
-      <feGaussianBlur stdDeviation="8" result="blur"/>
-      <feMerge>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="blur"/>
-        <feMergeNode in="SourceGraphic"/>
-      </feMerge>
-    </filter>
-    
-    <!-- Shadow -->
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="0" dy="6" stdDeviation="12" flood-color="#000" flood-opacity="0.4"/>
-    </filter>
-    
-    <!-- Inner Glow -->
-    <filter id="innerGlow">
-      <feGaussianBlur in="SourceAlpha" stdDeviation="3" result="blur"/>
-      <feOffset in="blur" dx="0" dy="0"/>
-      <feComposite in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1"/>
-      <feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0"/>
-      <feBlend in2="SourceGraphic"/>
-    </filter>
+    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
-
-  <!-- Background -->
-  <rect width="1200" height="630" fill="url(#bgGradient)"/>
-  
-  <!-- Animated Grid Pattern -->
-  <pattern id="grid" width="60" height="60" patternUnits="userSpaceOnUse">
-    <path d="M 60 0 L 0 0 0 60" fill="none" stroke="#ef4444" stroke-opacity="0.05" stroke-width="1"/>
-  </pattern>
-  <rect width="1200" height="630" fill="url(#grid)"/>
-  
-  <!-- Background Decorative Elements -->
-  <circle cx="0" cy="0" r="300" fill="#ef4444" fill-opacity="0.03"/>
-  <circle cx="1200" cy="630" r="350" fill="#dc2626" fill-opacity="0.04"/>
-  <circle cx="600" cy="315" r="400" fill="#dc2626" fill-opacity="0.02"/>
-  
-  <!-- Decorative Lines -->
-  <line x1="0" y1="200" x2="150" y2="200" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  <line x1="1050" y1="430" x2="1200" y2="430" stroke="#ef4444" stroke-width="1" opacity="0.3"/>
-  
-  <!-- Top Header Bar -->
-  <rect x="0" y="0" width="1200" height="6" fill="url(#accentGradient)"/>
-  
-  <!-- Category Badge -->
-  <g filter="url(#shadow)">
-    <rect x="40" y="25" width="160" height="40" rx="20" fill="url(#securityGradient)"/>
-    <text x="120" y="51" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">SECURITY</text>
-  </g>
-  
-  <!-- Date Badge -->
-  <g filter="url(#shadow)">
-    <rect x="1000" y="25" width="160" height="40" rx="20" fill="url(#accentGradient)"/>
-    <text x="1080" y="51" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">March 16, 2026</text>
-  </g>
-  
-  <!-- Main Title -->
-  <text x="600" y="110" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">: Go, AI,</text>
-  
-  <!-- Subtitle Line -->
-  <rect x="400" y="135" width="400" height="4" rx="2" fill="url(#accentGradient)"/>
-  
-  <!-- Icon Section - Left Side -->
-  <g opacity="0.95">
-    
-    <!-- Shield Icon -->
-    <g transform="translate(80, 280)">
-      <path d="M50 10 L90 30 L90 70 Q90 100 50 120 Q10 100 10 70 L10 30 Z" 
-            fill="url(#securityGradient)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
-      <path d="M35 60 L45 75 L70 45" fill="none" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
-    </g>
-    
-    <!-- Lock Icon -->
-    <g transform="translate(200, 300)">
-      <rect x="15" y="35" width="50" height="40" rx="5" fill="#dc2626" opacity="0.8"/>
-      <path d="M25 35 L25 25 Q25 10 40 10 Q55 10 55 25 L55 35" fill="none" stroke="#dc2626" stroke-width="4"/>
-      <circle cx="40" cy="55" r="6" fill="white"/>
-    </g>
-    
-    <!-- Alert Triangle -->
-    <g transform="translate(320, 290)">
-      <path d="M40 15 L75 75 L5 75 Z" fill="#f59e0b" stroke="#d97706" stroke-width="2"/>
-      <text x="40" y="60" font-family="Arial, sans-serif" font-size="28" font-weight="bold" fill="white" text-anchor="middle">!</text>
-    </g>
-    
-  </g>
-  
-  <!-- Main Content Card -->
-  <g transform="translate(450, 180)" filter="url(#shadow)">
-    <rect width="720" height="340" rx="16" fill="url(#cardGradient)" stroke="#ef4444" stroke-width="1" stroke-opacity="0.3"/>
-    
-    <!-- Card Header Accent -->
-    <rect x="0" y="0" width="720" height="8" rx="4" fill="url(#securityGradient)"/>
-    
-    <!-- Card Title -->
-    <text x="30" y="50" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="#ef4444">Key Highlights</text>
-    
-    <!-- Summary Content -->
-    <g transform="translate(30, 90)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">: Go, AI, ( )</text>
-    </g>
-    <g transform="translate(30, 125)">
-      <circle cx="8" cy="8" r="4" fill="#ef4444"/>
-      <text x="25" y="13" font-family="Arial, sans-serif" font-size="14" fill="#e2e8f0">( ) 2 .</text>
-    </g>
-    
-    <!-- Tags Section -->
-    <g transform="translate(30, 230)">
-      <rect x="0" y="0" width="168" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="84" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Security-Weekly</text>
-      <rect x="180" y="0" width="114" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="237" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#DevSecOps</text>
-      <rect x="306" y="0" width="159" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="385" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Cloud-Security</text>
-      <rect x="477" y="0" width="150" height="30" rx="15" fill="#ef4444" fill-opacity="0.15" stroke="#ef4444" stroke-width="1" stroke-opacity="0.4"/>
-      <text x="552" y="20" font-family="Arial, sans-serif" font-size="12" fill="#ef4444" text-anchor="middle">#Weekly-Digest</text>
-    </g>
-    
-    <!-- CTA Button -->
-    <g transform="translate(540, 280)">
-      <rect width="150" height="45" rx="22" fill="url(#accentGradient)" filter="url(#glow)"/>
-      <text x="75" y="29" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Read More</text>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <circle cx="600" cy="250" r="280" fill="#00add8" opacity="0.03" filter="url(#sg)"/>
+  <g transform="translate(600,225)">
+    <g filter="url(#shadow)">
+      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#00add8" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <line x1="60" y1="0" x2="40" y2="0" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <line x1="55" y1="30" x2="35" y2="15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
+      <circle cx="-15" cy="-25" r="8" fill="#00add8" opacity="0.3"/>
+      <circle cx="15" cy="-25" r="8" fill="#00add8" opacity="0.3"/>
+      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#00add8" text-anchor="middle" opacity="0.6">CVE</text>
     </g>
   </g>
-  
-  <!-- Bottom Section -->
-  <line x1="40" y1="560" x2="1160" y2="560" stroke="#334155" stroke-width="1"/>
-  
-  <!-- Blog Branding -->
-  <g transform="translate(50, 575)">
-    <rect width="45" height="45" rx="10" fill="url(#securityGradient)" filter="url(#shadow)"/>
-    <text x="22" y="32" font-family="Arial, sans-serif" font-size="20" font-weight="bold" fill="white" text-anchor="middle">TD</text>
-  </g>
-  
-  <text x="110" y="595" font-family="Arial, sans-serif" font-size="18" font-weight="bold" fill="white">Twodragon Tech Blog</text>
-  <text x="110" y="615" font-family="Arial, sans-serif" font-size="12" fill="#64748b">tech.2twodragon.com</text>
-  
-  <!-- Tech Stack -->
-  <text x="1150" y="595" font-family="Arial, sans-serif" font-size="12" fill="#64748b" text-anchor="end">DevSecOps | Cloud | Security | AI</text>
-  <text x="1150" y="615" font-family="Arial, sans-serif" font-size="11" fill="#475569" text-anchor="end">Powered by Claude AI</text>
+  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Go + AI Malware</text>
+  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Binary + AI Threats</text>
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#00add8" opacity="0.2" stroke="#00add8" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#00add8" text-anchor="middle">WEEKLY</text>
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 28, 2026</text>
+  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>


### PR DESCRIPTION
## Summary
- 2025년 SVG 28개: 카드 그리드 레이아웃 → 다크 테마 단일 그래픽으로 전환
- 2026년 1월 SVG 30개: 주제별 맞춤 비주얼 (보안, AI, 클라우드, 블록체인 등)
- 2026년 2월 SVG 47개: 키워드 기반 비주얼 타입 매핑 (ai_agent, vuln_target, radar, shield 등)
- 총 97개 파일, 17,718줄 삭제 → 3,632줄 추가 (텍스트 대폭 축소, 비주얼 중심)

## Changes
- Old template (card grid + text heavy) → New template (dark gradient + single main graphic)
- All SVGs: 1200x630 viewport, dark background, glow/shadow filters
- XML validation passed, no Korean text in SVG elements

## Test plan
- [x] All 97 SVG files pass XML parsing validation
- [x] No Korean text detected in any SVG
- [x] No old template markers (Architecture Snapshot, Draw.io Style Diagram, etc.)
- [ ] Verify Vercel preview deployment renders images correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)