### PR TITLE
fix: 저품질 SVG 썸네일 25개 업그레이드

### DIFF
--- a/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
+++ b/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
@@ -3,13 +3,32 @@
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1520"/>
     </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f97316"/><stop offset="100%" style="stop-color:#22c55e"/>
+    </linearGradient>
     <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <filter id="softglow"><feGaussianBlur stdDeviation="20" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#sg)"/>
-  <g transform="translate(600,250)">
+
+  <!-- Grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff"/><line x1="120" y1="0" x2="120" y2="630" stroke="#fff"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff"/><line x1="240" y1="0" x2="240" y2="630" stroke="#fff"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff"/><line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff"/><line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="350" cy="180" r="150" fill="#22c55e" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="850" cy="380" r="180" fill="#3b82f6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Cloud icon with AWS + FinOps -->
+  <g transform="translate(600,250)" filter="url(#shadow)">
     <path d="M-120,20 C-140,20 -160,0 -150,-25 C-145,-55 -115,-70 -85,-65 C-75,-100 -40,-115 0,-105 C40,-115 75,-100 85,-65 C115,-70 145,-55 150,-25 C160,0 140,20 120,20 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+    <path d="M-100,15 C-115,15 -130,2 -125,-15 C-121,-38 -97,-48 -72,-44 C-64,-70 -35,-82 0,-74 C35,-82 64,-70 72,-44 C97,-48 121,-38 125,-15 C130,2 115,15 100,15 Z" fill="none" stroke="#f97316" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
     <text x="-50" y="-20" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#f97316" opacity="0.8">AWS</text>
     <g transform="translate(50,-30)">
       <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
@@ -20,8 +39,28 @@
       <path d="M-8,5 L-3,12 L10,-2" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round"/>
     </g>
   </g>
+
+  <!-- Region markers -->
+  <g opacity="0.3">
+    <rect x="100" y="140" width="90" height="45" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+    <text x="145" y="167" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">us-east-1</text>
+    <rect x="1010" y="400" width="90" height="45" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+    <text x="1055" y="427" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">ap-ne-2</text>
+  </g>
+
+  <!-- Code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#f97316">
+    <text x="50" y="100">aws iam list-roles</text>
+    <text x="920" y="110">cost-explorer --monthly</text>
+    <text x="70" y="480">guardduty.enable()</text>
+    <text x="910" y="490">budget.alert(threshold)</text>
+  </g>
+
+  <!-- Title -->
   <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Security and FinOps</text>
   <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 3 | Cost Optimization</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
   <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CLOUD COURSE</text>
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>

--- a/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
+++ b/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
@@ -1,37 +1,86 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a15"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="260" fill="#dc2626" opacity="0.04" filter="url(#sg)"/>
-  <!-- Magnifying glass scanning vulnerability -->
-  <g transform="translate(600,250)">
-    <circle cx="-30" cy="-20" r="80" fill="none" stroke="#dc2626" stroke-width="3" opacity="0.6"/>
-    <circle cx="-30" cy="-20" r="70" fill="#1e293b" opacity="0.8"/>
-    <line x1="30" y1="40" x2="100" y2="110" stroke="#dc2626" stroke-width="8" stroke-linecap="round"/>
-    <!-- Bug inside magnifier -->
-    <circle cx="-30" cy="-30" r="18" fill="#ef4444" opacity="0.15"/>
-    <text x="-30" y="-20" font-family="Courier New" font-size="20" fill="#ef4444" text-anchor="middle">BUG</text>
-    <!-- Scan lines -->
-    <line x1="-80" y1="-50" x2="20" y2="-50" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
-    <line x1="-80" y1="-30" x2="20" y2="-30" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
-    <line x1="-80" y1="-10" x2="20" y2="-10" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
-    <line x1="-80" y1="10" x2="20" y2="10" stroke="#dc2626" stroke-width="0.8" opacity="0.3"/>
-    <!-- ISMS badge -->
-    <g transform="translate(140,-60)">
-      <rect x="-40" y="-20" width="80" height="40" rx="8" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
-      <text x="0" y="5" font-family="Courier New" font-size="14" fill="#60a5fa" text-anchor="middle">ISMS</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#06b6d4" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#3b82f6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#06b6d4" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,230)">
+      <path d="M-80,20 C-80,-40 -40,-70 10,-70 C30,-70 50,-60 60,-45 C70,-55 90,-55 105,-40 C130,-40 140,-20 140,0 C140,25 125,40 100,40 L-60,40 C-80,40 -100,25 -100,5 C-100,-5 -90,-15 -80,-15 Z" fill="#1e293b" stroke="#06b6d4" stroke-width="2.5"/>
+      <path d="M-60,20 C-60,-25 -25,-50 15,-50 C30,-50 45,-42 52,-30 C60,-38 75,-38 87,-27 C105,-27 115,-12 115,5 C115,22 103,33 82,33 L-42,33 C-58,33 -75,22 -75,5 C-75,-2 -68,-10 -60,-10 Z" fill="none" stroke="#06b6d4" stroke-width="1" stroke-dasharray="5,3" opacity="0.3"/>
+      <rect x="-15" y="-15" width="30" height="25" rx="4" fill="none" stroke="#06b6d4" stroke-width="2"/>
+      <path d="M-8,-15 L-8,-28 C-8,-38 8,-38 8,-28 L8,-15" fill="none" stroke="#06b6d4" stroke-width="2"/>
+      <circle cx="0" cy="0" r="4" fill="#06b6d4" opacity="0.7"/>
     </g>
   </g>
-  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Vulnerability Scan</text>
-  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 4 | ISMS Response</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#dc2626" opacity="0.2" stroke="#dc2626" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">CLOUD COURSE</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.3">
+      <rect x="100" y="130" width="80" height="50" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+      <text x="140" y="160" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">us-east-1</text>
+      <rect x="1020" y="400" width="80" height="50" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+      <text x="1060" y="430" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">ap-ne-2</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#06b6d4">
+    <text x="50" y="100">aws configure</text>
+    <text x="950" y="120">kubectl apply</text>
+    <text x="70" y="480">terraform plan</text>
+    <text x="920" y="500">cloud.deploy()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Vulnerability and ISMS</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Course 7th | Week 4 Practical Guide</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">COURSE</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 9, 2025</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">May 9, 2025</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
@@ -3,19 +3,35 @@
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2e"/>
     </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f97316"/><stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
     <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <filter id="softglow"><feGaussianBlur stdDeviation="20" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#sg)"/>
-  <g transform="translate(600,250)">
-    <!-- Conference stage -->
+
+  <!-- Grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff"/><line x1="120" y1="0" x2="120" y2="630" stroke="#fff"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff"/><line x1="240" y1="0" x2="240" y2="630" stroke="#fff"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff"/><line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff"/><line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="270" r="260" fill="#f97316" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="200" r="150" fill="#3b82f6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="350" r="180" fill="#f97316" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Conference stage + logo -->
+  <g transform="translate(600,250)" filter="url(#shadow)">
     <rect x="-200" y="40" width="400" height="8" rx="4" fill="#f97316" opacity="0.3"/>
-    <!-- Large AWS re:Inforce logo area -->
     <rect x="-120" y="-100" width="240" height="120" rx="16" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
+    <rect x="-115" y="-95" width="230" height="110" rx="12" fill="none" stroke="#f97316" stroke-width="1" stroke-dasharray="6,3" opacity="0.2"/>
     <text x="0" y="-45" font-family="Arial,sans-serif" font-size="16" fill="#f97316" text-anchor="middle">re:Inforce</text>
     <text x="0" y="-20" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="#f97316" text-anchor="middle" opacity="0.8">2025</text>
-    <!-- Shield with cloud -->
     <g transform="translate(0,80)">
       <path d="M0,-25 L30,-18 L30,5 C30,18 15,28 0,32 C-15,28 -30,18 -30,5 L-30,-18 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="2"/>
       <path d="M-10,-5 C-14,-5 -16,-8 -15,-12 C-14,-16 -10,-18 -6,-17 C-5,-22 0,-24 5,-22 C10,-24 15,-22 16,-17 C20,-18 24,-16 25,-12 C26,-8 24,-5 20,-5 Z" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.6"/>
@@ -24,10 +40,31 @@
     <g opacity="0.15">
       <path d="M-200,-150 L-50,-60" fill="none" stroke="#f97316" stroke-width="2"/>
       <path d="M200,-150 L50,-60" fill="none" stroke="#f97316" stroke-width="2"/>
+      <path d="M0,-200 L0,-100" fill="none" stroke="#f97316" stroke-width="1.5"/>
     </g>
   </g>
+
+  <!-- Audience dots -->
+  <g opacity="0.15" fill="#94a3b8">
+    <circle cx="350" cy="420" r="4"/><circle cx="380" cy="425" r="4"/><circle cx="410" cy="418" r="4"/>
+    <circle cx="440" cy="422" r="4"/><circle cx="470" cy="420" r="4"/><circle cx="500" cy="425" r="3"/>
+    <circle cx="700" cy="420" r="4"/><circle cx="730" cy="425" r="4"/><circle cx="760" cy="418" r="4"/>
+    <circle cx="790" cy="422" r="4"/><circle cx="820" cy="420" r="4"/><circle cx="850" cy="425" r="3"/>
+  </g>
+
+  <!-- Code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#f97316">
+    <text x="50" y="100">zero-trust.enable()</text>
+    <text x="930" y="110">iam.policy(least)</text>
+    <text x="60" y="480">guardduty.detect()</text>
+    <text x="920" y="490">securityhub.score()</text>
+  </g>
+
+  <!-- Title -->
   <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS re:Inforce 2025</text>
   <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Cloud Security Conference | Future of Security</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
   <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fdba74" text-anchor="middle">CONFERENCE</text>
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>

--- a/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
+++ b/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
@@ -3,31 +3,76 @@
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a100a"/>
     </linearGradient>
+    <linearGradient id="wormGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#f59e0b"/><stop offset="100%" style="stop-color:#ef4444"/>
+    </linearGradient>
     <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <filter id="softglow"><feGaussianBlur stdDeviation="20" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <filter id="redglow">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feFlood flood-color="#ef4444" flood-opacity="0.3" result="color"/>
+      <feComposite in="color" in2="blur" operator="in" result="shadow"/>
+      <feMerge><feMergeNode in="shadow"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="260" fill="#f59e0b" opacity="0.04" filter="url(#sg)"/>
-  <g transform="translate(600,250)">
-    <!-- Sandworm / snake shape representing Shai-Hulud -->
-    <path d="M-180,0 C-150,-60 -100,-80 -50,-40 C0,0 50,-40 100,-80 C150,-120 180,-60 160,0 C140,60 100,40 50,0 C0,-40 -50,0 -100,40 C-150,80 -180,60 -180,0 Z" fill="none" stroke="#f59e0b" stroke-width="3" opacity="0.5"/>
+
+  <!-- Grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff"/><line x1="120" y1="0" x2="120" y2="630" stroke="#fff"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff"/><line x1="240" y1="0" x2="240" y2="630" stroke="#fff"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff"/><line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff"/><line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="270" r="260" fill="#f59e0b" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="350" cy="200" r="150" fill="#ef4444" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="380" r="180" fill="#f59e0b" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Sandworm / Shai-Hulud -->
+  <g transform="translate(600,250)" filter="url(#shadow)">
+    <path d="M-180,0 C-150,-60 -100,-80 -50,-40 C0,0 50,-40 100,-80 C150,-120 180,-60 160,0 C140,60 100,40 50,0 C0,-40 -50,0 -100,40 C-150,80 -180,60 -180,0 Z" fill="none" stroke="url(#wormGrad)" stroke-width="3" opacity="0.6"/>
+    <path d="M-160,5 C-130,-45 -85,-60 -40,-25 C10,10 55,-30 95,-65 C135,-100 160,-50 142,5" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,3" opacity="0.2"/>
     <!-- Worm eye -->
-    <circle cx="-170" cy="0" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
-    <circle cx="-170" cy="0" r="5" fill="#f59e0b" opacity="0.8"/>
-    <!-- 180 packages count -->
-    <circle cx="0" cy="0" r="40" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
-    <text x="0" y="-5" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#ef4444" text-anchor="middle">180</text>
+    <circle cx="-170" cy="0" r="14" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+    <circle cx="-170" cy="0" r="6" fill="#f59e0b" opacity="0.8"/>
+    <!-- 180+ packages -->
+    <circle cx="0" cy="0" r="42" fill="#1e293b" stroke="#ef4444" stroke-width="2.5" filter="url(#redglow)"/>
+    <text x="0" y="-5" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#ef4444" text-anchor="middle">180+</text>
     <text x="0" y="15" font-family="Courier New" font-size="9" fill="#fca5a5" text-anchor="middle">packages</text>
     <!-- Scattered malicious package boxes -->
-    <g opacity="0.3">
+    <g opacity="0.4">
       <rect x="-140" y="50" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
       <rect x="60" y="60" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
       <rect x="120" y="30" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
       <rect x="-80" y="70" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
+      <rect x="-30" y="65" width="30" height="25" rx="3" fill="#1e293b" stroke="#ef4444" stroke-width="1"/>
     </g>
   </g>
+
+  <!-- Warning triangles -->
+  <g opacity="0.5">
+    <polygon points="160,430 175,405 190,430" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="175" y="426" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    <polygon points="1020,160 1035,135 1050,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+    <text x="1035" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+  </g>
+
+  <!-- Code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#f59e0b">
+    <text x="50" y="100">npm install worm-pkg</text>
+    <text x="920" y="110">postinstall: exec()</text>
+    <text x="60" y="480">self.replicate(npm)</text>
+    <text x="920" y="490">supply-chain.infect()</text>
+  </g>
+
+  <!-- Title -->
   <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Shai-Hulud Campaign</text>
   <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">180 Malicious npm Packages | Large-scale Analysis</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
   <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">THREAT INTEL</text>
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>

--- a/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
@@ -1,38 +1,88 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f97316"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- Fingerprint scan -->
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
-      <!-- Fingerprint lines -->
-      <path d="M-50,0 C-50,-30 -25,-50 0,-50" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.3"/>
-      <path d="M-40,10 C-40,-20 -18,-40 10,-40 C38,-40 50,-20 50,10" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.35"/>
-      <path d="M-30,20 C-30,-10 -10,-30 15,-30 C40,-30 45,-5 45,20" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.4"/>
-      <path d="M-20,25 C-20,0 -5,-20 15,-20 C35,-20 38,5 38,25" fill="none" stroke="#8b5cf6" stroke-width="2" opacity="0.45"/>
-      <path d="M-10,30 C-10,10 0,-10 15,-10 C30,-10 32,15 30,30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.5"/>
-      <!-- Scan line -->
-      <rect x="-80" y="-2" width="160" height="4" rx="2" fill="#8b5cf6" opacity="0.3">
-        <animate attributeName="y" values="-80;80;-80" dur="3s" repeatCount="indefinite"/>
-      </rect>
-      <!-- Alert at center -->
-      <circle cx="5" cy="5" r="8" fill="#ef4444" opacity="0.5"/>
-      <text x="5" y="9" font-family="Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">!</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f97316" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,250)">
+      <path d="M0,-130 L110,-85 L110,30 C110,90 55,135 0,160 C-55,135 -110,90 -110,30 L-110,-85 Z" fill="#ef4444" opacity="0.12" stroke="#ef4444" stroke-width="2"/>
+      <path d="M0,-110 L90,-72 L90,22 C90,72 45,110 0,132 C-45,110 -90,72 -90,22 L-90,-72 Z" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="8,4" opacity="0.3"/>
+      <line x1="-40" y1="-50" x2="40" y2="50" stroke="#ef4444" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <line x1="40" y1="-50" x2="-40" y2="50" stroke="#ef4444" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <circle cx="0" cy="0" r="20" fill="none" stroke="#ef4444" stroke-width="2.5" opacity="0.6"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security Weekly Digest</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Identity Threat Analysis | Weekly Intelligence</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.5">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1020,150 1035,125 1050,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1035" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="950,450 965,425 980,450" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="965" y="446" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">CVE-2026-XXXX</text>
+    <text x="950" y="120">CVSS: 9.8 CRITICAL</text>
+    <text x="70" y="480">patch --apply fix</text>
+    <text x="920" y="500">vuln.scan(target)</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">VMware vCenter KEV Patch</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Fortinet SSO Bypass + Sandworm DynoWiper</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 25, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 25, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
+++ b/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
@@ -1,29 +1,89 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
-      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
-      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
-      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">0-DAY</text>
-    </g>
-    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#ef4444" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">OpenSSL Zero-Day</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly | AI + OWASP Agentic + Fortinet</text>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f59e0b" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-55" y="-65" width="110" height="110" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="55" y2="-30" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <text x="0" y="-40" font-family="Arial" font-size="16" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.8">0-DAY</text>
+      <text x="0" y="5" font-family="Courier New" font-size="36" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.5">0</text>
+      <line x1="-30" y1="-20" x2="30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+      <line x1="30" y1="-20" x2="-30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+    </g>
+  </g>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="180,160 195,135 210,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="195" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="990,420 1005,395 1020,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1005" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1050,150 1065,125 1080,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1065" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">CVE-2026-XXXX</text>
+    <text x="950" y="120">exploit(0day)</text>
+    <text x="70" y="480">patch: PENDING</text>
+    <text x="920" y="500">alert: CRITICAL</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Finds 12 OpenSSL 0-Days</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | OWASP Agentic AI + Fortinet Patch</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 1, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 1, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
+++ b/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
@@ -1,27 +1,92 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a1a0a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#22c55e"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#d97706" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#d97706" stroke-width="2"/>
-      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#d97706" stroke-width="2.5" stroke-linecap="round"/>
-      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
-      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#22c55e" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#3b82f6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#22c55e" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,235)">
+      <rect x="-80" y="-55" width="160" height="110" rx="10" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
+      <rect x="-75" y="-50" width="150" height="20" rx="4" fill="#22c55e" opacity="0.1"/>
+      <circle cx="-60" cy="-40" r="4" fill="#ef4444" opacity="0.6"/>
+      <circle cx="-48" cy="-40" r="4" fill="#fbbf24" opacity="0.6"/>
+      <circle cx="-36" cy="-40" r="4" fill="#22c55e" opacity="0.6"/>
+      <text x="-60" y="-15" font-family="Courier New" font-size="10" fill="#22c55e" opacity="0.7">$ code --secure</text>
+      <text x="-60" y="2" font-family="Courier New" font-size="10" fill="#3b82f6" opacity="0.5">  scanning...</text>
+      <text x="-60" y="19" font-family="Courier New" font-size="10" fill="#ef4444" opacity="0.5">  3 vulns found</text>
+      <text x="-60" y="36" font-family="Courier New" font-size="10" fill="#22c55e" opacity="0.7">$ fix --apply</text>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Coding Battle</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Claude Code vs AI Assistants | Head-to-Head</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#d97706" opacity="0.2" stroke="#d97706" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#d97706" text-anchor="middle">AI COMPARE</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.3">
+      <rect x="100" y="130" width="120" height="60" rx="6" fill="none" stroke="#3b82f6" stroke-width="1"/>
+      <text x="160" y="155" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">main.go</text>
+      <text x="160" y="175" font-family="Courier New" font-size="9" fill="#22c55e" text-anchor="middle">SAFE</text>
+      <rect x="980" y="400" width="120" height="60" rx="6" fill="none" stroke="#ef4444" stroke-width="1"/>
+      <text x="1040" y="425" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">api.py</text>
+      <text x="1040" y="445" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">VULN</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#22c55e">
+    <text x="50" y="100">lint --fix</text>
+    <text x="950" y="120">test --coverage</text>
+    <text x="70" y="480">audit --strict</text>
+    <text x="920" y="500">deploy --safe</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Coding Assistant Comparison</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Claude Code vs Copilot | Security + DevSecOps + FinOps</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">DEEP DIVE</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
@@ -1,31 +1,91 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#0db7ed" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M-55,8 L75,8 C80,8 85,3 85,-7 L85,-28 C85,-33 80,-38 75,-38 L-35,-38 C-40,-38 -45,-36 -47,-33 L-65,-8 C-70,-3 -65,3 -55,8 Z" fill="#1e293b" stroke="#0db7ed" stroke-width="2.5"/>
-      <rect x="-25" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="-5" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="15" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="35" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.4" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="55" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="-5" y="-48" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <circle cx="-50" cy="-3" r="3" fill="#0db7ed"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#06b6d4" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#3b82f6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#06b6d4" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,235)">
+      <rect x="-80" y="-20" width="160" height="80" rx="10" fill="#1e293b" stroke="#06b6d4" stroke-width="2.5"/>
+      <g transform="translate(-50,-5)">
+        <rect x="0" y="0" width="22" height="18" rx="2" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.6"/>
+        <rect x="28" y="0" width="22" height="18" rx="2" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.6"/>
+        <rect x="56" y="0" width="22" height="18" rx="2" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.6"/>
+        <rect x="0" y="24" width="22" height="18" rx="2" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.6"/>
+        <rect x="28" y="24" width="22" height="18" rx="2" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.6"/>
+        <rect x="56" y="24" width="22" height="18" rx="2" fill="#ef4444" stroke="#ef4444" stroke-width="1.5" opacity="0.3"/>
+      </g>
+      <path d="M-80,-20 C-100,-40 -60,-55 -40,-50 C-20,-60 20,-60 40,-50 C60,-55 100,-40 80,-20" fill="none" stroke="#06b6d4" stroke-width="1.5" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Docker + Go</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Container + Language Security</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0db7ed" opacity="0.2" stroke="#0db7ed" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#0db7ed" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g font-family="Courier New" font-size="10" fill="#06b6d4" opacity="0.15">
+      <text x="80" y="140">docker build .</text>
+      <text x="950" y="160">container.run()</text>
+      <text x="60" y="430">FROM alpine:3.20</text>
+      <text x="930" y="450">EXPOSE 8080</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#06b6d4">
+    <text x="50" y="100">docker pull img</text>
+    <text x="950" y="120">container.exec()</text>
+    <text x="70" y="480">Dockerfile</text>
+    <text x="920" y="500">compose up -d</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Docker AI CVE-2025-11953</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | CVSS 9.8 RCE + Data Pipeline Attack</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 4, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
@@ -1,33 +1,96 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0505"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
-      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <line x1="60" y1="0" x2="40" y2="0" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="30" x2="35" y2="15" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <circle cx="-15" cy="-25" r="8" fill="#ef4444" opacity="0.3"/>
-      <circle cx="15" cy="-25" r="8" fill="#ef4444" opacity="0.3"/>
-      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#ef4444" text-anchor="middle" opacity="0.6">CVE</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#8b5cf6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="35" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+      <circle cx="-12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="-12" cy="-8" r="3" fill="#0a0a1a"/>
+      <circle cx="12" cy="-8" r="3" fill="#0a0a1a"/>
+      <path d="M-12,15 L12,15" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="-50" y1="-25" x2="-80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="-25" x2="80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-50" y1="25" x2="-80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="25" x2="80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="-85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="-85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CVE + AI Malware</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Security Threats</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1030,160 1045,135 1060,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1045" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">C2: connect()</text>
+    <text x="950" y="120">exfil(data)</text>
+    <text x="70" y="480">persist(rootkit)</text>
+    <text x="920" y="500">lateral_move()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">n8n RCE + NGINX Hijack</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AsyncRAT Campaign + CVE Analysis</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 5, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 5, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
@@ -1,28 +1,89 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-45" y="-5" width="90" height="70" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
-      <path d="M-25,-5 L-25,-35 C-25,-55 -12,-68 0,-68 C12,-68 25,-55 25,-35 L25,-5" fill="none" stroke="#ef4444" stroke-width="4"/>
-      <circle cx="0" cy="28" r="10" fill="#ef4444" opacity="0.3"/>
-      <rect x="-3" y="32" width="6" height="15" rx="2" fill="#ef4444" opacity="0.3"/>
-      <text x="0" y="32" font-family="Arial,sans-serif" font-size="16" fill="#ef4444" text-anchor="middle" opacity="0.6">$</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f59e0b" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,230)">
+      <path d="M0,-100 L0,-20 C0,10 -25,30 -25,30 C-25,30 0,50 25,30 C25,30 50,10 50,-20 L50,-35" fill="none" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <circle cx="-25" cy="35" r="6" fill="#ef4444" opacity="0.6"/>
+      <line x1="0" y1="-100" x2="0" y2="-140" stroke="#ef4444" stroke-width="2" opacity="0.3"/>
+      <rect x="-50" y="60" width="100" height="65" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <line x1="-50" y1="65" x2="0" y2="95" stroke="#f59e0b" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="65" x2="0" y2="95" stroke="#f59e0b" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-30" y1="105" x2="30" y2="105" stroke="#f59e0b" stroke-width="1" opacity="0.3"/>
+      <line x1="-25" y1="115" x2="25" y2="115" stroke="#f59e0b" stroke-width="1" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Ransomware</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Data Breach + Ransomware</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.3">
+      <text x="150" y="180" font-family="Courier New" font-size="10" fill="#ef4444">From: admin@...</text>
+      <text x="900" y="200" font-family="Courier New" font-size="10" fill="#ef4444">Click here now</text>
+      <text x="120" y="440" font-family="Courier New" font-size="10" fill="#ef4444">credential.steal</text>
+      <text x="920" y="430" font-family="Courier New" font-size="10" fill="#ef4444">redirect(evil)</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">phish.send()</text>
+    <text x="950" y="120">cred.capture()</text>
+    <text x="70" y="480">vishing_call()</text>
+    <text x="920" y="500">social_eng()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Signal Phishing + Ransomware</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | State-Sponsored Attack + BlackField</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 8, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 8, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
+++ b/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
@@ -1,28 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0f00"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#f97316"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#f59e0b" stroke-width="3"/>
-      <circle cx="0" cy="0" r="65" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
-      <text x="0" y="18" font-family="Arial,sans-serif" font-size="60" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.6">B</text>
-      <line x1="-5" y1="-30" x2="-5" y2="35" stroke="#f59e0b" stroke-width="2" opacity="0.3"/>
-      <line x1="5" y1="-30" x2="5" y2="35" stroke="#f59e0b" stroke-width="2" opacity="0.3"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#f59e0b" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f97316" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#f59e0b" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-80" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <rect x="-15" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <rect x="50" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <line x1="-30" y1="-10" x2="-15" y2="-10" stroke="#f59e0b" stroke-width="2"/>
+      <line x1="35" y1="-10" x2="50" y2="-10" stroke="#f59e0b" stroke-width="2"/>
+      <text x="-55" y="-4" font-family="Courier New" font-size="14" fill="#f59e0b" text-anchor="middle" opacity="0.7">#1</text>
+      <text x="10" y="-4" font-family="Courier New" font-size="14" fill="#f59e0b" text-anchor="middle" opacity="0.7">#2</text>
+      <text x="75" y="-4" font-family="Courier New" font-size="14" fill="#f59e0b" text-anchor="middle" opacity="0.7">#3</text>
+      <text x="10" y="50" font-family="Arial" font-size="28" fill="#f59e0b" text-anchor="middle" font-weight="bold" opacity="0.3">B</text>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Blockchain Digest</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Bithumb + Bitcoin | Crypto Intelligence</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.2">
+      <text x="130" y="180" font-family="Courier New" font-size="11" fill="#f59e0b">hash: 0x7f3a...</text>
+      <text x="900" y="200" font-family="Courier New" font-size="11" fill="#f59e0b">nonce: 42981</text>
+      <text x="100" y="420" font-family="Courier New" font-size="11" fill="#f59e0b">block.verify()</text>
+      <text x="930" y="440" font-family="Courier New" font-size="11" fill="#f59e0b">tx.confirm()</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#f59e0b">
+    <text x="50" y="100">tx.sign(key)</text>
+    <text x="950" y="120">block.hash()</text>
+    <text x="70" y="480">BTC: $71,000</text>
+    <text x="920" y="500">ledger.verify()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Bithumb $44B Incident</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Blockchain Digest | Bitcoin $71K + Operational Security</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">BLOCKCHAIN</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">BLOCKCHAIN</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
+++ b/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
@@ -1,26 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#7c3aed"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M-30,-60 C-55,-60 -75,-42 -75,-20 C-95,-20 -110,-2 -110,15 C-110,40 -90,52 -70,52 L70,52 C90,52 110,40 110,15 C110,-2 95,-20 75,-20 C75,-42 55,-60 30,-60 C12,-60 0,-50 -5,-42 C-10,-50 -18,-60 -30,-60 Z" fill="#1e293b" stroke="#f97316" stroke-width="2.5"/>
-      <path d="M0,-35 L25,-22 L25,10 C25,22 14,30 0,35 C-14,30 -25,22 -25,10 L-25,-22 Z" fill="#f97316" opacity="0.15" stroke="#f97316" stroke-width="1.5"/>
-      <path d="M-6,5 L-2,10 L10,-2" fill="none" stroke="#f97316" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#8b5cf6" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#7c3aed" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#8b5cf6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-90" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="-15" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="60" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <line x1="-30" y1="0" x2="-15" y2="0" stroke="#8b5cf6" stroke-width="2" marker-end="none"/>
+      <line x1="45" y1="0" x2="60" y2="0" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="15" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="90" y="6" font-family="Courier New" font-size="16" fill="#ef4444" text-anchor="middle">!!</text>
+      <path d="M90,-30 L90,-55 C90,-55 90,-70 75,-70 L-75,-70 C-75,-70 -90,-70 -90,-55 L-90,-30" fill="none" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Digest</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI + VirusTotal + AWS Agentic</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">CLOUD</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <circle cx="200" cy="150" r="4" fill="#8b5cf6"/><circle cx="220" cy="160" r="3" fill="#8b5cf6"/>
+      <line x1="200" y1="150" x2="220" y2="160" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="1000" cy="420" r="4" fill="#8b5cf6"/><circle cx="980" cy="410" r="3" fill="#8b5cf6"/>
+      <line x1="1000" y1="420" x2="980" y2="410" stroke="#8b5cf6" stroke-width="1"/>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#8b5cf6">
+    <text x="50" y="100">npm install pkg</text>
+    <text x="950" y="120">pip install lib</text>
+    <text x="70" y="480">verify(hash)</text>
+    <text x="920" y="500">dependency.lock</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Supply Chain Security</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security Digest | VirusTotal AI + AWS Agentic</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">SECURITY</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 9, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
+++ b/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
@@ -1,27 +1,94 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#06b6d4"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
-      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#3b82f6" stroke-width="2.5" stroke-linecap="round"/>
-      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
-      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#3b82f6" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#06b6d4" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#3b82f6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="60" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+      <circle cx="0" cy="0" r="45" fill="none" stroke="#3b82f6" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <circle cx="-15" cy="-10" r="8" fill="#3b82f6" opacity="0.5"/>
+      <circle cx="15" cy="-10" r="8" fill="#3b82f6" opacity="0.5"/>
+      <path d="M-20,15 Q0,30 20,15" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
+      <line x1="-60" y1="-30" x2="-95" y2="-55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-100" cy="-60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="60" y1="-30" x2="95" y2="-55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="100" cy="-60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-55" y1="30" x2="-85" y2="55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-90" cy="60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="55" y1="30" x2="85" y2="55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="90" cy="60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Cloud Digest</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Meta Prometheus + Google OTLP + AWS</text>
+
+  <!-- Theme extras -->
+
+    <g font-family="Courier New" font-size="10" fill="#3b82f6" opacity="0.12">
+      <text x="80" y="130">model.predict()</text>
+      <text x="950" y="160">tensor.eval()</text>
+      <text x="60" y="440">agent.run(task)</text>
+      <text x="920" y="430">llm.generate()</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#3b82f6">
+    <text x="50" y="100">agent.execute()</text>
+    <text x="950" y="120">model.eval()</text>
+    <text x="70" y="480">prompt_inject()</text>
+    <text x="920" y="500">guardrail.check()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Meta Prometheus + OTLP</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Cloud Digest | Google Observability + AWS Update</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">CLOUD</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">AI CLOUD</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
+++ b/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
@@ -1,28 +1,96 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0505"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
-      <circle cx="0" cy="0" r="55" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
-      <text x="0" y="-10" font-family="Courier New" font-size="14" fill="#ef4444" text-anchor="middle" opacity="0.8">APT</text>
-      <text x="0" y="10" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle" opacity="0.5">UNC3886</text>
-    </g>
-    <g opacity="0.3"><line x1="-100" y1="-50" x2="-60" y2="-30" stroke="#ef4444" stroke-width="1.5"/><line x1="100" y1="-50" x2="60" y2="-30" stroke="#ef4444" stroke-width="1.5"/><line x1="-100" y1="50" x2="-60" y2="30" stroke="#ef4444" stroke-width="1.5"/><line x1="100" y1="50" x2="60" y2="30" stroke="#ef4444" stroke-width="1.5"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SolarWinds + LLM</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">UNC3886 APT + LLM Attack Vectors</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">THREAT</text>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#8b5cf6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="35" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+      <circle cx="-12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="-12" cy="-8" r="3" fill="#0a0a1a"/>
+      <circle cx="12" cy="-8" r="3" fill="#0a0a1a"/>
+      <path d="M-12,15 L12,15" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="-50" y1="-25" x2="-80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="-25" x2="80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-50" y1="25" x2="-80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="25" x2="80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="-85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="-85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
+    </g>
+  </g>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1030,160 1045,135 1060,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1045" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">C2: connect()</text>
+    <text x="950" y="120">exfil(data)</text>
+    <text x="70" y="480">persist(rootkit)</text>
+    <text x="920" y="500">lateral_move()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">SolarWinds RCE + UNC3886</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security Digest | Telecom Espionage + LLM Attack</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">SECURITY</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 10, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
+++ b/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
@@ -1,26 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#7c3aed"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="3"/>
-      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#3b82f6" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
-      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#3b82f6" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#8b5cf6" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#7c3aed" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#8b5cf6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-90" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="-15" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="60" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <line x1="-30" y1="0" x2="-15" y2="0" stroke="#8b5cf6" stroke-width="2" marker-end="none"/>
+      <line x1="45" y1="0" x2="60" y2="0" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="15" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="90" y="6" font-family="Courier New" font-size="16" fill="#ef4444" text-anchor="middle">!!</text>
+      <path d="M90,-30 L90,-55 C90,-55 90,-70 75,-70 L-75,-70 C-75,-70 -90,-70 -90,-55 L-90,-30" fill="none" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Agent</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Agent + Cloud Defense</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <circle cx="200" cy="150" r="4" fill="#8b5cf6"/><circle cx="220" cy="160" r="3" fill="#8b5cf6"/>
+      <line x1="200" y1="150" x2="220" y2="160" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="1000" cy="420" r="4" fill="#8b5cf6"/><circle cx="980" cy="410" r="3" fill="#8b5cf6"/>
+      <line x1="1000" y1="420" x2="980" y2="410" stroke="#8b5cf6" stroke-width="1"/>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#8b5cf6">
+    <text x="50" y="100">npm install pkg</text>
+    <text x="950" y="120">pip install lib</text>
+    <text x="70" y="480">verify(hash)</text>
+    <text x="920" y="500">dependency.lock</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Supply Chain + APT36 RAT</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Outlook Add-in Attack + Windows Update</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 12, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 12, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
+++ b/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
@@ -1,26 +1,90 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#7c3aed"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#00add8" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#00add8" stroke-width="3"/>
-      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#00add8" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
-      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#00add8" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#8b5cf6" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#7c3aed" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#8b5cf6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-90" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="-15" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#8b5cf6" stroke-width="2"/>
+      <rect x="60" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <line x1="-30" y1="0" x2="-15" y2="0" stroke="#8b5cf6" stroke-width="2" marker-end="none"/>
+      <line x1="45" y1="0" x2="60" y2="0" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="15" y="6" font-family="Courier New" font-size="16" fill="#8b5cf6" text-anchor="middle">OK</text>
+      <text x="90" y="6" font-family="Courier New" font-size="16" fill="#ef4444" text-anchor="middle">!!</text>
+      <path d="M90,-30 L90,-55 C90,-55 90,-70 75,-70 L-75,-70 C-75,-70 -90,-70 -90,-55 L-90,-30" fill="none" stroke="#8b5cf6" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Go Security</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Agent Security</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#00add8" opacity="0.2" stroke="#00add8" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#00add8" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <circle cx="200" cy="150" r="4" fill="#8b5cf6"/><circle cx="220" cy="160" r="3" fill="#8b5cf6"/>
+      <line x1="200" y1="150" x2="220" y2="160" stroke="#8b5cf6" stroke-width="1"/>
+      <circle cx="1000" cy="420" r="4" fill="#8b5cf6"/><circle cx="980" cy="410" r="3" fill="#8b5cf6"/>
+      <line x1="1000" y1="420" x2="980" y2="410" stroke="#8b5cf6" stroke-width="1"/>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#8b5cf6">
+    <text x="50" y="100">npm install pkg</text>
+    <text x="950" y="120">pip install lib</text>
+    <text x="70" y="480">verify(hash)</text>
+    <text x="920" y="500">dependency.lock</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Lazarus Supply Chain Attack</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Copilot Studio Vuln + FinOps Security</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 13, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 13, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
+++ b/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
@@ -1,29 +1,89 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
-      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
-      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
-      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">0-DAY</text>
-    </g>
-    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#ef4444" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">MS + Apple Zero-Day</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly | Microsoft + Apple + Ivanti EPMM</text>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f59e0b" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-55" y="-65" width="110" height="110" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="55" y2="-30" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <text x="0" y="-40" font-family="Arial" font-size="16" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.8">0-DAY</text>
+      <text x="0" y="5" font-family="Courier New" font-size="36" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.5">0</text>
+      <line x1="-30" y1="-20" x2="30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+      <line x1="30" y1="-20" x2="-30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+    </g>
+  </g>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="180,160 195,135 210,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="195" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="990,420 1005,395 1020,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1005" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1050,150 1065,125 1080,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1065" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">CVE-2026-XXXX</text>
+    <text x="950" y="120">exploit(0day)</text>
+    <text x="70" y="480">patch: PENDING</text>
+    <text x="920" y="500">alert: CRITICAL</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Microsoft 6x Zero-Day Patch</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Apple Emergency + Ivanti EPMM Attack</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 14, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 14, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
+++ b/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
@@ -1,27 +1,94 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#06b6d4"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-150" y="-70" width="300" height="150" rx="10" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
-      <polyline points="-130,40 -90,20 -50,-10 -10,5 30,-25 70,-15 110,-40 130,-35" fill="none" stroke="#f59e0b" stroke-width="2.5" stroke-linecap="round"/>
-      <polyline points="-130,50 -90,35 -50,25 -10,30 30,10 70,20 110,5 130,10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-dasharray="4,3"/>
-      <g opacity="0.1"><line x1="-130" y1="-30" x2="130" y2="-30" stroke="#fff"/><line x1="-130" y1="0" x2="130" y2="0" stroke="#fff"/><line x1="-130" y1="30" x2="130" y2="30" stroke="#fff"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#3b82f6" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#06b6d4" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#3b82f6" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="60" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
+      <circle cx="0" cy="0" r="45" fill="none" stroke="#3b82f6" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <circle cx="-15" cy="-10" r="8" fill="#3b82f6" opacity="0.5"/>
+      <circle cx="15" cy="-10" r="8" fill="#3b82f6" opacity="0.5"/>
+      <path d="M-20,15 Q0,30 20,15" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
+      <line x1="-60" y1="-30" x2="-95" y2="-55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-100" cy="-60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="60" y1="-30" x2="95" y2="-55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="100" cy="-60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-55" y1="30" x2="-85" y2="55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-90" cy="60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
+      <line x1="55" y1="30" x2="85" y2="55" stroke="#06b6d4" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="90" cy="60" r="8" fill="#1e293b" stroke="#06b6d4" stroke-width="1.5" opacity="0.5"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Risk Analysis</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI + Cloud Risk Assessment</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g font-family="Courier New" font-size="10" fill="#3b82f6" opacity="0.12">
+      <text x="80" y="130">model.predict()</text>
+      <text x="950" y="160">tensor.eval()</text>
+      <text x="60" y="440">agent.run(task)</text>
+      <text x="920" y="430">llm.generate()</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#3b82f6">
+    <text x="50" y="100">agent.execute()</text>
+    <text x="950" y="120">model.eval()</text>
+    <text x="70" y="480">prompt_inject()</text>
+    <text x="920" y="500">guardrail.check()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent + Patch Tuesday</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cloud Cost Optimization + Kimwolf Botnet</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 17, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 17, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
+++ b/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
@@ -1,29 +1,89 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#f97316" stroke-width="2"/>
-      <circle cx="0" cy="0" r="65" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.4"/>
-      <circle cx="0" cy="0" r="40" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.5"/>
-      <circle cx="0" cy="0" r="15" fill="#f97316" opacity="0.3"/>
-      <text x="0" y="2" font-family="Courier New" font-size="9" fill="#f97316" text-anchor="middle">0-DAY</text>
-    </g>
-    <g opacity="0.4"><line x1="-150" y1="-50" x2="-20" y2="-5" stroke="#f97316" stroke-width="1.5"/><polygon points="-25,-8 -15,-2 -25,2" fill="#f97316"/></g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AWS Zero-Day CVE</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AWS Security Vulnerabilities</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">WEEKLY</text>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f59e0b" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-55" y="-65" width="110" height="110" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="55" y2="-30" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <text x="0" y="-40" font-family="Arial" font-size="16" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.8">0-DAY</text>
+      <text x="0" y="5" font-family="Courier New" font-size="36" fill="#ef4444" text-anchor="middle" font-weight="bold" opacity="0.5">0</text>
+      <line x1="-30" y1="-20" x2="30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+      <line x1="30" y1="-20" x2="-30" y2="40" stroke="#f59e0b" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+    </g>
+  </g>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="180,160 195,135 210,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="195" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="990,420 1005,395 1020,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1005" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1050,150 1065,125 1080,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1065" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">CVE-2026-XXXX</text>
+    <text x="950" y="120">exploit(0day)</text>
+    <text x="70" y="480">patch: PENDING</text>
+    <text x="920" y="500">alert: CRITICAL</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Dell RecoverPoint 0-Day</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AWS Security Update + CVE-2026-2329</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 19, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 19, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
+++ b/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
@@ -1,26 +1,86 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0a1e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M-30,-60 C-55,-60 -75,-42 -75,-20 C-95,-20 -110,-2 -110,15 C-110,40 -90,52 -70,52 L70,52 C90,52 110,40 110,15 C110,-2 95,-20 75,-20 C75,-42 55,-60 30,-60 C12,-60 0,-50 -5,-42 C-10,-50 -18,-60 -30,-60 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="2.5"/>
-      <path d="M0,-35 L25,-22 L25,10 C25,22 14,30 0,35 C-14,30 -25,22 -25,10 L-25,-22 Z" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" stroke-width="1.5"/>
-      <path d="M-6,5 L-2,10 L10,-2" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#06b6d4" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#3b82f6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#06b6d4" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,230)">
+      <path d="M-80,20 C-80,-40 -40,-70 10,-70 C30,-70 50,-60 60,-45 C70,-55 90,-55 105,-40 C130,-40 140,-20 140,0 C140,25 125,40 100,40 L-60,40 C-80,40 -100,25 -100,5 C-100,-5 -90,-15 -80,-15 Z" fill="#1e293b" stroke="#06b6d4" stroke-width="2.5"/>
+      <path d="M-60,20 C-60,-25 -25,-50 15,-50 C30,-50 45,-42 52,-30 C60,-38 75,-38 87,-27 C105,-27 115,-12 115,5 C115,22 103,33 82,33 L-42,33 C-58,33 -75,22 -75,5 C-75,-2 -68,-10 -60,-10 Z" fill="none" stroke="#06b6d4" stroke-width="1" stroke-dasharray="5,3" opacity="0.3"/>
+      <rect x="-15" y="-15" width="30" height="25" rx="4" fill="none" stroke="#06b6d4" stroke-width="2"/>
+      <path d="M-8,-15 L-8,-28 C-8,-38 8,-38 8,-28 L8,-15" fill="none" stroke="#06b6d4" stroke-width="2"/>
+      <circle cx="0" cy="0" r="4" fill="#06b6d4" opacity="0.7"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Data + Cloud</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Tech Blog Digest</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#3b82f6" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.3">
+      <rect x="100" y="130" width="80" height="50" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+      <text x="140" y="160" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">us-east-1</text>
+      <rect x="1020" y="400" width="80" height="50" rx="4" fill="none" stroke="#3b82f6" stroke-width="1"/>
+      <text x="1060" y="430" font-family="Courier New" font-size="9" fill="#3b82f6" text-anchor="middle">ap-ne-2</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#06b6d4">
+    <text x="50" y="100">aws configure</text>
+    <text x="950" y="120">kubectl apply</text>
+    <text x="70" y="480">terraform plan</text>
+    <text x="920" y="500">cloud.deploy()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Alignment + EKS Flyte</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Docker Security + Cloud Native Trends</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 20, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 20, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
+++ b/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
@@ -1,33 +1,88 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f97316"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ce422b" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#ce422b" stroke-width="2.5"/>
-      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <line x1="60" y1="0" x2="40" y2="0" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="30" x2="35" y2="15" stroke="#ce422b" stroke-width="2" opacity="0.4"/>
-      <circle cx="-15" cy="-25" r="8" fill="#ce422b" opacity="0.3"/>
-      <circle cx="15" cy="-25" r="8" fill="#ce422b" opacity="0.3"/>
-      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#ce422b" text-anchor="middle" opacity="0.6">CVE</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f97316" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,250)">
+      <path d="M0,-130 L110,-85 L110,30 C110,90 55,135 0,160 C-55,135 -110,90 -110,30 L-110,-85 Z" fill="#ef4444" opacity="0.12" stroke="#ef4444" stroke-width="2"/>
+      <path d="M0,-110 L90,-72 L90,22 C90,72 45,110 0,132 C-45,110 -90,72 -90,22 L-90,-72 Z" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="8,4" opacity="0.3"/>
+      <line x1="-40" y1="-50" x2="40" y2="50" stroke="#ef4444" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <line x1="40" y1="-50" x2="-40" y2="50" stroke="#ef4444" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <circle cx="0" cy="0" r="20" fill="none" stroke="#ef4444" stroke-width="2.5" opacity="0.6"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Data + Rust + AI</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Rust Security + AI Threats</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ce422b" opacity="0.2" stroke="#ce422b" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ce422b" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.5">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1020,150 1035,125 1050,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1035" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="950,450 965,425 980,450" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="965" y="446" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">CVE-2026-XXXX</text>
+    <text x="950" y="120">CVSS: 9.8 CRITICAL</text>
+    <text x="70" y="480">patch --apply fix</text>
+    <text x="920" y="500">vuln.scan(target)</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CVE-2025-49113 + Rust Supply</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Ransomware Response + Claude Security</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 21, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 21, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
+++ b/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
@@ -1,28 +1,87 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0505"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#dc2626"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-45" y="-5" width="90" height="70" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="3"/>
-      <path d="M-25,-5 L-25,-35 C-25,-55 -12,-68 0,-68 C12,-68 25,-55 25,-35 L25,-5" fill="none" stroke="#ef4444" stroke-width="4"/>
-      <circle cx="0" cy="28" r="10" fill="#ef4444" opacity="0.3"/>
-      <rect x="-3" y="32" width="6" height="15" rx="2" fill="#ef4444" opacity="0.3"/>
-      <text x="0" y="32" font-family="Arial,sans-serif" font-size="16" fill="#ef4444" text-anchor="middle" opacity="0.6">$</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#dc2626" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <rect x="-50" y="-40" width="100" height="80" rx="10" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
+      <path d="M-25,-40 L-25,-65 C-25,-90 25,-90 25,-65 L25,-40" fill="none" stroke="#ef4444" stroke-width="3.5" stroke-linecap="round"/>
+      <circle cx="0" cy="0" r="12" fill="#ef4444" opacity="0.7"/>
+      <rect x="-3" y="2" width="6" height="18" rx="3" fill="#ef4444" opacity="0.9"/>
+      <path d="M-80,-10 L-55,-10 M-80,10 L-55,10" stroke="#ef4444" stroke-width="2" stroke-dasharray="4,2" opacity="0.4"/>
+      <path d="M55,-10 L80,-10 M55,10 L80,10" stroke="#ef4444" stroke-width="2" stroke-dasharray="4,2" opacity="0.4"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ransomware + Bitcoin</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Ransomware + Crypto</text>
+
+  <!-- Theme extras -->
+
+    <g font-family="Courier New" font-size="12" fill="#ef4444" opacity="0.15">
+      <text x="80" y="150">ENCRYPTED</text>
+      <text x="950" y="180">LOCKED</text>
+      <text x="100" y="430">$$$ RANSOM $$$</text>
+      <text x="920" y="450">decrypt.key</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">encrypt(data)</text>
+    <text x="950" y="120">ransom_note.txt</text>
+    <text x="70" y="480">bitcoin: bc1q...</text>
+    <text x="920" y="500">key_exchange()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Vertical AI + BlackField</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Ransomware Defense + Data Protection</text>
+
+  <!-- Top badges -->
   <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 23, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 23, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
+++ b/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
@@ -1,31 +1,96 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0505"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#0db7ed" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M-55,8 L75,8 C80,8 85,3 85,-7 L85,-28 C85,-33 80,-38 75,-38 L-35,-38 C-40,-38 -45,-36 -47,-33 L-65,-8 C-70,-3 -65,3 -55,8 Z" fill="#1e293b" stroke="#0db7ed" stroke-width="2.5"/>
-      <rect x="-25" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="-5" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="15" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="35" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.4" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="55" y="-33" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <rect x="-5" y="-48" width="16" height="12" rx="2" fill="#0db7ed" opacity="0.3" stroke="#0db7ed" stroke-width="1"/>
-      <circle cx="-50" cy="-3" r="3" fill="#0db7ed"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#8b5cf6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="35" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+      <circle cx="-12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="-12" cy="-8" r="3" fill="#0a0a1a"/>
+      <circle cx="12" cy="-8" r="3" fill="#0a0a1a"/>
+      <path d="M-12,15 L12,15" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="-50" y1="-25" x2="-80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="-25" x2="80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-50" y1="25" x2="-80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="25" x2="80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="-85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="-85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Malware + Docker LLM</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Malware + Container</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#0db7ed" opacity="0.2" stroke="#0db7ed" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#0db7ed" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1030,160 1045,135 1060,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1045" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">C2: connect()</text>
+    <text x="950" y="120">exfil(data)</text>
+    <text x="70" y="480">persist(rootkit)</text>
+    <text x="920" y="500">lateral_move()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">APT28 MacroMaze Campaign</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Docker Hardening + LLM Operations Risk</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 24, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 24, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
+++ b/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
@@ -1,26 +1,96 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0505"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#8b5cf6"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f97316" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <path d="M0,-90 L100,-60 L100,25 C100,60 55,85 0,100 C-55,85 -100,60 -100,25 L-100,-60 Z" fill="#1e293b" stroke="#f97316" stroke-width="3"/>
-      <path d="M0,-70 L75,-48 L75,18 C75,45 42,65 0,75 C-42,65 -75,45 -75,18 L-75,-48 Z" fill="none" stroke="#f97316" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
-      <path d="M-15,5 L-5,18 L20,-10" fill="none" stroke="#f97316" stroke-width="4" stroke-linecap="round"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#8b5cf6" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <circle cx="0" cy="0" r="35" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+      <circle cx="-12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="12" cy="-8" r="7" fill="#ef4444" opacity="0.7"/>
+      <circle cx="-12" cy="-8" r="3" fill="#0a0a1a"/>
+      <circle cx="12" cy="-8" r="3" fill="#0a0a1a"/>
+      <path d="M-12,15 L12,15" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="-50" y1="-25" x2="-80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="-25" x2="80" y2="-50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-50" y1="25" x2="-80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="25" x2="80" y2="50" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="-85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="-55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="-85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
+      <circle cx="85" cy="55" r="5" fill="#ef4444" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI + Go + AWS API</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | API Security</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f97316" opacity="0.2" stroke="#f97316" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.4">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1030,160 1045,135 1060,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1045" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">C2: connect()</text>
+    <text x="950" y="120">exfil(data)</text>
+    <text x="70" y="480">persist(rootkit)</text>
+    <text x="920" y="500">lateral_move()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">UNC2814 GRIDTIDE Campaign</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Claude Code RCE + Vishing Trends</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 26, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 26, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
+++ b/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
@@ -1,33 +1,89 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#00add8" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <ellipse cx="0" cy="0" rx="50" ry="65" fill="#1e293b" stroke="#00add8" stroke-width="2.5"/>
-      <line x1="-55" y1="-30" x2="-35" y2="-15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="-30" x2="35" y2="-15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <line x1="-60" y1="0" x2="-40" y2="0" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <line x1="60" y1="0" x2="40" y2="0" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <line x1="-55" y1="30" x2="-35" y2="15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <line x1="55" y1="30" x2="35" y2="15" stroke="#00add8" stroke-width="2" opacity="0.4"/>
-      <circle cx="-15" cy="-25" r="8" fill="#00add8" opacity="0.3"/>
-      <circle cx="15" cy="-25" r="8" fill="#00add8" opacity="0.3"/>
-      <text x="0" y="15" font-family="Courier New" font-size="12" fill="#00add8" text-anchor="middle" opacity="0.6">CVE</text>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="#ef4444" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="#f59e0b" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="#ef4444" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+
+    <g transform="translate(600,230)">
+      <path d="M0,-100 L0,-20 C0,10 -25,30 -25,30 C-25,30 0,50 25,30 C25,30 50,10 50,-20 L50,-35" fill="none" stroke="#ef4444" stroke-width="4" stroke-linecap="round"/>
+      <circle cx="-25" cy="35" r="6" fill="#ef4444" opacity="0.6"/>
+      <line x1="0" y1="-100" x2="0" y2="-140" stroke="#ef4444" stroke-width="2" opacity="0.3"/>
+      <rect x="-50" y="60" width="100" height="65" rx="6" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+      <line x1="-50" y1="65" x2="0" y2="95" stroke="#f59e0b" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="65" x2="0" y2="95" stroke="#f59e0b" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-30" y1="105" x2="30" y2="105" stroke="#f59e0b" stroke-width="1" opacity="0.3"/>
+      <line x1="-25" y1="115" x2="25" y2="115" stroke="#f59e0b" stroke-width="1" opacity="0.3"/>
     </g>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Go + AI Malware</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go Binary + AI Threats</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#00add8" opacity="0.2" stroke="#00add8" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#00add8" text-anchor="middle">WEEKLY</text>
+
+  <!-- Theme extras -->
+
+    <g opacity="0.3">
+      <text x="150" y="180" font-family="Courier New" font-size="10" fill="#ef4444">From: admin@...</text>
+      <text x="900" y="200" font-family="Courier New" font-size="10" fill="#ef4444">Click here now</text>
+      <text x="120" y="440" font-family="Courier New" font-size="10" fill="#ef4444">credential.steal</text>
+      <text x="920" y="430" font-family="Courier New" font-size="10" fill="#ef4444">redirect(evil)</text>
+    </g>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="#ef4444">
+    <text x="50" y="100">phish.send()</text>
+    <text x="950" y="120">cred.capture()</text>
+    <text x="70" y="480">vishing_call()</text>
+    <text x="920" y="500">social_eng()</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Pig Butchering $61M Seized</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | FreePBX Mass Breach + Go Crypto Backdoor</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+
   <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 28, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 28, 2026</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/scripts/upgrade_low_quality_svgs.py
+++ b/scripts/upgrade_low_quality_svgs.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Upgrade low-quality post thumbnail SVGs with richer visual elements."""
+
+import os
+import re
+import json
+from datetime import datetime
+
+# Theme definitions with unique visual elements
+THEMES = {
+    "vulnerability": {
+        "accent": "#ef4444", "accent2": "#f97316", "bg2": "#1a0a0a",
+        "icon": """
+    <g transform="translate(600,250)">
+      <path d="M0,-130 L110,-85 L110,30 C110,90 55,135 0,160 C-55,135 -110,90 -110,30 L-110,-85 Z" fill="{accent}" opacity="0.12" stroke="{accent}" stroke-width="2"/>
+      <path d="M0,-110 L90,-72 L90,22 C90,72 45,110 0,132 C-45,110 -90,72 -90,22 L-90,-72 Z" fill="none" stroke="{accent}" stroke-width="1.5" stroke-dasharray="8,4" opacity="0.3"/>
+      <line x1="-40" y1="-50" x2="40" y2="50" stroke="{accent}" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <line x1="40" y1="-50" x2="-40" y2="50" stroke="{accent}" stroke-width="4" stroke-linecap="round" opacity="0.8"/>
+      <circle cx="0" cy="0" r="20" fill="none" stroke="{accent}" stroke-width="2.5" opacity="0.6"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.5">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1020,150 1035,125 1050,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1035" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="950,450 965,425 980,450" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="965" y="446" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>""",
+        "code_lines": ["CVE-2026-XXXX", "CVSS: 9.8 CRITICAL", "patch --apply fix", "vuln.scan(target)"],
+    },
+    "ransomware": {
+        "accent": "#ef4444", "accent2": "#dc2626", "bg2": "#1a0505",
+        "icon": """
+    <g transform="translate(600,240)">
+      <rect x="-50" y="-40" width="100" height="80" rx="10" fill="#1e293b" stroke="{accent}" stroke-width="2.5"/>
+      <path d="M-25,-40 L-25,-65 C-25,-90 25,-90 25,-65 L25,-40" fill="none" stroke="{accent}" stroke-width="3.5" stroke-linecap="round"/>
+      <circle cx="0" cy="0" r="12" fill="{accent}" opacity="0.7"/>
+      <rect x="-3" y="2" width="6" height="18" rx="3" fill="{accent}" opacity="0.9"/>
+      <path d="M-80,-10 L-55,-10 M-80,10 L-55,10" stroke="{accent}" stroke-width="2" stroke-dasharray="4,2" opacity="0.4"/>
+      <path d="M55,-10 L80,-10 M55,10 L80,10" stroke="{accent}" stroke-width="2" stroke-dasharray="4,2" opacity="0.4"/>
+    </g>""",
+        "extras": """
+    <g font-family="Courier New" font-size="12" fill="{accent}" opacity="0.15">
+      <text x="80" y="150">ENCRYPTED</text>
+      <text x="950" y="180">LOCKED</text>
+      <text x="100" y="430">$$$ RANSOM $$$</text>
+      <text x="920" y="450">decrypt.key</text>
+    </g>""",
+        "code_lines": ["encrypt(data)", "ransom_note.txt", "bitcoin: bc1q...", "key_exchange()"],
+    },
+    "supply_chain": {
+        "accent": "#8b5cf6", "accent2": "#7c3aed", "bg2": "#0a0a1e",
+        "icon": """
+    <g transform="translate(600,240)">
+      <rect x="-90" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <rect x="-15" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <rect x="60" y="-30" width="60" height="60" rx="8" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+      <line x1="-30" y1="0" x2="-15" y2="0" stroke="{accent}" stroke-width="2" marker-end="none"/>
+      <line x1="45" y1="0" x2="60" y2="0" stroke="#ef4444" stroke-width="2"/>
+      <text x="-60" y="6" font-family="Courier New" font-size="16" fill="{accent}" text-anchor="middle">OK</text>
+      <text x="15" y="6" font-family="Courier New" font-size="16" fill="{accent}" text-anchor="middle">OK</text>
+      <text x="90" y="6" font-family="Courier New" font-size="16" fill="#ef4444" text-anchor="middle">!!</text>
+      <path d="M90,-30 L90,-55 C90,-55 90,-70 75,-70 L-75,-70 C-75,-70 -90,-70 -90,-55 L-90,-30" fill="none" stroke="{accent}" stroke-width="1" stroke-dasharray="4,3" opacity="0.3"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.4">
+      <circle cx="200" cy="150" r="4" fill="{accent}"/><circle cx="220" cy="160" r="3" fill="{accent}"/>
+      <line x1="200" y1="150" x2="220" y2="160" stroke="{accent}" stroke-width="1"/>
+      <circle cx="1000" cy="420" r="4" fill="{accent}"/><circle cx="980" cy="410" r="3" fill="{accent}"/>
+      <line x1="1000" y1="420" x2="980" y2="410" stroke="{accent}" stroke-width="1"/>
+    </g>""",
+        "code_lines": ["npm install pkg", "pip install lib", "verify(hash)", "dependency.lock"],
+    },
+    "ai_security": {
+        "accent": "#3b82f6", "accent2": "#06b6d4", "bg2": "#0a0a1e",
+        "icon": """
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="60" fill="#1e293b" stroke="{accent}" stroke-width="2.5"/>
+      <circle cx="0" cy="0" r="45" fill="none" stroke="{accent}" stroke-width="1" stroke-dasharray="6,3" opacity="0.3"/>
+      <circle cx="-15" cy="-10" r="8" fill="{accent}" opacity="0.5"/>
+      <circle cx="15" cy="-10" r="8" fill="{accent}" opacity="0.5"/>
+      <path d="M-20,15 Q0,30 20,15" fill="none" stroke="{accent}" stroke-width="2" stroke-linecap="round"/>
+      <line x1="-60" y1="-30" x2="-95" y2="-55" stroke="{accent2}" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-100" cy="-60" r="8" fill="#1e293b" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="60" y1="-30" x2="95" y2="-55" stroke="{accent2}" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="100" cy="-60" r="8" fill="#1e293b" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-55" y1="30" x2="-85" y2="55" stroke="{accent2}" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="-90" cy="60" r="8" fill="#1e293b" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="55" y1="30" x2="85" y2="55" stroke="{accent2}" stroke-width="1.5" opacity="0.4"/>
+      <circle cx="90" cy="60" r="8" fill="#1e293b" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+    </g>""",
+        "extras": """
+    <g font-family="Courier New" font-size="10" fill="{accent}" opacity="0.12">
+      <text x="80" y="130">model.predict()</text>
+      <text x="950" y="160">tensor.eval()</text>
+      <text x="60" y="440">agent.run(task)</text>
+      <text x="920" y="430">llm.generate()</text>
+    </g>""",
+        "code_lines": ["agent.execute()", "model.eval()", "prompt_inject()", "guardrail.check()"],
+    },
+    "cloud": {
+        "accent": "#06b6d4", "accent2": "#3b82f6", "bg2": "#0a0a1e",
+        "icon": """
+    <g transform="translate(600,230)">
+      <path d="M-80,20 C-80,-40 -40,-70 10,-70 C30,-70 50,-60 60,-45 C70,-55 90,-55 105,-40 C130,-40 140,-20 140,0 C140,25 125,40 100,40 L-60,40 C-80,40 -100,25 -100,5 C-100,-5 -90,-15 -80,-15 Z" fill="#1e293b" stroke="{accent}" stroke-width="2.5"/>
+      <path d="M-60,20 C-60,-25 -25,-50 15,-50 C30,-50 45,-42 52,-30 C60,-38 75,-38 87,-27 C105,-27 115,-12 115,5 C115,22 103,33 82,33 L-42,33 C-58,33 -75,22 -75,5 C-75,-2 -68,-10 -60,-10 Z" fill="none" stroke="{accent}" stroke-width="1" stroke-dasharray="5,3" opacity="0.3"/>
+      <rect x="-15" y="-15" width="30" height="25" rx="4" fill="none" stroke="{accent}" stroke-width="2"/>
+      <path d="M-8,-15 L-8,-28 C-8,-38 8,-38 8,-28 L8,-15" fill="none" stroke="{accent}" stroke-width="2"/>
+      <circle cx="0" cy="0" r="4" fill="{accent}" opacity="0.7"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.3">
+      <rect x="100" y="130" width="80" height="50" rx="4" fill="none" stroke="{accent2}" stroke-width="1"/>
+      <text x="140" y="160" font-family="Courier New" font-size="9" fill="{accent2}" text-anchor="middle">us-east-1</text>
+      <rect x="1020" y="400" width="80" height="50" rx="4" fill="none" stroke="{accent2}" stroke-width="1"/>
+      <text x="1060" y="430" font-family="Courier New" font-size="9" fill="{accent2}" text-anchor="middle">ap-ne-2</text>
+    </g>""",
+        "code_lines": ["aws configure", "kubectl apply", "terraform plan", "cloud.deploy()"],
+    },
+    "blockchain": {
+        "accent": "#f59e0b", "accent2": "#f97316", "bg2": "#1a0f00",
+        "icon": """
+    <g transform="translate(600,240)">
+      <rect x="-80" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <rect x="-15" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <rect x="50" y="-35" width="50" height="50" rx="6" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <line x1="-30" y1="-10" x2="-15" y2="-10" stroke="{accent}" stroke-width="2"/>
+      <line x1="35" y1="-10" x2="50" y2="-10" stroke="{accent}" stroke-width="2"/>
+      <text x="-55" y="-4" font-family="Courier New" font-size="14" fill="{accent}" text-anchor="middle" opacity="0.7">#1</text>
+      <text x="10" y="-4" font-family="Courier New" font-size="14" fill="{accent}" text-anchor="middle" opacity="0.7">#2</text>
+      <text x="75" y="-4" font-family="Courier New" font-size="14" fill="{accent}" text-anchor="middle" opacity="0.7">#3</text>
+      <text x="10" y="50" font-family="Arial" font-size="28" fill="{accent}" text-anchor="middle" font-weight="bold" opacity="0.3">B</text>
+    </g>""",
+        "extras": """
+    <g opacity="0.2">
+      <text x="130" y="180" font-family="Courier New" font-size="11" fill="{accent}">hash: 0x7f3a...</text>
+      <text x="900" y="200" font-family="Courier New" font-size="11" fill="{accent}">nonce: 42981</text>
+      <text x="100" y="420" font-family="Courier New" font-size="11" fill="{accent}">block.verify()</text>
+      <text x="930" y="440" font-family="Courier New" font-size="11" fill="{accent}">tx.confirm()</text>
+    </g>""",
+        "code_lines": ["tx.sign(key)", "block.hash()", "BTC: $71,000", "ledger.verify()"],
+    },
+    "apt_malware": {
+        "accent": "#ef4444", "accent2": "#8b5cf6", "bg2": "#1a0505",
+        "icon": """
+    <g transform="translate(600,240)">
+      <circle cx="0" cy="0" r="50" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <circle cx="0" cy="0" r="35" fill="none" stroke="{accent}" stroke-width="1" stroke-dasharray="4,3" opacity="0.4"/>
+      <circle cx="-12" cy="-8" r="7" fill="{accent}" opacity="0.7"/>
+      <circle cx="12" cy="-8" r="7" fill="{accent}" opacity="0.7"/>
+      <circle cx="-12" cy="-8" r="3" fill="#0a0a1a"/>
+      <circle cx="12" cy="-8" r="3" fill="#0a0a1a"/>
+      <path d="M-12,15 L12,15" stroke="{accent}" stroke-width="2.5" stroke-linecap="round"/>
+      <line x1="-50" y1="-25" x2="-80" y2="-50" stroke="{accent}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="-25" x2="80" y2="-50" stroke="{accent}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-50" y1="25" x2="-80" y2="50" stroke="{accent}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="25" x2="80" y2="50" stroke="{accent}" stroke-width="1.5" opacity="0.5"/>
+      <circle cx="-85" cy="-55" r="5" fill="{accent}" opacity="0.3"/>
+      <circle cx="85" cy="-55" r="5" fill="{accent}" opacity="0.3"/>
+      <circle cx="-85" cy="55" r="5" fill="{accent}" opacity="0.3"/>
+      <circle cx="85" cy="55" r="5" fill="{accent}" opacity="0.3"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.4">
+      <polygon points="150,420 165,395 180,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="165" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1030,160 1045,135 1060,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1045" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>""",
+        "code_lines": ["C2: connect()", "exfil(data)", "persist(rootkit)", "lateral_move()"],
+    },
+    "zero_day": {
+        "accent": "#ef4444", "accent2": "#f59e0b", "bg2": "#1a0808",
+        "icon": """
+    <g transform="translate(600,240)">
+      <rect x="-55" y="-65" width="110" height="110" rx="12" fill="#1e293b" stroke="{accent}" stroke-width="2.5"/>
+      <line x1="-55" y1="-30" x2="55" y2="-30" stroke="{accent}" stroke-width="1.5" opacity="0.5"/>
+      <text x="0" y="-40" font-family="Arial" font-size="16" fill="{accent}" text-anchor="middle" font-weight="bold" opacity="0.8">0-DAY</text>
+      <text x="0" y="5" font-family="Courier New" font-size="36" fill="{accent}" text-anchor="middle" font-weight="bold" opacity="0.5">0</text>
+      <line x1="-30" y1="-20" x2="30" y2="40" stroke="{accent2}" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+      <line x1="30" y1="-20" x2="-30" y2="40" stroke="{accent2}" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.4">
+      <polygon points="180,160 195,135 210,160" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="195" y="156" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="990,420 1005,395 1020,420" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1005" y="416" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+      <polygon points="1050,150 1065,125 1080,150" fill="none" stroke="#fbbf24" stroke-width="1.5"/>
+      <text x="1065" y="146" font-family="Arial" font-size="10" fill="#fbbf24" text-anchor="middle">!</text>
+    </g>""",
+        "code_lines": ["CVE-2026-XXXX", "exploit(0day)", "patch: PENDING", "alert: CRITICAL"],
+    },
+    "docker": {
+        "accent": "#06b6d4", "accent2": "#3b82f6", "bg2": "#0a0a1e",
+        "icon": """
+    <g transform="translate(600,235)">
+      <rect x="-80" y="-20" width="160" height="80" rx="10" fill="#1e293b" stroke="{accent}" stroke-width="2.5"/>
+      <g transform="translate(-50,-5)">
+        <rect x="0" y="0" width="22" height="18" rx="2" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.6"/>
+        <rect x="28" y="0" width="22" height="18" rx="2" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.6"/>
+        <rect x="56" y="0" width="22" height="18" rx="2" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.6"/>
+        <rect x="0" y="24" width="22" height="18" rx="2" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.6"/>
+        <rect x="28" y="24" width="22" height="18" rx="2" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.6"/>
+        <rect x="56" y="24" width="22" height="18" rx="2" fill="#ef4444" stroke="#ef4444" stroke-width="1.5" opacity="0.3"/>
+      </g>
+      <path d="M-80,-20 C-100,-40 -60,-55 -40,-50 C-20,-60 20,-60 40,-50 C60,-55 100,-40 80,-20" fill="none" stroke="{accent}" stroke-width="1.5" opacity="0.3"/>
+    </g>""",
+        "extras": """
+    <g font-family="Courier New" font-size="10" fill="{accent}" opacity="0.15">
+      <text x="80" y="140">docker build .</text>
+      <text x="950" y="160">container.run()</text>
+      <text x="60" y="430">FROM alpine:3.20</text>
+      <text x="930" y="450">EXPOSE 8080</text>
+    </g>""",
+        "code_lines": ["docker pull img", "container.exec()", "Dockerfile", "compose up -d"],
+    },
+    "phishing": {
+        "accent": "#ef4444", "accent2": "#f59e0b", "bg2": "#1a0808",
+        "icon": """
+    <g transform="translate(600,230)">
+      <path d="M0,-100 L0,-20 C0,10 -25,30 -25,30 C-25,30 0,50 25,30 C25,30 50,10 50,-20 L50,-35" fill="none" stroke="{accent}" stroke-width="4" stroke-linecap="round"/>
+      <circle cx="-25" cy="35" r="6" fill="{accent}" opacity="0.6"/>
+      <line x1="0" y1="-100" x2="0" y2="-140" stroke="{accent}" stroke-width="2" opacity="0.3"/>
+      <rect x="-50" y="60" width="100" height="65" rx="6" fill="#1e293b" stroke="{accent2}" stroke-width="2"/>
+      <line x1="-50" y1="65" x2="0" y2="95" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="50" y1="65" x2="0" y2="95" stroke="{accent2}" stroke-width="1.5" opacity="0.5"/>
+      <line x1="-30" y1="105" x2="30" y2="105" stroke="{accent2}" stroke-width="1" opacity="0.3"/>
+      <line x1="-25" y1="115" x2="25" y2="115" stroke="{accent2}" stroke-width="1" opacity="0.3"/>
+    </g>""",
+        "extras": """
+    <g opacity="0.3">
+      <text x="150" y="180" font-family="Courier New" font-size="10" fill="{accent}">From: admin@...</text>
+      <text x="900" y="200" font-family="Courier New" font-size="10" fill="{accent}">Click here now</text>
+      <text x="120" y="440" font-family="Courier New" font-size="10" fill="{accent}">credential.steal</text>
+      <text x="920" y="430" font-family="Courier New" font-size="10" fill="{accent}">redirect(evil)</text>
+    </g>""",
+        "code_lines": ["phish.send()", "cred.capture()", "vishing_call()", "social_eng()"],
+    },
+    "code_security": {
+        "accent": "#22c55e", "accent2": "#3b82f6", "bg2": "#0a1a0a",
+        "icon": """
+    <g transform="translate(600,235)">
+      <rect x="-80" y="-55" width="160" height="110" rx="10" fill="#1e293b" stroke="{accent}" stroke-width="2"/>
+      <rect x="-75" y="-50" width="150" height="20" rx="4" fill="{accent}" opacity="0.1"/>
+      <circle cx="-60" cy="-40" r="4" fill="#ef4444" opacity="0.6"/>
+      <circle cx="-48" cy="-40" r="4" fill="#fbbf24" opacity="0.6"/>
+      <circle cx="-36" cy="-40" r="4" fill="#22c55e" opacity="0.6"/>
+      <text x="-60" y="-15" font-family="Courier New" font-size="10" fill="{accent}" opacity="0.7">$ code --secure</text>
+      <text x="-60" y="2" font-family="Courier New" font-size="10" fill="{accent2}" opacity="0.5">  scanning...</text>
+      <text x="-60" y="19" font-family="Courier New" font-size="10" fill="#ef4444" opacity="0.5">  3 vulns found</text>
+      <text x="-60" y="36" font-family="Courier New" font-size="10" fill="{accent}" opacity="0.7">$ fix --apply</text>
+    </g>""",
+        "extras": """
+    <g opacity="0.3">
+      <rect x="100" y="130" width="120" height="60" rx="6" fill="none" stroke="{accent2}" stroke-width="1"/>
+      <text x="160" y="155" font-family="Courier New" font-size="9" fill="{accent2}" text-anchor="middle">main.go</text>
+      <text x="160" y="175" font-family="Courier New" font-size="9" fill="{accent}" text-anchor="middle">SAFE</text>
+      <rect x="980" y="400" width="120" height="60" rx="6" fill="none" stroke="#ef4444" stroke-width="1"/>
+      <text x="1040" y="425" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">api.py</text>
+      <text x="1040" y="445" font-family="Courier New" font-size="9" fill="#ef4444" text-anchor="middle">VULN</text>
+    </g>""",
+        "code_lines": ["lint --fix", "test --coverage", "audit --strict", "deploy --safe"],
+    },
+}
+
+# SVG data for each file to upgrade
+UPGRADES = [
+    {
+        "file": "2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg",
+        "theme": "cloud",
+        "title": "AWS Vulnerability & ISMS",
+        "subtitle": "Cloud Security Course 7th | Week 4 Practical Guide",
+        "badge": "COURSE",
+        "date": "May 9, 2025",
+    },
+    {
+        "file": "2026-01-25-Tech_Security_Weekly_Digest.svg",
+        "theme": "vulnerability",
+        "title": "VMware vCenter KEV Patch",
+        "subtitle": "Weekly Digest | Fortinet SSO Bypass + Sandworm DynoWiper",
+        "badge": "WEEKLY DIGEST",
+        "date": "Jan 25, 2026",
+    },
+    {
+        "file": "2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg",
+        "theme": "zero_day",
+        "title": "AI Finds 12 OpenSSL 0-Days",
+        "subtitle": "Weekly Digest | OWASP Agentic AI + Fortinet Patch",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 1, 2026",
+    },
+    {
+        "file": "2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg",
+        "theme": "code_security",
+        "title": "AI Coding Assistant Comparison",
+        "subtitle": "Claude Code vs Copilot | Security + DevSecOps + FinOps",
+        "badge": "DEEP DIVE",
+        "date": "Feb 4, 2026",
+    },
+    {
+        "file": "2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg",
+        "theme": "docker",
+        "title": "Docker AI CVE-2025-11953",
+        "subtitle": "Weekly Digest | CVSS 9.8 RCE + Data Pipeline Attack",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 4, 2026",
+    },
+    {
+        "file": "2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg",
+        "theme": "apt_malware",
+        "title": "n8n RCE + NGINX Hijack",
+        "subtitle": "Weekly Digest | AsyncRAT Campaign + CVE Analysis",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 5, 2026",
+    },
+    {
+        "file": "2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg",
+        "theme": "phishing",
+        "title": "Signal Phishing + Ransomware",
+        "subtitle": "Weekly Digest | State-Sponsored Attack + BlackField",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 8, 2026",
+    },
+    {
+        "file": "2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg",
+        "theme": "blockchain",
+        "title": "Bithumb $44B Incident",
+        "subtitle": "Blockchain Digest | Bitcoin $71K + Operational Security",
+        "badge": "BLOCKCHAIN",
+        "date": "Feb 9, 2026",
+    },
+    {
+        "file": "2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg",
+        "theme": "supply_chain",
+        "title": "AI Supply Chain Security",
+        "subtitle": "Security Digest | VirusTotal AI + AWS Agentic",
+        "badge": "SECURITY",
+        "date": "Feb 9, 2026",
+    },
+    {
+        "file": "2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg",
+        "theme": "ai_security",
+        "title": "Meta Prometheus + OTLP",
+        "subtitle": "AI Cloud Digest | Google Observability + AWS Update",
+        "badge": "AI CLOUD",
+        "date": "Feb 10, 2026",
+    },
+    {
+        "file": "2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg",
+        "theme": "apt_malware",
+        "title": "SolarWinds RCE + UNC3886",
+        "subtitle": "Security Digest | Telecom Espionage + LLM Attack",
+        "badge": "SECURITY",
+        "date": "Feb 10, 2026",
+    },
+    {
+        "file": "2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg",
+        "theme": "supply_chain",
+        "title": "Supply Chain + APT36 RAT",
+        "subtitle": "Weekly Digest | Outlook Add-in Attack + Windows Update",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 12, 2026",
+    },
+    {
+        "file": "2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg",
+        "theme": "supply_chain",
+        "title": "Lazarus Supply Chain Attack",
+        "subtitle": "Weekly Digest | Copilot Studio Vuln + FinOps Security",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 13, 2026",
+    },
+    {
+        "file": "2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg",
+        "theme": "zero_day",
+        "title": "Microsoft 6x Zero-Day Patch",
+        "subtitle": "Weekly Digest | Apple Emergency + Ivanti EPMM Attack",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 14, 2026",
+    },
+    {
+        "file": "2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg",
+        "theme": "ai_security",
+        "title": "AI Agent + Patch Tuesday",
+        "subtitle": "Weekly Digest | Cloud Cost Optimization + Kimwolf Botnet",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 17, 2026",
+    },
+    {
+        "file": "2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg",
+        "theme": "zero_day",
+        "title": "Dell RecoverPoint 0-Day",
+        "subtitle": "Weekly Digest | AWS Security Update + CVE-2026-2329",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 19, 2026",
+    },
+    {
+        "file": "2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg",
+        "theme": "cloud",
+        "title": "AI Alignment + EKS Flyte",
+        "subtitle": "Weekly Digest | Docker Security + Cloud Native Trends",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 20, 2026",
+    },
+    {
+        "file": "2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg",
+        "theme": "vulnerability",
+        "title": "CVE-2025-49113 + Rust Supply",
+        "subtitle": "Weekly Digest | Ransomware Response + Claude Security",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 21, 2026",
+    },
+    {
+        "file": "2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg",
+        "theme": "ransomware",
+        "title": "Vertical AI + BlackField",
+        "subtitle": "Weekly Digest | Ransomware Defense + Data Protection",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 23, 2026",
+    },
+    {
+        "file": "2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg",
+        "theme": "apt_malware",
+        "title": "APT28 MacroMaze Campaign",
+        "subtitle": "Weekly Digest | Docker Hardening + LLM Operations Risk",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 24, 2026",
+    },
+    {
+        "file": "2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg",
+        "theme": "apt_malware",
+        "title": "UNC2814 GRIDTIDE Campaign",
+        "subtitle": "Weekly Digest | Claude Code RCE + Vishing Trends",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 26, 2026",
+    },
+    {
+        "file": "2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg",
+        "theme": "phishing",
+        "title": "Pig Butchering $61M Seized",
+        "subtitle": "Weekly Digest | FreePBX Mass Breach + Go Crypto Backdoor",
+        "badge": "WEEKLY DIGEST",
+        "date": "Feb 28, 2026",
+    },
+]
+
+
+def generate_svg(cfg):
+    theme = THEMES[cfg["theme"]]
+    accent = theme["accent"]
+    accent2 = theme["accent2"]
+    bg2 = theme["bg2"]
+    icon = theme["icon"].replace("{accent}", accent).replace("{accent2}", accent2)
+    extras = theme["extras"].replace("{accent}", accent).replace("{accent2}", accent2)
+    code_lines = theme["code_lines"]
+
+    # Badge color mapping
+    badge_color = accent
+    if cfg["badge"] in ("WEEKLY DIGEST", "WEEKLY"):
+        badge_color = "#ef4444"
+    elif cfg["badge"] in ("DEEP DIVE", "COURSE"):
+        badge_color = "#8b5cf6"
+    elif cfg["badge"] == "BLOCKCHAIN":
+        badge_color = "#f59e0b"
+    elif cfg["badge"] in ("SECURITY", "AI CLOUD"):
+        badge_color = "#3b82f6"
+
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:{bg2}"/>
+    </linearGradient>
+    <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:{accent}"/>
+      <stop offset="100%" style="stop-color:{accent2}"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="softglow">
+      <feGaussianBlur stdDeviation="20" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shadow">
+      <feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04">
+    <line x1="60" y1="0" x2="60" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="120" y1="0" x2="120" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="180" y1="0" x2="180" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="240" y1="0" x2="240" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="960" y1="0" x2="960" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1020" y1="0" x2="1020" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1080" y1="0" x2="1080" y2="630" stroke="#fff" stroke-width="1"/>
+    <line x1="1140" y1="0" x2="1140" y2="630" stroke="#fff" stroke-width="1"/>
+  </g>
+
+  <!-- Ambient glow -->
+  <circle cx="600" cy="280" r="250" fill="{accent}" opacity="0.04" filter="url(#softglow)"/>
+  <circle cx="300" cy="180" r="150" fill="{accent2}" opacity="0.05" filter="url(#softglow)"/>
+  <circle cx="900" cy="400" r="180" fill="{accent}" opacity="0.03" filter="url(#softglow)"/>
+
+  <!-- Central icon -->
+  <g filter="url(#shadow)">
+{icon}
+  </g>
+
+  <!-- Theme extras -->
+{extras}
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" opacity="0.12" fill="{accent}">
+    <text x="50" y="100">{code_lines[0]}</text>
+    <text x="950" y="120">{code_lines[1]}</text>
+    <text x="70" y="480">{code_lines[2]}</text>
+    <text x="920" y="500">{code_lines[3]}</text>
+  </g>
+
+  <!-- Title -->
+  <text x="600" y="510" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">{cfg["title"]}</text>
+  <text x="600" y="548" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">{cfg["subtitle"]}</text>
+
+  <!-- Top badges -->
+  <rect x="40" y="25" width="160" height="32" rx="16" fill="{badge_color}" opacity="0.2" stroke="{badge_color}" stroke-width="1"/>
+  <text x="120" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="{badge_color}" text-anchor="middle">{cfg["badge"]}</text>
+
+  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1080" y="47" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">{cfg["date"]}</text>
+
+  <!-- Footer -->
+  <text x="1160" y="615" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</svg>'''
+    return svg
+
+
+def main():
+    img_dir = "assets/images"
+    updated = 0
+    for cfg in UPGRADES:
+        path = os.path.join(img_dir, cfg["file"])
+        if not os.path.exists(path):
+            print(f"  SKIP (not found): {cfg['file']}")
+            continue
+        svg = generate_svg(cfg)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(svg)
+        updated += 1
+        print(f"  UPGRADED: {cfg['file']} ({len(svg)}B, theme={cfg['theme']})")
+
+    print(f"\nTotal upgraded: {updated}/{len(UPGRADES)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 25개 저품질 포스트 썸네일 SVG를 테마별 고품질 디자인으로 업그레이드
- 전체 113개 썸네일 품질 점수 5/7 이상 달성 (이전 25개가 4/7 이하)
- XML 유효성 오류 1건 수정

## Changes
- 22개 Weekly Digest 썸네일: 11가지 테마(vulnerability, ransomware, supply_chain, ai_security, cloud, blockchain, apt_malware, zero_day, docker, phishing, code_security)별 고유 아이콘, 그라디언트, 앰비언트 효과, 코드 프래그먼트 추가
- 3개 2025년 포스트 썸네일(AWS Course, re:Inforce, NPM Shai-Hulud): 그리드, 글로우, 셰도우 필터 보강
- `scripts/upgrade_low_quality_svgs.py` 생성 스크립트 포함

## Test plan
- [x] 전체 113개 SVG XML 유효성 검사 통과
- [x] 한글/특수문자 0건
- [x] 품질 점수 5/7 미만 썸네일 0개

🤖 Generated with [Claude Code](https://claude.com/claude-code)