### PR TITLE
fix: 포스트 제목 개선 - 반복 접두사 제거 및 구체화 (46개)

### DIFF
--- a/_posts/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.md
+++ b/_posts/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-01-23 10:00:00 +0900
 description: '2026년 1월 23일 주요 기술/보안 뉴스: Microsoft AitM 피싱 경고, HashiCorp Agentic AI Zero Trust NHI 관리, OpenAI PostgreSQL 8억 사용자 스케일링 아키텍처, vLLM 제작자 Inferact $150M 투자까지...'
-excerpt: "기술·보안 주간 다이제스트: Microsoft AitM 피싱 경고, Agentic AI Zero Trust, - 2026년 1월 23일 주요 기술/보안 뉴스: Microsoft AitM 피싱 경고, HashiCorp Agentic AI"
+excerpt: "Microsoft AitM 피싱 경고, Agentic AI Zero Trust, - 2026년 1월 23일 주요 기술/보안 뉴스: Microsoft AitM 피싱 경고, HashiCorp Agentic AI"
 image: /assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
 image_alt: Tech and Security Weekly Digest January 2026 - AitM Phishing, Zero Trust,
   PostgreSQL Scaling
@@ -26,8 +26,7 @@ tags:
 - vLLM
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: Microsoft AitM 피싱 경고, Agentic AI Zero Trust,
-  OpenAI PostgreSQL 8억 사용자 스케일링'
+title: "Microsoft AitM 피싱 경고, Agentic AI Zero Trust, OpenAI PostgreSQL 보안"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.md
+++ b/_posts/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-01-24 10:00:00 +0900
 description: '2026년 1월 24일 주요 기술/보안 뉴스: Microsoft FBI BitLocker 암호화 복구 키 제공 논란과 암호화 신뢰성 재검토, Cloudflare 1월 22일 BGP Route Leak 사건 상세 분석과 RPKI 대응, CNCF 자율 기업 4가지 플랫폼 제어 기둥...'
-excerpt: "기술·보안 주간 다이제스트: Microsoft BitLocker FBI 키 제공, Cloudflare Route - 2026년 1월 24일 주요 기술/보안 뉴스: Microsoft FBI BitLocker 암호화 복구 키 제공 논란과 암호화"
+excerpt: "Microsoft BitLocker FBI 키 제공, Cloudflare Route - 2026년 1월 24일 주요 기술/보안 뉴스: Microsoft FBI BitLocker 암호화 복구 키 제공 논란과 암호화"
 image: /assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
 image_alt: Tech and Security Weekly Digest January 2026 - BitLocker, Route Leak, Agentic
   Enterprise
@@ -28,8 +28,7 @@ tags:
 - CNCF
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: Microsoft BitLocker FBI 키 제공, Cloudflare Route
-  Leak, 자율 기업 2026 전망'
+title: "Microsoft BitLocker FBI 키 제공, Cloudflare Route Leak, Docker 보안"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
+++ b/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-01-25 10:00:00 +0900
 description: '2026년 1월 25일 주요 기술/보안 뉴스: CISA KEV 추가 VMware vCenter CVE-2024-37079 활성 익스플로잇 긴급 패치, Fortinet FortiGate 완전 패치 환경 FortiCloud SSO 우회 제로데이, Sandworm APT 폴란드 전력망...'
-excerpt: "기술·보안 주간 다이제스트: VMware vCenter KEV 긴급 패치, Fortinet SSO 우회, - 2026년 1월 25일 주요 기술/보안 뉴스: CISA KEV 추가 VMware vCenter CVE-2024-37079"
+excerpt: "VMware vCenter KEV 긴급 패치, Fortinet SSO 우회, - 2026년 1월 25일 주요 기술/보안 뉴스: CISA KEV 추가 VMware vCenter CVE-2024-37079"
 image: /assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
 image_alt: Tech and Security Weekly Digest January 2026 - VMware vCenter KEV, Fortinet
   SSO Bypass, Sandworm DynoWiper
@@ -29,8 +29,7 @@ tags:
 - Airflow
 - Platform-Engineering
 - '2026'
-title: '기술·보안 주간 다이제스트: VMware vCenter KEV 긴급 패치, Fortinet SSO 우회,
-  Sandworm DynoWiper 폴란드 공격'
+title: "VMware vCenter KEV 긴급 패치, Fortinet SSO 우회, Sandworm DynoWiper"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks.md
+++ b/_posts/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks.md
@@ -26,8 +26,7 @@ tags:
 - Prompt-Injection
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: Zero Trust for AI Agents, Chrome 기술지원 사기 방지,
-  Terraform Stacks 혁신'
+title: "Zero Trust for AI Agents, Chrome 기술지원 사기 방지, Terraform Stacks"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.md
+++ b/_posts/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.md
@@ -26,8 +26,7 @@ tags:
 - ChatGPT-Containers
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: MS Office Zero-Day 긴급패치, Kimi K2.5 오픈소스 에이전트,
-  Kimwolf 봇넷 위협'
+title: "MS Office Zero-Day 긴급패치, Kimi K2.5 오픈소스 에이전트, Kimwolf 봇넷"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.md
+++ b/_posts/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-28 12:06:07 +0900
 description: '2026년 1월 28일 보안 뉴스: Microsoft Office Zero-Day 취약점 긴급 패치 방법, CTEM 5단계
   프레임워크 실무 적용, Grist-Core RCE 취약점 분석 및 대응 가이드'
-excerpt: "기술·보안 주간 다이제스트: Microsoft Office Zero-Day 긴급 패치, CTEM 실무 적용, - 2026년 1월 28일 보안 뉴스: Microsoft Office Zero-Day 취약점 긴급 패치 방법, CTEM 5단계"
+excerpt: "Microsoft Office Zero-Day 긴급 패치, CTEM 실무 적용, - 2026년 1월 28일 보안 뉴스: Microsoft Office Zero-Day 취약점 긴급 패치 방법, CTEM 5단계"
 image: /assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
 image_alt: Tech and Security Weekly Digest January 2026 - CVE-2026-21509 MS Office
   Zero-Day CTEM Framework
@@ -24,8 +24,7 @@ tags:
 - RCE
 - Cloud-Security
 - '2026'
-title: '기술·보안 주간 다이제스트: Microsoft Office Zero-Day 긴급 패치, CTEM 실무 적용,
-  Grist-Core RCE 취약점'
+title: "Microsoft Office Zero-Day 패치, CTEM 실무 적용, Grist Core RCE"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.md
+++ b/_posts/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-01-29 10:00:00 +0900
 description: '2026년 1월 29일 보안 뉴스: n8n 워크플로우 RCE 취약점(CVE-2026-1470, CVSS 9.9), D-Link 단종 장비 Zero-Day(CVE-2026-0625), Kubernetes AI 에이전트 보안 과제, Infomaniak Swiss Sovereign...'
-excerpt: "기술·보안 주간 다이제스트: n8n Critical RCE, D-Link 단종 장비 Zero-Day, Kubernetes - 2026년 1월 29일 보안 뉴스: n8n 워크플로우 RCE 취약점(CVE-2026-1470, CVSS 9.9), D-Link"
+excerpt: "n8n Critical RCE, D-Link 단종 장비 Zero-Day, Kubernetes - 2026년 1월 29일 보안 뉴스: n8n 워크플로우 RCE 취약점(CVE-2026-1470, CVSS 9.9), D-Link"
 image: /assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
 image_alt: Tech Security Weekly Digest January 29 2026 n8n RCE D-Link Zero-Day Kubernetes
   AI Agent
@@ -27,8 +27,7 @@ tags:
 - NHI
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: n8n Critical RCE, D-Link 단종 장비 Zero-Day, Kubernetes
-  AI 에이전트 보안'
+title: "n8n Critical RCE, D-Link Zero-Day, Kubernetes AI Agent 보안"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.md
+++ b/_posts/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-01-30 10:00:00 +0900
 description: '2026년 1월 30일 보안 뉴스: Ollama AI 서버 175,000대 인터넷 노출(LLMjacking), SolarWinds Web Help Desk Critical RCE 6건(CVSS 9.8 x4), Google GTIG IPIDEA 6.1M IP 레지덴셜 프록시 차단,...'
-excerpt: "기술·보안 주간 다이제스트: Ollama AI 서버 175K 노출, SolarWinds WHD Critical - 2026년 1월 30일 보안 뉴스: Ollama AI 서버 175,000대 인터넷 노출(LLMjacking), SolarWinds"
+excerpt: "Ollama AI 서버 175K 노출, SolarWinds WHD Critical - 2026년 1월 30일 보안 뉴스: Ollama AI 서버 175,000대 인터넷 노출(LLMjacking), SolarWinds"
 image: /assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
 image_alt: Tech Security Weekly Digest January 30 2026 Ollama AI Exposure SolarWinds
   RCE Google IPIDEA Disruption
@@ -26,8 +26,7 @@ tags:
 - ICS
 - DevSecOps
 - '2026'
-title: '기술·보안 주간 다이제스트: Ollama AI 서버 175K 노출, SolarWinds WHD Critical
-  RCE 6건, Google IPIDEA 프록시 차단'
+title: "Ollama AI 서버 175K 노출, SolarWinds WHD Critical RCE, Google IPIDEA"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.md
+++ b/_posts/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.md
@@ -25,8 +25,7 @@ tags:
 - CERT-Polska
 - Cloud-Security
 - '2026'
-title: '기술·보안 주간 다이제스트: ShinyHunters Vishing MFA 우회, Chrome 확장 ChatGPT
-  탈취, 폴란드 에너지 OT 공격'
+title: "ShinyHunters Vishing MFA 우회, Chrome 확장 위협, OT 공격 동향"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.md
+++ b/_posts/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-02-01 10:00:00 +0900
 description: '2026년 2월 1일 보안 뉴스: AI 시스템이 OpenSSL 제로데이 12건을 모두 발견한 역사적 사건, OWASP Agentic AI 보안 프레임워크, Microsoft NIST 기반 AI 에이전트 거버넌스, Fortinet FortiCloud SSO 제로데이, Azure...'
-excerpt: "기술·보안 주간 다이제스트: AI가 OpenSSL 제로데이 12건 발견, OWASP Agentic AI 프레임워크, - 2026년 2월 1일 보안 뉴스: AI 시스템이 OpenSSL 제로데이 12건을 모두 발견한 역사적 사건, OWASP Agentic"
+excerpt: "AI가 OpenSSL 제로데이 12건 발견, OWASP Agentic AI 프레임워크, - 2026년 2월 1일 보안 뉴스: AI 시스템이 OpenSSL 제로데이 12건을 모두 발견한 역사적 사건, OWASP Agentic"
 image: /assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
 image_alt: Security Digest - AI OpenSSL Zero-Day OWASP Agentic AI Fortinet Analysis
 layout: post
@@ -26,8 +26,7 @@ tags:
 - eScan
 - NIST
 - '2026'
-title: '기술·보안 주간 다이제스트: AI가 OpenSSL 제로데이 12건 발견, OWASP Agentic AI 프레임워크,
-  Fortinet SSO 제로데이'
+title: "AI가 OpenSSL 제로데이 12건 발견, OWASP Agentic AI 프레임워크, Fortinet 패치"
 toc: true
 ---
 {%- include ai-summary-card.html

--- a/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
+++ b/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
@@ -30,7 +30,7 @@ tags:
 - AI
 - Malware
 - Go
-title: "기술·보안 주간 다이제스트: n8n RCE, NGINX 하이재킹, AsyncRAT 캠페인"
+title: "n8n RCE, NGINX 하이재킹, AsyncRAT 캠페인 분석"
 toc: true
 ---
 

--- a/_posts/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.md
+++ b/_posts/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-02-06 12:30:12 +0900
 description: '2026년 02월 06일 보안 뉴스: CrashFix ClickFix 변종 Python RAT 배포, AISURU/Kimwolf 31.4 Tbps DDoS 기록 경신, Codespaces RCE/AsyncRAT C2/BYOVD 복합 위협. DevSecOps 실무 위협 분석,...'
-excerpt: "2026-02-06 기술·보안 주간 다이제스트: CrashFix Python RAT, AISURU 31.4 Tbps DDoS, Codespaces RCE, BYOVD - 2026년 02월 06일 보안 뉴스: CrashFix ClickFix 변종 Python..."
+excerpt: "CrashFix Python RAT, AISURU 31.4 Tbps DDoS, Codespaces RCE, BYOVD - 2026년 02월 06일 보안 뉴스: CrashFix ClickFix 변종 Python..."
 image: /assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
 image_alt: Tech Security Weekly Digest February 06 2026 AI Botnet Cloud
 layout: post
@@ -21,7 +21,7 @@ tags:
 - Botnet
 - Cloud
 - Threat
-title: "기술·보안 주간 다이제스트: CrashFix RAT, 초대형 DDoS, Codespaces RCE"
+title: "CrashFix RAT, 초대형 DDoS 봇넷, Codespaces RCE 취약점"
 toc: true
 ---
 {% include ai-summary-card.html

--- a/_posts/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.md
+++ b/_posts/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.md
@@ -30,7 +30,7 @@ tags:
 - Malware
 - Go
 - Security
-title: "기술·보안 주간 다이제스트: APT 침해, AitM 라우터 공격, 공급망 보안"
+title: "APT 침해 분석, AitM 라우터 공격, 공급망 보안 동향"
 toc: true
 ---
 

--- a/_posts/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.md
+++ b/_posts/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.md
@@ -7,7 +7,7 @@ categories:
 comments: true
 date: 2026-02-08 10:58:46 +0900
 description: '2026년 02월 08일 보안 뉴스: 독일 BfV/BSI가 경고한 러시아 연계 Signal 피싱 공격(정치인/군인/언론인 타겟), BlackField 랜섬웨어 코드 재활용, 제로트러스트 데이터 중심 보안전략. DevSecOps 실무 위협 분석, MITRE ATT&CK 매핑, 탐지...'
-excerpt: "2026-02-08 기술·보안 주간 다이제스트: Signal 피싱 국가지원 공격, BlackField 랜섬웨어, - 2026년 02월 08일 보안 뉴스: 독일 BfV/BSI가 경고한 러시아 연계 Signal 피싱 공격(정치인/군인/언론인"
+excerpt: "Signal 피싱 국가지원 공격, BlackField 랜섬웨어, - 2026년 02월 08일 보안 뉴스: 독일 BfV/BSI가 경고한 러시아 연계 Signal 피싱 공격(정치인/군인/언론인"
 image: /assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
 image_alt: Tech Security Weekly Digest February 08 2026 Signal Phishing BlackField
   Ransomware Zero Trust Data
@@ -22,8 +22,7 @@ tags:
 - BlackField-Ransomware
 - Zero-Trust
 - Data-Security
-title: '2026-02-08 기술·보안 주간 다이제스트: Signal 피싱 국가지원 공격, BlackField 랜섬웨어,
-  제로트러스트 데이터 보안'
+title: "Signal 피싱 국가지원 공격, BlackField 랜섬웨어, 데이터 보안"
 toc: true
 ---
 {% include ai-summary-card.html

--- a/_posts/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.md
+++ b/_posts/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.md
@@ -30,7 +30,7 @@ tags:
 - Ransomware
 - Patch
 - AI
-title: "기술·보안 주간 다이제스트: 랜섬웨어, Fortinet 패치, AI 보안"
+title: "랜섬웨어 대응, Fortinet 긴급 패치, AI 보안 위협 분석"
 toc: true
 ---
 

--- a/_posts/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.md
+++ b/_posts/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 공급망 침해, Windows 보안, APT36"
+title: "공급망 침해 사례, Windows 보안 업데이트, APT36 분석"
 date: 2026-02-12 12:41:50 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Cloud, Security, Agent]

--- a/_posts/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.md
+++ b/_posts/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: Lazarus 공급망, Copilot Studio, FinOps"
+title: "Lazarus 공급망 공격, Copilot Studio 취약점, FinOps 보안"
 date: 2026-02-13 12:39:45 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Go, Security, Agent]

--- a/_posts/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.md
+++ b/_posts/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: '기술·보안 주간 다이제스트: AI 에이전트 토큰 탈취, 패스워드 매니저 취약점, 서버리스 방어'
+title: "AI 에이전트 토큰 탈취, 패스워드 매니저 취약점, 서버리스 방어 전략"
 date: 2026-02-17 12:35:29 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI-Agent, Password-Manager, Serverless]

--- a/_posts/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.md
+++ b/_posts/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: "2026년 2월 3주차 기술·보안 주간 다이제스트: AI 에이전트 보안, Patch Tuesday, 클라우드 비용"
+title: "AI 에이전트 보안, Patch Tuesday 분석, 클라우드 비용 최적화"
 date: 2026-02-17 10:00:00 +0900
 categories: [security, devsecops, cloud]
 tags: [Weekly-Digest, Security-Weekly, AI-Security, Threat-Intel, Patch-Tuesday, Cloud, FinOps, DevOps, "2026"]

--- a/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
+++ b/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 클라우드 보안, 안드로이드 악성코드, 업데이트 리스크"
+title: "클라우드 보안 위협, 안드로이드 악성코드, 업데이트 리스크 분석"
 date: 2026-02-18 11:12:32 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Cloud, Malware, Update]

--- a/_posts/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.md
+++ b/_posts/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.md
@@ -1,7 +1,7 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AWS 보안, Zero-Day, CVE-2026-2329"
+title: "AWS 보안 업데이트, Zero-Day 패치, CVE-2026-2329 분석"
 date: 2026-02-19 12:36:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AWS, Security, Zero-Day, CVE]

--- a/_posts/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.md
+++ b/_posts/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "2026-02-20 기술·보안 주간 다이제스트: AI 정렬 연구·EKS Flyte·Docker 보안·Cloud Native"
+title: "AI 정렬 연구, EKS Flyte 워크플로, Docker 보안, Cloud Native 동향"
 date: 2026-02-20 08:15:29 +0900
 categories: [tech, devops]
 tags: [Tech-Blog, Weekly-Digest, Developer, 2026, AI, Data, Cloud, Go]
-excerpt: "2026-02-20 기술·보안 주간 다이제스트: AI 정렬 연구·EKS Flyte·Docker 보안·Cloud Native를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "AI 정렬 연구·EKS Flyte·Docker 보안·Cloud Native를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 20일 테크 블로그 다이제스트: OpenAI Blog, Google AI Blog, AWS Machine Learning Blog 등 15건. AI, Data, Cloud, Go 관련 개발자 뉴스 및 트렌드 분석."
 keywords: [Tech-Blog, Weekly-Digest, Developer, 2026, AI, Data, Cloud, Go]
 author: Twodragon

--- a/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
+++ b/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: Gemini 3.1 Pro, AI 공급망 공격, Kubernetes"
+title: "Gemini 3.1 Pro 출시, AI 공급망 공격, Kubernetes 보안 강화"
 date: 2026-02-20 09:00:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Gemini, AI, Supply-Chain, Kubernetes]
-excerpt: "기술·보안 주간 다이제스트: Gemini 3.1 Pro, AI 공급망 공격, Kubernetes를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "Gemini 3.1 Pro, AI 공급망 공격, Kubernetes를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 20일 보안 뉴스: The Hacker News, Google Cloud, Snyk 등 29건. Gemini 3.1 Pro, AI 공급망 공격, Kubernetes Ingress NGINX 은퇴 관련 DevSecOps 실무 위협 분석 및 대응 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.md
+++ b/_posts/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: CVE-2025-49113, 랜섬웨어, Rust 공급망"
+title: "CVE-2025-49113 분석, 랜섬웨어 대응, Rust 공급망 보안"
 date: 2026-02-21 00:12:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Vulnerability, AI, Security, AWS]
-excerpt: "기술·보안 주간 다이제스트: CVE-2025-49113, 랜섬웨어, Rust 공급망를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "CVE-2025-49113, 랜섬웨어, Rust 공급망를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 21일 보안 뉴스: The Hacker News, SK쉴더스 보안 리포트 등 15건. Vulnerability, AI, Security, AWS 관련 DevSecOps 실무 위협 분석 및 대응 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.md
+++ b/_posts/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AI 위협 행위자, Roundcube KEV, Claude Code 보안"
+title: "AI 위협 행위자 분석, Roundcube KEV 긴급, Claude Code 보안 점검"
 date: 2026-02-22 12:35:56 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Threat, Vulnerability, Security]
-excerpt: "기술·보안 주간 다이제스트: AI 위협 행위자, Roundcube KEV, Claude Code 보안를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "AI 위협 행위자, Roundcube KEV, Claude Code 보안를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 22일 보안 뉴스: AI 활용 위협 행위자의 55개국 FortiGate 대규모 침해, CISA Roundcube 웹메일 취약점 2건 KEV 긴급 추가, Anthropic Claude Code Security 출시 등 DevSecOps 실무 위협 분석 및 대응 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.md
+++ b/_posts/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: Vertical AI 보안, BlackField 랜섬웨어, 데이터 전략"
+title: "Vertical AI 보안 전략, BlackField 랜섬웨어, 데이터 보호 동향"
 date: 2026-02-23 12:39:51 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Ransomware, Zero-Trust, OT-Security, Bitcoin]
-excerpt: "기술·보안 주간 다이제스트: Vertical AI 보안, BlackField 랜섬웨어, 데이터 전략를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "Vertical AI 보안, BlackField 랜섬웨어, 데이터 전략를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "SK쉴더스 11~12월호 보안 리포트 5건 심층 분석(Vertical AI, BlackField 랜섬웨어, 제로트러스트 데이터, EQST insight, OT 보안), 비트코인 $65K 급락, 러시아 제재 우회 거래소 네트워크 적발 등 DevSecOps 실무 위협 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
+++ b/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: APT28 악성코드, Docker 보안, LLM 운영"
+title: "APT28 악성코드 분석, Docker 보안 강화, LLM 운영 리스크"
 date: 2026-02-24 09:49:56 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Malware, AI, Docker, LLM]
-excerpt: "기술·보안 주간 다이제스트: APT28 악성코드, Docker 보안, LLM 운영를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "APT28 악성코드, Docker 보안, LLM 운영를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 24일 보안 뉴스: APT28 유럽 타겟 웹훅 멀웨어, XMRig 웜 캠페인 BYOVD, Weekly Recap 주요 위협, Docker Gordon AI, KubeCon Europe SecurityCon 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
+++ b/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AI, 악성코드, 랜섬웨어"
+title: "Copilot 악용 토큰 유출, UAC-0050 금융기관 공격, LLM 보안 운영"
 date: 2026-02-25 12:36:07 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Malware, Ransomware, LLM]
-excerpt: "기술·보안 주간 다이제스트: AI, 악성코드, 랜섬웨어를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "AI, 악성코드, 랜섬웨어를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 25일 보안 뉴스: The Hacker News, Microsoft Security Blog 등 14건. GitHub Codespaces RoguePilot RCE, UAC-0050 유럽 금융기관 공격, 악성 Next.js C2 캠페인 등 DevSecOps 실무..."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.md
+++ b/_posts/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "기술·보안 주간 다이제스트: AI, Go, AWS"
+title: "UNC2814 GRIDTIDE 캠페인, Claude Code RCE 취약점, 음성 피싱 동향"
 date: 2026-02-26 11:05:21 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Go, AWS, API]
-excerpt: "기술·보안 주간 다이제스트: AI, Go, AWS를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "AI, Go, AWS를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 26일 보안 뉴스: The Hacker News 등 23건. AI, Go, AWS, API 관련 DevSecOps 실무 위협 분석 및 대응 가이드."
 keywords: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Go, AWS]
 author: Twodragon

--- a/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
+++ b/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AI, 봇넷, 블록체인"
+title: "Aeternum 블록체인 C2 봇넷, AWS ISO 42001 AI 감사, 공급망 보안"
 date: 2026-02-27 12:28:30 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Botnet, Blockchain, Go]
-excerpt: "기술·보안 주간 다이제스트: AI, 봇넷, 블록체인를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "AI, 봇넷, 블록체인를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 27일 보안 뉴스: The Hacker News, AWS Security Blog 등 30건. AI, Botnet, Blockchain, Go 관련 DevSecOps 실무 위협 분석 및 대응 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
+++ b/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
@@ -1,10 +1,10 @@
 ---
 layout: post
-title: "기술·보안 주간 다이제스트: Go, AI, 악성코드"
+title: "Pig Butchering $6100만 압수, FreePBX 대규모 침해, Go Crypto 백도어"
 date: 2026-02-28 11:16:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Go, AI, Malware]
-excerpt: "기술·보안 주간 다이제스트: Go, AI, 악성코드를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
+excerpt: "Go, AI, 악성코드를 기준으로 기술 관점(공격 경로·영향 자산·탐지 포인트)과 경영진 관점(서비스 영향·우선순위·의사결정 체크리스트)을 함께 정리한 2월 하순 주간 다이제스트입니다."
 description: "2026년 02월 28일 보안 뉴스: The Hacker News 등 26건. Go, AI, Malware 관련 DevSecOps 실무 위협 분석 및 대응 가이드."
 keywords: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Go, AI, Malware]
 author: Twodragon

--- a/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
+++ b/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AI 에이전트 보안, Gentlemen 랜섬웨어, 운영 대응"
+title: "AI 에이전트 보안 위협, Gentlemen 랜섬웨어, 운영 대응 전략"
 date: 2026-03-01 23:23:38 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Agent, Ransomware]
-excerpt: "기술·보안 주간 다이제스트: AI 에이전트 보안, Gentlemen 랜섬웨어, 운영 대응에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "AI 에이전트 보안, Gentlemen 랜섬웨어, 운영 대응에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "NVIDIA Agentic AI 통신 자율 네트워크, SK쉴더스 OT 보안·Gentlemen 랜섬웨어 위협 분석, AWS MCP Registry 에이전트 플랫폼, 토큰화 금 시장 등 17건의 DevSecOps 실무 위협 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.md
+++ b/_posts/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 제로트러스트 가시성, 암호화폐 규제, 랜섬웨어 대응"
+title: "제로트러스트 가시성, 암호화폐 규제 동향, 랜섬웨어 대응 전략"
 date: 2026-03-02 12:29:39 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Zero-Trust, Crypto-Regulation, Weekly-Digest, 2026]
-excerpt: "기술·보안 주간 다이제스트: 제로트러스트 가시성, 암호화폐 규제, 랜섬웨어 대응에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "제로트러스트 가시성, 암호화폐 규제, 랜섬웨어 대응에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "SK쉴더스 제로트러스트 가시성 분석 리포트, Trump Media 암호화폐 사업 확대, X 광고 정책 변경, Anthropic AI 교육 과정 공개 등 6건의 심층 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
+++ b/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: JWT 인증 위협, 암호화폐 유출, 금융 AI 거버넌스"
+title: "JWT 인증 위협, 암호화폐 유출 사고, 금융 AI 거버넌스"
 date: 2026-03-04 14:05:06 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, JWT, Blockchain, AI-Governance]
-excerpt: "기술·보안 주간 다이제스트: JWT 인증 위협, 암호화폐 유출, 금융 AI 거버넌스에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "JWT 인증 위협, 암호화폐 유출, 금융 AI 거버넌스에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "JWT 서명키 유출이 초래하는 인증 체계 붕괴 위험, 미-이스라엘 공습 후 이란 거래소 $1,030만 비트코인 유출, 금융분야 AI 7대 원칙과 글로벌 정책 동향 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.md
+++ b/_posts/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: Coruna iOS 익스플로잇, 핵티비스트 DDoS, 대응 우선순위"
+title: "Coruna iOS 익스플로잇, 핵티비스트 DDoS, 보안 대응 우선순위"
 date: 2026-03-05 10:30:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, iOS-Exploit, DDoS, AI-Governance]
-excerpt: "기술·보안 주간 다이제스트: Coruna iOS 익스플로잇, 핵티비스트 DDoS, 대응 우선순위에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "Coruna iOS 익스플로잇, 핵티비스트 DDoS, 대응 우선순위에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "Google이 공개한 Coruna iOS 익스플로잇 킷(23개 익스플로잇, 5개 체인), 중동 분쟁 후 16개국 110개 기관 대상 핵티비스트 DDoS 공격 149건, AI 거버넌스 RFP 템플릿 등 17건의 DevSecOps 실무 위협 분석."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
+++ b/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: CVE-2026-20122, Cisco 보안, AWS 운영"
+title: "CVE-2026-20122 Cisco 보안 패치, AWS 운영 보안, AI 위협 분석"
 date: 2026-03-06 12:29:02 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Security, Threat, AI, AWS]
-excerpt: "기술·보안 주간 다이제스트: CVE-2026-20122, Cisco 보안, AWS 운영에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "CVE-2026-20122, Cisco 보안, AWS 운영에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "Cisco Catalyst SD-WAN Manager CVE-2026-20122 활성 공격 확인, Europol의 Tycoon 2FA PhaaS 해체(64,000건 공격), APT28 우크라이나 표적 신규 악성코드 배포, GPT-5.4 출시 및 Google Cloud 보안..."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
+++ b/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: Android 129개 취약점, DevSecOps 보안 부채, K8s 공격 급증"
+title: "Android 129개 취약점 패치, DevSecOps 보안 부채, K8s 공격 급증"
 date: 2026-03-07 12:00:00 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Android, Zero-Day, Kubernetes, Supply-Chain]
-excerpt: "기술·보안 주간 다이제스트: Android 129개 취약점, DevSecOps 보안 부채, K8s 공격 급증에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "Android 129개 취약점, DevSecOps 보안 부채, K8s 공격 급증에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "Google Android 129개 취약점 패치(Qualcomm 제로데이 CVE-2026-21385 활성 공격), VMware Aria Operations CVE-2026-22719 KEV 등재, Datadog DevSecOps 보고서(87% 조직 취약), VoidLink AI..."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.md
+++ b/_posts/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: OpenAI Codex 보안 스캔, Claude Firefox 취약점, USDC 동향"
+title: "OpenAI Codex 보안 스캔, Claude Firefox 취약점, USDC 동향"
 date: 2026-03-08 12:33:37 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Security]
-excerpt: "기술·보안 주간 다이제스트: OpenAI Codex 보안 스캔, Claude Firefox 취약점, USDC 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "OpenAI Codex 보안 스캔, Claude Firefox 취약점, USDC 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[High] 애플리케이션 보안 - AI 스캔 결과를 기존 SAST와 교차 검증 필요. [High] Firefox 148 업데이트 필수(14건 High 취약점 수정). 2026년 03월 08일 보안 뉴스 12건. DevSecOps 실무 위협 분석 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.md
+++ b/_posts/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: AI 에이전트 보안 위협, Saylor 비트코인 매수, Agent Safehouse"
+title: "AI 에이전트 보안 위협, Saylor 비트코인 매수, Agent Safehouse"
 date: 2026-03-09 12:37:51 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Security, Go, Bitcoin]
-excerpt: "기술·보안 주간 다이제스트: AI 에이전트 보안 위협, Saylor 비트코인 매수, Agent Safehouse에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "AI 에이전트 보안 위협, Saylor 비트코인 매수, Agent Safehouse에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[High] AI 에이전트 보안 위협 - 프롬프트 인젝션·과도한 권한·공급망 공격(Krebs on Security). [High] 민감 데이터 접근 경로 최소화, 감사 로그 점검. 2026년 03월 09일 보안 뉴스 11건. DevSecOps 실무 위협 분석 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
+++ b/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 암호화폐 침해, 모바일 제로데이, AI 운영 리스크"
+title: "암호화폐 침해 사고, 모바일 제로데이 패치, AI 운영 리스크"
 date: 2026-03-10 09:42:33 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Malware, Security, Data]
-excerpt: "기술·보안 주간 다이제스트: 암호화폐 침해, 모바일 제로데이, AI 운영 리스크에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "암호화폐 침해, 모바일 제로데이, AI 운영 리스크에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[Critical] Qualcomm 0-Day, iOS 익스플로잇 체인, AirSnitch 공격 등 주간 보안 요약. [High] 공급망 공격 인식 확대와 중견기업 보안 플랫폼 대응 전략. 2026년 03월 10일 보안 뉴스 27건. DevSecOps 실무 위협 분석 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
+++ b/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 공격 표면 인텔리전스, 블록체인 시장 리스크, 기술 동향"
+title: "공격 표면 인텔리전스, 블록체인 시장 리스크, AI 보안 동향"
 date: 2026-03-11 21:08:57 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Cloud, Security, Blockchain, Tech]
-excerpt: "기술·보안 주간 다이제스트: 공격 표면 인텔리전스, 블록체인 시장 리스크, 기술 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "공격 표면 인텔리전스, 블록체인 시장 리스크, 기술 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[Critical] Cloudflare 공격 표면 인텔리전스 - 인터넷 노출 자산 실시간 파악 필요. [High] 외부 노출 서비스 식별, 지갑/계정 MFA 재검증. 2026년 03월 11일 보안 뉴스 11건. DevSecOps 실무 위협 분석 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
+++ b/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: 블록체인 신뢰 리스크, Vertical AI 전략, 기술 동향"
+title: "블록체인 신뢰 리스크, Vertical AI 전략, AWS 보안 패치"
 date: 2026-03-12 21:46:13 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Blockchain, Vertical-AI, Tech, DeFi]
-excerpt: "기술·보안 주간 다이제스트: 블록체인 신뢰 리스크, Vertical AI 전략, 기술 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "블록체인 신뢰 리스크, Vertical AI 전략, 기술 동향에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[High] 지갑/계정 보호 - 주소 오염, 피싱, 관리 계정 접근정책 재검증 필요. 2026년 03월 12일 보안 뉴스 10건. 블록체인 시장 동향, Vertical AI, 기술 이슈를 운영 리스크 기준으로 정리한 DevSecOps 실무 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
+++ b/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
@@ -1,11 +1,11 @@
 ---
 
 layout: post
-title: "기술·보안 주간 다이제스트: GlassWorm 공급망 공격, AI 에이전트 보안, AWS IAM 멀티리전"
+title: "GlassWorm 공급망 공격, AI 에이전트 보안, AWS IAM 멀티리전"
 date: 2026-03-15 10:24:40 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AWS, SupplyChain, AI-Security, Bitcoin]
-excerpt: "기술·보안 주간 다이제스트: GlassWorm 공급망 공격, AI 에이전트 보안, AWS IAM 멀티리전에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
+excerpt: "GlassWorm 공급망 공격, AI 에이전트 보안, AWS IAM 멀티리전에서 확인된 주요 위협과 기술 변화를 운영 관점으로 요약하고, 보안팀·플랫폼팀이 바로 실행할 우선 대응 항목을 정리한 주간 다이제스트입니다."
 description: "[Critical] GlassWorm 공급망 공격 대응 - VS Code Open VSX 확장 감사, AI 에이전트 입출력 검증, AWS IAM Identity Center 멀티리전 접근 정책 재검토 필요. 2026년 03월 15일 보안 뉴스 9건. 공급망 보안, AI 에이전트 취약점, 클라우드 접근 관리를 운영 리스크 기준으로 정리한 DevSecOps 실무 가이드."
 author: Twodragon
 comments: true

--- a/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
+++ b/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "기술·보안 주간 다이제스트: 블록체인, 클라우드 보안, AI"
+title: "AI 에이전트 레드팀 오픈소스, Bedrock 멀티에이전트, Aave Shield 출시"
 date: 2026-03-16 10:27:53 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Agent, Open-Source, Update]

--- a/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.md
+++ b/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "기술·보안 주간 다이제스트: 블록체인, AI, 기술 동향"
+title: "아르헨티나 Libra 토큰 포렌식, 스테이블코인 규제, 암호화폐 시장 동향"
 date: 2026-03-16 18:32:58 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, AI, Bitcoin]

--- a/_posts/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.md
+++ b/_posts/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: "기술·보안 주간 다이제스트: 클라우드 보안, 보안 위협, AI"
+title: "GlassWorm GitHub 토큰 탈취, Chrome 제로데이, 라우터 봇넷 위협"
 date: 2026-03-17 10:19:25 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Malware, AI, AWS, Botnet]


### PR DESCRIPTION
## Summary
- 46개 포스트에서 "기술·보안 주간 다이제스트:" 반복 접두사 제거
- 31개 포스트 excerpt에서도 동일 접두사 제거
- 모호한 제목(예: "AI, Go, AWS")은 실제 기사 헤드라인 기반으로 구체화
  - 예: "AI, Go, AWS" → "UNC2814 GRIDTIDE 캠페인, Claude Code RCE 취약점, 음성 피싱 동향"

## Test plan
- [x] 46개 제목 업데이트 확인
- [x] 31개 excerpt 업데이트 확인
- [ ] Vercel 프리뷰에서 제목이 잘 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)