### PR TITLE
feat: dynamic tech-blog briefing and executive section unit tests

### DIFF
--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -1351,19 +1351,84 @@ def _generate_executive_and_risk_sections(
     ).lower()
 
     if mode == "tech-blog":
-        briefing = (
-            "- 이번 주기는 기술 도입 속도와 운영 안정성 간 균형이 핵심이며, "
-            "AI/클라우드/개발도구 변화에 대한 표준화된 검증 절차가 필요합니다.\n"
-            "- 단기적으로는 배포 전 검증 기준, 권한/비용 통제, 장애 대응 리허설을 "
-            "동일 주기로 관리하는 것이 효과적입니다."
-        )
+        # Build dynamic briefing from actual tech news
+        briefing_parts = []
+        # Identify dominant topics
+        topic_counts = {}
+        for item in news_items:
+            cat = item.get("category", "tech")
+            topic_counts[cat] = topic_counts.get(cat, 0) + 1
+        top_cats = sorted(topic_counts.items(), key=lambda x: -x[1])[:3]
+        top_cat_names = {
+            "ai": "AI/ML", "cloud": "클라우드", "devops": "DevOps",
+            "security": "보안", "blockchain": "블록체인", "kubernetes": "Kubernetes",
+        }
+        top_labels = [top_cat_names.get(c, c) for c, _ in top_cats]
+
+        if high_titles:
+            briefing_parts.append(
+                f"- **주요 기술 동향**: {', '.join(high_titles[:2])} 등 "
+                f"주목할 업데이트 {high_count}건이 발표되었습니다."
+            )
+        if top_labels:
+            briefing_parts.append(
+                f"- 이번 주기 핵심 분야는 **{', '.join(top_labels)}**이며, "
+                "관련 도구 및 서비스 변경사항에 대한 검증 절차가 필요합니다."
+            )
+        if not briefing_parts:
+            briefing_parts.append(
+                "- 이번 주기는 기술 도입 속도와 운영 안정성 간 균형이 핵심이며, "
+                "표준화된 검증 절차가 필요합니다."
+            )
+        # Add context-specific guidance
+        if any(kw in text_blob for kw in ["kubernetes", "k8s", "docker", "container"]):
+            briefing_parts.append(
+                "- 컨테이너/K8s 관련 변경이 확인되었으며, 클러스터 호환성 검증과 보안 설정 점검을 권고합니다."
+            )
+        elif any(kw in text_blob for kw in ["ai", "llm", "agent", "model"]):
+            briefing_parts.append(
+                "- AI/ML 도구 업데이트가 확인되었으며, 도입 전 보안 경계 설계와 비용 영향 평가를 권고합니다."
+            )
+        else:
+            briefing_parts.append(
+                "- 단기적으로는 배포 전 검증 기준, 권한/비용 통제, 장애 대응 리허설을 "
+                "동일 주기로 관리하는 것이 효과적입니다."
+            )
+        briefing = "\n".join(briefing_parts)
+
+        # Build dynamic scorecard for tech-blog mode
+        tech_areas = []
+        if any(kw in text_blob for kw in ["deploy", "release", "ci", "cd", "pipeline"]):
+            tech_areas.append(
+                "| 배포 안정성 | Medium | 릴리즈 체크리스트와 롤백 절차 점검 |"
+            )
+        if any(kw in text_blob for kw in ["ai", "llm", "agent", "model", "ml"]):
+            tech_areas.append(
+                "| AI 도입 관리 | Medium | AI 도구 표준화 및 접근 권한 검토 |"
+            )
+        if any(kw in text_blob for kw in ["kubernetes", "k8s", "docker", "container", "helm"]):
+            tech_areas.append(
+                "| 컨테이너 운영 | Medium | 클러스터 업그레이드 호환성 및 보안 점검 |"
+            )
+        if any(kw in text_blob for kw in ["cloud", "aws", "gcp", "azure"]):
+            tech_areas.append(
+                "| 클라우드 비용 | Low | 사용량 모니터링과 예산 임계치 알림 설정 |"
+            )
+        if any(kw in text_blob for kw in ["go", "rust", "python", "java", "typescript"]):
+            tech_areas.append(
+                "| 개발 생산성 | Medium | 핵심 도구 표준화 및 팀 가이드 업데이트 |"
+            )
+        if not tech_areas:
+            tech_areas = [
+                "| 배포 안정성 | Medium | 릴리즈 체크리스트와 롤백 절차 점검 |",
+                "| 개발 생산성 | Medium | 핵심 도구 표준화 및 팀 가이드 업데이트 |",
+                "| 비용/운영 | Low | 사용량 모니터링과 예산 임계치 알림 설정 |",
+            ]
+        tech_areas = tech_areas[:4]
         rows = [
             "| 영역 | 현재 위험도 | 즉시 조치 |",
             "|------|-------------|-----------|",
-            "| 배포 안정성 | Medium | 릴리즈 체크리스트와 롤백 절차 점검 |",
-            "| 개발 생산성 | Medium | 핵심 도구 표준화 및 팀 가이드 업데이트 |",
-            "| 비용/운영 | Low | 사용량 모니터링과 예산 임계치 알림 설정 |",
-        ]
+        ] + tech_areas
     else:
         # Build dynamic briefing from actual top news
         briefing_parts = []

--- a/scripts/tests/test_news_templates.py
+++ b/scripts/tests/test_news_templates.py
@@ -2045,3 +2045,172 @@ class TestDevopsTemplatePriorityDatabase:
         item = {"title": title, "summary": ""}
         result = _generate_devops_template(item)
         assert expected in result, f"Expected '{expected}' for '{title}', got: {result[:80]}"
+
+
+# ===========================================================================
+# TestExecutiveBriefingSections
+# ===========================================================================
+
+
+class TestExecutiveBriefingSections:
+    """Tests for _generate_executive_and_risk_sections dynamic content."""
+
+    def _item(self, title="", summary="", category="security"):
+        return {"title": title, "summary": summary, "content": "", "category": category}
+
+    def _critical_item(self, title):
+        """Item that _determine_severity classifies as Critical."""
+        return self._item(
+            title=title,
+            summary=f"{title} zero-day exploit actively exploited critical",
+        )
+
+    def _high_item(self, title):
+        """Item that _determine_severity classifies as High."""
+        return self._item(
+            title=title,
+            summary=f"{title} high severity security vulnerability",
+        )
+
+    # ------------------------------------------------------------------
+    # 1. Critical titles appear in briefing
+    # ------------------------------------------------------------------
+    def test_critical_titles_in_briefing(self):
+        # The title is transformed by _korean_display_title; assert on the
+        # structural label that proves critical items were found and surfaced.
+        items = [self._critical_item("Apache RCE CVE-2026-9999")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "긴급 대응 필요" in result
+        assert "Critical 등급" in result
+
+    def test_critical_count_in_briefing(self):
+        items = [self._critical_item("OpenSSL zero-day exploit")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        # The count "1건" must appear next to the critical label
+        assert "1건" in result
+
+    # ------------------------------------------------------------------
+    # 2. High titles appear in briefing
+    # ------------------------------------------------------------------
+    def test_high_titles_in_briefing(self):
+        # High items surface under 주요 모니터링 대상 with a count
+        items = [self._high_item("Windows privilege escalation")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "주요 모니터링 대상" in result
+        assert "High 등급" in result
+
+    def test_high_titles_triggers_monitoring_label(self):
+        items = [self._high_item("Linux kernel vulnerability")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "주요 모니터링 대상" in result
+
+    # ------------------------------------------------------------------
+    # 3. Ransomware keyword triggers ransomware guidance
+    # ------------------------------------------------------------------
+    def test_ransomware_title_triggers_guidance(self):
+        items = [self._item(title="Ransomware campaign targeting hospitals", summary="ransomware attack")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "랜섬웨어" in result
+        assert "백업" in result
+
+    def test_ransomware_summary_triggers_guidance(self):
+        items = [self._item(title="New malware wave", summary="ransomware encryption spreading")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "랜섬웨어" in result
+
+    # ------------------------------------------------------------------
+    # 4. Zero-day keyword triggers zero-day guidance
+    # ------------------------------------------------------------------
+    def test_zero_day_title_triggers_guidance(self):
+        items = [self._item(title="zero-day in Chrome exploited in wild")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "제로데이" in result
+        assert "임시 완화" in result or "패치" in result
+
+    def test_zero_day_summary_triggers_guidance(self):
+        items = [self._item(title="Browser vuln", summary="0-day actively used by threat actor")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "제로데이" in result
+
+    # ------------------------------------------------------------------
+    # 5. Dynamic risk scorecard - CVE detection
+    # ------------------------------------------------------------------
+    def test_cve_in_title_adds_vuln_row(self):
+        items = [self._item(title="CVE-2026-1234 critical patch released")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "취약점 관리" in result
+
+    def test_vulnerability_keyword_adds_vuln_row(self):
+        items = [self._item(title="Critical vulnerability in OpenSSL", summary="patch available")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "취약점 관리" in result
+
+    # ------------------------------------------------------------------
+    # 6. Dynamic risk scorecard - cloud detection
+    # ------------------------------------------------------------------
+    def test_aws_keyword_adds_cloud_row(self):
+        items = [self._item(title="AWS IAM misconfiguration exposes S3 buckets")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "클라우드 보안" in result
+
+    def test_kubernetes_keyword_adds_cloud_row(self):
+        items = [self._item(title="Kubernetes RBAC bypass vulnerability found")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "클라우드 보안" in result
+
+    # ------------------------------------------------------------------
+    # 7. Dynamic risk scorecard - AI detection
+    # ------------------------------------------------------------------
+    def test_ai_keyword_adds_ai_row(self):
+        items = [self._item(title="AI model poisoning attack discovered")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "AI/ML 보안" in result
+
+    def test_llm_keyword_adds_ai_row(self):
+        items = [self._item(title="LLM prompt injection in enterprise chatbot", summary="LLM security issue")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        assert "AI/ML 보안" in result
+
+    # ------------------------------------------------------------------
+    # 8. Fallback when no keywords match
+    # ------------------------------------------------------------------
+    def test_no_keywords_fallback_rows(self):
+        items = [self._item(title="Quarterly board meeting notes", summary="financials discussed")]
+        result = _generate_executive_and_risk_sections(items, mode="security")
+        # Fallback rows should contain these labels
+        assert "위협 대응" in result
+        assert "탐지/모니터링" in result
+
+    def test_empty_items_fallback_rows(self):
+        result = _generate_executive_and_risk_sections([], mode="security")
+        assert "위협 대응" in result or "경영진 브리핑" in result
+
+    # ------------------------------------------------------------------
+    # 9. tech-blog mode returns expected structure
+    # ------------------------------------------------------------------
+    def test_tech_blog_mode_has_briefing_header(self):
+        items = [self._item(title="AI coding tool update")]
+        result = _generate_executive_and_risk_sections(items, mode="tech-blog")
+        assert "경영진 브리핑" in result
+
+    def test_tech_blog_mode_has_scorecard_header(self):
+        items = [self._item(title="Cloud infrastructure news")]
+        result = _generate_executive_and_risk_sections(items, mode="tech-blog")
+        assert "위험 스코어카드" in result
+
+    # ------------------------------------------------------------------
+    # 10. Max 4 rows in scorecard
+    # ------------------------------------------------------------------
+    def test_max_four_rows_in_scorecard(self):
+        # Item with many keyword matches: CVE, ransomware, cloud, AI, malware, supply chain
+        item = self._item(
+            title="CVE-2026-1234 ransomware AWS AI malware supply chain attack",
+            summary="cve vulnerability ransomware aws kubernetes ai llm malware dependency sbom",
+        )
+        result = _generate_executive_and_risk_sections([item], mode="security")
+        # Count table data rows (lines starting with "| " that are not header or separator)
+        table_rows = [
+            line for line in result.split("\n")
+            if line.startswith("| ") and "---" not in line and "영역" not in line
+        ]
+        assert len(table_rows) <= 4


### PR DESCRIPTION
## Summary
- **tech-blog mode dynamic briefing**: Now generates context-aware content from actual news topics (AI, K8s, cloud, etc.) instead of static text
- **tech-blog scorecard**: Risk rows derived from detected content themes (AI, container, cloud, deploy)
- **19 unit tests**: Coverage for `_generate_executive_and_risk_sections` covering both security and tech-blog modes

## Changes
- `scripts/auto_publish_news.py`: Dynamic tech-blog briefing/scorecard (+75/-10 lines)
- `scripts/tests/test_news_templates.py`: 19 new test cases (+169 lines)

## Verification
- 321 tests pass (302 existing + 19 new, 0.23s)
- Python syntax validation OK

## Test plan
- [x] `pytest scripts/tests/test_news_templates.py` - 321 passed
- [x] Syntax validation - OK
- [x] No regression on existing 302 tests