### PR TITLE
fix: AdSense 400 에러 및 CLS 레이아웃 시프트 개선

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -333,6 +333,10 @@
       height: 0 !important;
       min-height: 0 !important;
     }
+    /* CLS prevention: contain auto-placed ads */
+    .google-auto-placed {
+      contain: layout style;
+    }
   </style>
   {% endif %}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -96,20 +96,9 @@ layout: default
 
   {% include series-nav.html %}
 
-  {% comment %} TOC 아래 광고 - 긴 글에서만 표시 {% endcomment %}
-  {% assign word_count = content | number_of_words %}
-  {% if word_count > 500 and site.google_adsense %}
-  {% include adsense.html type="in-article" %}
-  {% endif %}
-
   <div class="post-content" itemprop="articleBody" lang="ko">
     {{ content }}
   </div>
-
-  {% comment %} 콘텐츠 하단 광고 {% endcomment %}
-  {% if site.google_adsense %}
-  {% include adsense.html type="multiplex" %}
-  {% endif %}
 
   <footer class="post-footer">
     {% include share-buttons.html %}
@@ -123,11 +112,6 @@ layout: default
     {% assign related = posts | where_exp: "post", "post.categories contains cat" | limit: 3 %}
   {% else %}
     {% assign related = posts | limit: 3 %}
-  {% endif %}
-
-  {% comment %} 관련 포스트 위 광고 {% endcomment %}
-  {% if site.google_adsense %}
-  {% include adsense.html type="footer" %}
   {% endif %}
 
   {% if related.size > 0 %}

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -456,6 +456,8 @@
   position: relative;
   width: 100%;
   margin: 1.5em 0;
+  min-height: 3em;
+  contain: content;
   overflow-x: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--color-primary) var(--color-bg-tertiary);

--- a/index.html
+++ b/index.html
@@ -202,10 +202,6 @@ title: Home
             </div>
           </a>
         </article>
-        {% comment %} 6번째 포스트 후에 인피드 광고 삽입 {% endcomment %}
-        {% if forloop.index == 6 and site.google_adsense %}
-          {% include adsense.html type="infeed" %}
-        {% endif %}
       {% endfor %}
     </div>
 
@@ -216,11 +212,6 @@ title: Home
       </a>
     </div>
   </section>
-
-  {% comment %} 카테고리 섹션 위 광고 {% endcomment %}
-  {% if site.google_adsense %}
-  {% include adsense.html type="responsive" %}
-  {% endif %}
 
   <!-- Categories Quick Links -->
   <section class="categories-section">


### PR DESCRIPTION
## Summary
- 수동 AdSense `<ins>` 태그 5개 제거 (`data-ad-slot="auto"`는 유효하지 않아 400 에러 발생)
  - `post.html`: in-article, multiplex, footer 광고 3개
  - `index.html`: infeed, responsive 광고 2개
- Auto Ads 페이지 레벨 코드는 유지 (자동 배치)
- CLS 방지: `table-wrapper`에 `min-height`, `contain: content` 추가
- CLS 방지: `google-auto-placed`에 `contain: layout style` 추가

## Test plan
- [x] 수동 광고 삽입 코드 제거 확인
- [x] Auto Ads 설정 유지 확인
- [ ] Vercel 프리뷰에서 400 에러 사라졌는지 확인
- [ ] CLS 점수 개선 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)