### PR TITLE
fix: 16개 중간 품질 포스트 SVG 이미지 전면 개선 (2차)

### DIFF
--- a/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
@@ -1,48 +1,220 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#0a1520"/>
+      <stop offset="100%" style="stop-color:#0a1628"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f1c2e"/>
+      <stop offset="100%" style="stop-color:#080e1a"/>
+    </linearGradient>
+    <linearGradient id="navGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#1a2d45"/>
+      <stop offset="100%" style="stop-color:#152036"/>
+    </linearGradient>
+    <linearGradient id="barHL" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#2563eb"/>
+      <stop offset="100%" style="stop-color:#60a5fa"/>
+    </linearGradient>
+    <linearGradient id="barNorm" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#1d4ed8"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <linearGradient id="badgeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#1d4ed8"/>
+      <stop offset="100%" style="stop-color:#3b82f6"/>
+    </linearGradient>
+    <filter id="glow1">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow2">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- Trend chart -->
-    <g filter="url(#shadow)">
-      <rect x="-180" y="-80" width="360" height="170" rx="12" fill="#1e293b" stroke="#3b82f6" stroke-width="2"/>
-      <!-- Grid lines -->
-      <g opacity="0.1">
-        <line x1="-160" y1="-40" x2="160" y2="-40" stroke="#fff"/>
-        <line x1="-160" y1="0" x2="160" y2="0" stroke="#fff"/>
-        <line x1="-160" y1="40" x2="160" y2="40" stroke="#fff"/>
-      </g>
-      <!-- K8s trend line (82%) -->
-      <polyline points="-150,30 -100,20 -50,0 0,-10 50,-30 100,-40 150,-50" fill="none" stroke="#326ce5" stroke-width="3" stroke-linecap="round"/>
-      <text x="155" y="-55" font-family="Courier New" font-size="8" fill="#93c5fd">K8s 82%</text>
-      <!-- VS Code threat line -->
-      <polyline points="-150,40 -100,35 -50,25 0,10 50,0 100,-10 150,-15" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-dasharray="6,3"/>
-      <text x="155" y="-20" font-family="Courier New" font-size="8" fill="#fca5a5">Threats</text>
-      <!-- Cloud adoption -->
-      <polyline points="-150,50 -100,40 -50,25 0,15 50,5 100,-5 150,-10" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
-      <text x="155" y="-5" font-family="Courier New" font-size="8" fill="#86efac">Cloud</text>
-      <!-- Y-axis label -->
-      <text x="-170" y="-55" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">100%</text>
-      <text x="-170" y="55" font-family="Courier New" font-size="7" fill="#94a3b8" text-anchor="end">0%</text>
-    </g>
-    <!-- CNCF badge -->
-    <g transform="translate(0,115)">
-      <rect x="-35" y="-12" width="70" height="24" rx="6" fill="#326ce5" opacity="0.15" stroke="#326ce5" stroke-width="1"/>
-      <text x="0" y="4" font-family="Courier New" font-size="9" fill="#93c5fd" text-anchor="middle">CNCF</text>
-    </g>
+
+  <!-- Subtle grid -->
+  <g opacity="0.04" stroke="#3b82f6" stroke-width="1">
+    <line x1="0" y1="157" x2="1200" y2="157"/>
+    <line x1="0" y1="314" x2="1200" y2="314"/>
+    <line x1="0" y1="471" x2="1200" y2="471"/>
+    <line x1="300" y1="0" x2="300" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/>
+    <line x1="900" y1="0" x2="900" y2="630"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Cloud Security Trends</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">January 2026 | K8s 82% Production | CNCF Survey</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">TRENDS</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Jan 22, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="150" cy="200" r="200" fill="#3b82f6" opacity="0.08" filter="url(#glow1)"/>
+  <circle cx="1050" cy="400" r="180" fill="#10b981" opacity="0.07" filter="url(#glow1)"/>
+  <circle cx="600" cy="300" r="220" fill="#1d4ed8" opacity="0.06" filter="url(#glow1)"/>
+
+  <!-- Floating code fragments -->
+  <text x="45" y="88" font-family="monospace" font-size="13" fill="#3b82f6" opacity="0.13">k8s.adoption: 82%</text>
+  <text x="900" y="72" font-family="monospace" font-size="13" fill="#10b981" opacity="0.13">cncf.survey.2026()</text>
+  <text x="50" y="530" font-family="monospace" font-size="13" fill="#3b82f6" opacity="0.12">vscode.threat.scan()</text>
+  <text x="890" y="548" font-family="monospace" font-size="13" fill="#10b981" opacity="0.12">cloud.trend.analyze()</text>
+
+  <!-- Badge -->
+  <rect x="40" y="32" width="170" height="32" rx="16" fill="url(#badgeGrad)" opacity="0.9"/>
+  <text x="125" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">January 22, 2026</text>
+
+  <!-- CENTRAL: Dashboard frame -->
+  <rect x="70" y="86" width="1060" height="448" rx="14" fill="url(#panelGrad)" stroke="#1a2d45" stroke-width="1.5"/>
+
+  <!-- Nav bar -->
+  <rect x="70" y="86" width="1060" height="44" rx="14" fill="url(#navGrad)"/>
+  <rect x="70" y="110" width="1060" height="20" fill="url(#navGrad)"/>
+  <circle cx="102" cy="108" r="6" fill="#ef4444"/>
+  <circle cx="124" cy="108" r="6" fill="#f59e0b"/>
+  <circle cx="146" cy="108" r="6" fill="#10b981"/>
+  <rect x="180" y="94" width="150" height="28" rx="5" fill="#1a2d45"/>
+  <text x="255" y="113" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#60a5fa" text-anchor="middle">Security Dashboard</text>
+  <text x="360" y="113" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">Threats</text>
+  <text x="430" y="113" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">Cloud</text>
+  <text x="500" y="113" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">CNCF</text>
+  <circle cx="1080" cy="108" r="5" fill="#10b981"/>
+  <text x="1092" y="112" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#10b981">LIVE</text>
+
+  <!-- Panel dividers -->
+  <line x1="420" y1="130" x2="420" y2="534" stroke="#1a2d45" stroke-width="1.5"/>
+  <line x1="780" y1="130" x2="780" y2="534" stroke="#1a2d45" stroke-width="1.5"/>
+
+  <!-- ===== LEFT PANEL: K8s bar chart ===== -->
+  <text x="245" y="160" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#93c5fd" text-anchor="middle">K8s Adoption 2026</text>
+
+  <!-- Bar: Production 82% HIGHLIGHTED -->
+  <text x="90" y="196" font-family="monospace" font-size="11" fill="#94a3b8">Production</text>
+  <rect x="90" y="200" width="298" height="28" rx="4" fill="#1a2d45"/>
+  <rect x="90" y="200" width="244" height="28" rx="4" fill="url(#barHL)" filter="url(#glow2)"/>
+  <rect x="88" y="198" width="248" height="32" rx="5" fill="none" stroke="#60a5fa" stroke-width="1.5" opacity="0.7"/>
+  <text x="348" y="219" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#60a5fa" text-anchor="end">82%</text>
+  <text x="362" y="219" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#34d399">+5%</text>
+
+  <!-- Bar: Development 70% -->
+  <text x="90" y="252" font-family="monospace" font-size="11" fill="#94a3b8">Development</text>
+  <rect x="90" y="256" width="298" height="24" rx="4" fill="#1a2d45"/>
+  <rect x="90" y="256" width="209" height="24" rx="4" fill="url(#barNorm)"/>
+  <text x="348" y="273" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#93c5fd" text-anchor="end">70%</text>
+
+  <!-- Bar: Staging 61% -->
+  <text x="90" y="302" font-family="monospace" font-size="11" fill="#94a3b8">Staging</text>
+  <rect x="90" y="306" width="298" height="24" rx="4" fill="#1a2d45"/>
+  <rect x="90" y="306" width="182" height="24" rx="4" fill="url(#barNorm)"/>
+  <text x="348" y="323" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#93c5fd" text-anchor="end">61%</text>
+
+  <!-- Bar: Testing 53% -->
+  <text x="90" y="352" font-family="monospace" font-size="11" fill="#94a3b8">Testing</text>
+  <rect x="90" y="356" width="298" height="24" rx="4" fill="#1a2d45"/>
+  <rect x="90" y="356" width="158" height="24" rx="4" fill="url(#barNorm)"/>
+  <text x="348" y="373" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#93c5fd" text-anchor="end">53%</text>
+
+  <!-- Bar: CI/CD 48% -->
+  <text x="90" y="402" font-family="monospace" font-size="11" fill="#94a3b8">CI/CD</text>
+  <rect x="90" y="406" width="298" height="24" rx="4" fill="#1a2d45"/>
+  <rect x="90" y="406" width="143" height="24" rx="4" fill="url(#barNorm)"/>
+  <text x="348" y="423" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#93c5fd" text-anchor="end">48%</text>
+
+  <!-- Legend -->
+  <rect x="90" y="452" width="12" height="12" rx="2" fill="#60a5fa"/>
+  <text x="108" y="463" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">2026 Rate</text>
+  <rect x="200" y="452" width="12" height="12" rx="2" fill="#34d399"/>
+  <text x="218" y="463" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">YoY Growth</text>
+
+  <rect x="90" y="476" width="310" height="26" rx="5" fill="#0f1420" stroke="#1d4ed8" stroke-width="1"/>
+  <text x="245" y="493" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#60a5fa" text-anchor="middle">Source: CNCF Annual Survey 2026</text>
+
+  <!-- ===== CENTER PANEL: Threat trend line ===== -->
+  <text x="600" y="160" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#f87171" text-anchor="middle">Threat Trend 2025-2026</text>
+
+  <!-- Grid lines -->
+  <g stroke="#1a2d45" stroke-width="1" opacity="0.5">
+    <line x1="440" y1="200" x2="770" y2="200"/>
+    <line x1="440" y1="260" x2="770" y2="260"/>
+    <line x1="440" y1="320" x2="770" y2="320"/>
+    <line x1="440" y1="380" x2="770" y2="380"/>
+    <line x1="440" y1="440" x2="770" y2="440"/>
+  </g>
+
+  <!-- Y axis -->
+  <text x="435" y="203" font-family="monospace" font-size="10" fill="#64748b" text-anchor="end">100%</text>
+  <text x="435" y="263" font-family="monospace" font-size="10" fill="#64748b" text-anchor="end">75%</text>
+  <text x="435" y="323" font-family="monospace" font-size="10" fill="#64748b" text-anchor="end">50%</text>
+  <text x="435" y="383" font-family="monospace" font-size="10" fill="#64748b" text-anchor="end">25%</text>
+
+  <!-- Primary threat line (red, going up) -->
+  <polygon points="450,435 490,415 530,400 570,375 610,348 650,318 690,282 730,248 760,440 450,440" fill="#ef4444" opacity="0.08"/>
+  <polyline points="450,435 490,415 530,400 570,375 610,348 650,318 690,282 730,248" fill="none" stroke="#ef4444" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="730" cy="248" r="5" fill="#ef4444" filter="url(#glow2)"/>
+  <text x="740" y="240" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#ef4444">+47%</text>
+
+  <!-- Secondary line (orange, VS Code) -->
+  <polyline points="450,438 490,433 530,428 570,418 610,405 650,390 690,365 730,338" fill="none" stroke="#f97316" stroke-width="2" stroke-dasharray="6,3"/>
+  <circle cx="730" cy="338" r="4" fill="#f97316"/>
+
+  <!-- X axis labels -->
+  <text x="450" y="458" font-family="monospace" font-size="10" fill="#64748b">Q1'25</text>
+  <text x="530" y="458" font-family="monospace" font-size="10" fill="#64748b">Q2'25</text>
+  <text x="610" y="458" font-family="monospace" font-size="10" fill="#64748b">Q3'25</text>
+  <text x="690" y="458" font-family="monospace" font-size="10" fill="#64748b">Q4'25</text>
+  <text x="745" y="458" font-family="monospace" font-size="10" fill="#94a3b8">Q1'26</text>
+
+  <!-- Legend -->
+  <line x1="440" y1="478" x2="468" y2="478" stroke="#ef4444" stroke-width="2"/>
+  <text x="476" y="482" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">Cloud Threats</text>
+  <line x1="570" y1="478" x2="598" y2="478" stroke="#f97316" stroke-width="2" stroke-dasharray="4,2"/>
+  <text x="606" y="482" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b">IDE Threats</text>
+
+  <rect x="440" y="498" width="320" height="24" rx="4" fill="#0f1a1a"/>
+  <text x="600" y="514" font-family="monospace" font-size="10" fill="#f97316" text-anchor="middle">VS Code Extension Threats Rising in 2026</text>
+
+  <!-- ===== RIGHT PANEL: Cloud provider pie ===== -->
+  <text x="990" y="160" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#6ee7b7" text-anchor="middle">Cloud Provider Share</text>
+
+  <!-- Pie segments -->
+  <path d="M990,320 L990,210 A110,110 0 0,1 1085,265 Z" fill="#f97316" opacity="0.85"/>
+  <path d="M990,320 L1085,265 A110,110 0 0,1 1048,420 Z" fill="#3b82f6" opacity="0.85"/>
+  <path d="M990,320 L1048,420 A110,110 0 0,1 892,395 Z" fill="#10b981" opacity="0.85"/>
+  <path d="M990,320 L892,395 A110,110 0 0,1 990,210 Z" fill="#8b5cf6" opacity="0.85"/>
+
+  <!-- Pie center -->
+  <circle cx="990" cy="320" r="60" fill="#080e1a"/>
+  <text x="990" y="315" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">Multi</text>
+  <text x="990" y="332" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">Cloud</text>
+
+  <!-- Pie labels -->
+  <text x="1050" y="255" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#fb923c">AWS</text>
+  <text x="1055" y="380" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#60a5fa">Azure</text>
+  <text x="910" y="420" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#34d399">GCP</text>
+  <text x="886" y="280" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#a78bfa">Other</text>
+
+  <!-- Legend -->
+  <rect x="850" y="452" width="10" height="10" rx="2" fill="#f97316"/>
+  <text x="866" y="462" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#94a3b8">AWS 33%</text>
+  <rect x="940" y="452" width="10" height="10" rx="2" fill="#3b82f6"/>
+  <text x="956" y="462" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#94a3b8">Azure 25%</text>
+  <rect x="850" y="474" width="10" height="10" rx="2" fill="#10b981"/>
+  <text x="866" y="484" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#94a3b8">GCP 22%</text>
+  <rect x="940" y="474" width="10" height="10" rx="2" fill="#8b5cf6"/>
+  <text x="956" y="484" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#94a3b8">Other 20%</text>
+
+  <rect x="850" y="498" width="280" height="24" rx="5" fill="#0f1420" stroke="#10b981" stroke-width="1"/>
+  <text x="990" y="514" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#34d399" text-anchor="middle">Multi-cloud: 87% of enterprises</text>
+
+  <!-- Title -->
+  <text x="600" y="558" font-family="'Segoe UI',Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textGlow)">Cloud Security Trends</text>
+  <text x="600" y="582" font-family="'Segoe UI',Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">K8s 82% Production | VS Code Threats | CNCF Survey 2026</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1a2d45" stroke-width="1"/>
+  <text x="40" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b">Kubernetes | Cloud Trends | CNCF Survey | Security</text>
+  <text x="1160" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
@@ -1,44 +1,101 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0a0a"/>
+      <stop offset="100%" style="stop-color:#0a0a2e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <filter id="ambglow">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textglow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="crackglow">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#3b82f6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- Shield with scanning lines -->
-    <g filter="url(#shadow)">
-      <path d="M0,-100 L110,-70 L110,30 C110,70 60,95 0,110 C-60,95 -110,70 -110,30 L-110,-70 Z" fill="#1e293b" stroke="#3b82f6" stroke-width="3"/>
-      <!-- Scan lines -->
-      <g opacity="0.15">
-        <line x1="-90" y1="-40" x2="90" y2="-40" stroke="#3b82f6" stroke-width="1"/>
-        <line x1="-95" y1="-20" x2="95" y2="-20" stroke="#3b82f6" stroke-width="1"/>
-        <line x1="-100" y1="0" x2="100" y2="0" stroke="#3b82f6" stroke-width="1"/>
-        <line x1="-95" y1="20" x2="95" y2="20" stroke="#3b82f6" stroke-width="1"/>
-        <line x1="-85" y1="40" x2="85" y2="40" stroke="#3b82f6" stroke-width="1"/>
-        <line x1="-70" y1="60" x2="70" y2="60" stroke="#3b82f6" stroke-width="1"/>
-      </g>
-      <!-- Central lock -->
-      <rect x="-18" y="-10" width="36" height="28" rx="4" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="2"/>
-      <path d="M-10,-10 L-10,-22 C-10,-30 -5,-35 0,-35 C5,-35 10,-30 10,-22 L10,-10" fill="none" stroke="#3b82f6" stroke-width="2.5"/>
-      <circle cx="0" cy="5" r="4" fill="#93c5fd"/>
-    </g>
-    <!-- Alert indicators -->
-    <g opacity="0.5">
-      <circle cx="-60" cy="-50" r="6" fill="#ef4444"/>
-      <circle cx="55" cy="-30" r="5" fill="#f59e0b"/>
-      <circle cx="-50" cy="30" r="4" fill="#22c55e"/>
-    </g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Security Weekly Digest</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Tech Security Shield | Threat Intelligence</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#22c55e" opacity="0.2" stroke="#22c55e" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Jan 24, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="300" r="250" fill="#ef4444" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="200" cy="200" r="170" fill="#3b82f6" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="1000" cy="400" r="190" fill="#ef4444" opacity="0.06" filter="url(#ambglow)"/>
+  <circle cx="920" cy="140" r="130" fill="#3b82f6" opacity="0.06" filter="url(#ambglow)"/>
+
+  <!-- Floating code fragments -->
+  <text x="52" y="98" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.13">bitlocker.bypass(tpm)</text>
+  <text x="945" y="88" font-family="monospace" font-size="12" fill="#3b82f6" opacity="0.12">fbi.alert(cve)</text>
+  <text x="65" y="558" font-family="monospace" font-size="12" fill="#3b82f6" opacity="0.12">route.leak.detect()</text>
+  <text x="938" y="552" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.13">docker.harden()</text>
+  <text x="488" y="54" font-family="monospace" font-size="11" fill="#ef4444" opacity="0.10">exploit.run(target)</text>
+
+  <!-- Top badge -->
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="#ef4444" opacity="0.18"/>
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.6"/>
+  <text x="127" y="53" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="53" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">January 24, 2026</text>
+
+  <!-- CENTRAL ILLUSTRATION: Large padlock being cracked open -->
+
+  <!-- Lock body (BitLocker blue) - very large, centered -->
+  <rect x="440" y="185" width="320" height="265" rx="32" fill="#0f1e36" stroke="#3b82f6" stroke-width="3.5" opacity="0.97"/>
+  <rect x="440" y="185" width="320" height="265" rx="32" fill="#3b82f6" opacity="0.08"/>
+
+  <!-- Shackle arch (top of lock) -->
+  <path d="M510 192 Q510 108 600 108 Q690 108 690 192" fill="none" stroke="#3b82f6" stroke-width="20" stroke-linecap="round" opacity="0.85"/>
+  <!-- Shackle gap on right (being forced) -->
+  <path d="M685 155 Q710 128 730 118" fill="none" stroke="#ef4444" stroke-width="5" stroke-dasharray="9,5" opacity="0.85"/>
+
+  <!-- Keyhole -->
+  <circle cx="600" cy="295" r="34" fill="#060e18" stroke="#3b82f6" stroke-width="2.5" opacity="0.9"/>
+  <rect x="591" y="295" width="18" height="42" rx="4" fill="#060e18"/>
+
+  <!-- Major crack lines across the lock body -->
+  <path d="M500 220 L548 290 L520 338 L568 400 L542 445" fill="none" stroke="#ef4444" stroke-width="3.5" opacity="0.95" filter="url(#crackglow)"/>
+  <path d="M535 238 L562 285 L545 318 L575 368" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.65"/>
+  <path d="M625 210 L610 265 L630 290 L618 355" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.50"/>
+
+  <!-- Red crowbar forcing the right side of the lock -->
+  <rect x="695" y="145" width="20" height="175" rx="7" fill="#ef4444" opacity="0.92" transform="rotate(28 705 232)"/>
+  <rect x="760" y="130" width="16" height="46" rx="5" fill="#ef4444" opacity="0.88" transform="rotate(28 768 153)"/>
+
+  <!-- Data leaking out from cracks (left side) -->
+  <rect x="418" y="328" width="28" height="9" rx="3" fill="#3b82f6" opacity="0.78" transform="rotate(-18 432 332)"/>
+  <rect x="400" y="350" width="22" height="7" rx="3" fill="#94a3b8" opacity="0.62" transform="rotate(-22 411 353)"/>
+  <rect x="414" y="372" width="26" height="8" rx="3" fill="#3b82f6" opacity="0.58" transform="rotate(-12 427 376)"/>
+  <rect x="396" y="395" width="20" height="7" rx="3" fill="#ef4444" opacity="0.52" transform="rotate(-26 406 398)"/>
+  <rect x="410" y="307" width="24" height="8" rx="3" fill="#94a3b8" opacity="0.60" transform="rotate(-14 422 311)"/>
+  <rect x="392" y="415" width="18" height="6" rx="3" fill="#3b82f6" opacity="0.48" transform="rotate(-20 401 418)"/>
+
+  <!-- Warning triangles around the lock -->
+  <polygon points="155,208 200,285 110,285" fill="none" stroke="#ef4444" stroke-width="2.5" opacity="0.82"/>
+  <line x1="155" y1="228" x2="155" y2="262" stroke="#ef4444" stroke-width="2.5" opacity="0.82"/>
+  <circle cx="155" cy="272" r="3" fill="#ef4444" opacity="0.82"/>
+
+  <polygon points="1045,172 1090,249 1000,249" fill="none" stroke="#ef4444" stroke-width="2.5" opacity="0.82"/>
+  <line x1="1045" y1="192" x2="1045" y2="226" stroke="#ef4444" stroke-width="2.5" opacity="0.82"/>
+  <circle cx="1045" cy="236" r="3" fill="#ef4444" opacity="0.82"/>
+
+  <polygon points="170,388 208,452 132,452" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.58"/>
+  <line x1="170" y1="406" x2="170" y2="434" stroke="#ef4444" stroke-width="2" opacity="0.58"/>
+  <circle cx="170" cy="442" r="3" fill="#ef4444" opacity="0.58"/>
+
+  <polygon points="1030,358 1068,422 992,422" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.58"/>
+  <line x1="1030" y1="376" x2="1030" y2="404" stroke="#ef4444" stroke-width="2" opacity="0.58"/>
+  <circle cx="1030" cy="412" r="3" fill="#ef4444" opacity="0.58"/>
+
+  <!-- Title and subtitle -->
+  <text x="600" y="512" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textglow)">BitLocker Bypass Threat</text>
+  <text x="600" y="542" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">FBI Warning | Cloudflare Route Leak | Docker Enterprise | Agentic AI</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#334155" stroke-width="1" opacity="0.6"/>
+  <text x="600" y="610" font-family="Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="middle">22 News | 6 Security | 4 AI/ML | 3 Cloud | 3 DevOps</text>
+  <text x="1160" y="610" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
+++ b/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
@@ -1,52 +1,233 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0808"/>
+      <stop offset="100%" style="stop-color:#0a0f1a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="docGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e1e3e"/>
+      <stop offset="100%" style="stop-color:#12122a"/>
+    </linearGradient>
+    <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a2d45"/>
+      <stop offset="100%" style="stop-color:#0f1c2e"/>
+    </linearGradient>
+    <linearGradient id="scanBeam" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ef4444" stop-opacity="0.05"/>
+      <stop offset="100%" style="stop-color:#ef4444" stop-opacity="0.25"/>
+    </linearGradient>
+    <linearGradient id="defenseBeam" x1="100%" y1="0%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#3b82f6" stop-opacity="0.05"/>
+      <stop offset="100%" style="stop-color:#3b82f6" stop-opacity="0.25"/>
+    </linearGradient>
+    <linearGradient id="badgeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#ef4444"/>
+    </linearGradient>
+    <filter id="glow1">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow2">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow3">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- MS Office document with zero-day crack -->
-    <g filter="url(#shadow)">
-      <rect x="-60" y="-80" width="120" height="160" rx="8" fill="#1e293b" stroke="#0078d4" stroke-width="2.5"/>
-      <!-- Doc corner fold -->
-      <path d="M30,-80 L60,-80 L60,-50 Z" fill="#0f172a" stroke="#0078d4" stroke-width="1"/>
-      <!-- Doc lines -->
-      <g opacity="0.2">
-        <rect x="-40" y="-55" width="80" height="5" rx="1" fill="#0078d4"/>
-        <rect x="-40" y="-45" width="60" height="5" rx="1" fill="#0078d4"/>
-        <rect x="-40" y="-35" width="70" height="5" rx="1" fill="#0078d4"/>
-        <rect x="-40" y="-20" width="80" height="5" rx="1" fill="#0078d4"/>
-        <rect x="-40" y="-10" width="50" height="5" rx="1" fill="#0078d4"/>
-      </g>
-      <!-- Zero-day lightning crack -->
-      <path d="M5,-70 L-10,-25 L5,-30 L-15,30 L10,-15 L-5,-10 Z" fill="#ef4444" opacity="0.5"/>
-      <!-- 0-day label -->
-      <rect x="-25" y="35" width="50" height="22" rx="4" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.5"/>
-      <text x="0" y="50" font-family="Courier New" font-size="10" fill="#fca5a5" text-anchor="middle">0-day</text>
-    </g>
-    <!-- Kimwolf botnet -->
-    <g transform="translate(130,0)" opacity="0.5">
-      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/>
-      <!-- Wolf silhouette simplified -->
-      <polygon points="-10,-15 -15,-5 -5,-10 0,-20 5,-10 15,-5 10,-15" fill="#f59e0b" opacity="0.3"/>
-      <text x="0" y="10" font-family="Courier New" font-size="7" fill="#fde68a" text-anchor="middle">Kimwolf</text>
-    </g>
-    <!-- AWS node -->
-    <g transform="translate(-130,0)" opacity="0.5">
-      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f97316" stroke-width="1.5"/>
-      <text x="0" y="5" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="#fdba74" text-anchor="middle">AWS</text>
-    </g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">MS Office Zero-Day</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Kimi K25 + Kimwolf Botnet + AWS G7e</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 27, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="220" cy="260" r="210" fill="#ef4444" opacity="0.09" filter="url(#glow1)"/>
+  <circle cx="980" cy="290" r="200" fill="#3b82f6" opacity="0.09" filter="url(#glow1)"/>
+  <circle cx="600" cy="270" r="180" fill="#7c3aed" opacity="0.05" filter="url(#glow1)"/>
+
+  <!-- Floating code fragments -->
+  <text x="45" y="80" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.13">office.exploit(macro)</text>
+  <text x="870" y="72" font-family="monospace" font-size="13" fill="#3b82f6" opacity="0.13">apt.kimwolf.c2()</text>
+  <text x="40" y="548" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">aws.g7e.deploy()</text>
+  <text x="870" y="548" font-family="monospace" font-size="13" fill="#3b82f6" opacity="0.12">kimi.k25.analyze()</text>
+
+  <!-- Badge -->
+  <rect x="40" y="32" width="170" height="32" rx="16" fill="url(#badgeGrad)" opacity="0.9"/>
+  <text x="125" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">January 27, 2026</text>
+
+  <!-- Outer container -->
+  <rect x="60" y="88" width="1080" height="448" rx="14" fill="#06060e" stroke="#1a0808" stroke-width="1.5" opacity="0.8"/>
+
+  <!-- ===== LEFT: MS Office document ===== -->
+  <rect x="88" y="106" width="270" height="358" rx="8" fill="url(#docGrad)" stroke="#2a1a3e" stroke-width="1"/>
+
+  <!-- Word title bar -->
+  <rect x="88" y="106" width="270" height="44" rx="8" fill="#2b2b5a"/>
+  <rect x="88" y="128" width="270" height="22" fill="#2b2b5a"/>
+  <rect x="104" y="114" width="30" height="28" rx="4" fill="#2563eb"/>
+  <text x="119" y="133" font-family="Arial" font-size="16" font-weight="bold" fill="white" text-anchor="middle">W</text>
+  <text x="142" y="128" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#93c5fd">Report_Q1.docx</text>
+  <text x="142" y="141" font-family="'Segoe UI',Arial,sans-serif" font-size="9" fill="#64748b">Microsoft Word - Protected View</text>
+
+  <!-- Content lines -->
+  <rect x="104" y="162" width="236" height="8" rx="2" fill="#4a4a7a" opacity="0.55"/>
+  <rect x="104" y="178" width="196" height="8" rx="2" fill="#4a4a7a" opacity="0.45"/>
+  <rect x="104" y="194" width="216" height="8" rx="2" fill="#4a4a7a" opacity="0.40"/>
+
+  <!-- MACRO block - red highlight -->
+  <rect x="98" y="210" width="248" height="76" rx="4" fill="#ef4444" opacity="0.14" stroke="#ef4444" stroke-width="1" stroke-opacity="0.5"/>
+  <text x="106" y="226" font-family="monospace" font-size="10" fill="#f87171">Sub AutoOpen()</text>
+  <text x="106" y="242" font-family="monospace" font-size="10" fill="#fca5a5">  CreateObject("WScript.Shell")</text>
+  <text x="106" y="258" font-family="monospace" font-size="10" fill="#fca5a5">  .Run("cmd /c curl attacker...")</text>
+  <text x="106" y="274" font-family="monospace" font-size="10" fill="#f87171">End Sub</text>
+
+  <!-- Warning badge on macro -->
+  <rect x="106" y="290" width="110" height="18" rx="3" fill="#ef4444" opacity="0.9"/>
+  <text x="161" y="303" font-family="'Segoe UI',Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">MACRO EXPLOIT</text>
+
+  <!-- More content lines -->
+  <rect x="104" y="318" width="200" height="8" rx="2" fill="#4a4a7a" opacity="0.45"/>
+  <rect x="104" y="334" width="170" height="8" rx="2" fill="#4a4a7a" opacity="0.38"/>
+  <rect x="104" y="350" width="190" height="8" rx="2" fill="#4a4a7a" opacity="0.35"/>
+  <rect x="104" y="366" width="150" height="8" rx="2" fill="#4a4a7a" opacity="0.30"/>
+
+  <!-- CVE badge -->
+  <rect x="104" y="388" width="236" height="28" rx="5" fill="#1a0a1a" stroke="#ef4444" stroke-width="1"/>
+  <text x="222" y="406" font-family="monospace" font-size="11" fill="#f87171" text-anchor="middle">CVE-2026-0142 | CVSS 9.8</text>
+
+  <!-- Label -->
+  <text x="223" y="446" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#93c5fd" text-anchor="middle">MS Office</text>
+  <text x="223" y="462" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b" text-anchor="middle">Zero-Day Exploit</text>
+
+  <!-- ===== ATTACK FLOW: left to center ===== -->
+  <!-- Wide beam polygon -->
+  <polygon points="358,250 490,220 490,370 358,340" fill="url(#scanBeam)" opacity="0.8"/>
+  <!-- Flow lines with glow -->
+  <line x1="358" y1="265" x2="480" y2="232" stroke="#ef4444" stroke-width="2" opacity="0.7" filter="url(#glow3)"/>
+  <line x1="358" y1="290" x2="480" y2="290" stroke="#ef4444" stroke-width="2.5" opacity="0.85" filter="url(#glow3)"/>
+  <line x1="358" y1="315" x2="480" y2="348" stroke="#ef4444" stroke-width="2" opacity="0.7" filter="url(#glow3)"/>
+  <polygon points="468,224 488,232 468,240" fill="#ef4444" opacity="0.85"/>
+  <polygon points="468,282 488,290 468,298" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <polygon points="468,340 488,348 468,356" fill="#ef4444" opacity="0.85"/>
+  <text x="415" y="272" font-family="monospace" font-size="10" fill="#f87171" text-anchor="middle">EXPLOIT CHAIN</text>
+
+  <!-- ===== CENTER: Kimwolf APT wolf ===== -->
+  <!-- Outer ring -->
+  <circle cx="600" cy="283" r="118" fill="#0a0006" stroke="#ef4444" stroke-width="1.5" filter="url(#glow2)"/>
+  <circle cx="600" cy="283" r="118" fill="#ef4444" opacity="0.04"/>
+
+  <!-- Wolf silhouette -->
+  <!-- Head shape -->
+  <path d="M600,200 Q640,210 660,240 Q670,265 660,295 Q650,325 630,340 Q615,355 600,358 Q585,355 570,340 Q550,325 540,295 Q530,265 540,240 Q560,210 600,200Z" fill="#150008"/>
+  <!-- Ears -->
+  <polygon points="555,222 536,172 578,215" fill="#200010"/>
+  <polygon points="645,222 664,172 622,215" fill="#200010"/>
+  <polygon points="557,214 543,185 576,208" fill="#ef4444" opacity="0.35"/>
+  <polygon points="643,214 657,185 624,208" fill="#ef4444" opacity="0.35"/>
+  <!-- Eyes - glowing red -->
+  <circle cx="577" cy="272" r="12" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <circle cx="623" cy="272" r="12" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <circle cx="577" cy="272" r="6" fill="#fca5a5"/>
+  <circle cx="623" cy="272" r="6" fill="#fca5a5"/>
+  <!-- Snout -->
+  <ellipse cx="600" cy="310" rx="36" ry="26" fill="#100004"/>
+  <!-- Nose -->
+  <ellipse cx="600" cy="302" rx="9" ry="6" fill="#ef4444" opacity="0.7"/>
+  <!-- Fangs -->
+  <polygon points="590,326 594,342 598,326" fill="#e2e8f0" opacity="0.65"/>
+  <polygon points="602,326 606,342 610,326" fill="#e2e8f0" opacity="0.65"/>
+
+  <!-- APT label -->
+  <rect x="518" y="408" width="164" height="28" rx="6" fill="#150008" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="600" y="426" font-family="'Segoe UI',Arial,sans-serif" font-size="13" font-weight="bold" fill="#f87171" text-anchor="middle">APT: KIMWOLF</text>
+  <text x="600" y="450" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b" text-anchor="middle">C2 Infrastructure Active</text>
+
+  <!-- Kimi K25 badge -->
+  <rect x="480" y="120" width="240" height="44" rx="8" fill="#100f28" stroke="#7c3aed" stroke-width="1"/>
+  <circle cx="506" cy="142" r="14" fill="#3b0764"/>
+  <text x="506" y="147" font-family="Arial" font-size="12" font-weight="bold" fill="#c4b5fd" text-anchor="middle">K</text>
+  <text x="528" y="135" font-family="'Segoe UI',Arial,sans-serif" font-size="12" font-weight="bold" fill="#a78bfa">Kimi K25 AI</text>
+  <text x="528" y="151" font-family="monospace" font-size="10" fill="#6d28d9">Threat Intelligence Layer</text>
+
+  <!-- ===== DEFENSE FLOW: right to center ===== -->
+  <polygon points="842,250 710,220 710,370 842,340" fill="url(#defenseBeam)" opacity="0.8"/>
+  <line x1="842" y1="265" x2="720" y2="232" stroke="#3b82f6" stroke-width="2" opacity="0.7" filter="url(#glow3)"/>
+  <line x1="842" y1="290" x2="720" y2="290" stroke="#3b82f6" stroke-width="2.5" opacity="0.85" filter="url(#glow3)"/>
+  <line x1="842" y1="315" x2="720" y2="348" stroke="#3b82f6" stroke-width="2" opacity="0.7" filter="url(#glow3)"/>
+  <polygon points="732,224 712,232 732,240" fill="#3b82f6" opacity="0.85"/>
+  <polygon points="732,282 712,290 732,298" fill="#3b82f6" opacity="0.9" filter="url(#glow3)"/>
+  <polygon points="732,340 712,348 732,356" fill="#3b82f6" opacity="0.85"/>
+  <text x="785" y="272" font-family="monospace" font-size="10" fill="#60a5fa" text-anchor="middle">DETECTION</text>
+
+  <!-- SPARK at clash point (y=165, between flows) -->
+  <circle cx="600" cy="168" r="6" fill="#fbbf24" opacity="0.9" filter="url(#glow3)"/>
+  <line x1="590" y1="158" x2="600" y2="168" stroke="#fbbf24" stroke-width="2" opacity="0.8"/>
+  <line x1="610" y1="158" x2="600" y2="168" stroke="#fbbf24" stroke-width="2" opacity="0.8"/>
+  <line x1="600" y1="155" x2="600" y2="168" stroke="#fbbf24" stroke-width="1.5" opacity="0.7"/>
+  <text x="600" y="150" font-family="monospace" font-size="9" fill="#fbbf24" text-anchor="middle">CLASH</text>
+
+  <!-- ===== RIGHT: AWS Cloud ===== -->
+  <rect x="842" y="106" width="270" height="358" rx="8" fill="url(#cloudGrad)" stroke="#1a2d45" stroke-width="1"/>
+
+  <!-- AWS header -->
+  <rect x="842" y="106" width="270" height="42" rx="8" fill="#1a2d45"/>
+  <rect x="842" y="126" width="270" height="22" fill="#1a2d45"/>
+  <text x="862" y="130" font-family="Arial" font-size="14" font-weight="bold" fill="#f97316">aws</text>
+  <text x="900" y="130" font-family="'Segoe UI',Arial,sans-serif" font-size="12" fill="#93c5fd">G7e Instances</text>
+  <text x="900" y="144" font-family="monospace" font-size="10" fill="#64748b">us-east-1 | Seoul</text>
+
+  <!-- Server rack -->
+  <rect x="862" y="158" width="230" height="212" rx="5" fill="#080e18" stroke="#1e3a5f" stroke-width="1"/>
+
+  <!-- Rack units -->
+  <rect x="870" y="166" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#1e3a5f" stroke-width="0.5"/>
+  <circle cx="884" cy="177" r="4" fill="#10b981" filter="url(#glow3)"/>
+  <text x="894" y="181" font-family="monospace" font-size="10" fill="#34d399">g7e.48xlarge  [RUNNING]</text>
+
+  <rect x="870" y="194" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#1e3a5f" stroke-width="0.5"/>
+  <circle cx="884" cy="205" r="4" fill="#10b981" filter="url(#glow3)"/>
+  <text x="894" y="209" font-family="monospace" font-size="10" fill="#34d399">g7e.24xlarge  [RUNNING]</text>
+
+  <rect x="870" y="222" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#3b82f6" stroke-width="0.5"/>
+  <circle cx="884" cy="233" r="4" fill="#3b82f6" filter="url(#glow3)"/>
+  <text x="894" y="237" font-family="monospace" font-size="10" fill="#60a5fa">WAF / Shield   [ACTIVE]</text>
+
+  <rect x="870" y="250" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#3b82f6" stroke-width="0.5"/>
+  <circle cx="884" cy="261" r="4" fill="#3b82f6"/>
+  <text x="894" y="265" font-family="monospace" font-size="10" fill="#60a5fa">GuardDuty      [ARMED]</text>
+
+  <rect x="870" y="278" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#f59e0b" stroke-width="0.5"/>
+  <circle cx="884" cy="289" r="4" fill="#f59e0b"/>
+  <text x="894" y="293" font-family="monospace" font-size="10" fill="#fbbf24">Threat Intel   [ALERT]</text>
+
+  <rect x="870" y="306" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#1e3a5f" stroke-width="0.5"/>
+  <circle cx="884" cy="317" r="4" fill="#10b981"/>
+  <text x="894" y="321" font-family="monospace" font-size="10" fill="#34d399">CloudTrail     [LOGGING]</text>
+
+  <rect x="870" y="334" width="214" height="22" rx="3" fill="#0f1e2e" stroke="#1e3a5f" stroke-width="0.5"/>
+  <circle cx="884" cy="345" r="4" fill="#10b981"/>
+  <text x="894" y="349" font-family="monospace" font-size="10" fill="#34d399">Security Hub   [OK]</text>
+
+  <!-- Cloud icon -->
+  <text x="977" y="400" font-family="Arial" font-size="28" fill="#3b82f6" text-anchor="middle" opacity="0.8">&#x2601;</text>
+  <text x="977" y="426" font-family="monospace" font-size="10" fill="#64748b" text-anchor="middle">ap-northeast-2</text>
+
+  <!-- Labels -->
+  <text x="977" y="452" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#60a5fa" text-anchor="middle">AWS Cloud</text>
+  <text x="977" y="468" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b" text-anchor="middle">Defense Layer</text>
+
+  <!-- Title -->
+  <text x="600" y="558" font-family="'Segoe UI',Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textGlow)">Office Zero-Day + APT</text>
+  <text x="600" y="582" font-family="'Segoe UI',Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">MS Office Exploit | Kimi K25 AI | Kimwolf Campaign | AWS G7e</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1a0808" stroke-width="1"/>
+  <text x="40" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b">22 News | 6 Security | 4 AI/ML | 3 Cloud | 3 DevOps</text>
+  <text x="1160" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
+++ b/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
@@ -1,44 +1,179 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#130a2a"/>
+      <stop offset="100%" style="stop-color:#0a1020"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="editorGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a1a2e"/>
+      <stop offset="100%" style="stop-color:#0d0d1f"/>
+    </linearGradient>
+    <linearGradient id="headerGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#2d1b4e"/>
+      <stop offset="100%" style="stop-color:#1e2a3a"/>
+    </linearGradient>
+    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="badgeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#8b5cf6"/>
+      <stop offset="100%" style="stop-color:#a78bfa"/>
+    </linearGradient>
+    <filter id="glow1">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow2">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#d97706" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- CLAUDE.md file -->
-    <g filter="url(#shadow)">
-      <rect x="-80" y="-90" width="160" height="190" rx="10" fill="#1e293b" stroke="#d97706" stroke-width="2.5"/>
-      <!-- File tab -->
-      <rect x="-80" y="-90" width="100" height="25" rx="10" fill="#d97706" opacity="0.15"/>
-      <text x="-30" y="-73" font-family="Courier New" font-size="10" fill="#fbbf24" text-anchor="middle">CLAUDE.md</text>
-      <!-- Markdown content -->
-      <text x="-60" y="-48" font-family="Courier New" font-size="9" fill="#d97706" opacity="0.7"># Security</text>
-      <rect x="-60" y="-38" width="100" height="4" rx="1" fill="#334155" opacity="0.4"/>
-      <rect x="-60" y="-28" width="80" height="4" rx="1" fill="#334155" opacity="0.3"/>
-      <text x="-60" y="-12" font-family="Courier New" font-size="9" fill="#d97706" opacity="0.7">## Rules</text>
-      <rect x="-60" y="-2" width="90" height="4" rx="1" fill="#334155" opacity="0.4"/>
-      <rect x="-60" y="8" width="70" height="4" rx="1" fill="#ef4444" opacity="0.3"/>
-      <rect x="-60" y="18" width="85" height="4" rx="1" fill="#334155" opacity="0.3"/>
-      <text x="-60" y="38" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- No secrets</text>
-      <text x="-60" y="52" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- Validate input</text>
-      <text x="-60" y="66" font-family="Courier New" font-size="9" fill="#22c55e" opacity="0.7">- Mask logs</text>
-    </g>
-    <!-- Security shield beside -->
-    <g transform="translate(130,0)" opacity="0.5">
-      <path d="M0,-40 L45,-25 L45,15 C45,35 25,48 0,55 C-25,48 -45,35 -45,15 L-45,-25 Z" fill="#1e293b" stroke="#22c55e" stroke-width="2"/>
-      <path d="M-10,5 L-4,12 L12,-5" fill="none" stroke="#22c55e" stroke-width="3" stroke-linecap="round"/>
-    </g>
+
+  <!-- Ambient glow circles -->
+  <circle cx="200" cy="150" r="180" fill="#8b5cf6" opacity="0.08" filter="url(#glow1)"/>
+  <circle cx="1000" cy="480" r="200" fill="#f97316" opacity="0.07" filter="url(#glow1)"/>
+  <circle cx="600" cy="315" r="250" fill="#6d28d9" opacity="0.06" filter="url(#glow1)"/>
+
+  <!-- Floating code fragments -->
+  <text x="60" y="100" font-family="monospace" font-size="13" fill="#8b5cf6" opacity="0.13">claude.config.harden()</text>
+  <text x="880" y="80" font-family="monospace" font-size="13" fill="#f97316" opacity="0.12">prompt.inject.block()</text>
+  <text x="40" y="520" font-family="monospace" font-size="13" fill="#8b5cf6" opacity="0.11">permission.least_priv()</text>
+  <text x="900" y="555" font-family="monospace" font-size="13" fill="#f97316" opacity="0.12">secret.mask(env)</text>
+
+  <!-- Top badge -->
+  <rect x="40" y="32" width="120" height="32" rx="16" fill="url(#badgeGrad)" opacity="0.9"/>
+  <text x="100" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="13" font-weight="bold" fill="white" text-anchor="middle">GUIDE</text>
+  <text x="1160" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">January 28, 2026</text>
+
+  <!-- CENTRAL: Large editor window -->
+  <rect x="120" y="88" width="960" height="438" rx="12" fill="url(#editorGrad)" stroke="#2d1b4e" stroke-width="1.5"/>
+
+  <!-- Editor title bar -->
+  <rect x="120" y="88" width="960" height="40" rx="12" fill="url(#headerGrad)"/>
+  <rect x="120" y="110" width="960" height="18" fill="url(#headerGrad)"/>
+  <circle cx="152" cy="108" r="6" fill="#ef4444"/>
+  <circle cx="174" cy="108" r="6" fill="#f59e0b"/>
+  <circle cx="196" cy="108" r="6" fill="#10b981"/>
+  <rect x="220" y="94" width="130" height="28" rx="4" fill="#2d1b4e"/>
+  <text x="285" y="113" font-family="monospace" font-size="12" fill="#a78bfa" text-anchor="middle">CLAUDE.md</text>
+  <rect x="360" y="96" width="120" height="24" rx="4" fill="none" stroke="#3d2b5e" stroke-width="1"/>
+  <text x="420" y="113" font-family="monospace" font-size="11" fill="#6b7280" text-anchor="middle">settings.json</text>
+
+  <!-- Line number gutter -->
+  <rect x="120" y="128" width="52" height="398" fill="#0f0f1e"/>
+
+  <!-- Line numbers -->
+  <text x="162" y="162" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">1</text>
+  <text x="162" y="190" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">2</text>
+  <text x="162" y="218" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">3</text>
+  <text x="162" y="246" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">4</text>
+  <text x="162" y="274" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">5</text>
+  <text x="162" y="302" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">6</text>
+  <text x="162" y="330" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">7</text>
+  <text x="162" y="358" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">8</text>
+  <text x="162" y="386" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">9</text>
+  <text x="162" y="414" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">10</text>
+  <text x="162" y="442" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">11</text>
+  <text x="162" y="470" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">12</text>
+  <text x="162" y="498" font-family="monospace" font-size="12" fill="#4a5568" text-anchor="end">13</text>
+
+  <!-- Code content lines -->
+  <text x="186" y="162" font-family="monospace" font-size="13" fill="#6a7fa8"># AI Security Configuration</text>
+
+  <!-- SAFE line 2 -->
+  <rect x="180" y="171" width="700" height="26" rx="3" fill="#10b981" opacity="0.12"/>
+  <text x="186" y="189" font-family="monospace" font-size="13" fill="#34d399">permissions:</text>
+  <text x="300" y="189" font-family="monospace" font-size="13" fill="#6ee7b7">allow: [read, write_approved_dirs]</text>
+  <text x="1040" y="189" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- SAFE line 3 -->
+  <rect x="180" y="199" width="680" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="217" font-family="monospace" font-size="13" fill="#34d399">prompt_injection:</text>
+  <text x="330" y="217" font-family="monospace" font-size="13" fill="#6ee7b7">block_external_instructions: true</text>
+  <text x="1040" y="217" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- SAFE line 4 -->
+  <rect x="180" y="227" width="660" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="245" font-family="monospace" font-size="13" fill="#34d399">secret_masking:</text>
+  <text x="318" y="245" font-family="monospace" font-size="13" fill="#6ee7b7">enabled: true   patterns: [API_KEY, TOKEN]</text>
+  <text x="1040" y="245" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- UNSAFE line 5 - red highlight -->
+  <rect x="180" y="255" width="760" height="26" rx="3" fill="#ef4444" opacity="0.18"/>
+  <text x="186" y="273" font-family="monospace" font-size="13" fill="#f87171">api_key:</text>
+  <text x="268" y="273" font-family="monospace" font-size="13" fill="#fca5a5">sk-proj-HARDCODED_SECRET_KEY_12345abcdef</text>
+  <rect x="850" y="257" width="150" height="18" rx="3" fill="#ef4444" opacity="0.9"/>
+  <text x="925" y="270" font-family="'Segoe UI',Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">HARDCODED SECRET</text>
+
+  <!-- SAFE line 6 -->
+  <rect x="180" y="283" width="640" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="301" font-family="monospace" font-size="13" fill="#34d399">env_vars:</text>
+  <text x="270" y="301" font-family="monospace" font-size="13" fill="#6ee7b7">ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}</text>
+  <text x="1040" y="301" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- UNSAFE line 7 -->
+  <rect x="180" y="311" width="740" height="26" rx="3" fill="#ef4444" opacity="0.18"/>
+  <text x="186" y="329" font-family="monospace" font-size="13" fill="#f87171">system_prompt:</text>
+  <text x="318" y="329" font-family="monospace" font-size="13" fill="#fca5a5">ignore_previous_instructions: true</text>
+  <rect x="820" y="313" width="170" height="18" rx="3" fill="#ef4444" opacity="0.9"/>
+  <text x="905" y="326" font-family="'Segoe UI',Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">PROMPT INJECTION RISK</text>
+
+  <!-- SAFE line 8 -->
+  <rect x="180" y="339" width="600" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="357" font-family="monospace" font-size="13" fill="#34d399">output_filtering:</text>
+  <text x="326" y="357" font-family="monospace" font-size="13" fill="#6ee7b7">sanitize_output: true</text>
+  <text x="1040" y="357" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- SAFE line 9 -->
+  <rect x="180" y="367" width="620" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="385" font-family="monospace" font-size="13" fill="#34d399">least_privilege:</text>
+  <text x="318" y="385" font-family="monospace" font-size="13" fill="#6ee7b7">restrict_file_access: true</text>
+  <text x="1040" y="385" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- UNSAFE line 10 -->
+  <rect x="180" y="395" width="700" height="26" rx="3" fill="#ef4444" opacity="0.18"/>
+  <text x="186" y="413" font-family="monospace" font-size="13" fill="#f87171">tools:</text>
+  <text x="240" y="413" font-family="monospace" font-size="13" fill="#fca5a5">allow_all_bash_commands: true</text>
+  <rect x="780" y="397" width="120" height="18" rx="3" fill="#f97316" opacity="0.9"/>
+  <text x="840" y="410" font-family="'Segoe UI',Arial,sans-serif" font-size="10" fill="white" text-anchor="middle">OVERPRIVILEGED</text>
+
+  <!-- SAFE line 11 -->
+  <rect x="180" y="423" width="580" height="26" rx="3" fill="#10b981" opacity="0.10"/>
+  <text x="186" y="441" font-family="monospace" font-size="13" fill="#34d399">audit_logging:</text>
+  <text x="306" y="441" font-family="monospace" font-size="13" fill="#6ee7b7">enabled: true   retention: 90d</text>
+  <text x="1040" y="441" font-family="monospace" font-size="14" fill="#10b981">&#x1F512;</text>
+
+  <!-- line 12 -->
+  <text x="186" y="469" font-family="monospace" font-size="13" fill="#6a7fa8"># End of security configuration</text>
+
+  <!-- Cursor blink -->
+  <rect x="186" y="482" width="8" height="16" fill="#8b5cf6" opacity="0.9"/>
+
+  <!-- Shield overlay on top-right of editor -->
+  <g transform="translate(940, 88)" filter="url(#glow2)">
+    <polygon points="70,12 108,30 108,85 70,108 32,85 32,30" fill="url(#shieldGrad)" opacity="0.95"/>
+    <polygon points="70,24 98,39 98,82 70,98 42,82 42,39" fill="#0f0820" opacity="0.7"/>
+    <text x="70" y="75" font-family="Arial" font-size="30" fill="white" text-anchor="middle">&#x1F6E1;</text>
+    <text x="70" y="105" font-family="'Segoe UI',Arial,sans-serif" font-size="9" fill="#c4b5fd" text-anchor="middle">HARDENED</text>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">CLAUDE.md Security</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Agent Security Guide | Safe Configuration Rules</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#d97706" opacity="0.2" stroke="#d97706" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fbbf24" text-anchor="middle">AI SECURITY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 28, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Lock icons next to SAFE lines (visual accent) -->
+  <text x="1060" y="162" font-family="monospace" font-size="11" fill="#6a7fa8">// safe config</text>
+
+  <!-- Title -->
+  <text x="600" y="558" font-family="'Segoe UI',Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textGlow)">CLAUDE.md Security</text>
+  <text x="600" y="582" font-family="'Segoe UI',Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI Configuration Hardening | Prompt Injection Defense | Best Practices</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#2d1b4e" stroke-width="1"/>
+  <text x="40" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b">Security | Configuration | AI Safety | Best Practices</text>
+  <text x="1160" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
+++ b/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
@@ -1,44 +1,177 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a0a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0808"/>
+      <stop offset="100%" style="stop-color:#0a0a1a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="docGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ef4444;stop-opacity:0.9"/>
+      <stop offset="100%" style="stop-color:#991b1b;stop-opacity:0.9"/>
+    </linearGradient>
+    <linearGradient id="chainGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ef4444"/>
+      <stop offset="100%" style="stop-color:#f59e0b"/>
+    </linearGradient>
+    <filter id="glow25">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow8">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- Vulnerability target -->
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="90" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
-      <circle cx="0" cy="0" r="65" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-      <circle cx="0" cy="0" r="40" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
-      <circle cx="0" cy="0" r="15" fill="#ef4444" opacity="0.3"/>
-      <!-- CVE markers -->
-      <text x="0" y="-2" font-family="Courier New" font-size="8" fill="#fca5a5" text-anchor="middle">CVE</text>
-      <text x="0" y="10" font-family="Courier New" font-size="7" fill="#ef4444" text-anchor="middle">0-Day</text>
-    </g>
-    <!-- RCE exploit arrow -->
-    <g transform="translate(0,0)">
-      <line x1="-180" y1="-60" x2="-20" y2="-5" stroke="#ef4444" stroke-width="2" opacity="0.4"/>
-      <polygon points="-25,-8 -15,-2 -25,2" fill="#ef4444" opacity="0.4"/>
-      <text x="-160" y="-65" font-family="Courier New" font-size="9" fill="#fca5a5" opacity="0.6">RCE</text>
-    </g>
-    <!-- CTEM cycle -->
-    <g transform="translate(140,30)" opacity="0.5">
-      <circle cx="0" cy="0" r="35" fill="#1e293b" stroke="#3b82f6" stroke-width="1.5"/>
-      <path d="M0,-25 A25,25 0 1,1 -18,18" fill="none" stroke="#3b82f6" stroke-width="2"/>
-      <polygon points="-22,14 -14,22 -20,10" fill="#3b82f6"/>
-      <text x="0" y="5" font-family="Courier New" font-size="8" fill="#93c5fd" text-anchor="middle">CTEM</text>
-    </g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Zero-Day + CTEM + RCE</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | MS Office 0-Day + Grist Core RCE</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 28, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="200" cy="150" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow25)"/>
+  <circle cx="1000" cy="480" r="220" fill="#f59e0b" opacity="0.07" filter="url(#glow25)"/>
+  <circle cx="600" cy="315" r="280" fill="#ef4444" opacity="0.04" filter="url(#glow25)"/>
+  <circle cx="900" cy="120" r="160" fill="#f59e0b" opacity="0.05" filter="url(#glow25)"/>
+
+  <!-- Floating code fragments -->
+  <text x="60" y="200" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">exploit.chain(office_doc)</text>
+  <text x="900" y="90" font-family="monospace" font-size="13" fill="#f59e0b" opacity="0.12">ctem.assess(surface)</text>
+  <text x="80" y="520" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.10">grist.rce.payload()</text>
+  <text x="870" y="548" font-family="monospace" font-size="13" fill="#f59e0b" opacity="0.11">patch.verify(cve)</text>
+  <text x="420" y="578" font-family="monospace" font-size="11" fill="#ef4444" opacity="0.10">0day.trigger(macro)</text>
+
+  <!-- ===== CENTRAL ILLUSTRATION ===== -->
+
+  <!-- Main document body (large, ~60% canvas height) -->
+  <rect x="410" y="85" width="280" height="360" rx="14" fill="#1e1e2e" stroke="#ef4444" stroke-width="2.5"/>
+  <!-- Document header tab -->
+  <rect x="410" y="85" width="280" height="46" rx="14" fill="#ef4444" opacity="0.88"/>
+  <rect x="410" y="117" width="280" height="14" fill="#ef4444" opacity="0.88"/>
+  <!-- W icon + label -->
+  <text x="432" y="118" font-family="Arial Black,sans-serif" font-size="24" font-weight="900" fill="white">W</text>
+  <text x="462" y="118" font-family="Arial,sans-serif" font-size="13" fill="white" opacity="0.9">MS Office Document</text>
+
+  <!-- Document content lines -->
+  <rect x="434" y="146" width="200" height="9" rx="4" fill="#374151" opacity="0.7"/>
+  <rect x="434" y="164" width="160" height="9" rx="4" fill="#374151" opacity="0.5"/>
+  <rect x="434" y="182" width="180" height="9" rx="4" fill="#374151" opacity="0.5"/>
+  <rect x="434" y="200" width="130" height="9" rx="4" fill="#374151" opacity="0.4"/>
+  <rect x="434" y="218" width="170" height="9" rx="4" fill="#374151" opacity="0.35"/>
+  <rect x="434" y="236" width="140" height="9" rx="4" fill="#374151" opacity="0.3"/>
+
+  <!-- Warning tint overlay on document -->
+  <rect x="410" y="85" width="280" height="360" rx="14" fill="#ef4444" opacity="0.06"/>
+
+  <!-- CRACK main diagonal -->
+  <polyline points="528,85 498,155 535,215 500,275 520,340 545,445"
+    stroke="#ef4444" stroke-width="3.5" fill="none" stroke-linecap="round" opacity="0.95"/>
+  <!-- Crack glow -->
+  <polyline points="528,85 498,155 535,215 500,275 520,340 545,445"
+    stroke="#ef4444" stroke-width="12" fill="none" opacity="0.10" stroke-linecap="round"/>
+  <!-- Branch cracks -->
+  <line x1="498" y1="155" x2="446" y2="182" stroke="#f59e0b" stroke-width="2" opacity="0.8"/>
+  <line x1="535" y1="215" x2="585" y2="236" stroke="#f59e0b" stroke-width="2" opacity="0.8"/>
+  <line x1="500" y1="275" x2="452" y2="300" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
+  <line x1="520" y1="340" x2="572" y2="358" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
+
+  <!-- Warning triangle on document -->
+  <polygon points="555,250 532,292 578,292" fill="none" stroke="#f59e0b" stroke-width="2.5" opacity="0.9"/>
+  <text x="552" y="287" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#f59e0b" opacity="0.9">!</text>
+
+  <!-- Chain to EMAIL (upper-left) -->
+  <line x1="418" y1="190" x2="220" y2="165" stroke="url(#chainGrad)" stroke-width="2.2" stroke-dasharray="8,4" opacity="0.85"/>
+  <circle cx="356" cy="177" r="5" fill="#ef4444" opacity="0.85"/>
+  <circle cx="290" cy="171" r="5" fill="#f59e0b" opacity="0.85"/>
+  <text x="298" y="162" font-family="monospace" font-size="10" fill="#f59e0b" opacity="0.9">phishing</text>
+  <!-- Email icon -->
+  <rect x="158" y="144" width="62" height="46" rx="7" fill="#1e1e2e" stroke="#ef4444" stroke-width="2"/>
+  <polyline points="158,148 189,175 220,148" fill="none" stroke="#ef4444" stroke-width="1.8"/>
+  <text x="169" y="204" font-family="monospace" font-size="10" fill="#94a3b8">Email</text>
+
+  <!-- Chain to BROWSER (mid-left) -->
+  <line x1="413" y1="285" x2="200" y2="305" stroke="url(#chainGrad)" stroke-width="2.2" stroke-dasharray="8,4" opacity="0.85"/>
+  <circle cx="340" cy="294" r="5" fill="#ef4444" opacity="0.85"/>
+  <circle cx="272" cy="300" r="5" fill="#f59e0b" opacity="0.85"/>
+  <text x="265" y="289" font-family="monospace" font-size="10" fill="#f59e0b" opacity="0.9">macro.exec</text>
+  <!-- Browser icon -->
+  <circle cx="170" cy="308" r="30" fill="#1e1e2e" stroke="#ef4444" stroke-width="2"/>
+  <circle cx="170" cy="308" r="15" fill="none" stroke="#ef4444" stroke-width="1.5"/>
+  <line x1="154" y1="308" x2="186" y2="308" stroke="#ef4444" stroke-width="1.5"/>
+  <line x1="170" y1="278" x2="170" y2="338" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="148" y="354" font-family="monospace" font-size="10" fill="#94a3b8">Browser</text>
+
+  <!-- Chain to SERVER (lower-left) -->
+  <line x1="420" y1="380" x2="215" y2="420" stroke="url(#chainGrad)" stroke-width="2.2" stroke-dasharray="8,4" opacity="0.85"/>
+  <circle cx="352" cy="397" r="5" fill="#ef4444" opacity="0.85"/>
+  <circle cx="285" cy="410" r="5" fill="#f59e0b" opacity="0.85"/>
+  <text x="278" y="402" font-family="monospace" font-size="10" fill="#f59e0b" opacity="0.9">RCE</text>
+  <!-- Server icon -->
+  <rect x="165" y="400" width="60" height="48" rx="6" fill="#1e1e2e" stroke="#ef4444" stroke-width="2"/>
+  <rect x="173" y="408" width="44" height="11" rx="3" fill="#374151"/>
+  <rect x="173" y="424" width="44" height="11" rx="3" fill="#374151"/>
+  <circle cx="211" cy="413" r="3" fill="#ef4444"/>
+  <circle cx="211" cy="429" r="3" fill="#f59e0b"/>
+  <text x="163" y="462" font-family="monospace" font-size="10" fill="#94a3b8">Server</text>
+
+  <!-- CTEM Framework panel (right) -->
+  <rect x="750" y="100" width="215" height="310" rx="10" fill="#0f172a" stroke="#f59e0b" stroke-width="1.5" opacity="0.95"/>
+  <rect x="750" y="100" width="215" height="36" rx="10" fill="#f59e0b" opacity="0.18"/>
+  <text x="768" y="123" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b">CTEM Framework</text>
+
+  <rect x="768" y="150" width="180" height="24" rx="5" fill="#1e293b"/>
+  <text x="780" y="166" font-family="monospace" font-size="11" fill="#94a3b8">1. Scoping</text>
+  <circle cx="932" cy="162" r="5" fill="#22c55e"/>
+
+  <rect x="768" y="182" width="180" height="24" rx="5" fill="#1e293b"/>
+  <text x="780" y="198" font-family="monospace" font-size="11" fill="#94a3b8">2. Discovery</text>
+  <circle cx="932" cy="194" r="5" fill="#22c55e"/>
+
+  <rect x="768" y="214" width="180" height="24" rx="5" fill="#1e293b"/>
+  <text x="780" y="230" font-family="monospace" font-size="11" fill="#f59e0b">3. Prioritization</text>
+  <circle cx="932" cy="226" r="5" fill="#f59e0b"/>
+
+  <rect x="768" y="246" width="180" height="24" rx="5" fill="#1e293b"/>
+  <text x="780" y="262" font-family="monospace" font-size="11" fill="#ef4444">4. Validation</text>
+  <circle cx="932" cy="258" r="5" fill="#ef4444"/>
+
+  <rect x="768" y="278" width="180" height="24" rx="5" fill="#1e293b"/>
+  <text x="780" y="294" font-family="monospace" font-size="11" fill="#ef4444">5. Mobilization</text>
+  <circle cx="932" cy="290" r="5" fill="#ef4444"/>
+
+  <!-- CVE badge -->
+  <rect x="768" y="318" width="180" height="76" rx="6" fill="#1a0808" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="780" y="337" font-family="monospace" font-size="11" fill="#ef4444" font-weight="bold">CVE-2026-XXXX</text>
+  <text x="780" y="354" font-family="monospace" font-size="10" fill="#94a3b8">CVSS: 9.8 CRITICAL</text>
+  <text x="780" y="370" font-family="monospace" font-size="10" fill="#94a3b8">Vector: RCE / Network</text>
+  <text x="780" y="386" font-family="monospace" font-size="10" fill="#f59e0b">Patch: Pending</text>
+
+  <!-- ===== END CENTRAL ILLUSTRATION ===== -->
+
+  <!-- Top badge pill -->
+  <rect x="40" y="34" width="272" height="34" rx="17" fill="#1e1e2e" stroke="#ef4444" stroke-width="1.5"/>
+  <rect x="40" y="34" width="128" height="34" rx="17" fill="#ef4444" opacity="0.92"/>
+  <text x="104" y="56" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="240" y="56" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">January 28, 2026</text>
+
+  <!-- Title -->
+  <text x="40" y="508" font-family="Arial Black,sans-serif" font-size="36" font-weight="900" fill="white" filter="url(#textGlow)">MS Office Zero-Day Chain</text>
+
+  <!-- Subtitle -->
+  <text x="40" y="540" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8">CTEM Framework  |  Grist Core RCE  |  Exploit Chain Analysis</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1.5"/>
+
+  <!-- Footer counts -->
+  <text x="40" y="610" font-family="monospace" font-size="12" fill="#64748b">21 News</text>
+  <text x="132" y="610" font-family="monospace" font-size="12" fill="#ef4444">6 Security</text>
+  <text x="244" y="610" font-family="monospace" font-size="12" fill="#8b5cf6">3 AI/ML</text>
+  <text x="336" y="610" font-family="monospace" font-size="12" fill="#06b6d4">2 Cloud</text>
+  <text x="418" y="610" font-family="monospace" font-size="12" fill="#22c55e">4 DevOps</text>
+
+  <!-- Site URL -->
+  <text x="1160" y="610" font-family="monospace" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
+++ b/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
@@ -1,50 +1,255 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a2a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0c00"/>
+      <stop offset="100%" style="stop-color:#1a0600"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="rackGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#181818"/>
+      <stop offset="100%" style="stop-color:#080808"/>
+    </linearGradient>
+    <linearGradient id="globeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f1a2e"/>
+      <stop offset="100%" style="stop-color:#050a14"/>
+    </linearGradient>
+    <linearGradient id="sunGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#fb923c"/>
+      <stop offset="100%" style="stop-color:#ea580c"/>
+    </linearGradient>
+    <linearGradient id="badgeGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#c2410c"/>
+      <stop offset="100%" style="stop-color:#f97316"/>
+    </linearGradient>
+    <linearGradient id="scanBeam" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#ef4444" stop-opacity="0"/>
+      <stop offset="100%" style="stop-color:#ef4444" stop-opacity="0.3"/>
+    </linearGradient>
+    <filter id="glow1">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow2">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow3">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <!-- Ollama llama silhouette -->
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
-      <!-- Simple llama shape -->
-      <path d="M-20,-40 C-20,-55 -10,-60 -5,-55 L-5,-30 M20,-40 C20,-55 10,-60 5,-55 L5,-30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.5"/>
-      <ellipse cx="0" cy="0" rx="35" ry="30" fill="none" stroke="#c4b5fd" stroke-width="2" opacity="0.3"/>
-      <text x="0" y="8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#c4b5fd" text-anchor="middle">Ollama</text>
-      <!-- AI sparkle -->
-      <circle cx="30" cy="-25" r="4" fill="#c4b5fd" opacity="0.5"/>
-    </g>
-    <!-- SolarWinds breach -->
-    <g transform="translate(-130,30)" opacity="0.5">
-      <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/>
-      <!-- Sun rays -->
-      <g opacity="0.3">
-        <line x1="0" y1="-28" x2="0" y2="-20" stroke="#ef4444" stroke-width="2"/>
-        <line x1="20" y1="-20" x2="14" y2="-14" stroke="#ef4444" stroke-width="2"/>
-        <line x1="28" y1="0" x2="20" y2="0" stroke="#ef4444" stroke-width="2"/>
-        <line x1="-28" y1="0" x2="-20" y2="0" stroke="#ef4444" stroke-width="2"/>
-      </g>
-      <text x="0" y="4" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">SOLAR</text>
-      <text x="0" y="44" font-family="Courier New" font-size="7" fill="#fca5a5" text-anchor="middle">RCE</text>
-    </g>
-    <!-- Google/IPIDEA -->
-    <g transform="translate(130,30)" opacity="0.5">
-      <circle cx="0" cy="0" r="28" fill="#1e293b" stroke="#4285f4" stroke-width="1.5"/>
-      <text x="0" y="-2" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#93c5fd" text-anchor="middle">G</text>
-      <text x="0" y="10" font-family="Courier New" font-size="6" fill="#60a5fa" text-anchor="middle">IPIDEA</text>
-    </g>
+
+  <!-- Ambient glow circles -->
+  <circle cx="185" cy="295" r="220" fill="#ef4444" opacity="0.07" filter="url(#glow1)"/>
+  <circle cx="1015" cy="285" r="200" fill="#f97316" opacity="0.08" filter="url(#glow1)"/>
+  <circle cx="600" cy="295" r="210" fill="#dc2626" opacity="0.05" filter="url(#glow1)"/>
+
+  <!-- Floating code fragments -->
+  <text x="45" y="78" font-family="monospace" font-size="13" fill="#f97316" opacity="0.13">ollama.serve(0.0.0.0)</text>
+  <text x="860" y="72" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.13">solarwinds.rce.exploit()</text>
+  <text x="40" y="548" font-family="monospace" font-size="13" fill="#f97316" opacity="0.12">shodan.scan(port:11434)</text>
+  <text x="850" y="548" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">model.exfil(weights)</text>
+
+  <!-- Badge -->
+  <rect x="40" y="32" width="170" height="32" rx="16" fill="url(#badgeGrad)" opacity="0.9"/>
+  <text x="125" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="52" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">January 30, 2026</text>
+
+  <!-- ===== LEFT: Internet Globe ===== -->
+  <!-- Globe glow backdrop -->
+  <circle cx="192" cy="288" r="125" fill="#1d4ed8" opacity="0.05" filter="url(#glow2)"/>
+  <!-- Globe main circle -->
+  <circle cx="192" cy="288" r="108" fill="url(#globeGrad)" stroke="#1e3a5f" stroke-width="1.5"/>
+
+  <!-- Globe latitude/longitude grid -->
+  <ellipse cx="192" cy="288" rx="108" ry="38" fill="none" stroke="#1e3a5f" stroke-width="1" opacity="0.5"/>
+  <ellipse cx="192" cy="288" rx="108" ry="65" fill="none" stroke="#1e3a5f" stroke-width="0.8" opacity="0.4"/>
+  <ellipse cx="192" cy="288" rx="108" ry="90" fill="none" stroke="#1e3a5f" stroke-width="0.7" opacity="0.3"/>
+  <line x1="192" y1="180" x2="192" y2="396" stroke="#1e3a5f" stroke-width="1" opacity="0.5"/>
+  <line x1="84" y1="288" x2="300" y2="288" stroke="#1e3a5f" stroke-width="1" opacity="0.5"/>
+  <line x1="108" y1="222" x2="276" y2="222" stroke="#1e3a5f" stroke-width="0.8" opacity="0.4"/>
+  <line x1="108" y1="354" x2="276" y2="354" stroke="#1e3a5f" stroke-width="0.8" opacity="0.4"/>
+
+  <!-- Continents -->
+  <path d="M130,248 Q145,232 168,240 Q184,230 198,244 Q210,258 200,272 Q182,278 160,270 Q138,264 130,248Z" fill="#1e3a5f" opacity="0.65"/>
+  <path d="M208,300 Q222,290 244,297 Q258,306 254,320 Q240,330 220,323 Q208,315 208,300Z" fill="#1e3a5f" opacity="0.55"/>
+  <path d="M155,310 Q165,318 158,330 Q148,335 140,326 Q138,315 148,310Z" fill="#1e3a5f" opacity="0.45"/>
+
+  <!-- INTERNET label -->
+  <text x="192" y="420" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#60a5fa" text-anchor="middle">INTERNET</text>
+  <rect x="132" y="428" width="120" height="20" rx="4" fill="#0a101e" stroke="#3b82f6" stroke-width="1"/>
+  <text x="192" y="442" font-family="monospace" font-size="10" fill="#60a5fa" text-anchor="middle">Shodan scanning...</text>
+
+  <!-- Port indicator -->
+  <rect x="132" y="452" width="120" height="18" rx="3" fill="#0a101e"/>
+  <text x="192" y="465" font-family="monospace" font-size="10" fill="#f87171" text-anchor="middle">port 11434 open!</text>
+
+  <!-- Shodan "eye" symbol -->
+  <circle cx="192" cy="240" r="12" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1"/>
+  <circle cx="192" cy="240" r="5" fill="#3b82f6" filter="url(#glow3)"/>
+
+  <!-- ===== SCAN BEAMS: Globe -> Server ===== -->
+  <!-- Wide cone polygon -->
+  <polygon points="300,230 590,185 590,385 300,345" fill="url(#scanBeam)"/>
+  <!-- Scan beam lines with glow -->
+  <line x1="300" y1="248" x2="584" y2="202" stroke="#ef4444" stroke-width="1.5" opacity="0.55" filter="url(#glow3)"/>
+  <line x1="300" y1="288" x2="584" y2="288" stroke="#ef4444" stroke-width="2.5" opacity="0.75" filter="url(#glow3)"/>
+  <line x1="300" y1="328" x2="584" y2="374" stroke="#ef4444" stroke-width="1.5" opacity="0.55" filter="url(#glow3)"/>
+  <!-- Arrowheads -->
+  <polygon points="572,195 590,202 572,209" fill="#ef4444" opacity="0.8"/>
+  <polygon points="572,280 590,288 572,296" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <polygon points="572,366 590,374 572,382" fill="#ef4444" opacity="0.8"/>
+
+  <!-- Port label on beam -->
+  <circle cx="442" cy="288" r="10" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <circle cx="442" cy="288" r="18" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.5"/>
+  <text x="442" y="270" font-family="monospace" font-size="10" fill="#f87171" text-anchor="middle">:11434</text>
+
+  <!-- ===== CENTER: Ollama Server Rack ===== -->
+  <!-- Rack outer frame -->
+  <rect x="584" y="108" width="292" height="398" rx="10" fill="url(#rackGrad)" stroke="#2a2a2a" stroke-width="2"/>
+
+  <!-- Rack top strip -->
+  <rect x="584" y="108" width="292" height="38" rx="10" fill="#141414"/>
+  <rect x="584" y="128" width="292" height="18" fill="#141414"/>
+
+  <!-- Ollama brand -->
+  <rect x="600" y="114" width="88" height="24" rx="4" fill="#061a06" stroke="#10b981" stroke-width="1"/>
+  <text x="644" y="130" font-family="monospace" font-size="13" font-weight="bold" fill="#34d399" text-anchor="middle">ollama</text>
+
+  <!-- EXPOSED warning -->
+  <rect x="698" y="114" width="162" height="24" rx="4" fill="#1c0606" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="779" y="130" font-family="'Segoe UI',Arial,sans-serif" font-size="11" font-weight="bold" fill="#f87171" text-anchor="middle">EXPOSED: 0.0.0.0</text>
+
+  <!-- Open rack front panel -->
+  <rect x="600" y="152" width="260" height="338" rx="4" fill="#060606" stroke="#222" stroke-width="1"/>
+
+  <!-- Hinge (left side - door open) -->
+  <rect x="584" y="152" width="16" height="338" rx="2" fill="#1a1a1a" stroke="#2a2a2a" stroke-width="1"/>
+  <circle cx="592" cy="188" r="3" fill="#333"/>
+  <circle cx="592" cy="310" r="3" fill="#333"/>
+  <circle cx="592" cy="452" r="3" fill="#333"/>
+
+  <!-- Model file slot 1 - normal -->
+  <rect x="608" y="162" width="244" height="42" rx="3" fill="#0a160a" stroke="#1a3a1a" stroke-width="1"/>
+  <rect x="614" y="170" width="6" height="26" rx="1" fill="#10b981"/>
+  <text x="628" y="181" font-family="monospace" font-size="11" fill="#34d399">llama3.2:70b</text>
+  <text x="628" y="196" font-family="monospace" font-size="10" fill="#4a7a4a">weights/ 40GB  format: GGUF</text>
+  <circle cx="826" cy="183" r="9" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <text x="826" y="187" font-family="Arial" font-size="10" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <!-- Model file slot 2 - normal -->
+  <rect x="608" y="210" width="244" height="42" rx="3" fill="#0a160a" stroke="#1a3a1a" stroke-width="1"/>
+  <rect x="614" y="218" width="6" height="26" rx="1" fill="#10b981"/>
+  <text x="628" y="229" font-family="monospace" font-size="11" fill="#34d399">mistral:7b-instruct</text>
+  <text x="628" y="244" font-family="monospace" font-size="10" fill="#4a7a4a">weights/ 4.1GB format: GGUF</text>
+  <circle cx="826" cy="231" r="9" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <text x="826" y="235" font-family="Arial" font-size="10" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <!-- Model file slot 3 - ACTIVELY EXFILTRATING -->
+  <rect x="608" y="258" width="244" height="46" rx="3" fill="#1c0606" stroke="#ef4444" stroke-width="1.5"/>
+  <rect x="614" y="266" width="6" height="30" rx="1" fill="#ef4444" filter="url(#glow3)"/>
+  <text x="628" y="277" font-family="monospace" font-size="11" fill="#f87171">codellama:34b</text>
+  <text x="628" y="292" font-family="monospace" font-size="10" fill="#ef4444">EXFILTRATING... 18.2GB sent</text>
+  <circle cx="826" cy="281" r="9" fill="#ef4444" filter="url(#glow3)"/>
+  <text x="826" y="285" font-family="Arial" font-size="10" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <!-- Progress bar for exfil -->
+  <rect x="614" y="297" width="230" height="5" rx="2" fill="#1a1a1a"/>
+  <rect x="614" y="297" width="148" height="5" rx="2" fill="#ef4444" filter="url(#glow3)"/>
+
+  <!-- API endpoint info -->
+  <rect x="608" y="310" width="244" height="28" rx="3" fill="#0e0606" stroke="#ef4444" stroke-width="1"/>
+  <text x="730" y="328" font-family="monospace" font-size="11" fill="#f87171" text-anchor="middle">GET /api/pull  HTTP/1.1</text>
+
+  <!-- Config rows -->
+  <rect x="608" y="344" width="118" height="22" rx="3" fill="#0e0606"/>
+  <text x="667" y="359" font-family="monospace" font-size="10" fill="#f87171" text-anchor="middle">Auth: NONE</text>
+  <rect x="734" y="344" width="118" height="22" rx="3" fill="#0e0606"/>
+  <text x="793" y="359" font-family="monospace" font-size="10" fill="#f97316" text-anchor="middle">Rate: UNLIMITED</text>
+
+  <!-- Model count row -->
+  <rect x="608" y="372" width="244" height="26" rx="3" fill="#080e08" stroke="#1a3a1a" stroke-width="1"/>
+  <text x="680" y="389" font-family="monospace" font-size="11" fill="#34d399">3 models loaded</text>
+  <circle cx="830" cy="385" r="5" fill="#10b981"/>
+
+  <!-- Google IPIDEA note -->
+  <rect x="608" y="404" width="244" height="26" rx="3" fill="#0a0a1e" stroke="#6366f1" stroke-width="1"/>
+  <text x="730" y="421" font-family="monospace" font-size="10" fill="#818cf8" text-anchor="middle">Google IPIDEA proxy chain</text>
+
+  <!-- Cursor blink -->
+  <rect x="614" y="436" width="6" height="16" fill="#f97316" opacity="0.9"/>
+
+  <!-- Ollama label -->
+  <text x="730" y="490" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#34d399" text-anchor="middle">Ollama AI Server</text>
+  <text x="730" y="508" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b" text-anchor="middle">Unauthenticated Model Exposure</text>
+
+  <!-- ===== RIGHT: SolarWinds Sun ===== -->
+  <!-- Sun glow -->
+  <circle cx="1010" cy="288" r="100" fill="#f97316" opacity="0.07" filter="url(#glow2)"/>
+
+  <!-- Sun rays -->
+  <g stroke="#f97316" stroke-width="3" stroke-linecap="round">
+    <line x1="1010" y1="196" x2="1010" y2="178"/>
+    <line x1="1063" y1="214" x2="1076" y2="201"/>
+    <line x1="1082" y1="266" x2="1100" y2="266"/>
+    <line x1="1063" y1="362" x2="1076" y2="375"/>
+    <line x1="1010" y1="380" x2="1010" y2="398"/>
+    <line x1="957" y1="362" x2="944" y2="375"/>
+    <line x1="938" y1="266" x2="920" y2="266"/>
+    <line x1="957" y1="214" x2="944" y2="201"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="34" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Ollama AI + SolarWinds</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | AI Security + RCE + Google IPIDEA</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Jan 30, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Broken/cracked ray accent -->
+  <polyline points="1035,202 1045,211 1040,218" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.7"/>
+  <polyline points="985,202 975,211 980,218" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.7"/>
+
+  <!-- Sun body -->
+  <circle cx="1010" cy="288" r="75" fill="url(#sunGrad)" opacity="0.9"/>
+  <circle cx="1010" cy="288" r="60" fill="#140800"/>
+
+  <!-- Inner sun text -->
+  <text x="1010" y="280" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#fbbf24" text-anchor="middle">Solar</text>
+  <text x="1010" y="298" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#fbbf24" text-anchor="middle">Winds</text>
+
+  <!-- RCE badge on sun -->
+  <rect x="964" y="238" width="92" height="22" rx="5" fill="#ef4444" opacity="0.95"/>
+  <text x="1010" y="253" font-family="'Segoe UI',Arial,sans-serif" font-size="11" font-weight="bold" fill="white" text-anchor="middle">RCE EXPLOIT</text>
+
+  <!-- Vulnerability warning circles -->
+  <circle cx="942" cy="208" r="14" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <text x="942" y="213" font-family="Arial" font-size="12" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <circle cx="1078" cy="208" r="14" fill="#ef4444" opacity="0.9" filter="url(#glow3)"/>
+  <text x="1078" y="213" font-family="Arial" font-size="12" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <circle cx="1094" cy="340" r="14" fill="#f97316" opacity="0.9" filter="url(#glow3)"/>
+  <text x="1094" y="345" font-family="Arial" font-size="12" font-weight="bold" fill="white" text-anchor="middle">!</text>
+
+  <!-- CVE label -->
+  <rect x="948" y="368" width="124" height="24" rx="4" fill="#140800" stroke="#f97316" stroke-width="1"/>
+  <text x="1010" y="384" font-family="monospace" font-size="11" fill="#fb923c" text-anchor="middle">CVE-2026-1234</text>
+
+  <!-- SolarWinds label -->
+  <text x="1010" y="422" font-family="'Segoe UI',Arial,sans-serif" font-size="14" font-weight="bold" fill="#fb923c" text-anchor="middle">SolarWinds</text>
+  <text x="1010" y="440" font-family="'Segoe UI',Arial,sans-serif" font-size="11" fill="#64748b" text-anchor="middle">Remote Code Execution</text>
+
+  <!-- Connection: rack -> sun -->
+  <line x1="876" y1="288" x2="934" y2="288" stroke="#f97316" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.6"/>
+  <polygon points="922,282 938,288 922,294" fill="#f97316" opacity="0.8"/>
+
+  <!-- Title -->
+  <text x="600" y="558" font-family="'Segoe UI',Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textGlow)">Ollama AI Exposure</text>
+  <text x="600" y="582" font-family="'Segoe UI',Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">SolarWinds RCE | Google IPIDEA | AI Model Server Risks</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1a0800" stroke-width="1"/>
+  <text x="40" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b">21 News | 5 Security | 4 AI/ML | 3 Cloud | 3 DevOps</text>
+  <text x="1160" y="610" font-family="'Segoe UI',Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
+++ b/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
@@ -1,33 +1,202 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#150a1a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="infraLayer" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    <linearGradient id="platformLayer" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#2e1065"/>
+      <stop offset="100%" style="stop-color:#1e1b4b"/>
+    </linearGradient>
+    <linearGradient id="agentLayer" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a5f"/>
+      <stop offset="100%" style="stop-color:#172554"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="ambiGlow">
+      <feGaussianBlur stdDeviation="25"/>
+    </filter>
+    <filter id="redArrowGlow">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feFlood flood-color="#ef4444" flood-opacity="0.4" result="c"/>
+      <feComposite in="c" in2="blur" operator="in" result="s"/>
+      <feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="shieldGlow">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feFlood flood-color="#22c55e" flood-opacity="0.5" result="c"/>
+      <feComposite in="c" in2="blur" operator="in" result="s"/>
+      <feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
-      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
-      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
-      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-    </g>
-    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
+
+  <!-- Grid -->
+  <g opacity="0.035">
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(150,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(350,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(850,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(1050,0)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-130)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-260)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-390)"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Agentic AI Security</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2026 Attack Vectors + Defense Architecture</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">AI SECURITY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 1, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="300" r="240" fill="#7c3aed" opacity="0.04" filter="url(#ambiGlow)"/>
+  <circle cx="200" cy="300" r="180" fill="#ef4444" opacity="0.06" filter="url(#ambiGlow)"/>
+  <circle cx="1000" cy="300" r="160" fill="#3b82f6" opacity="0.05" filter="url(#ambiGlow)"/>
+
+  <!-- ===== CENTRAL: LAYERED DEFENSE ARCHITECTURE ===== -->
+  <!-- Layer 1: Infrastructure (bottom) -->
+  <rect x="250" y="390" width="700" height="95" rx="10" fill="url(#infraLayer)" opacity="0.9" stroke="#475569" stroke-width="2"/>
+  <text x="600" y="415" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#94a3b8" text-anchor="middle">INFRASTRUCTURE LAYER</text>
+  <!-- Infra components -->
+  <rect x="280" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="325" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Compute</text>
+  <text x="325" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">EC2 / GKE</text>
+  <rect x="390" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="435" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Storage</text>
+  <text x="435" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">S3 / GCS</text>
+  <rect x="500" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="545" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Network</text>
+  <text x="545" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">VPC / FW</text>
+  <rect x="610" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="655" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Identity</text>
+  <text x="655" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">IAM / RBAC</text>
+  <rect x="720" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="765" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Logging</text>
+  <text x="765" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">SIEM / ELK</text>
+  <rect x="830" y="425" width="90" height="45" rx="6" fill="#1e293b" stroke="#475569" stroke-width="1"/>
+  <text x="875" y="443" font-family="Arial, sans-serif" font-size="9" fill="#94a3b8" text-anchor="middle">Secrets</text>
+  <text x="875" y="459" font-family="Courier New, monospace" font-size="8" fill="#60a5fa" text-anchor="middle">Vault / KMS</text>
+
+  <!-- Layer 2: AI Platform (middle) -->
+  <rect x="300" y="270" width="600" height="100" rx="10" fill="url(#platformLayer)" opacity="0.9" stroke="#7c3aed" stroke-width="2"/>
+  <text x="600" y="295" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#a78bfa" text-anchor="middle">AI PLATFORM LAYER</text>
+  <!-- Platform components -->
+  <rect x="330" y="305" width="100" height="48" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="380" y="323" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Model</text>
+  <text x="380" y="337" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Registry</text>
+  <text x="380" y="349" font-family="Courier New, monospace" font-size="8" fill="#c4b5fd" text-anchor="middle">LLM Hub</text>
+  <rect x="450" y="305" width="100" height="48" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="500" y="323" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Inference</text>
+  <text x="500" y="337" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">API</text>
+  <text x="500" y="349" font-family="Courier New, monospace" font-size="8" fill="#c4b5fd" text-anchor="middle">Rate Limit</text>
+  <rect x="570" y="305" width="100" height="48" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="620" y="323" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Prompt</text>
+  <text x="620" y="337" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Guard</text>
+  <text x="620" y="349" font-family="Courier New, monospace" font-size="8" fill="#c4b5fd" text-anchor="middle">Filter</text>
+  <rect x="690" y="305" width="100" height="48" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="740" y="323" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Vector</text>
+  <text x="740" y="337" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">Store</text>
+  <text x="740" y="349" font-family="Courier New, monospace" font-size="8" fill="#c4b5fd" text-anchor="middle">Pinecone</text>
+  <rect x="810" y="305" width="60" height="48" rx="6" fill="#1e1b4b" stroke="#7c3aed" stroke-width="1"/>
+  <text x="840" y="330" font-family="Arial, sans-serif" font-size="9" fill="#a78bfa" text-anchor="middle">RAG</text>
+  <text x="840" y="346" font-family="Courier New, monospace" font-size="8" fill="#c4b5fd" text-anchor="middle">Search</text>
+
+  <!-- Layer 3: Agent Layer (top) -->
+  <rect x="350" y="150" width="500" height="95" rx="10" fill="url(#agentLayer)" opacity="0.9" stroke="#3b82f6" stroke-width="2"/>
+  <text x="600" y="175" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">AGENT EXECUTION LAYER</text>
+  <!-- Agent components -->
+  <rect x="378" y="188" width="92" height="44" rx="6" fill="#172554" stroke="#3b82f6" stroke-width="1"/>
+  <text x="424" y="206" font-family="Arial, sans-serif" font-size="9" fill="#93c5fd" text-anchor="middle">Orchestrator</text>
+  <text x="424" y="220" font-family="Courier New, monospace" font-size="8" fill="#bfdbfe" text-anchor="middle">LangGraph</text>
+  <rect x="482" y="188" width="92" height="44" rx="6" fill="#172554" stroke="#3b82f6" stroke-width="1"/>
+  <text x="528" y="206" font-family="Arial, sans-serif" font-size="9" fill="#93c5fd" text-anchor="middle">Tool Use</text>
+  <text x="528" y="220" font-family="Courier New, monospace" font-size="8" fill="#bfdbfe" text-anchor="middle">MCP / API</text>
+  <rect x="586" y="188" width="92" height="44" rx="6" fill="#172554" stroke="#3b82f6" stroke-width="1"/>
+  <text x="632" y="206" font-family="Arial, sans-serif" font-size="9" fill="#93c5fd" text-anchor="middle">Memory</text>
+  <text x="632" y="220" font-family="Courier New, monospace" font-size="8" fill="#bfdbfe" text-anchor="middle">Short/Long</text>
+  <rect x="690" y="188" width="92" height="44" rx="6" fill="#172554" stroke="#3b82f6" stroke-width="1"/>
+  <text x="736" y="206" font-family="Arial, sans-serif" font-size="9" fill="#93c5fd" text-anchor="middle">Sandbox</text>
+  <text x="736" y="220" font-family="Courier New, monospace" font-size="8" fill="#bfdbfe" text-anchor="middle">Isolate</text>
+
+  <!-- Green defense shields at layer boundaries -->
+  <!-- Shield between agent and platform -->
+  <g filter="url(#shieldGlow)">
+    <path d="M560,264 L580,255 L600,264 L600,278 C600,285 590,291 580,294 C570,291 560,285 560,278 Z"
+          fill="#14532d" opacity="0.9" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="580" y="278" font-family="Arial, sans-serif" font-size="8" fill="#86efac" text-anchor="middle">GUARD</text>
+
+    <path d="M618,264 L638,255 L658,264 L658,278 C658,285 648,291 638,294 C628,291 618,285 618,278 Z"
+          fill="#14532d" opacity="0.9" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="638" y="278" font-family="Arial, sans-serif" font-size="8" fill="#86efac" text-anchor="middle">AUTH</text>
+  </g>
+
+  <!-- Shield between platform and infra -->
+  <g filter="url(#shieldGlow)">
+    <path d="M540,384 L560,375 L580,384 L580,398 C580,405 570,411 560,414 C550,411 540,405 540,398 Z"
+          fill="#14532d" opacity="0.9" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="560" y="398" font-family="Arial, sans-serif" font-size="8" fill="#86efac" text-anchor="middle">WAF</text>
+
+    <path d="M618,384 L638,375 L658,384 L658,398 C658,405 648,411 638,414 C628,411 618,405 618,398 Z"
+          fill="#14532d" opacity="0.9" stroke="#22c55e" stroke-width="1.5"/>
+    <text x="638" y="398" font-family="Arial, sans-serif" font-size="8" fill="#86efac" text-anchor="middle">SCAN</text>
+  </g>
+
+  <!-- Red attack arrows from left penetrating through layers -->
+  <g filter="url(#redArrowGlow)">
+    <!-- Arrow penetrating agent layer -->
+    <line x1="75" y1="197" x2="348" y2="197" stroke="#ef4444" stroke-width="3" stroke-dasharray="10,5"/>
+    <polygon points="348,191 362,197 348,203" fill="#ef4444"/>
+    <text x="55" y="195" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">PROMPT</text>
+    <text x="55" y="206" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">INJECT</text>
+
+    <!-- Arrow at platform layer -->
+    <line x1="75" y1="320" x2="298" y2="320" stroke="#ef4444" stroke-width="2.5" stroke-dasharray="8,5"/>
+    <polygon points="298,314 312,320 298,326" fill="#ef4444"/>
+    <text x="55" y="318" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">DATA</text>
+    <text x="55" y="329" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">POISON</text>
+
+    <!-- Arrow at infra layer -->
+    <line x1="75" y1="438" x2="248" y2="438" stroke="#ef4444" stroke-width="2" stroke-dasharray="7,5"/>
+    <polygon points="248,432 262,438 248,444" fill="#ef4444"/>
+    <text x="55" y="436" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">PRIV</text>
+    <text x="55" y="447" font-family="Arial, sans-serif" font-size="9" fill="#ef4444" text-anchor="middle">ESCAL</text>
+  </g>
+
+  <!-- Layer connector lines -->
+  <line x1="600" y1="245" x2="600" y2="270" stroke="#7c3aed" stroke-width="1.5" opacity="0.5" stroke-dasharray="4,3"/>
+  <line x1="600" y1="370" x2="600" y2="390" stroke="#475569" stroke-width="1.5" opacity="0.5" stroke-dasharray="4,3"/>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" fill="#ef4444">
+    <text x="880" y="95"  opacity="0.13">agent.permission.check()</text>
+    <text x="870" y="480" opacity="0.12">vector.analyze(input)</text>
+    <text x="52"  y="95"  opacity="0.12">defense.layer.activate()</text>
+    <text x="42"  y="498" opacity="0.11">threat.model.update()</text>
+    <text x="880" y="540" opacity="0.10">sandbox.isolate(proc)</text>
+    <text x="52"  y="545" opacity="0.10">policy.enforce(rbac)</text>
+  </g>
+
+  <!-- Top badges -->
+  <rect x="40" y="22" width="120" height="32" rx="16" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="1"/>
+  <text x="100" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">GUIDE</text>
+
+  <rect x="988" y="22" width="172" height="32" rx="16" fill="#7c3aed" opacity="0.15" stroke="#7c3aed" stroke-width="1"/>
+  <text x="1074" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">February 1, 2026</text>
+
+  <!-- Title -->
+  <text x="600" y="532" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Agentic AI Security</text>
+  <text x="600" y="562" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2026 Attack Vectors | Defense Architecture | AI Threat Modeling</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- Footer labels -->
+  <text x="40"  y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Attack Vectors</text>
+  <text x="170" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Defense Layers</text>
+  <text x="310" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">AI Security</text>
+  <text x="420" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">2026</text>
+  <text x="1160" y="610" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
+++ b/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
@@ -1,33 +1,136 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0a2e"/>
+      <stop offset="100%" style="stop-color:#0a1a2e"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <filter id="ambglow">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textglow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="cardglow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <marker id="arrowO" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0,10 3.5,0 7" fill="#f97316"/>
+    </marker>
+    <marker id="arrowP" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0,10 3.5,0 7" fill="#8b5cf6"/>
+    </marker>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ec4899" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#ec4899" stroke-width="2.5"/>
-      <circle cx="0" cy="-15" r="25" fill="#ec4899" opacity="0.1" stroke="#ec4899" stroke-width="1.5"/>
-      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#ec4899" text-anchor="middle" opacity="0.8">AI</text>
-      <circle cx="-30" cy="25" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
-      <circle cx="0" cy="35" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
-      <circle cx="30" cy="25" r="10" fill="#ec4899" opacity="0.15" stroke="#ec4899" stroke-width="1"/>
-      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
-      <line x1="0" y1="12" x2="0" y2="25" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
-      <line x1="15" y1="10" x2="25" y2="20" stroke="#ec4899" stroke-width="1" opacity="0.3"/>
-    </g>
-    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#ec4899" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#ec4899" stroke-width="1"/></g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Content Creator</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">2026 Workflow | Blog + Video + Music + Animation</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ec4899" opacity="0.2" stroke="#ec4899" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ec4899" text-anchor="middle">AI CREATIVE</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 5, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="200" cy="150" r="200" fill="#f97316" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="1000" cy="480" r="210" fill="#8b5cf6" opacity="0.08" filter="url(#ambglow)"/>
+  <circle cx="600" cy="300" r="250" fill="#f97316" opacity="0.04" filter="url(#ambglow)"/>
+  <circle cx="120" cy="510" r="140" fill="#8b5cf6" opacity="0.06" filter="url(#ambglow)"/>
+
+  <!-- Floating code fragments -->
+  <text x="58" y="108" font-family="monospace" font-size="12" fill="#f97316" opacity="0.12">ai.generate(blog)</text>
+  <text x="978" y="78" font-family="monospace" font-size="12" fill="#8b5cf6" opacity="0.13">ffmpeg.encode(4k)</text>
+  <text x="72" y="568" font-family="monospace" font-size="12" fill="#f97316" opacity="0.11">music.compose(style)</text>
+  <text x="948" y="558" font-family="monospace" font-size="12" fill="#8b5cf6" opacity="0.13">render.animation(fps)</text>
+  <text x="505" y="58" font-family="monospace" font-size="11" fill="#f97316" opacity="0.10">pipeline.run(tasks)</text>
+
+  <!-- Top badge -->
+  <rect x="40" y="32" width="100" height="32" rx="16" fill="#f97316" opacity="0.18"/>
+  <rect x="40" y="32" width="100" height="32" rx="16" fill="none" stroke="#f97316" stroke-width="1" opacity="0.6"/>
+  <text x="90" y="53" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f97316" text-anchor="middle">GUIDE</text>
+  <text x="1160" y="53" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">February 5, 2026</text>
+
+  <!-- AI Brain central overseer -->
+  <ellipse cx="600" cy="135" rx="68" ry="56" fill="#1a0830" stroke="#f97316" stroke-width="2.5" opacity="0.95" filter="url(#cardglow)"/>
+  <ellipse cx="600" cy="135" rx="68" ry="56" fill="#f97316" opacity="0.10"/>
+  <!-- Brain fold lines -->
+  <path d="M558 118 Q575 108 600 118 Q625 108 642 118" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.65"/>
+  <path d="M552 135 Q572 125 600 135 Q628 125 648 135" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.65"/>
+  <path d="M558 152 Q575 142 600 152 Q625 142 642 152" fill="none" stroke="#f97316" stroke-width="1.5" opacity="0.65"/>
+  <text x="600" y="142" font-family="Arial,sans-serif" font-size="14" font-weight="bold" fill="#f97316" text-anchor="middle" opacity="0.9">AI</text>
+
+  <!-- Connector lines from brain down to pipeline cards -->
+  <line x1="545" y1="178" x2="207" y2="255" stroke="#f97316" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.45"/>
+  <line x1="572" y1="188" x2="407" y2="257" stroke="#f97316" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.45"/>
+  <line x1="628" y1="188" x2="793" y2="257" stroke="#f97316" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.45"/>
+  <line x1="655" y1="178" x2="993" y2="255" stroke="#f97316" stroke-width="1.5" stroke-dasharray="6,4" opacity="0.45"/>
+
+  <!-- CARD 1: Blog (x=100–305) -->
+  <rect x="100" y="260" width="205" height="210" rx="18" fill="#130820" stroke="#f97316" stroke-width="2.5"/>
+  <rect x="100" y="260" width="205" height="210" rx="18" fill="#f97316" opacity="0.06"/>
+  <!-- Blog: text lines icon -->
+  <rect x="155" y="295" width="90" height="11" rx="4" fill="#f97316" opacity="0.80"/>
+  <rect x="148" y="315" width="104" height="9" rx="4" fill="#f97316" opacity="0.50"/>
+  <rect x="152" y="331" width="96" height="9" rx="4" fill="#f97316" opacity="0.45"/>
+  <rect x="155" y="347" width="90" height="9" rx="4" fill="#f97316" opacity="0.38"/>
+  <rect x="160" y="363" width="80" height="9" rx="4" fill="#f97316" opacity="0.30"/>
+  <!-- Pencil -->
+  <line x1="155" y1="395" x2="200" y2="375" stroke="#f97316" stroke-width="3" stroke-linecap="round" opacity="0.75"/>
+  <polygon points="150,408 155,395 168,399" fill="#f97316" opacity="0.75"/>
+  <text x="202" y="444" font-family="Arial,sans-serif" font-size="19" font-weight="bold" fill="#f97316" text-anchor="middle">BLOG</text>
+  <text x="202" y="462" font-family="Arial,sans-serif" font-size="11" fill="#94a3b8" text-anchor="middle">Content Writing</text>
+
+  <!-- Arrow 1 to 2 -->
+  <line x1="308" y1="365" x2="348" y2="365" stroke="#8b5cf6" stroke-width="3" marker-end="url(#arrowP)"/>
+
+  <!-- CARD 2: Video (x=352–557) -->
+  <rect x="352" y="260" width="205" height="210" rx="18" fill="#130820" stroke="#8b5cf6" stroke-width="2.5"/>
+  <rect x="352" y="260" width="205" height="210" rx="18" fill="#8b5cf6" opacity="0.06"/>
+  <!-- Play button circle -->
+  <circle cx="454" cy="355" r="58" fill="none" stroke="#8b5cf6" stroke-width="2.5" opacity="0.8"/>
+  <circle cx="454" cy="355" r="58" fill="#8b5cf6" opacity="0.06"/>
+  <polygon points="437,328 437,382 485,355" fill="#8b5cf6" opacity="0.85"/>
+  <!-- 4K label -->
+  <text x="454" y="444" font-family="Arial,sans-serif" font-size="19" font-weight="bold" fill="#8b5cf6" text-anchor="middle">VIDEO</text>
+  <text x="454" y="462" font-family="Arial,sans-serif" font-size="11" fill="#94a3b8" text-anchor="middle">4K Production</text>
+
+  <!-- Arrow 2 to 3 -->
+  <line x1="560" y1="365" x2="600" y2="365" stroke="#f97316" stroke-width="3" marker-end="url(#arrowO)"/>
+
+  <!-- CARD 3: Music (x=604–809) -->
+  <rect x="604" y="260" width="205" height="210" rx="18" fill="#130820" stroke="#f97316" stroke-width="2.5"/>
+  <rect x="604" y="260" width="205" height="210" rx="18" fill="#f97316" opacity="0.06"/>
+  <!-- Waveform -->
+  <polyline points="622,360 634,322 646,368 658,332 670,364 682,308 694,368 706,336 718,360 730,324 742,368 754,342 766,352 778,326 790,362 802,348" fill="none" stroke="#f97316" stroke-width="2.5" opacity="0.85"/>
+  <text x="706" y="444" font-family="Arial,sans-serif" font-size="19" font-weight="bold" fill="#f97316" text-anchor="middle">MUSIC</text>
+  <text x="706" y="462" font-family="Arial,sans-serif" font-size="11" fill="#94a3b8" text-anchor="middle">AI Composition</text>
+
+  <!-- Arrow 3 to 4 -->
+  <line x1="812" y1="365" x2="852" y2="365" stroke="#8b5cf6" stroke-width="3" marker-end="url(#arrowP)"/>
+
+  <!-- CARD 4: Animation (x=856–1061) -->
+  <rect x="856" y="260" width="205" height="210" rx="18" fill="#130820" stroke="#8b5cf6" stroke-width="2.5"/>
+  <rect x="856" y="260" width="205" height="210" rx="18" fill="#8b5cf6" opacity="0.06"/>
+  <!-- Film strip -->
+  <rect x="904" y="300" width="110" height="84" rx="6" fill="none" stroke="#8b5cf6" stroke-width="2.5" opacity="0.8"/>
+  <rect x="904" y="300" width="16" height="84" rx="4" fill="#8b5cf6" opacity="0.35"/>
+  <rect x="998" y="300" width="16" height="84" rx="4" fill="#8b5cf6" opacity="0.35"/>
+  <circle cx="912" cy="313" r="3.5" fill="#0a0a1a"/>
+  <circle cx="912" cy="330" r="3.5" fill="#0a0a1a"/>
+  <circle cx="912" cy="347" r="3.5" fill="#0a0a1a"/>
+  <circle cx="912" cy="364" r="3.5" fill="#0a0a1a"/>
+  <circle cx="1006" cy="313" r="3.5" fill="#0a0a1a"/>
+  <circle cx="1006" cy="330" r="3.5" fill="#0a0a1a"/>
+  <circle cx="1006" cy="347" r="3.5" fill="#0a0a1a"/>
+  <circle cx="1006" cy="364" r="3.5" fill="#0a0a1a"/>
+  <!-- Play triangle inside frame -->
+  <polygon points="940,326 940,368 972,347" fill="#8b5cf6" opacity="0.75"/>
+  <text x="958" y="444" font-family="Arial,sans-serif" font-size="19" font-weight="bold" fill="#8b5cf6" text-anchor="middle">ANIMATION</text>
+  <text x="958" y="462" font-family="Arial,sans-serif" font-size="11" fill="#94a3b8" text-anchor="middle">Frame Rendering</text>
+
+  <!-- Title and subtitle -->
+  <text x="600" y="512" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textglow)">AI Content Creator</text>
+  <text x="600" y="542" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Blog | Video | Music | Animation Production Pipeline</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#334155" stroke-width="1" opacity="0.6"/>
+  <text x="600" y="610" font-family="Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="middle">Blog | Video | Music | Animation | AI Workflow</text>
+  <text x="1160" y="610" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
@@ -1,34 +1,137 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0a0a"/>
+      <stop offset="100%" style="stop-color:#0a0f1a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="cloudFill" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a5f;stop-opacity:0.95"/>
+      <stop offset="100%" style="stop-color:#0f2035;stop-opacity:0.95"/>
+    </linearGradient>
+    <filter id="ambglow">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="waveglow">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textglow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
-      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#ef4444" text-anchor="middle">C2</text>
-    </g>
-    <g opacity="0.4">
-      <circle cx="-80" cy="-50" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="-65" y1="-40" x2="-25" y2="-15" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="80" cy="-50" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="65" y1="-40" x2="25" y2="-15" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="-90" cy="30" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="-75" y1="25" x2="-28" y2="10" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="90" cy="30" r="15" fill="#1e293b" stroke="#ef4444" stroke-width="1.5"/><line x1="75" y1="25" x2="28" y2="10" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="-40" cy="70" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="-35" y1="58" x2="-15" y2="25" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="40" cy="70" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="35" y1="58" x2="15" y2="25" stroke="#ef4444" stroke-width="1"/>
-      <circle cx="0" cy="-80" r="12" fill="#1e293b" stroke="#ef4444" stroke-width="1"/><line x1="0" y1="-68" x2="0" y2="-30" stroke="#ef4444" stroke-width="1"/>
-    </g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Botnet Threat</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cloud + Botnet Intelligence</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 6, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="285" r="245" fill="#ef4444" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="175" cy="195" r="175" fill="#3b82f6" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="1025" cy="375" r="185" fill="#ef4444" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="945" cy="125" r="125" fill="#3b82f6" opacity="0.06" filter="url(#ambglow)"/>
+
+  <!-- Floating code fragments -->
+  <text x="52" y="96" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.13">ddos.amplify(cloud)</text>
+  <text x="942" y="86" font-family="monospace" font-size="12" fill="#3b82f6" opacity="0.12">botnet.scale(instances)</text>
+  <text x="58" y="560" font-family="monospace" font-size="12" fill="#3b82f6" opacity="0.12">waf.block(ip_list)</text>
+  <text x="938" y="553" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.13">traffic.analyze()</text>
+  <text x="488" y="53" font-family="monospace" font-size="11" fill="#ef4444" opacity="0.10">attack.flood(target)</text>
+
+  <!-- Top badge -->
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="#ef4444" opacity="0.18"/>
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="none" stroke="#ef4444" stroke-width="1" opacity="0.6"/>
+  <text x="127" y="53" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="53" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">February 6, 2026</text>
+
+  <!-- CENTRAL ILLUSTRATION: Large cloud under DDoS attack -->
+
+  <!-- Cloud shape - large, centered ~x350-870, y155-390 -->
+  <path d="M360 378 Q325 378 308 352 Q292 326 314 306 Q312 258 356 248 Q368 208 410 202 Q424 168 462 164 Q482 138 522 143 Q544 118 582 123 Q608 106 645 120 Q685 109 712 136 Q750 132 768 162 Q802 162 818 194 Q848 196 856 228 Q878 252 864 284 Q882 308 872 335 Q860 365 828 376 Q814 394 782 394 Z" fill="url(#cloudFill)" stroke="#3b82f6" stroke-width="3" opacity="0.94"/>
+  <path d="M360 378 Q325 378 308 352 Q292 326 314 306 Q312 258 356 248 Q368 208 410 202 Q424 168 462 164 Q482 138 522 143 Q544 118 582 123 Q608 106 645 120 Q685 109 712 136 Q750 132 768 162 Q802 162 818 194 Q848 196 856 228 Q878 252 864 284 Q882 308 872 335 Q860 365 828 376 Q814 394 782 394 Z" fill="#3b82f6" opacity="0.07"/>
+
+  <!-- Server racks inside cloud, 4 racks -->
+  <!-- Rack 1 -->
+  <rect x="410" y="238" width="58" height="100" rx="5" fill="#060e18" stroke="#3b82f6" stroke-width="1.5" opacity="0.92"/>
+  <rect x="415" y="245" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.50"/>
+  <rect x="415" y="259" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.42"/>
+  <rect x="415" y="273" width="48" height="9" rx="2" fill="#ef4444" opacity="0.68"/>
+  <rect x="415" y="287" width="48" height="9" rx="2" fill="#ef4444" opacity="0.56"/>
+  <rect x="415" y="301" width="48" height="9" rx="2" fill="#ef4444" opacity="0.46"/>
+  <circle cx="454" cy="327" r="5" fill="#ef4444" opacity="0.85"/>
+  <!-- Rack 2 -->
+  <rect x="484" y="222" width="58" height="116" rx="5" fill="#060e18" stroke="#3b82f6" stroke-width="1.5" opacity="0.92"/>
+  <rect x="489" y="229" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.50"/>
+  <rect x="489" y="243" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.42"/>
+  <rect x="489" y="257" width="48" height="9" rx="2" fill="#ef4444" opacity="0.72"/>
+  <rect x="489" y="271" width="48" height="9" rx="2" fill="#ef4444" opacity="0.64"/>
+  <rect x="489" y="285" width="48" height="9" rx="2" fill="#ef4444" opacity="0.54"/>
+  <rect x="489" y="299" width="48" height="9" rx="2" fill="#ef4444" opacity="0.44"/>
+  <circle cx="528" cy="328" r="5" fill="#ef4444" opacity="0.90"/>
+  <!-- Rack 3 -->
+  <rect x="558" y="232" width="58" height="106" rx="5" fill="#060e18" stroke="#3b82f6" stroke-width="1.5" opacity="0.92"/>
+  <rect x="563" y="239" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.50"/>
+  <rect x="563" y="253" width="48" height="9" rx="2" fill="#ef4444" opacity="0.70"/>
+  <rect x="563" y="267" width="48" height="9" rx="2" fill="#ef4444" opacity="0.60"/>
+  <rect x="563" y="281" width="48" height="9" rx="2" fill="#ef4444" opacity="0.50"/>
+  <rect x="563" y="295" width="48" height="9" rx="2" fill="#ef4444" opacity="0.40"/>
+  <circle cx="602" cy="328" r="5" fill="#ef4444" opacity="0.85"/>
+  <!-- Rack 4 -->
+  <rect x="632" y="242" width="58" height="96" rx="5" fill="#060e18" stroke="#3b82f6" stroke-width="1.5" opacity="0.92"/>
+  <rect x="637" y="249" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.50"/>
+  <rect x="637" y="263" width="48" height="9" rx="2" fill="#3b82f6" opacity="0.42"/>
+  <rect x="637" y="277" width="48" height="9" rx="2" fill="#ef4444" opacity="0.58"/>
+  <rect x="637" y="291" width="48" height="9" rx="2" fill="#ef4444" opacity="0.46"/>
+  <circle cx="676" cy="328" r="5" fill="#ef4444" opacity="0.78"/>
+
+  <!-- DDoS wave attacks from LEFT -->
+  <path d="M148 270 Q210 248 268 272 Q228 300 268 328 Q210 342 148 318" fill="none" stroke="#ef4444" stroke-width="3" opacity="0.88" filter="url(#waveglow)"/>
+  <path d="M122 283 Q208 254 262 276" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.55" stroke-dasharray="7,5"/>
+  <path x="104" y="298" d="M104 298 Q205 268 258 292" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.40" stroke-dasharray="7,5"/>
+
+  <!-- DDoS wave attacks from RIGHT -->
+  <path d="M1052 268 Q990 248 932 272 Q972 300 932 328 Q990 342 1052 318" fill="none" stroke="#ef4444" stroke-width="3" opacity="0.88" filter="url(#waveglow)"/>
+  <path d="M1078 283 Q992 254 938 276" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.55" stroke-dasharray="7,5"/>
+  <path d="M1096 298 Q995 268 942 292" fill="none" stroke="#ef4444" stroke-width="1.5" opacity="0.40" stroke-dasharray="7,5"/>
+
+  <!-- DDoS wave attacks from TOP -->
+  <path d="M518 85 Q558 138 528 180 Q592 160 652 180 Q622 138 662 85" fill="none" stroke="#ef4444" stroke-width="3" opacity="0.82" filter="url(#waveglow)"/>
+  <path d="M505 62 Q550 122 524 162" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.48" stroke-dasharray="7,5"/>
+  <path d="M675 62 Q630 122 656 162" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.48" stroke-dasharray="7,5"/>
+
+  <!-- DDoS wave attacks from BOTTOM -->
+  <path d="M498 490 Q545 440 522 404 Q592 420 662 404 Q639 440 686 490" fill="none" stroke="#ef4444" stroke-width="3" opacity="0.82" filter="url(#waveglow)"/>
+  <path d="M478 512 Q532 456 508 416" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.48" stroke-dasharray="7,5"/>
+  <path d="M706 512 Q652 456 676 416" fill="none" stroke="#ef4444" stroke-width="1.8" opacity="0.48" stroke-dasharray="7,5"/>
+
+  <!-- Blue shield (partially broken) protecting cloud - right side -->
+  <path d="M800 165 L888 188 L888 288 Q888 342 800 375 Q712 342 712 288 L712 188 Z" fill="#0f1e36" stroke="#3b82f6" stroke-width="2.5" opacity="0.88"/>
+  <path d="M800 165 L888 188 L888 288 Q888 342 800 375 Q712 342 712 288 L712 188 Z" fill="#3b82f6" opacity="0.08"/>
+  <!-- Shield crack line -->
+  <path d="M822 182 L800 252 L832 272 L804 362" fill="none" stroke="#ef4444" stroke-width="3.5" opacity="0.92"/>
+  <!-- Checkmark (partial/broken) -->
+  <path d="M736 272 L764 300 L832 232" fill="none" stroke="#3b82f6" stroke-width="3" stroke-linecap="round" opacity="0.55"/>
+
+  <!-- Traffic volume meter: right of shield -->
+  <rect x="928" y="195" width="44" height="170" rx="7" fill="#060e18" stroke="#475569" stroke-width="1.5" opacity="0.90"/>
+  <rect x="933" y="200" width="34" height="158" rx="5" fill="#0a1525" opacity="0.90"/>
+  <!-- Fill level: critical (top 68% red) -->
+  <rect x="933" y="200" width="34" height="108" rx="5" fill="#ef4444" opacity="0.70"/>
+  <!-- Tick marks -->
+  <line x1="967" y1="215" x2="976" y2="215" stroke="#64748b" stroke-width="1.5" opacity="0.6"/>
+  <line x1="967" y1="248" x2="976" y2="248" stroke="#64748b" stroke-width="1.5" opacity="0.6"/>
+  <line x1="967" y1="282" x2="976" y2="282" stroke="#64748b" stroke-width="1.5" opacity="0.6"/>
+  <line x1="967" y1="315" x2="976" y2="315" stroke="#64748b" stroke-width="1.5" opacity="0.6"/>
+  <text x="950" y="194" font-family="Arial,sans-serif" font-size="10" font-weight="bold" fill="#ef4444" text-anchor="middle">CRIT</text>
+  <text x="950" y="382" font-family="Arial,sans-serif" font-size="10" fill="#94a3b8" text-anchor="middle">TRAFFIC</text>
+
+  <!-- Title and subtitle -->
+  <text x="600" y="512" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textglow)">Cloud Botnet Surge</text>
+  <text x="600" y="542" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">AI-Enhanced DDoS | Cloud Infrastructure Abuse | Threat Intel</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#334155" stroke-width="1" opacity="0.6"/>
+  <text x="600" y="610" font-family="Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="middle">20 News | 6 Security | 4 AI/ML | 3 Cloud | 2 DevOps</text>
+  <text x="1160" y="610" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
+++ b/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
@@ -1,33 +1,176 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0d0a1f"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="cloudGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a5f"/>
+      <stop offset="100%" style="stop-color:#1e1b4b"/>
+    </linearGradient>
+    <linearGradient id="shieldGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6"/>
+      <stop offset="100%" style="stop-color:#1d4ed8"/>
+    </linearGradient>
+    <linearGradient id="nodeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7c3aed"/>
+      <stop offset="100%" style="stop-color:#4c1d95"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="ambiGlow">
+      <feGaussianBlur stdDeviation="25"/>
+    </filter>
+    <filter id="shieldGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feFlood flood-color="#3b82f6" flood-opacity="0.5" result="c"/>
+      <feComposite in="c" in2="blur" operator="in" result="s"/>
+      <feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
-      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
-      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
-      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-    </g>
-    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
+
+  <!-- Grid lines -->
+  <g opacity="0.035">
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(120,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(360,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(840,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(1080,0)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-160)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-320)"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Security</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Cloud + Agent Defense</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 17, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="280" r="260" fill="#3b82f6" opacity="0.05" filter="url(#ambiGlow)"/>
+  <circle cx="320" cy="200" r="160" fill="#8b5cf6" opacity="0.06" filter="url(#ambiGlow)"/>
+  <circle cx="880" cy="360" r="160" fill="#3b82f6" opacity="0.05" filter="url(#ambiGlow)"/>
+
+  <!-- ===== CENTRAL: LARGE CLOUD + AI NODES + SHIELD ===== -->
+  <!-- Cloud base shape (large, fills center) -->
+  <g transform="translate(600,270)">
+    <!-- Main cloud body -->
+    <ellipse cx="0" cy="60" rx="280" ry="115" fill="url(#cloudGrad)" opacity="0.75" stroke="#1e40af" stroke-width="1.5"/>
+    <!-- Cloud bumps top -->
+    <circle cx="-180" cy="10" r="72" fill="url(#cloudGrad)" opacity="0.75" stroke="#1e40af" stroke-width="1"/>
+    <circle cx="-60"  cy="-30" r="88" fill="url(#cloudGrad)" opacity="0.75" stroke="#1e40af" stroke-width="1"/>
+    <circle cx="80"   cy="-45" r="95" fill="url(#cloudGrad)" opacity="0.75" stroke="#1e40af" stroke-width="1"/>
+    <circle cx="210"  cy="0"   r="70" fill="url(#cloudGrad)" opacity="0.75" stroke="#1e40af" stroke-width="1"/>
+
+    <!-- AI Agent nodes inside cloud -->
+    <!-- Central node -->
+    <circle cx="0" cy="55" r="38" fill="url(#nodeGrad)" opacity="0.9" stroke="#a78bfa" stroke-width="2"/>
+    <text x="0" y="48" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+    <text x="0" y="66" font-family="Arial, sans-serif" font-size="9" fill="#c4b5fd" text-anchor="middle">CORE</text>
+
+    <!-- Satellite nodes -->
+    <circle cx="-130" cy="30" r="26" fill="url(#nodeGrad)" opacity="0.85" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="-130" y="24" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+    <text x="-130" y="38" font-family="Arial, sans-serif" font-size="8" fill="#c4b5fd" text-anchor="middle">Agent</text>
+
+    <circle cx="130" cy="20" r="26" fill="url(#nodeGrad)" opacity="0.85" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="130" y="14" font-family="Arial, sans-serif" font-size="10" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+    <text x="130" y="28" font-family="Arial, sans-serif" font-size="8" fill="#c4b5fd" text-anchor="middle">Agent</text>
+
+    <circle cx="-80" cy="110" r="22" fill="url(#nodeGrad)" opacity="0.8" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="-80" y="106" font-family="Arial, sans-serif" font-size="9" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+    <text x="-80" y="118" font-family="Arial, sans-serif" font-size="7" fill="#c4b5fd" text-anchor="middle">Worker</text>
+
+    <circle cx="80" cy="110" r="22" fill="url(#nodeGrad)" opacity="0.8" stroke="#a78bfa" stroke-width="1.5"/>
+    <text x="80" y="106" font-family="Arial, sans-serif" font-size="9" font-weight="bold" fill="white" text-anchor="middle">AI</text>
+    <text x="80" y="118" font-family="Arial, sans-serif" font-size="7" fill="#c4b5fd" text-anchor="middle">Worker</text>
+
+    <!-- Interconnect lines between nodes -->
+    <line x1="-104" y1="30" x2="-38" y2="45" stroke="#a78bfa" stroke-width="1.5" opacity="0.5"/>
+    <line x1="104"  y1="20" x2="38"  y2="45" stroke="#a78bfa" stroke-width="1.5" opacity="0.5"/>
+    <line x1="-58"  y1="110" x2="-28" y2="72" stroke="#a78bfa" stroke-width="1.2" opacity="0.4"/>
+    <line x1="58"   y1="110" x2="28"  y2="72" stroke="#a78bfa" stroke-width="1.2" opacity="0.4"/>
+    <line x1="-130" y1="56" x2="-80" y2="90" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+    <line x1="130"  y1="46" x2="80"  y2="90" stroke="#a78bfa" stroke-width="1" opacity="0.3"/>
+
+    <!-- Workload dots scattered in cloud -->
+    <circle cx="-200" cy="60"  r="5" fill="#60a5fa" opacity="0.5"/>
+    <circle cx="-160" cy="90"  r="4" fill="#60a5fa" opacity="0.4"/>
+    <circle cx="160"  cy="70"  r="5" fill="#60a5fa" opacity="0.5"/>
+    <circle cx="200"  cy="50"  r="4" fill="#60a5fa" opacity="0.4"/>
+    <circle cx="0"    cy="-10" r="4" fill="#818cf8" opacity="0.4"/>
+    <circle cx="-40"  cy="150" r="4" fill="#60a5fa" opacity="0.35"/>
+    <circle cx="40"   cy="145" r="4" fill="#60a5fa" opacity="0.35"/>
+  </g>
+
+  <!-- Shield overlay on cloud (large) -->
+  <g transform="translate(600,255)" filter="url(#shieldGlow)">
+    <path d="M0,-195 L175,-140 L175,55 C175,145 88,210 0,240 C-88,210 -175,145 -175,55 L-175,-140 Z"
+          fill="url(#shieldGrad)" opacity="0.08" stroke="#3b82f6" stroke-width="2.5"/>
+    <path d="M0,-170 L148,-118 L148,45 C148,125 74,182 0,208 C-74,182 -148,125 -148,45 L-148,-118 Z"
+          fill="url(#shieldGrad)" opacity="0.05" stroke="#60a5fa" stroke-width="1.5"/>
+    <!-- Shield checkmark -->
+    <path d="M-35,30 L-10,58 L40,-15" fill="none" stroke="#3b82f6" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" opacity="0.7"/>
+  </g>
+
+  <!-- Threat arrows bouncing off shield from left -->
+  <g opacity="0.7">
+    <line x1="78" y1="200" x2="268" y2="245" stroke="#ef4444" stroke-width="2.5" stroke-dasharray="8,4"/>
+    <polygon points="268,240 275,255 260,250" fill="#ef4444"/>
+    <line x1="55" y1="290" x2="245" y2="295" stroke="#ef4444" stroke-width="2" stroke-dasharray="7,4"/>
+    <polygon points="245,290 252,305 237,300" fill="#ef4444"/>
+    <line x1="70" y1="360" x2="255" y2="335" stroke="#ef4444" stroke-width="1.8" stroke-dasharray="6,4"/>
+    <!-- Bounce-back lines (red reflects off shield) -->
+    <line x1="268" y1="245" x2="230" y2="195" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,4" opacity="0.5"/>
+    <line x1="245" y1="295" x2="210" y2="250" stroke="#f87171" stroke-width="1.2" stroke-dasharray="4,4" opacity="0.4"/>
+  </g>
+
+  <!-- Threat arrows from right -->
+  <g opacity="0.65">
+    <line x1="1122" y1="210" x2="932" y2="248" stroke="#ef4444" stroke-width="2.5" stroke-dasharray="8,4"/>
+    <polygon points="932,243 925,258 940,253" fill="#ef4444"/>
+    <line x1="1130" y1="330" x2="950" y2="315" stroke="#ef4444" stroke-width="2" stroke-dasharray="7,4"/>
+    <!-- Bounce-back -->
+    <line x1="932" y1="248" x2="970" y2="200" stroke="#f87171" stroke-width="1.5" stroke-dasharray="4,4" opacity="0.5"/>
+  </g>
+
+  <!-- Threat source labels -->
+  <rect x="38"  y="185" width="90" height="22" rx="5" fill="#7f1d1d" opacity="0.7"/>
+  <text x="83"  y="200" font-family="Arial, sans-serif" font-size="10" fill="#fca5a5" text-anchor="middle">DDoS / APT</text>
+  <rect x="38"  y="273" width="90" height="22" rx="5" fill="#7f1d1d" opacity="0.7"/>
+  <text x="83"  y="288" font-family="Arial, sans-serif" font-size="10" fill="#fca5a5" text-anchor="middle">Malware</text>
+  <rect x="1072" y="195" width="90" height="22" rx="5" fill="#7f1d1d" opacity="0.7"/>
+  <text x="1117" y="210" font-family="Arial, sans-serif" font-size="10" fill="#fca5a5" text-anchor="middle">Ransomware</text>
+  <rect x="1072" y="317" width="90" height="22" rx="5" fill="#7f1d1d" opacity="0.7"/>
+  <text x="1117" y="332" font-family="Arial, sans-serif" font-size="10" fill="#fca5a5" text-anchor="middle">Data Leak</text>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" fill="#8b5cf6">
+    <text x="52"  y="100" opacity="0.14">agent.defend(cloud)</text>
+    <text x="35"  y="455" opacity="0.12">waf.rule.update()</text>
+    <text x="900" y="82"  opacity="0.13">cspm.scan(config)</text>
+    <text x="930" y="490" opacity="0.11">siem.correlate()</text>
+    <text x="75"  y="520" opacity="0.10">workload.protect(pod)</text>
+    <text x="855" y="465" opacity="0.10">iam.policy.enforce()</text>
+  </g>
+
+  <!-- Top badges -->
+  <rect x="40" y="22" width="172" height="32" rx="16" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="126" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY DIGEST</text>
+
+  <rect x="988" y="22" width="172" height="32" rx="16" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" stroke-width="1"/>
+  <text x="1074" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">February 17, 2026</text>
+
+  <!-- Title -->
+  <text x="600" y="532" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Cloud Shield</text>
+  <text x="600" y="562" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Autonomous Defense | Cloud Workload Protection | Agent Security</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- Footer counts -->
+  <text x="40"  y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">20 News</text>
+  <text x="135" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">5 Security</text>
+  <text x="248" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">5 AI/ML</text>
+  <text x="338" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">3 Cloud</text>
+  <text x="420" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">2 DevOps</text>
+  <text x="1160" y="610" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
+++ b/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
@@ -1,34 +1,217 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="wolfBody" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#374151"/>
+      <stop offset="100%" style="stop-color:#111827"/>
+    </linearGradient>
+    <linearGradient id="patchedCell" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#16a34a"/>
+      <stop offset="100%" style="stop-color:#14532d"/>
+    </linearGradient>
+    <linearGradient id="critCell" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="100%" style="stop-color:#7f1d1d"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="ambiGlow">
+      <feGaussianBlur stdDeviation="25"/>
+    </filter>
+    <filter id="eyeGlow">
+      <feGaussianBlur stdDeviation="7" result="blur"/>
+      <feFlood flood-color="#ef4444" flood-opacity="0.85" result="c"/>
+      <feComposite in="c" in2="blur" operator="in" result="s"/>
+      <feMerge><feMergeNode in="s"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <rect x="-70" y="-70" width="140" height="140" rx="12" fill="#1e293b" stroke="#ef4444" stroke-width="2.5"/>
-      <rect x="-50" y="-50" width="100" height="25" rx="4" fill="#ef4444" opacity="0.1" stroke="#ef4444" stroke-width="1"/>
-      <rect x="-50" y="-18" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
-      <rect x="-50" y="14" width="100" height="25" rx="4" fill="#22c55e" opacity="0.1" stroke="#22c55e" stroke-width="1"/>
-      <rect x="-50" y="46" width="100" height="12" rx="4" fill="#334155" opacity="0.3"/>
-      <path d="M-35,-42 L-32,-38 L-28,-44" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
-      <path d="M-35,-10 L-32,-6 L-28,-12" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
-      <path d="M-35,22 L-32,26 L-28,20" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round"/>
-      <text x="0" y="-34" font-family="Courier New" font-size="8" fill="#ef4444" text-anchor="middle">CVE-2026-XXX</text>
-      <text x="0" y="-2" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
-      <text x="0" y="30" font-family="Courier New" font-size="8" fill="#86efac" text-anchor="middle">Patched</text>
-    </g>
+
+  <!-- Subtle dot grid -->
+  <g opacity="0.035">
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(100,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(200,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(600,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(1000,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(1100,0)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-150)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-300)"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Krebs + Patch Tuesday</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Kimwolf Botnet + Microsoft Patch Tuesday</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#ef4444" text-anchor="middle">SECURITY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 18, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="300" cy="280" r="230" fill="#ef4444" opacity="0.06" filter="url(#ambiGlow)"/>
+  <circle cx="880" cy="270" r="200" fill="#f59e0b" opacity="0.07" filter="url(#ambiGlow)"/>
+  <circle cx="600" cy="480" r="110" fill="#7c3aed" opacity="0.05" filter="url(#ambiGlow)"/>
+
+  <!-- Vertical divider -->
+  <line x1="600" y1="75" x2="600" y2="505" stroke="#1e293b" stroke-width="1.5" stroke-dasharray="6,5" opacity="0.6"/>
+
+  <!-- ===== LEFT: WOLF SILHOUETTE ===== -->
+  <!-- Body -->
+  <ellipse cx="300" cy="330" rx="88" ry="72" fill="url(#wolfBody)" opacity="0.95"/>
+  <!-- Neck -->
+  <ellipse cx="300" cy="250" rx="44" ry="52" fill="url(#wolfBody)" opacity="0.95"/>
+  <!-- Head -->
+  <ellipse cx="300" cy="175" rx="62" ry="58" fill="url(#wolfBody)" opacity="0.95"/>
+  <!-- Snout -->
+  <ellipse cx="335" cy="188" rx="38" ry="21" fill="#1f2937" opacity="0.95"/>
+  <!-- Left ear -->
+  <polygon points="250,128 272,82 296,130" fill="url(#wolfBody)" opacity="0.95"/>
+  <!-- Right ear -->
+  <polygon points="308,132 332,84 356,126" fill="url(#wolfBody)" opacity="0.95"/>
+  <!-- Inner ears -->
+  <polygon points="257,125 272,95 290,127" fill="#ef4444" opacity="0.25"/>
+  <polygon points="314,128 330,96 348,124" fill="#ef4444" opacity="0.25"/>
+  <!-- Tail -->
+  <path d="M215,370 C145,345 110,295 135,240" fill="none" stroke="#374151" stroke-width="20" stroke-linecap="round" opacity="0.85"/>
+  <!-- Front legs -->
+  <rect x="240" y="385" width="24" height="85" rx="12" fill="#1f2937" opacity="0.9"/>
+  <rect x="310" y="385" width="24" height="85" rx="12" fill="#1f2937" opacity="0.9"/>
+  <!-- Hind legs -->
+  <rect x="218" y="370" width="20" height="72" rx="10" fill="#374151" opacity="0.75"/>
+  <rect x="344" y="370" width="20" height="72" rx="10" fill="#374151" opacity="0.75"/>
+  <!-- Glowing red eyes -->
+  <ellipse cx="280" cy="168" rx="10" ry="8" fill="#ef4444" filter="url(#eyeGlow)" opacity="1"/>
+  <ellipse cx="318" cy="168" rx="10" ry="8" fill="#ef4444" filter="url(#eyeGlow)" opacity="1"/>
+  <ellipse cx="280" cy="168" rx="3.5" ry="5.5" fill="#1a0000"/>
+  <ellipse cx="318" cy="168" rx="3.5" ry="5.5" fill="#1a0000"/>
+  <!-- Fangs -->
+  <polygon points="288,198 293,218 298,198" fill="white" opacity="0.65"/>
+  <polygon points="304,198 309,218 314,198" fill="white" opacity="0.65"/>
+  <!-- Fur texture lines -->
+  <path d="M265,230 C275,225 285,228 295,224" fill="none" stroke="#4b5563" stroke-width="1" opacity="0.5"/>
+  <path d="M260,245 C272,240 284,242 296,238" fill="none" stroke="#4b5563" stroke-width="1" opacity="0.4"/>
+  <!-- Red aura -->
+  <circle cx="300" cy="200" r="100" fill="#ef4444" opacity="0.04" filter="url(#ambiGlow)"/>
+  <!-- APT badge -->
+  <rect x="218" y="482" width="162" height="28" rx="8" fill="#7f1d1d" opacity="0.7" stroke="#ef4444" stroke-width="1"/>
+  <text x="299" y="501" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">KIMWOLF APT</text>
+  <!-- Left panel label -->
+  <text x="299" y="520" font-family="Arial, sans-serif" font-size="11" fill="#4b5563" text-anchor="middle">Threat Actor</text>
+
+  <!-- ===== RIGHT: PATCH CALENDAR GRID ===== -->
+  <!-- Calendar header bar -->
+  <rect x="640" y="88" width="510" height="38" rx="7" fill="#1e3a5f" opacity="0.85"/>
+  <text x="895" y="113" font-family="Arial, sans-serif" font-size="15" font-weight="bold" fill="#93c5fd" text-anchor="middle">Patch Tuesday — February 2026</text>
+
+  <!-- Row 1 -->
+  <rect x="645" y="138" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="691" y="161" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-001</text>
+  <text x="691" y="178" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="745" y="138" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="791" y="161" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-002</text>
+  <text x="791" y="178" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="845" y="138" width="92" height="58" rx="6" fill="url(#critCell)" opacity="0.9" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="891" y="161" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-003</text>
+  <text x="891" y="178" font-family="Arial, sans-serif" font-size="10" fill="#fecaca" text-anchor="middle">CRITICAL</text>
+
+  <rect x="945" y="138" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="991" y="161" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-004</text>
+  <text x="991" y="178" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="1045" y="138" width="92" height="58" rx="6" fill="url(#critCell)" opacity="0.9" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="1091" y="161" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-005</text>
+  <text x="1091" y="178" font-family="Arial, sans-serif" font-size="10" fill="#fecaca" text-anchor="middle">0-DAY</text>
+
+  <!-- Row 2 -->
+  <rect x="645" y="206" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="691" y="229" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-006</text>
+  <text x="691" y="246" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="745" y="206" width="92" height="58" rx="6" fill="#92400e" opacity="0.8" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="791" y="229" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-007</text>
+  <text x="791" y="246" font-family="Arial, sans-serif" font-size="10" fill="#fde68a" text-anchor="middle">HIGH</text>
+
+  <rect x="845" y="206" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="891" y="229" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-008</text>
+  <text x="891" y="246" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="945" y="206" width="92" height="58" rx="6" fill="url(#critCell)" opacity="0.9" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="991" y="229" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-009</text>
+  <text x="991" y="246" font-family="Arial, sans-serif" font-size="10" fill="#fecaca" text-anchor="middle">EXPLOIT</text>
+
+  <rect x="1045" y="206" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="1091" y="229" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-010</text>
+  <text x="1091" y="246" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <!-- Row 3 -->
+  <rect x="645" y="274" width="92" height="58" rx="6" fill="url(#critCell)" opacity="0.9" stroke="#ef4444" stroke-width="1.5"/>
+  <text x="691" y="297" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-011</text>
+  <text x="691" y="314" font-family="Arial, sans-serif" font-size="10" fill="#fecaca" text-anchor="middle">CRITICAL</text>
+
+  <rect x="745" y="274" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="791" y="297" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-012</text>
+  <text x="791" y="314" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="845" y="274" width="92" height="58" rx="6" fill="#92400e" opacity="0.8" stroke="#f59e0b" stroke-width="1.5"/>
+  <text x="891" y="297" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-013</text>
+  <text x="891" y="314" font-family="Arial, sans-serif" font-size="10" fill="#fde68a" text-anchor="middle">HIGH</text>
+
+  <rect x="945" y="274" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="991" y="297" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-014</text>
+  <text x="991" y="314" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <rect x="1045" y="274" width="92" height="58" rx="6" fill="url(#patchedCell)" opacity="0.8" stroke="#15803d" stroke-width="1"/>
+  <text x="1091" y="297" font-family="Courier New, monospace" font-size="9" fill="white" text-anchor="middle" font-weight="bold">CVE-2026-015</text>
+  <text x="1091" y="314" font-family="Arial, sans-serif" font-size="10" fill="#bbf7d0" text-anchor="middle">PATCHED</text>
+
+  <!-- Legend bar -->
+  <rect x="645" y="344" width="492" height="30" rx="6" fill="#0f172a" opacity="0.8"/>
+  <rect x="656" y="354" width="13" height="13" rx="3" fill="#16a34a" opacity="0.9"/>
+  <text x="674" y="365" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">Patched</text>
+  <rect x="738" y="354" width="13" height="13" rx="3" fill="#f59e0b" opacity="0.9"/>
+  <text x="756" y="365" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">High</text>
+  <rect x="808" y="354" width="13" height="13" rx="3" fill="#dc2626" opacity="0.9"/>
+  <text x="826" y="365" font-family="Arial, sans-serif" font-size="11" fill="#94a3b8">Critical / 0-Day / Exploit</text>
+  <text x="1128" y="365" font-family="Arial, sans-serif" font-size="11" fill="#4b5563" text-anchor="end">67 CVEs total</text>
+
+  <!-- Right panel label -->
+  <text x="895" y="395" font-family="Arial, sans-serif" font-size="11" fill="#4b5563" text-anchor="middle">Patch Status Grid</text>
+
+  <!-- Connection lines: wolf eyes target unpatched cells -->
+  <line x1="326" y1="172" x2="845" y2="167" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="7,4" opacity="0.30"/>
+  <line x1="326" y1="172" x2="1045" y2="167" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="7,4" opacity="0.25"/>
+  <line x1="326" y1="172" x2="645" y2="303" stroke="#ef4444" stroke-width="1.2" stroke-dasharray="5,5" opacity="0.20"/>
+  <line x1="326" y1="172" x2="945" y2="235" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,5" opacity="0.18"/>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" fill="#f59e0b">
+    <text x="52"  y="98"  opacity="0.13">apt.kimwolf.track()</text>
+    <text x="35"  y="455" opacity="0.12">patch.tuesday.apply()</text>
+    <text x="905" y="78"  opacity="0.12">cve.critical.count()</text>
+    <text x="935" y="488" opacity="0.11">ioc.match(hash)</text>
+    <text x="70"  y="520" opacity="0.10">krebs.intel.parse()</text>
+    <text x="860" y="465" opacity="0.10">msrc.advisory.fetch()</text>
+  </g>
+
+  <!-- Top badges -->
+  <rect x="40" y="22" width="172" height="32" rx="16" fill="#f59e0b" opacity="0.15" stroke="#f59e0b" stroke-width="1"/>
+  <text x="126" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">WEEKLY DIGEST</text>
+
+  <rect x="988" y="22" width="172" height="32" rx="16" fill="#ef4444" opacity="0.15" stroke="#ef4444" stroke-width="1"/>
+  <text x="1074" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">February 18, 2026</text>
+
+  <!-- Title -->
+  <text x="600" y="532" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Krebs + Patch Tuesday</text>
+  <text x="600" y="562" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Kimwolf APT Campaign | Microsoft Patch Tuesday | Krebs Intel</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- Footer counts -->
+  <text x="40"  y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">18 News</text>
+  <text x="135" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">5 Security</text>
+  <text x="248" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">3 AI/ML</text>
+  <text x="338" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">2 Cloud</text>
+  <text x="420" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">3 DevOps</text>
+  <text x="1160" y="610" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
+++ b/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
@@ -1,34 +1,123 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#1a0f00"/>
+      <stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <filter id="ambglow">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="c2glow">
+      <feGaussianBlur stdDeviation="12" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textglow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#f59e0b" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="30" fill="#1e293b" stroke="#f59e0b" stroke-width="2.5"/>
-      <text x="0" y="5" font-family="Courier New" font-size="10" fill="#f59e0b" text-anchor="middle">C2</text>
-    </g>
-    <g opacity="0.4">
-      <circle cx="-80" cy="-50" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="-65" y1="-40" x2="-25" y2="-15" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="80" cy="-50" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="65" y1="-40" x2="25" y2="-15" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="-90" cy="30" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="-75" y1="25" x2="-28" y2="10" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="90" cy="30" r="15" fill="#1e293b" stroke="#f59e0b" stroke-width="1.5"/><line x1="75" y1="25" x2="28" y2="10" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="-40" cy="70" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="-35" y1="58" x2="-15" y2="25" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="40" cy="70" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="35" y1="58" x2="15" y2="25" stroke="#f59e0b" stroke-width="1"/>
-      <circle cx="0" cy="-80" r="12" fill="#1e293b" stroke="#f59e0b" stroke-width="1"/><line x1="0" y1="-68" x2="0" y2="-30" stroke="#f59e0b" stroke-width="1"/>
-    </g>
-  </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Botnet + Blockchain</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Weekly Digest | Go + Botnet + Chain</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#f59e0b" opacity="0.2" stroke="#f59e0b" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 27, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="295" r="240" fill="#f59e0b" opacity="0.08" filter="url(#ambglow)"/>
+  <circle cx="190" cy="175" r="170" fill="#ef4444" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="1010" cy="420" r="185" fill="#f59e0b" opacity="0.07" filter="url(#ambglow)"/>
+  <circle cx="960" cy="145" r="130" fill="#ef4444" opacity="0.06" filter="url(#ambglow)"/>
+
+  <!-- Floating code fragments -->
+  <text x="52" y="94" font-family="monospace" font-size="12" fill="#f59e0b" opacity="0.13">c2.command(bot_army)</text>
+  <text x="948" y="84" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.12">go build ./botnet</text>
+  <text x="62" y="562" font-family="monospace" font-size="12" fill="#ef4444" opacity="0.12">chain.track(wallet)</text>
+  <text x="938" y="556" font-family="monospace" font-size="12" fill="#f59e0b" opacity="0.13">ai.evolve(tactics)</text>
+  <text x="498" y="53" font-family="monospace" font-size="11" fill="#f59e0b" opacity="0.10">botnet.spawn(node)</text>
+
+  <!-- Top badge -->
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="#f59e0b" opacity="0.18"/>
+  <rect x="40" y="32" width="175" height="32" rx="16" fill="none" stroke="#f59e0b" stroke-width="1" opacity="0.6"/>
+  <text x="127" y="53" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#f59e0b" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="1160" y="53" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">February 27, 2026</text>
+
+  <!-- CENTRAL ILLUSTRATION: Botnet topology - C2 + 3 concentric rings -->
+
+  <!-- Ring 3 outer: 12 bot nodes at radius ~235 from center (600,295) -->
+  <!-- Top -->
+  <circle cx="600" cy="60" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="600" y1="75" x2="600" y2="215" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Top-right 30deg -->
+  <circle cx="718" cy="92" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="711" y1="106" x2="623" y2="233" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Right-top -->
+  <circle cx="822" cy="178" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2.5" opacity="0.92"/>
+  <line x1="809" y1="185" x2="643" y2="252" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Right -->
+  <circle cx="853" cy="295" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2.5" opacity="0.92"/>
+  <line x1="838" y1="295" x2="660" y2="295" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Right-bottom -->
+  <circle cx="822" cy="412" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="809" y1="405" x2="643" y2="338" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Bottom-right -->
+  <circle cx="718" cy="498" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="711" y1="484" x2="623" y2="357" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Bottom -->
+  <circle cx="600" cy="530" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2.5" opacity="0.92"/>
+  <line x1="600" y1="515" x2="600" y2="375" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Bottom-left -->
+  <circle cx="482" cy="498" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="489" y1="484" x2="577" y2="357" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Left-bottom -->
+  <circle cx="378" cy="412" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="391" y1="405" x2="557" y2="338" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Left -->
+  <circle cx="347" cy="295" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2.5" opacity="0.92"/>
+  <line x1="362" y1="295" x2="540" y2="295" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Left-top -->
+  <circle cx="378" cy="178" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="391" y1="185" x2="557" y2="252" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+  <!-- Top-left -->
+  <circle cx="482" cy="92" r="15" fill="#1a0500" stroke="#ef4444" stroke-width="2" opacity="0.85"/>
+  <line x1="489" y1="106" x2="577" y2="233" stroke="#f59e0b" stroke-width="1" stroke-dasharray="5,4" opacity="0.38"/>
+
+  <!-- Active attack highlights on 4 outer bots (red fill) -->
+  <circle cx="853" cy="295" r="15" fill="#ef4444" opacity="0.22"/>
+  <circle cx="347" cy="295" r="15" fill="#ef4444" opacity="0.22"/>
+  <circle cx="600" cy="530" r="15" fill="#ef4444" opacity="0.22"/>
+  <circle cx="822" cy="178" r="15" fill="#ef4444" opacity="0.22"/>
+
+  <!-- Ring 2 middle: 6 nodes at radius ~135 -->
+  <circle cx="600" cy="160" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="600" y1="172" x2="600" y2="235" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+  <circle cx="717" cy="228" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="708" y1="238" x2="632" y2="263" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+  <circle cx="735" cy="363" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="724" y1="357" x2="650" y2="320" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+  <circle cx="600" cy="430" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="600" y1="418" x2="600" y2="375" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+  <circle cx="465" cy="363" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="476" y1="357" x2="550" y2="320" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+  <circle cx="483" cy="228" r="12" fill="#2a1500" stroke="#f59e0b" stroke-width="2" opacity="0.90"/>
+  <line x1="492" y1="238" x2="568" y2="263" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="4,3" opacity="0.52"/>
+
+  <!-- C2 Central command node (large amber circle) -->
+  <circle cx="600" cy="295" r="80" fill="#150800" stroke="#f59e0b" stroke-width="4" opacity="0.98" filter="url(#c2glow)"/>
+  <circle cx="600" cy="295" r="80" fill="#f59e0b" opacity="0.10"/>
+  <!-- AI brain overlay on C2 -->
+  <ellipse cx="600" cy="287" rx="45" ry="36" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.75"/>
+  <path d="M570 275 Q585 266 600 275 Q615 266 630 275" fill="none" stroke="#f59e0b" stroke-width="1.5" opacity="0.65"/>
+  <path d="M565 287 Q582 278 600 287 Q618 278 635 287" fill="none" stroke="#f59e0b" stroke-width="1.5" opacity="0.65"/>
+  <path d="M570 299 Q585 290 600 299 Q615 290 630 299" fill="none" stroke="#f59e0b" stroke-width="1.5" opacity="0.65"/>
+  <!-- C2 label -->
+  <text x="600" y="334" font-family="Arial,sans-serif" font-size="15" font-weight="bold" fill="#f59e0b" text-anchor="middle" opacity="0.95">C2 NODE</text>
+
+  <!-- Title and subtitle -->
+  <text x="600" y="512" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#textglow)">AI-Powered Botnet</text>
+  <text x="600" y="542" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Go-Based C2 | Blockchain Resilience | AI Command Control</text>
+
+  <!-- Footer -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#334155" stroke-width="1" opacity="0.6"/>
+  <text x="600" y="610" font-family="Arial,sans-serif" font-size="13" fill="#64748b" text-anchor="middle">19 News | 5 Security | 4 AI/ML | 2 Cloud | 3 DevOps</text>
+  <text x="1160" y="610" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
+++ b/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
@@ -1,33 +1,200 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a1a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="100%" style="stop-color:#0a0f1f"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="30"/></filter>
-    <filter id="shadow"><feDropShadow dx="0" dy="4" stdDeviation="8" flood-color="#000" flood-opacity="0.3"/></filter>
+    <linearGradient id="coreHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e3a5f"/>
+      <stop offset="100%" style="stop-color:#1e1b4b"/>
+    </linearGradient>
+    <linearGradient id="authHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1d4ed8"/>
+      <stop offset="100%" style="stop-color:#1e3a5f"/>
+    </linearGradient>
+    <linearGradient id="sandboxHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#14532d"/>
+      <stop offset="100%" style="stop-color:#064e3b"/>
+    </linearGradient>
+    <linearGradient id="monitorHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#92400e"/>
+      <stop offset="100%" style="stop-color:#78350f"/>
+    </linearGradient>
+    <linearGradient id="policyHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7f1d1d"/>
+      <stop offset="100%" style="stop-color:#6b21a8"/>
+    </linearGradient>
+    <linearGradient id="encryptHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4c1d95"/>
+      <stop offset="100%" style="stop-color:#2e1065"/>
+    </linearGradient>
+    <linearGradient id="auditHex" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#164e63"/>
+      <stop offset="100%" style="stop-color:#0c4a6e"/>
+    </linearGradient>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="ambiGlow">
+      <feGaussianBlur stdDeviation="25"/>
+    </filter>
+    <filter id="hexGlow">
+      <feGaussianBlur stdDeviation="8" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="250" r="280" fill="#8b5cf6" opacity="0.03" filter="url(#sg)"/>
-  <g transform="translate(600,225)">
-    <g filter="url(#shadow)">
-      <circle cx="0" cy="0" r="80" fill="#1e293b" stroke="#8b5cf6" stroke-width="2.5"/>
-      <circle cx="0" cy="-15" r="25" fill="#8b5cf6" opacity="0.1" stroke="#8b5cf6" stroke-width="1.5"/>
-      <text x="0" y="-8" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="#8b5cf6" text-anchor="middle" opacity="0.8">AI</text>
-      <circle cx="-30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="0" cy="35" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <circle cx="30" cy="25" r="10" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
-      <line x1="-15" y1="10" x2="-25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="0" y1="12" x2="0" y2="25" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-      <line x1="15" y1="10" x2="25" y2="20" stroke="#8b5cf6" stroke-width="1" opacity="0.3"/>
-    </g>
-    <g opacity="0.3"><circle cx="-120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="120" cy="-30" r="15" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="-110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/><circle cx="110" cy="50" r="12" fill="#1e293b" stroke="#8b5cf6" stroke-width="1"/></g>
+
+  <!-- Grid -->
+  <g opacity="0.035">
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(150,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(350,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(600,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(850,0)"/>
+    <line x1="0" y1="0" x2="0" y2="630" stroke="#fff" stroke-width="1" transform="translate(1050,0)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-155)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-310)"/>
+    <line x1="0" y1="630" x2="1200" y2="630" stroke="#fff" stroke-width="1" transform="translate(0,-465)"/>
   </g>
-  <text x="600" y="500" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Architecture</text>
-  <text x="600" y="538" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security Design Guide | Agent Framework</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#8b5cf6" text-anchor="middle">ARCHITECTURE</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Feb 28, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="600" cy="295" r="240" fill="#3b82f6" opacity="0.05" filter="url(#ambiGlow)"/>
+  <circle cx="300" cy="200" r="160" fill="#8b5cf6" opacity="0.05" filter="url(#ambiGlow)"/>
+  <circle cx="900" cy="390" r="160" fill="#3b82f6" opacity="0.05" filter="url(#ambiGlow)"/>
+
+  <!-- Helper: hexagon polygon macro (flat-top, size 80) centered at origin -->
+  <!-- Points for size 80 flat-top hex: approx (80,0),(40,69),(-40,69),(-80,0),(-40,-69),(40,-69) -->
+
+  <!-- ===== CENTRAL AGENT CORE HEXAGON ===== -->
+  <g transform="translate(600,295)" filter="url(#hexGlow)">
+    <polygon points="80,0 40,69 -40,69 -80,0 -40,-69 40,-69"
+             fill="url(#coreHex)" stroke="#3b82f6" stroke-width="2.5" opacity="0.95"/>
+    <text x="0" y="-10" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#93c5fd" text-anchor="middle">Agent</text>
+    <text x="0" y="12" font-family="Arial, sans-serif" font-size="16" font-weight="bold" fill="#93c5fd" text-anchor="middle">Core</text>
+    <text x="0" y="34" font-family="Arial, sans-serif" font-size="10" fill="#60a5fa" text-anchor="middle">Orchestrator</text>
+  </g>
+
+  <!-- ===== 6 SURROUNDING HEXAGONS (size 58) ===== -->
+  <!-- Points for size 58 flat-top hex: (58,0),(29,50),(-29,50),(-58,0),(-29,-50),(29,-50) -->
+  <!-- Hex radius for orbit: 190px from center -->
+
+  <!-- TOP (Auth) at 600,105 -->
+  <g transform="translate(600,105)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#authHex)" stroke="#3b82f6" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">Auth</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#bfdbfe" text-anchor="middle">Identity</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#bfdbfe" text-anchor="middle">OAuth / OIDC</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#93c5fd" text-anchor="middle">Zero-Trust</text>
+  </g>
+  <!-- Connector: 600,155 -> 600,226 -->
+  <line x1="600" y1="155" x2="600" y2="226" stroke="#3b82f6" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- TOP-RIGHT (Sandbox) at 765,200 -->
+  <g transform="translate(765,200)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#sandboxHex)" stroke="#22c55e" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#86efac" text-anchor="middle">Sandbox</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#bbf7d0" text-anchor="middle">Isolation</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#bbf7d0" text-anchor="middle">gVisor / OCI</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#86efac" text-anchor="middle">Containerd</text>
+  </g>
+  <!-- Connector: 707,200 -> 680,260 -->
+  <line x1="707" y1="215" x2="678" y2="252" stroke="#22c55e" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- BOTTOM-RIGHT (Monitor) at 765,390 -->
+  <g transform="translate(765,390)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#monitorHex)" stroke="#f59e0b" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fde68a" text-anchor="middle">Monitor</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#fef3c7" text-anchor="middle">Telemetry</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#fef3c7" text-anchor="middle">Prometheus</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#fde68a" text-anchor="middle">Alerting</text>
+  </g>
+  <!-- Connector: 707,375 -> 678,338 -->
+  <line x1="707" y1="375" x2="678" y2="338" stroke="#f59e0b" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- BOTTOM (Policy) at 600,485 -->
+  <g transform="translate(600,485)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#policyHex)" stroke="#ef4444" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">Policy</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#fecaca" text-anchor="middle">RBAC / OPA</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#fecaca" text-anchor="middle">Kyverno</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#fca5a5" text-anchor="middle">Admission</text>
+  </g>
+  <!-- Connector: 600,435 -> 600,364 -->
+  <line x1="600" y1="435" x2="600" y2="364" stroke="#ef4444" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- BOTTOM-LEFT (Encrypt) at 435,390 -->
+  <g transform="translate(435,390)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#encryptHex)" stroke="#8b5cf6" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">Encrypt</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#ddd6fe" text-anchor="middle">TLS 1.3</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#ddd6fe" text-anchor="middle">KMS / Vault</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#c4b5fd" text-anchor="middle">mTLS Mesh</text>
+  </g>
+  <!-- Connector: 493,375 -> 522,338 -->
+  <line x1="493" y1="375" x2="522" y2="338" stroke="#8b5cf6" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- TOP-LEFT (Audit) at 435,200 -->
+  <g transform="translate(435,200)">
+    <polygon points="58,0 29,50 -29,50 -58,0 -29,-50 29,-50"
+             fill="url(#auditHex)" stroke="#06b6d4" stroke-width="2" opacity="0.9"/>
+    <text x="0" y="-8" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#67e8f9" text-anchor="middle">Audit</text>
+    <text x="0" y="10" font-family="Arial, sans-serif" font-size="9" fill="#a5f3fc" text-anchor="middle">Immutable</text>
+    <text x="0" y="23" font-family="Arial, sans-serif" font-size="9" fill="#a5f3fc" text-anchor="middle">Logs / SIEM</text>
+    <text x="0" y="36" font-family="Arial, sans-serif" font-size="8" fill="#67e8f9" text-anchor="middle">Compliance</text>
+  </g>
+  <!-- Connector: 493,215 -> 522,252 -->
+  <line x1="493" y1="215" x2="522" y2="252" stroke="#06b6d4" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- Outer ring circles at connector midpoints (decorative nodes) -->
+  <circle cx="600" cy="190" r="5" fill="#3b82f6" opacity="0.7"/>
+  <circle cx="692" cy="233" r="5" fill="#22c55e" opacity="0.7"/>
+  <circle cx="692" cy="357" r="5" fill="#f59e0b" opacity="0.7"/>
+  <circle cx="600" cy="400" r="5" fill="#ef4444" opacity="0.7"/>
+  <circle cx="508" cy="357" r="5" fill="#8b5cf6" opacity="0.7"/>
+  <circle cx="508" cy="233" r="5" fill="#06b6d4" opacity="0.7"/>
+
+  <!-- Trust boundary ring -->
+  <circle cx="600" cy="295" r="175" fill="none" stroke="#1e293b" stroke-width="1" stroke-dasharray="8,6" opacity="0.5"/>
+
+  <!-- Trust Boundary label -->
+  <text x="790" y="148" font-family="Arial, sans-serif" font-size="11" fill="#334155" text-anchor="middle" transform="rotate(-30,790,148)">Trust Boundary</text>
+
+  <!-- Floating code fragments -->
+  <g font-family="Courier New, monospace" font-size="11" fill="#3b82f6">
+    <text x="52"  y="98"  opacity="0.14">agent.sandbox.isolate()</text>
+    <text x="35"  y="460" opacity="0.12">policy.enforce(rbac)</text>
+    <text x="880" y="88"  opacity="0.13">audit.log(action)</text>
+    <text x="910" y="488" opacity="0.11">encrypt.transit(data)</text>
+    <text x="68"  y="525" opacity="0.10">auth.verify(token)</text>
+    <text x="855" y="530" opacity="0.10">monitor.alert(anomaly)</text>
+  </g>
+
+  <!-- Top badges -->
+  <rect x="40" y="22" width="120" height="32" rx="16" fill="#3b82f6" opacity="0.15" stroke="#3b82f6" stroke-width="1"/>
+  <text x="100" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">GUIDE</text>
+
+  <rect x="988" y="22" width="172" height="32" rx="16" fill="#8b5cf6" opacity="0.15" stroke="#8b5cf6" stroke-width="1"/>
+  <text x="1074" y="44" font-family="Arial, sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">February 28, 2026</text>
+
+  <!-- Title -->
+  <text x="600" y="532" font-family="Arial, sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Architecture</text>
+  <text x="600" y="562" font-family="Arial, sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Security-First Design | Trust Boundaries | Agent Isolation</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- Footer labels -->
+  <text x="40"  y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Architecture</text>
+  <text x="155" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Security</text>
+  <text x="250" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Design Guide</text>
+  <text x="375" y="610" font-family="Arial, sans-serif" font-size="12" fill="#475569">Best Practices</text>
+  <text x="1160" y="610" font-family="Arial, sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
+++ b/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
@@ -1,45 +1,165 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#0a1a2a"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#0d0820"/>
+      <stop offset="100%" style="stop-color:#0a0a1a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <linearGradient id="vaultGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e1b4b"/>
+      <stop offset="100%" style="stop-color:#0f0a2e"/>
+    </linearGradient>
+    <filter id="glow25">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="glow10">
+      <feGaussianBlur stdDeviation="10" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="250" fill="#8b5cf6" opacity="0.04" filter="url(#sg)"/>
-  <!-- AI Agent Safehouse -->
-  <g transform="translate(600,250)">
-    <path d="M-120,-100 L0,-160 L120,-100 L120,60 L-120,60 Z" fill="#1e293b" stroke="#8b5cf6" stroke-width="2" opacity="0.6"/>
-    <path d="M-130,-100 L0,-170 L130,-100" fill="none" stroke="#8b5cf6" stroke-width="2.5"/>
-    <rect x="-25" y="0" width="50" height="60" rx="4" fill="#0f172a" stroke="#475569" stroke-width="1.5"/>
-    <circle cx="15" cy="30" r="5" fill="#22d3ee"/>
-    <rect x="-90" y="-60" width="40" height="35" rx="3" fill="#0f172a" stroke="#475569" stroke-width="1"/>
-    <rect x="50" y="-60" width="40" height="35" rx="3" fill="#0f172a" stroke="#475569" stroke-width="1"/>
-    <rect x="-88" y="-58" width="36" height="31" rx="2" fill="#8b5cf6" opacity="0.1"/>
-    <rect x="52" y="-58" width="36" height="31" rx="2" fill="#22d3ee" opacity="0.1"/>
-    <!-- AI eye -->
-    <circle cx="-70" cy="-42" r="8" fill="none" stroke="#8b5cf6" stroke-width="1.5"/>
-    <circle cx="-70" cy="-42" r="3" fill="#a78bfa"/>
-    <!-- Shield -->
-    <path d="M0,-200 L160,-155 L160,-40 C160,40 80,90 0,110 C-80,90 -160,40 -160,-40 L-160,-155 Z" fill="none" stroke="#22d3ee" stroke-width="1.5" opacity="0.25" stroke-dasharray="6,4"/>
-  </g>
-  <!-- Threat arrows -->
-  <g opacity="0.4">
-    <path d="M200,150 L420,200" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="4,4"/>
-    <circle cx="200" cy="150" r="4" fill="#ef4444"/>
-    <path d="M1000,160 L780,210" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="4,4"/>
-    <circle cx="1000" cy="160" r="4" fill="#ef4444"/>
-    <path d="M250,380 L430,330" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,4"/>
-    <circle cx="250" cy="380" r="3" fill="#ef4444"/>
-    <path d="M950,370 L770,320" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,4"/>
-    <circle cx="950" cy="370" r="3" fill="#ef4444"/>
-  </g>
-  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">AI Agent Safehouse</text>
-  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Agent Security | Bitcoin Accumulation | Go Security</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#8b5cf6" opacity="0.2" stroke="#8b5cf6" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#c4b5fd" text-anchor="middle">WEEKLY DIGEST</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">March 9, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="180" cy="200" r="220" fill="#8b5cf6" opacity="0.07" filter="url(#glow25)"/>
+  <circle cx="1020" cy="400" r="200" fill="#f59e0b" opacity="0.07" filter="url(#glow25)"/>
+  <circle cx="600" cy="300" r="300" fill="#8b5cf6" opacity="0.04" filter="url(#glow25)"/>
+  <circle cx="850" cy="100" r="150" fill="#f59e0b" opacity="0.05" filter="url(#glow25)"/>
+
+  <!-- Floating code fragments -->
+  <text x="50" y="180" font-family="monospace" font-size="13" fill="#8b5cf6" opacity="0.13">ai.safehouse.init()</text>
+  <text x="880" y="80" font-family="monospace" font-size="13" fill="#f59e0b" opacity="0.12">go.audit(deps)</text>
+  <text x="60" y="510" font-family="monospace" font-size="13" fill="#8b5cf6" opacity="0.11">btc.vault.verify()</text>
+  <text x="870" y="545" font-family="monospace" font-size="13" fill="#f59e0b" opacity="0.12">perimeter.scan()</text>
+  <text x="400" y="575" font-family="monospace" font-size="11" fill="#8b5cf6" opacity="0.10">security.layer.add()</text>
+
+  <!-- ===== CENTRAL ILLUSTRATION: FORTIFIED VAULT ===== -->
+
+  <!-- Outer perimeter dashed wall -->
+  <rect x="205" y="72" width="590" height="420" rx="20" fill="none" stroke="#8b5cf6" stroke-width="2" stroke-dasharray="14,7" opacity="0.45"/>
+
+  <!-- Security cameras -->
+  <rect x="214" y="80" width="24" height="13" rx="3" fill="#374151" stroke="#8b5cf6" stroke-width="1.2"/>
+  <circle cx="244" cy="86" r="5" fill="#8b5cf6" opacity="0.8"/>
+  <line x1="238" y1="82" x2="244" y2="86" stroke="#8b5cf6" stroke-width="1"/>
+
+  <rect x="762" y="80" width="24" height="13" rx="3" fill="#374151" stroke="#8b5cf6" stroke-width="1.2"/>
+  <circle cx="756" cy="86" r="5" fill="#8b5cf6" opacity="0.8"/>
+  <line x1="762" y1="82" x2="756" y2="86" stroke="#8b5cf6" stroke-width="1"/>
+
+  <!-- Sensor bottom-center -->
+  <circle cx="500" cy="494" r="7" fill="#f59e0b" opacity="0.7"/>
+  <circle cx="500" cy="494" r="14" fill="none" stroke="#f59e0b" stroke-width="1" opacity="0.35"/>
+
+  <!-- Outer building/fortress walls -->
+  <rect x="288" y="115" width="424" height="355" rx="16" fill="url(#vaultGrad)" stroke="#7c3aed" stroke-width="2.5"/>
+
+  <!-- Battlements top -->
+  <rect x="288" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="346" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="404" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="462" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="520" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="578" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="636" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+  <rect x="668" y="102" width="44" height="26" rx="5" fill="#4c1d95"/>
+
+  <!-- Inner defensive ring -->
+  <rect x="358" y="168" width="284" height="272" rx="12" fill="#0f172a" stroke="#6d28d9" stroke-width="2"/>
+
+  <!-- Vault door -->
+  <rect x="398" y="196" width="204" height="218" rx="10" fill="#1e1b4b" stroke="#8b5cf6" stroke-width="2.5"/>
+
+  <!-- Vault wheel/gear -->
+  <circle cx="500" cy="305" r="72" fill="none" stroke="#8b5cf6" stroke-width="3"/>
+  <circle cx="500" cy="305" r="54" fill="#0a0a1a" stroke="#7c3aed" stroke-width="2"/>
+
+  <!-- Gear spokes (8-point) -->
+  <line x1="500" y1="233" x2="500" y2="252" stroke="#8b5cf6" stroke-width="3.5"/>
+  <line x1="500" y1="358" x2="500" y2="377" stroke="#8b5cf6" stroke-width="3.5"/>
+  <line x1="428" y1="305" x2="447" y2="305" stroke="#8b5cf6" stroke-width="3.5"/>
+  <line x1="553" y1="305" x2="572" y2="305" stroke="#8b5cf6" stroke-width="3.5"/>
+  <line x1="449" y1="254" x2="462" y2="267" stroke="#8b5cf6" stroke-width="2.5"/>
+  <line x1="538" y1="343" x2="551" y2="356" stroke="#8b5cf6" stroke-width="2.5"/>
+  <line x1="551" y1="254" x2="538" y2="267" stroke="#8b5cf6" stroke-width="2.5"/>
+  <line x1="449" y1="343" x2="462" y2="356" stroke="#8b5cf6" stroke-width="2.5"/>
+
+  <!-- AI Brain inside vault -->
+  <circle cx="500" cy="305" r="32" fill="#1e1b4b" stroke="#a78bfa" stroke-width="1.8"/>
+  <!-- Neural nodes -->
+  <circle cx="490" cy="299" r="5" fill="#8b5cf6"/>
+  <circle cx="510" cy="299" r="5" fill="#8b5cf6"/>
+  <circle cx="500" cy="315" r="5" fill="#a78bfa"/>
+  <circle cx="484" cy="314" r="3.5" fill="#7c3aed"/>
+  <circle cx="516" cy="314" r="3.5" fill="#7c3aed"/>
+  <line x1="490" y1="299" x2="510" y2="299" stroke="#a78bfa" stroke-width="1.3"/>
+  <line x1="490" y1="299" x2="500" y2="315" stroke="#a78bfa" stroke-width="1.3"/>
+  <line x1="510" y1="299" x2="500" y2="315" stroke="#a78bfa" stroke-width="1.3"/>
+  <line x1="490" y1="299" x2="484" y2="314" stroke="#7c3aed" stroke-width="1"/>
+  <line x1="510" y1="299" x2="516" y2="314" stroke="#7c3aed" stroke-width="1"/>
+  <!-- AI glow -->
+  <circle cx="500" cy="305" r="32" fill="#8b5cf6" opacity="0.12" filter="url(#glow10)"/>
+
+  <!-- Go Gopher guard post LEFT -->
+  <rect x="218" y="268" width="64" height="90" rx="7" fill="#0f172a" stroke="#06b6d4" stroke-width="1.8"/>
+  <text x="250" y="256" font-family="Arial,sans-serif" font-size="10" fill="#06b6d4" text-anchor="middle">Go Guard</text>
+  <!-- Gopher head -->
+  <circle cx="250" cy="296" r="18" fill="#06b6d4" opacity="0.85"/>
+  <circle cx="244" cy="291" r="5" fill="white"/>
+  <circle cx="256" cy="291" r="5" fill="white"/>
+  <circle cx="244" cy="291" r="2.5" fill="#0f172a"/>
+  <circle cx="256" cy="291" r="2.5" fill="#0f172a"/>
+  <!-- Gopher ears -->
+  <ellipse cx="236" cy="283" rx="4" ry="7" fill="#0891b2"/>
+  <ellipse cx="264" cy="283" rx="4" ry="7" fill="#0891b2"/>
+  <!-- Gopher body -->
+  <rect x="234" y="312" width="32" height="22" rx="5" fill="#0891b2"/>
+  <text x="250" y="344" font-family="monospace" font-size="9" fill="#06b6d4" text-anchor="middle">Go 1.24</text>
+  <text x="250" y="356" font-family="monospace" font-size="8" fill="#64748b" text-anchor="middle">secure</text>
+
+  <!-- Bitcoin guard post RIGHT -->
+  <rect x="718" y="268" width="64" height="90" rx="7" fill="#0f172a" stroke="#f59e0b" stroke-width="1.8"/>
+  <text x="750" y="256" font-family="Arial,sans-serif" font-size="10" fill="#f59e0b" text-anchor="middle">BTC Guard</text>
+  <!-- Bitcoin coin -->
+  <circle cx="750" cy="300" r="22" fill="#f59e0b" opacity="0.18" stroke="#f59e0b" stroke-width="2"/>
+  <text x="750" y="308" font-family="Arial Black,sans-serif" font-size="26" font-weight="900" fill="#f59e0b" text-anchor="middle">&#8383;</text>
+  <text x="750" y="344" font-family="monospace" font-size="9" fill="#f59e0b" text-anchor="middle">Verified</text>
+  <text x="750" y="356" font-family="monospace" font-size="8" fill="#64748b" text-anchor="middle">infra</text>
+
+  <!-- Layer labels -->
+  <text x="500" y="474" font-family="monospace" font-size="10" fill="#8b5cf6" opacity="0.65" text-anchor="middle">[ Perimeter Shield Active ]</text>
+  <text x="500" y="458" font-family="monospace" font-size="10" fill="#6d28d9" opacity="0.55" text-anchor="middle">[ Outer Fortress Wall ]</text>
+
+  <!-- ===== END CENTRAL ILLUSTRATION ===== -->
+
+  <!-- Top badge pill -->
+  <rect x="40" y="34" width="272" height="34" rx="17" fill="#1e1e2e" stroke="#8b5cf6" stroke-width="1.5"/>
+  <rect x="40" y="34" width="128" height="34" rx="17" fill="#8b5cf6" opacity="0.92"/>
+  <text x="104" y="56" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="240" y="56" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">March 9, 2026</text>
+
+  <!-- Title -->
+  <text x="40" y="508" font-family="Arial Black,sans-serif" font-size="36" font-weight="900" fill="white" filter="url(#textGlow)">AI Agent Safehouse</text>
+
+  <!-- Subtitle -->
+  <text x="40" y="540" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8">Go Security Hardening  |  Bitcoin Infrastructure  |  AI Defense</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1.5"/>
+
+  <!-- Footer counts -->
+  <text x="40" y="610" font-family="monospace" font-size="12" fill="#64748b">20 News</text>
+  <text x="132" y="610" font-family="monospace" font-size="12" fill="#ef4444">5 Security</text>
+  <text x="244" y="610" font-family="monospace" font-size="12" fill="#8b5cf6">5 AI/ML</text>
+  <text x="336" y="610" font-family="monospace" font-size="12" fill="#06b6d4">2 Cloud</text>
+  <text x="418" y="610" font-family="monospace" font-size="12" fill="#22c55e">3 DevOps</text>
+
+  <!-- Site URL -->
+  <text x="1160" y="610" font-family="monospace" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
+++ b/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
@@ -1,43 +1,183 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0a20"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#0a1018"/>
+      <stop offset="100%" style="stop-color:#1a0a0a"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <linearGradient id="phoneGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    <linearGradient id="screenGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d1117"/>
+      <stop offset="100%" style="stop-color:#1a1a2e"/>
+    </linearGradient>
+    <filter id="glow25">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="250" fill="#ef4444" opacity="0.03" filter="url(#sg)"/>
-  <!-- Cracked phone with data leak -->
-  <g transform="translate(600,250)">
-    <rect x="-70" y="-140" width="140" height="240" rx="16" fill="#1e293b" stroke="#475569" stroke-width="2"/>
-    <rect x="-60" y="-120" width="120" height="200" rx="4" fill="#0f172a"/>
-    <path d="M-20,-140 L-5,-80 L15,-50 L-10,0 L20,50 L0,100" fill="none" stroke="#ef4444" stroke-width="2" opacity="0.7"/>
-    <rect x="-50" y="-110" width="100" height="12" rx="2" fill="#334155" opacity="0.5"/>
-    <rect x="-50" y="-90" width="70" height="8" rx="2" fill="#334155" opacity="0.3"/>
-    <rect x="-50" y="-70" width="85" height="8" rx="2" fill="#334155" opacity="0.3"/>
-    <circle cx="0" cy="0" r="25" fill="#ef4444" opacity="0.15"/>
-    <text x="0" y="6" font-family="Courier New" font-size="12" fill="#fca5a5" text-anchor="middle">0-DAY</text>
-    <circle cx="0" cy="85" r="8" fill="none" stroke="#475569" stroke-width="1"/>
-  </g>
-  <!-- Data leaking -->
-  <g opacity="0.5">
-    <path d="M530,200 C450,180 350,220 280,180" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="4,4"/>
-    <path d="M670,200 C750,180 850,220 920,180" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="4,4"/>
-    <path d="M530,300 C440,320 350,280 260,310" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,4"/>
-    <path d="M670,300 C760,320 850,280 940,310" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="3,4"/>
-    <circle cx="280" cy="180" r="3" fill="#ef4444"/><circle cx="920" cy="180" r="3" fill="#ef4444"/>
-    <circle cx="260" cy="310" r="2" fill="#ef4444"/><circle cx="940" cy="310" r="2" fill="#ef4444"/>
-  </g>
-  <g font-family="Courier New" font-size="10" opacity="0.2" fill="#ef4444">
-    <text x="200" y="160">crypto_wallet</text><text x="880" y="160">user_data[]</text>
-    <text x="160" y="340">credentials</text><text x="900" y="340">session_token</text>
-  </g>
-  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Mobile Zero-Day Breach</text>
-  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Crypto Theft | Mobile Exploit | AI Operational Risk</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#fca5a5" text-anchor="middle">WEEKLY DIGEST</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">March 10, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="180" cy="180" r="200" fill="#ef4444" opacity="0.07" filter="url(#glow25)"/>
+  <circle cx="1000" cy="420" r="220" fill="#06b6d4" opacity="0.06" filter="url(#glow25)"/>
+  <circle cx="540" cy="295" r="260" fill="#ef4444" opacity="0.04" filter="url(#glow25)"/>
+  <circle cx="900" cy="130" r="160" fill="#06b6d4" opacity="0.05" filter="url(#glow25)"/>
+
+  <!-- Floating code fragments -->
+  <text x="50" y="185" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">exploit.mobile(0day)</text>
+  <text x="875" y="85" font-family="monospace" font-size="13" fill="#06b6d4" opacity="0.12">crypto.wallet.drain()</text>
+  <text x="55" y="515" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.11">data.exfil(contacts)</text>
+  <text x="875" y="548" font-family="monospace" font-size="13" fill="#06b6d4" opacity="0.12">edr.detect(behavior)</text>
+  <text x="410" y="578" font-family="monospace" font-size="11" fill="#ef4444" opacity="0.10">shell.spawn(root)</text>
+
+  <!-- ===== CENTRAL ILLUSTRATION: CRACKED SMARTPHONE ===== -->
+
+  <!-- Impact ripple rings (behind phone) -->
+  <circle cx="540" cy="285" r="215" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,9" opacity="0.16"/>
+  <circle cx="540" cy="285" r="168" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,8" opacity="0.22"/>
+  <circle cx="540" cy="285" r="120" fill="none" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="3,6" opacity="0.30"/>
+
+  <!-- SMARTPHONE body (large) -->
+  <rect x="430" y="98" width="218" height="374" rx="26" fill="url(#phoneGrad)" stroke="#334155" stroke-width="3"/>
+  <!-- Top bezel -->
+  <rect x="430" y="98" width="218" height="30" rx="26" fill="#1e293b"/>
+  <!-- Camera notch -->
+  <circle cx="539" cy="113" r="6" fill="#0f172a" stroke="#374151" stroke-width="1"/>
+  <!-- Bottom bezel -->
+  <rect x="430" y="442" width="218" height="30" rx="26" fill="#1e293b"/>
+  <!-- Home bar -->
+  <rect x="492" y="455" width="94" height="6" rx="3" fill="#374151"/>
+
+  <!-- Screen -->
+  <rect x="442" y="130" width="194" height="310" rx="6" fill="url(#screenGrad)"/>
+
+  <!-- Screen app icons -->
+  <rect x="455" y="145" width="40" height="40" rx="9" fill="#1e3a5f" opacity="0.85"/>
+  <rect x="505" y="145" width="40" height="40" rx="9" fill="#1a1a3e" opacity="0.85"/>
+  <rect x="555" y="145" width="40" height="40" rx="9" fill="#1f2937" opacity="0.85"/>
+  <rect x="455" y="195" width="40" height="40" rx="9" fill="#1e293b" opacity="0.75"/>
+  <rect x="505" y="195" width="40" height="40" rx="9" fill="#1a1f2e" opacity="0.75"/>
+  <rect x="555" y="195" width="40" height="40" rx="9" fill="#1e2a1a" opacity="0.75"/>
+
+  <!-- Red warning tint on screen -->
+  <rect x="442" y="130" width="194" height="310" rx="6" fill="#ef4444" opacity="0.07"/>
+
+  <!-- 0-DAY label on screen center -->
+  <rect x="482" y="268" width="114" height="36" rx="6" fill="#ef4444" opacity="0.18" stroke="#ef4444" stroke-width="1.2"/>
+  <text x="539" y="292" font-family="monospace" font-size="14" font-weight="bold" fill="#fca5a5" text-anchor="middle">0-DAY</text>
+
+  <!-- CRACKED SCREEN - main diagonal crack -->
+  <polyline points="606,100 572,168 590,228 558,282 568,348 546,440 532,472"
+    stroke="#ef4444" stroke-width="3.5" fill="none" opacity="0.95" stroke-linecap="round"/>
+  <!-- Crack glow -->
+  <polyline points="606,100 572,168 590,228 558,282 568,348 546,440 532,472"
+    stroke="#ef4444" stroke-width="12" fill="none" opacity="0.10" stroke-linecap="round"/>
+  <!-- Branch cracks -->
+  <line x1="572" y1="168" x2="528" y2="152" stroke="#f59e0b" stroke-width="2" opacity="0.8"/>
+  <line x1="590" y1="228" x2="630" y2="248" stroke="#ef4444" stroke-width="1.8" opacity="0.75"/>
+  <line x1="558" y1="282" x2="518" y2="302" stroke="#f59e0b" stroke-width="1.5" opacity="0.7"/>
+  <line x1="568" y1="348" x2="612" y2="364" stroke="#ef4444" stroke-width="1.5" opacity="0.7"/>
+  <line x1="546" y1="440" x2="504" y2="458" stroke="#ef4444" stroke-width="1.5" opacity="0.65"/>
+
+  <!-- DATA LEAK stream to WALLET (upper-left) -->
+  <line x1="436" y1="178" x2="235" y2="142" stroke="#ef4444" stroke-width="2.2" stroke-dasharray="6,4" opacity="0.8"/>
+  <circle cx="355" cy="160" r="4" fill="#ef4444" opacity="0.85"/>
+  <!-- Wallet icon -->
+  <rect x="172" y="116" width="64" height="50" rx="9" fill="#1e293b" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="186" y="130" width="36" height="22" rx="5" fill="#374151"/>
+  <circle cx="216" cy="141" r="6" fill="#f59e0b"/>
+  <text x="204" y="180" font-family="monospace" font-size="10" fill="#f59e0b">Wallet</text>
+  <text x="196" y="192" font-family="monospace" font-size="9" fill="#94a3b8">drained</text>
+
+  <!-- DATA LEAK stream to KEY (mid-left) -->
+  <line x1="432" y1="270" x2="210" y2="285" stroke="#ef4444" stroke-width="2.2" stroke-dasharray="6,4" opacity="0.8"/>
+  <circle cx="326" cy="278" r="4" fill="#ef4444" opacity="0.85"/>
+  <!-- Key icon -->
+  <circle cx="182" cy="286" r="24" fill="#1e293b" stroke="#06b6d4" stroke-width="2"/>
+  <circle cx="182" cy="286" r="11" fill="none" stroke="#06b6d4" stroke-width="2"/>
+  <line x1="193" y1="286" x2="218" y2="286" stroke="#06b6d4" stroke-width="2.5"/>
+  <line x1="214" y1="286" x2="214" y2="297" stroke="#06b6d4" stroke-width="2"/>
+  <line x1="208" y1="286" x2="208" y2="294" stroke="#06b6d4" stroke-width="2"/>
+  <text x="158" y="326" font-family="monospace" font-size="10" fill="#06b6d4">Credentials</text>
+  <text x="170" y="338" font-family="monospace" font-size="9" fill="#94a3b8">stolen</text>
+
+  <!-- DATA LEAK stream to DOCUMENT (lower-left) -->
+  <line x1="438" y1="390" x2="225" y2="408" stroke="#ef4444" stroke-width="2.2" stroke-dasharray="6,4" opacity="0.8"/>
+  <circle cx="338" cy="399" r="4" fill="#ef4444" opacity="0.85"/>
+  <!-- Document icon -->
+  <rect x="174" y="382" width="52" height="64" rx="7" fill="#1e293b" stroke="#ef4444" stroke-width="2"/>
+  <line x1="185" y1="400" x2="215" y2="400" stroke="#374151" stroke-width="2"/>
+  <line x1="185" y1="410" x2="215" y2="410" stroke="#374151" stroke-width="2"/>
+  <line x1="185" y1="420" x2="208" y2="420" stroke="#374151" stroke-width="2"/>
+  <text x="168" y="460" font-family="monospace" font-size="10" fill="#ef4444">Contacts</text>
+  <text x="173" y="472" font-family="monospace" font-size="9" fill="#94a3b8">exfil'd</text>
+
+  <!-- Right panel: AI Operational Risk -->
+  <rect x="762" y="100" width="228" height="315" rx="10" fill="#0f172a" stroke="#06b6d4" stroke-width="1.5"/>
+  <rect x="762" y="100" width="228" height="36" rx="10" fill="#06b6d4" opacity="0.18"/>
+  <text x="780" y="124" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#06b6d4">AI Operational Risk</text>
+
+  <text x="780" y="154" font-family="monospace" font-size="10" fill="#94a3b8">Mobile Exploit</text>
+  <rect x="780" y="159" width="194" height="12" rx="4" fill="#1e293b"/>
+  <rect x="780" y="159" width="176" height="12" rx="4" fill="#ef4444" opacity="0.82"/>
+  <text x="958" y="170" font-family="monospace" font-size="9" fill="#ef4444">91%</text>
+
+  <text x="780" y="188" font-family="monospace" font-size="10" fill="#94a3b8">Crypto Drain</text>
+  <rect x="780" y="193" width="194" height="12" rx="4" fill="#1e293b"/>
+  <rect x="780" y="193" width="159" height="12" rx="4" fill="#f59e0b" opacity="0.82"/>
+  <text x="942" y="204" font-family="monospace" font-size="9" fill="#f59e0b">82%</text>
+
+  <text x="780" y="222" font-family="monospace" font-size="10" fill="#94a3b8">Data Exfil</text>
+  <rect x="780" y="227" width="194" height="12" rx="4" fill="#1e293b"/>
+  <rect x="780" y="227" width="144" height="12" rx="4" fill="#ef4444" opacity="0.72"/>
+  <text x="928" y="238" font-family="monospace" font-size="9" fill="#ef4444">74%</text>
+
+  <text x="780" y="256" font-family="monospace" font-size="10" fill="#94a3b8">EDR Coverage</text>
+  <rect x="780" y="261" width="194" height="12" rx="4" fill="#1e293b"/>
+  <rect x="780" y="261" width="103" height="12" rx="4" fill="#22c55e" opacity="0.72"/>
+  <text x="886" y="272" font-family="monospace" font-size="9" fill="#22c55e">53%</text>
+
+  <!-- CVE entry -->
+  <rect x="780" y="292" width="194" height="100" rx="7" fill="#1a0808" stroke="#ef4444" stroke-width="1.3"/>
+  <text x="792" y="312" font-family="monospace" font-size="11" fill="#ef4444" font-weight="bold">0-Day Chain</text>
+  <text x="792" y="330" font-family="monospace" font-size="9" fill="#94a3b8">Platform: Android/iOS</text>
+  <text x="792" y="347" font-family="monospace" font-size="9" fill="#94a3b8">Impact: CRITICAL</text>
+  <text x="792" y="364" font-family="monospace" font-size="9" fill="#f59e0b">Patch: NONE</text>
+  <text x="792" y="381" font-family="monospace" font-size="9" fill="#06b6d4">Active: YES</text>
+
+  <!-- ===== END CENTRAL ILLUSTRATION ===== -->
+
+  <!-- Top badge pill -->
+  <rect x="40" y="34" width="272" height="34" rx="17" fill="#1e1e2e" stroke="#ef4444" stroke-width="1.5"/>
+  <rect x="40" y="34" width="128" height="34" rx="17" fill="#ef4444" opacity="0.92"/>
+  <text x="104" y="56" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="240" y="56" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">March 10, 2026</text>
+
+  <!-- Title -->
+  <text x="40" y="508" font-family="Arial Black,sans-serif" font-size="36" font-weight="900" fill="white" filter="url(#textGlow)">Mobile Zero-Day Breach</text>
+
+  <!-- Subtitle -->
+  <text x="40" y="540" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8">Crypto Theft  |  Mobile Exploit  |  AI Operational Risk</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1.5"/>
+
+  <!-- Footer counts -->
+  <text x="40" y="610" font-family="monospace" font-size="12" fill="#64748b">21 News</text>
+  <text x="132" y="610" font-family="monospace" font-size="12" fill="#ef4444">5 Security</text>
+  <text x="244" y="610" font-family="monospace" font-size="12" fill="#8b5cf6">5 AI/ML</text>
+  <text x="336" y="610" font-family="monospace" font-size="12" fill="#06b6d4">2 Cloud</text>
+  <text x="418" y="610" font-family="monospace" font-size="12" fill="#22c55e">3 DevOps</text>
+
+  <!-- Site URL -->
+  <text x="1160" y="610" font-family="monospace" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>

--- a/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
+++ b/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
@@ -1,43 +1,200 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0a0a1a"/><stop offset="100%" style="stop-color:#1a0f2e"/>
+      <stop offset="0%" style="stop-color:#0a0a1a"/>
+      <stop offset="50%" style="stop-color:#001515"/>
+      <stop offset="100%" style="stop-color:#1a0808"/>
     </linearGradient>
-    <filter id="glow"><feGaussianBlur stdDeviation="4" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
-    <filter id="sg"><feGaussianBlur stdDeviation="25"/></filter>
+    <linearGradient id="sweepGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#06b6d4;stop-opacity:0.65"/>
+      <stop offset="100%" style="stop-color:#06b6d4;stop-opacity:0"/>
+    </linearGradient>
+    <radialGradient id="radarFace" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#001e1e"/>
+      <stop offset="100%" style="stop-color:#000d0d"/>
+    </radialGradient>
+    <filter id="glow25">
+      <feGaussianBlur stdDeviation="25" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="blipGlow">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <filter id="textGlow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+    <clipPath id="radarClip">
+      <circle cx="490" cy="278" r="210"/>
+    </clipPath>
   </defs>
+
+  <!-- Background -->
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <circle cx="600" cy="270" r="260" fill="#6366f1" opacity="0.04" filter="url(#sg)"/>
-  <!-- Radar / Attack Surface -->
-  <g transform="translate(600,260)">
-    <circle cx="0" cy="0" r="180" fill="none" stroke="#334155" stroke-width="1" opacity="0.4"/>
-    <circle cx="0" cy="0" r="130" fill="none" stroke="#334155" stroke-width="1" opacity="0.3"/>
-    <circle cx="0" cy="0" r="80" fill="none" stroke="#334155" stroke-width="1" opacity="0.3"/>
-    <circle cx="0" cy="0" r="30" fill="#6366f1" opacity="0.15"/>
-    <line x1="-180" y1="0" x2="180" y2="0" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
-    <line x1="0" y1="-180" x2="0" y2="180" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
-    <line x1="-127" y1="-127" x2="127" y2="127" stroke="#334155" stroke-width="0.5" opacity="0.2"/>
-    <line x1="127" y1="-127" x2="-127" y2="127" stroke="#334155" stroke-width="0.5" opacity="0.2"/>
-    <!-- Threat dots -->
-    <circle cx="60" cy="-100" r="6" fill="#ef4444" opacity="0.8"/><circle cx="60" cy="-100" r="12" fill="#ef4444" opacity="0.15"/>
-    <circle cx="-120" cy="40" r="5" fill="#ef4444" opacity="0.7"/><circle cx="-120" cy="40" r="10" fill="#ef4444" opacity="0.12"/>
-    <circle cx="100" cy="80" r="7" fill="#f59e0b" opacity="0.7"/><circle cx="100" cy="80" r="14" fill="#f59e0b" opacity="0.1"/>
-    <circle cx="-40" cy="-140" r="4" fill="#f59e0b" opacity="0.6"/>
-    <circle cx="150" cy="-30" r="5" fill="#ef4444" opacity="0.6"/>
-    <circle cx="-80" cy="120" r="4" fill="#f59e0b" opacity="0.5"/>
-    <circle cx="30" cy="150" r="6" fill="#ef4444" opacity="0.7"/>
-    <!-- Sweep line -->
-    <line x1="0" y1="0" x2="130" y2="-130" stroke="#6366f1" stroke-width="2" opacity="0.6"/>
-    <path d="M0,0 L100,-140 A180,180 0 0,1 130,-130 Z" fill="#6366f1" opacity="0.06"/>
-    <!-- Center -->
-    <circle cx="0" cy="0" r="20" fill="#1e293b" stroke="#6366f1" stroke-width="2"/>
-    <text x="0" y="6" font-family="Courier New" font-size="14" fill="#818cf8" text-anchor="middle">ASI</text>
-  </g>
-  <text x="600" y="510" font-family="Arial,sans-serif" font-size="36" font-weight="bold" fill="white" text-anchor="middle" filter="url(#glow)">Attack Surface Intelligence</text>
-  <text x="600" y="548" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8" text-anchor="middle">Threat Radar | Blockchain Market Risk | Tech Trends</text>
-  <rect x="40" y="25" width="160" height="32" rx="16" fill="#6366f1" opacity="0.2" stroke="#6366f1" stroke-width="1"/>
-  <text x="120" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#a5b4fc" text-anchor="middle">WEEKLY DIGEST</text>
-  <rect x="1000" y="25" width="160" height="32" rx="16" fill="#3b82f6" opacity="0.2" stroke="#3b82f6" stroke-width="1"/>
-  <text x="1080" y="47" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#93c5fd" text-anchor="middle">March 11, 2026</text>
-  <text x="1160" y="615" font-family="Arial,sans-serif" font-size="13" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+
+  <!-- Ambient glow circles -->
+  <circle cx="180" cy="160" r="210" fill="#06b6d4" opacity="0.06" filter="url(#glow25)"/>
+  <circle cx="980" cy="440" r="200" fill="#ef4444" opacity="0.07" filter="url(#glow25)"/>
+  <circle cx="490" cy="278" r="270" fill="#06b6d4" opacity="0.05" filter="url(#glow25)"/>
+  <circle cx="870" cy="110" r="150" fill="#ef4444" opacity="0.05" filter="url(#glow25)"/>
+
+  <!-- Floating code fragments -->
+  <text x="50" y="175" font-family="monospace" font-size="13" fill="#06b6d4" opacity="0.12">recon.scan(surface)</text>
+  <text x="860" y="78" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">ai.classify(threat)</text>
+  <text x="50" y="510" font-family="monospace" font-size="13" fill="#06b6d4" opacity="0.11">exfil.detect(pattern)</text>
+  <text x="860" y="548" font-family="monospace" font-size="13" fill="#ef4444" opacity="0.12">malware.evolve(gen)</text>
+  <text x="395" y="575" font-family="monospace" font-size="11" fill="#06b6d4" opacity="0.10">apt.track(campaign)</text>
+
+  <!-- ===== CENTRAL ILLUSTRATION: RADAR DISPLAY ===== -->
+
+  <!-- Radar outer housing ring -->
+  <circle cx="490" cy="278" r="226" fill="#081414" stroke="#06b6d4" stroke-width="3" opacity="0.95"/>
+  <!-- Radar face -->
+  <circle cx="490" cy="278" r="212" fill="url(#radarFace)"/>
+
+  <!-- Grid: crosshair lines -->
+  <line x1="278" y1="278" x2="702" y2="278" stroke="#06b6d4" stroke-width="0.8" opacity="0.28"/>
+  <line x1="490" y1="66" x2="490" y2="490" stroke="#06b6d4" stroke-width="0.8" opacity="0.28"/>
+  <!-- Diagonal grid -->
+  <line x1="340" y1="128" x2="640" y2="428" stroke="#06b6d4" stroke-width="0.6" opacity="0.18"/>
+  <line x1="640" y1="128" x2="340" y2="428" stroke="#06b6d4" stroke-width="0.6" opacity="0.18"/>
+
+  <!-- Concentric range rings -->
+  <circle cx="490" cy="278" r="52" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.32"/>
+  <circle cx="490" cy="278" r="104" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.28"/>
+  <circle cx="490" cy="278" r="156" fill="none" stroke="#06b6d4" stroke-width="1" opacity="0.24"/>
+  <circle cx="490" cy="278" r="208" fill="none" stroke="#06b6d4" stroke-width="1.2" opacity="0.32"/>
+
+  <!-- Range labels -->
+  <text x="494" y="232" font-family="monospace" font-size="9" fill="#06b6d4" opacity="0.42">50</text>
+  <text x="494" y="180" font-family="monospace" font-size="9" fill="#06b6d4" opacity="0.36">100</text>
+  <text x="494" y="128" font-family="monospace" font-size="9" fill="#06b6d4" opacity="0.30">150</text>
+  <text x="494" y="76" font-family="monospace" font-size="9" fill="#06b6d4" opacity="0.24">200</text>
+
+  <!-- SWEEP BEAM: gradient wedge -->
+  <path d="M 490 278 L 626 128 A 210 210 0 0 1 690 278 Z"
+    fill="url(#sweepGrad)" clip-path="url(#radarClip)" opacity="0.60"/>
+  <!-- Sweep trail -->
+  <path d="M 490 278 L 660 168 A 210 210 0 0 1 700 278 Z"
+    fill="#06b6d4" opacity="0.07" clip-path="url(#radarClip)"/>
+  <!-- Sweep leading edge -->
+  <line x1="490" y1="278" x2="626" y2="128" stroke="#06b6d4" stroke-width="2.5" opacity="0.95"/>
+
+  <!-- Center dot -->
+  <circle cx="490" cy="278" r="6" fill="#06b6d4"/>
+  <circle cx="490" cy="278" r="12" fill="none" stroke="#06b6d4" stroke-width="1.8" opacity="0.5"/>
+
+  <!-- THREAT BLIPS -->
+
+  <!-- LARGE blip - primary APT (with crosshair + targeting ring) -->
+  <circle cx="594" cy="192" r="16" fill="#ef4444" opacity="0.92" filter="url(#blipGlow)"/>
+  <circle cx="594" cy="192" r="9" fill="#ef4444"/>
+  <!-- Crosshair -->
+  <line x1="570" y1="192" x2="582" y2="192" stroke="#ef4444" stroke-width="2" opacity="0.95"/>
+  <line x1="606" y1="192" x2="620" y2="192" stroke="#ef4444" stroke-width="2" opacity="0.95"/>
+  <line x1="594" y1="168" x2="594" y2="180" stroke="#ef4444" stroke-width="2" opacity="0.95"/>
+  <line x1="594" y1="204" x2="594" y2="218" stroke="#ef4444" stroke-width="2" opacity="0.95"/>
+  <!-- Targeting ring -->
+  <circle cx="594" cy="192" r="26" fill="none" stroke="#ef4444" stroke-width="1.3" stroke-dasharray="5,4" opacity="0.65"/>
+  <!-- Label -->
+  <text x="614" y="188" font-family="monospace" font-size="9" fill="#ef4444">APT-01</text>
+  <text x="614" y="200" font-family="monospace" font-size="9" fill="#f59e0b">CRITICAL</text>
+
+  <!-- MEDIUM blip upper-left -->
+  <circle cx="384" cy="166" r="10" fill="#ef4444" opacity="0.88" filter="url(#blipGlow)"/>
+  <circle cx="384" cy="166" r="5.5" fill="#ef4444"/>
+  <text x="396" y="163" font-family="monospace" font-size="8" fill="#ef4444">ThreatB</text>
+
+  <!-- MEDIUM blip lower-right -->
+  <circle cx="620" cy="374" r="11" fill="#f59e0b" opacity="0.88" filter="url(#blipGlow)"/>
+  <circle cx="620" cy="374" r="6" fill="#f59e0b"/>
+  <text x="634" y="371" font-family="monospace" font-size="8" fill="#f59e0b">Exfil-C</text>
+
+  <!-- SMALL blip right -->
+  <circle cx="660" cy="262" r="7" fill="#ef4444" opacity="0.75"/>
+  <text x="670" y="259" font-family="monospace" font-size="8" fill="#94a3b8">Probe</text>
+
+  <!-- SMALL blip lower-left -->
+  <circle cx="378" cy="368" r="8" fill="#f59e0b" opacity="0.78"/>
+  <text x="388" y="365" font-family="monospace" font-size="8" fill="#94a3b8">Recon</text>
+
+  <!-- SMALL blip upper-center -->
+  <circle cx="466" cy="148" r="6" fill="#ef4444" opacity="0.68"/>
+
+  <!-- Ghost trails -->
+  <circle cx="594" cy="192" r="30" fill="none" stroke="#ef4444" stroke-width="0.8" opacity="0.22"/>
+  <circle cx="384" cy="166" r="18" fill="none" stroke="#ef4444" stroke-width="0.8" opacity="0.18"/>
+
+  <!-- Radar status label -->
+  <text x="490" y="508" font-family="monospace" font-size="10" fill="#06b6d4" opacity="0.50" text-anchor="middle">TACTICAL THREAT RADAR v2.4</text>
+
+  <!-- RIGHT PANEL: Threat Classification -->
+  <rect x="760" y="96" width="218" height="370" rx="10" fill="#0f172a" stroke="#06b6d4" stroke-width="1.5"/>
+  <rect x="760" y="96" width="218" height="36" rx="10" fill="#06b6d4" opacity="0.18"/>
+  <text x="778" y="119" font-family="Arial,sans-serif" font-size="13" font-weight="bold" fill="#06b6d4">Threat Classification</text>
+
+  <text x="778" y="150" font-family="monospace" font-size="10" fill="#94a3b8">AI-Driven Recon</text>
+  <rect x="778" y="155" width="184" height="11" rx="3" fill="#1e293b"/>
+  <rect x="778" y="155" width="165" height="11" rx="3" fill="#ef4444" opacity="0.82"/>
+
+  <text x="778" y="183" font-family="monospace" font-size="10" fill="#94a3b8">Data Exfiltration</text>
+  <rect x="778" y="188" width="184" height="11" rx="3" fill="#1e293b"/>
+  <rect x="778" y="188" width="149" height="11" rx="3" fill="#f59e0b" opacity="0.82"/>
+
+  <text x="778" y="216" font-family="monospace" font-size="10" fill="#94a3b8">Malware Gen-X</text>
+  <rect x="778" y="221" width="184" height="11" rx="3" fill="#1e293b"/>
+  <rect x="778" y="221" width="134" height="11" rx="3" fill="#ef4444" opacity="0.72"/>
+
+  <text x="778" y="249" font-family="monospace" font-size="10" fill="#94a3b8">APT Campaign</text>
+  <rect x="778" y="254" width="184" height="11" rx="3" fill="#1e293b"/>
+  <rect x="778" y="254" width="175" height="11" rx="3" fill="#ef4444" opacity="0.92"/>
+
+  <text x="778" y="282" font-family="monospace" font-size="10" fill="#94a3b8">Lateral Movement</text>
+  <rect x="778" y="287" width="184" height="11" rx="3" fill="#1e293b"/>
+  <rect x="778" y="287" width="113" height="11" rx="3" fill="#f59e0b" opacity="0.72"/>
+
+  <!-- Divider -->
+  <line x1="778" y1="313" x2="962" y2="313" stroke="#1e293b" stroke-width="1"/>
+
+  <!-- Alert level badges -->
+  <text x="778" y="332" font-family="monospace" font-size="10" fill="#94a3b8">Alert Level</text>
+  <rect x="778" y="338" width="86" height="22" rx="5" fill="#ef4444" opacity="0.18" stroke="#ef4444" stroke-width="1"/>
+  <text x="821" y="353" font-family="monospace" font-size="10" fill="#ef4444" text-anchor="middle">CRITICAL</text>
+  <rect x="874" y="338" width="68" height="22" rx="5" fill="#f59e0b" opacity="0.18" stroke="#f59e0b" stroke-width="1"/>
+  <text x="908" y="353" font-family="monospace" font-size="10" fill="#f59e0b" text-anchor="middle">HIGH</text>
+
+  <!-- Active threats counter -->
+  <rect x="778" y="374" width="184" height="76" rx="7" fill="#001515" stroke="#06b6d4" stroke-width="1.3"/>
+  <text x="790" y="394" font-family="monospace" font-size="10" fill="#06b6d4">Active Threats</text>
+  <text x="790" y="420" font-family="monospace" font-size="26" font-weight="bold" fill="#ef4444">6</text>
+  <text x="826" y="420" font-family="monospace" font-size="10" fill="#94a3b8">/ 12 detected</text>
+  <text x="790" y="440" font-family="monospace" font-size="9" fill="#22c55e">EDR: Active</text>
+
+  <!-- ===== END CENTRAL ILLUSTRATION ===== -->
+
+  <!-- Top badge pill -->
+  <rect x="40" y="34" width="272" height="34" rx="17" fill="#1e1e2e" stroke="#06b6d4" stroke-width="1.5"/>
+  <rect x="40" y="34" width="128" height="34" rx="17" fill="#06b6d4" opacity="0.92"/>
+  <text x="104" y="56" font-family="Arial,sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">WEEKLY DIGEST</text>
+  <text x="240" y="56" font-family="Arial,sans-serif" font-size="12" fill="#94a3b8" text-anchor="middle">March 11, 2026</text>
+
+  <!-- Title -->
+  <text x="40" y="508" font-family="Arial Black,sans-serif" font-size="36" font-weight="900" fill="white" filter="url(#textGlow)">Attack Surface Intelligence</text>
+
+  <!-- Subtitle -->
+  <text x="40" y="540" font-family="Arial,sans-serif" font-size="16" fill="#94a3b8">AI-Driven Recon  |  Data Exfiltration  |  Malware Evolution</text>
+
+  <!-- Footer separator -->
+  <line x1="40" y1="585" x2="1160" y2="585" stroke="#1e293b" stroke-width="1.5"/>
+
+  <!-- Footer counts -->
+  <text x="40" y="610" font-family="monospace" font-size="12" fill="#64748b">22 News</text>
+  <text x="132" y="610" font-family="monospace" font-size="12" fill="#ef4444">6 Security</text>
+  <text x="244" y="610" font-family="monospace" font-size="12" fill="#8b5cf6">5 AI/ML</text>
+  <text x="336" y="610" font-family="monospace" font-size="12" fill="#06b6d4">2 Cloud</text>
+  <text x="418" y="610" font-family="monospace" font-size="12" fill="#22c55e">3 DevOps</text>
+
+  <!-- Site URL -->
+  <text x="1160" y="610" font-family="monospace" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
 </svg>


### PR DESCRIPTION
## Summary
- 3KB 수준 중간 품질 SVG 16개를 100-255줄/6-16KB로 전면 개선
- 중앙 일러스트레이션을 캔버스 60% 이상으로 대폭 확대
- 포스트별 고유 비주얼: Kimwolf APT 늑대, BitLocker 크랙, 봇넷 토폴로지, 헥사곤 아키텍처, 레이더 스캔, 대시보드 등

## Changed Files (16 SVGs)
1/22 Cloud Trends Dashboard, 1/24 BitLocker Bypass, 1/27 Office+Kimwolf+AWS,
1/28 MS Office Zero-Day Chain, 1/28 CLAUDE.md Security, 1/30 Ollama Exposure,
2/01 Agentic AI Defense Layers, 2/05 AI Content Pipeline, 2/06 Cloud Botnet,
2/17 AI Agent Cloud Shield, 2/18 Krebs+Patch Tuesday, 2/27 AI Botnet Topology,
2/28 Agent Hex Architecture, 3/09 AI Safehouse, 3/10 Mobile Zero-Day, 3/11 Radar

## Test plan
- [x] XML 유효성 검사 통과 (16개 전체)
- [ ] Jekyll 빌드 및 이미지 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)