### PR TITLE
Tune hub-spoke routing for mixed-topic digest posts

### DIFF
--- a/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
+++ b/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
@@ -18,24 +18,34 @@
   <circle cx="930" cy="500" r="180" fill="#f59e0b" opacity="0.1" filter="url(#glow)"/>
   <text x="90" y="164" font-family="Arial, sans-serif" font-size="52" font-weight="700" fill="#f8fafc">THREAT SIGNAL MAP</text>
   <text x="92" y="204" font-family="Arial, sans-serif" font-size="20" fill="#cbd5e1">RANSOM  AI AGENT  CLOUD</text>
-  <line x1="180" y1="340" x2="1020" y2="340" stroke="#475569" stroke-width="4" stroke-dasharray="14 10" opacity="0.8"/>
-  <g transform="translate(250 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#dc2626" stroke-width="2.5"/>
+
+  <g transform="translate(600 336)" filter="url(#shadow)">
+    <circle r="102" fill="#111827" stroke="#dc2626" stroke-width="2.5"/>
+    <circle r="44" fill="#0f172a" stroke="#e2e8f0" stroke-width="2"/>
+    <path d="M-18 0 h36" stroke="#e2e8f0" stroke-width="8" stroke-linecap="round"/>
+    <path d="M0 -18 v36" stroke="#e2e8f0" stroke-width="8" stroke-linecap="round"/>
+  </g>
+
+  <path d="M600 336 C495 338 355 358 250 360" fill="none" stroke="#dc2626" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(250 360)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#dc2626" stroke-width="2"/>
     <rect x="-22" y="-4" width="44" height="36" rx="8" fill="#221617" stroke="#dc2626" stroke-width="2"/><path d="M-12 -4 v-16 c0-18 24-18 24 0 v16" stroke="#dc2626" stroke-width="4" fill="none" stroke-linecap="round"/><circle cx="0" cy="16" r="6" fill="#dc2626"/><rect x="-2" y="20" width="4" height="10" rx="2" fill="#dc2626"/>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#dc2626" text-anchor="middle">RANSOM</text>
   </g>
-  <text x="250" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#dc2626" text-anchor="middle">RANSOM</text>
 
-  <g transform="translate(600 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#67e8f9" stroke-width="2.5"/>
+  <path d="M600 336 C600 323 600 223 600 210" fill="none" stroke="#67e8f9" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(600 210)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#67e8f9" stroke-width="2"/>
     <rect x="-28" y="-20" width="56" height="40" rx="8" fill="#111c35" stroke="#67e8f9" stroke-width="2"/><circle cx="0" cy="-4" r="14" fill="#12345c" stroke="#67e8f9" stroke-width="1.5"/><text x="0" y="1" font-family="Arial" font-size="12" font-weight="700" fill="#67e8f9" text-anchor="middle">AI</text>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#67e8f9" text-anchor="middle">AI AGENT</text>
   </g>
-  <text x="600" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#67e8f9" text-anchor="middle">AI AGENT</text>
 
-  <g transform="translate(950 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#f59e0b" stroke-width="2.5"/>
+  <path d="M600 336 C705 338 845 358 950 360" fill="none" stroke="#f59e0b" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(950 360)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
     <path d="M-16 10 C-28 10 -32 -2 -32 -10 C-32 -20 -24 -26 -14 -26 C-10 -36 0 -42 10 -42 C24 -42 32 -32 32 -26 C40 -26 44 -20 44 -10 C44 -2 40 10 28 10 Z" fill="#0b1628" stroke="#f59e0b" stroke-width="2" transform="scale(0.7)"/>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD</text>
   </g>
-  <text x="950" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD</text>
 
   <rect x="70" y="532" width="1060" height="1.5" fill="#334155" opacity="0.8"/>
   <text x="90" y="574" font-family="Arial, sans-serif" font-size="14" fill="#94a3b8">February 09, 2026</text>

--- a/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
+++ b/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
@@ -18,24 +18,34 @@
   <circle cx="930" cy="500" r="180" fill="#f59e0b" opacity="0.1" filter="url(#glow)"/>
   <text x="90" y="164" font-family="Arial, sans-serif" font-size="52" font-weight="700" fill="#f8fafc">TECH SIGNAL MAP</text>
   <text x="92" y="204" font-family="Arial, sans-serif" font-size="20" fill="#cbd5e1">CLOUD  AI  DOCKER</text>
-  <line x1="180" y1="340" x2="1020" y2="340" stroke="#475569" stroke-width="4" stroke-dasharray="14 10" opacity="0.8"/>
-  <g transform="translate(250 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#3b82f6" stroke-width="2.5"/>
+
+  <g transform="translate(600 336)" filter="url(#shadow)">
+    <circle r="102" fill="#111827" stroke="#3b82f6" stroke-width="2.5"/>
+    <circle r="44" fill="#0f172a" stroke="#e2e8f0" stroke-width="2"/>
+    <path d="M-18 0 h36" stroke="#e2e8f0" stroke-width="8" stroke-linecap="round"/>
+    <path d="M0 -18 v36" stroke="#e2e8f0" stroke-width="8" stroke-linecap="round"/>
+  </g>
+
+  <path d="M600 336 C495 338 355 358 250 360" fill="none" stroke="#3b82f6" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(250 360)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#3b82f6" stroke-width="2"/>
     <path d="M-16 10 C-28 10 -32 -2 -32 -10 C-32 -20 -24 -26 -14 -26 C-10 -36 0 -42 10 -42 C24 -42 32 -32 32 -26 C40 -26 44 -20 44 -10 C44 -2 40 10 28 10 Z" fill="#0b1628" stroke="#3b82f6" stroke-width="2" transform="scale(0.7)"/>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD</text>
   </g>
-  <text x="250" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD</text>
 
-  <g transform="translate(600 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#67e8f9" stroke-width="2.5"/>
+  <path d="M600 336 C600 323 600 223 600 210" fill="none" stroke="#67e8f9" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(600 210)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#67e8f9" stroke-width="2"/>
     <rect x="-28" y="-20" width="56" height="40" rx="8" fill="#111c35" stroke="#67e8f9" stroke-width="2"/><circle cx="0" cy="-4" r="14" fill="#12345c" stroke="#67e8f9" stroke-width="1.5"/><text x="0" y="1" font-family="Arial" font-size="12" font-weight="700" fill="#67e8f9" text-anchor="middle">AI</text>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#67e8f9" text-anchor="middle">AI</text>
   </g>
-  <text x="600" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#67e8f9" text-anchor="middle">AI</text>
 
-  <g transform="translate(950 340)" filter="url(#shadow)">
-    <circle r="56" fill="#0f172a" stroke="#f59e0b" stroke-width="2.5"/>
+  <path d="M600 336 C705 338 845 358 950 360" fill="none" stroke="#f59e0b" stroke-width="3" stroke-dasharray="12 10" stroke-linecap="round" opacity="0.8"/>
+  <g transform="translate(950 360)" filter="url(#shadow)">
+    <circle r="58" fill="#0f172a" stroke="#f59e0b" stroke-width="2"/>
     <circle r="18" fill="#f59e0b" opacity="0.18"/><circle r="8" fill="#f59e0b" opacity="0.3"/>
+    <text x="0" y="92" font-family="Arial, sans-serif" font-size="15" font-weight="700" fill="#f59e0b" text-anchor="middle">DOCKER</text>
   </g>
-  <text x="950" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#f59e0b" text-anchor="middle">DOCKER</text>
 
   <rect x="70" y="532" width="1060" height="1.5" fill="#334155" opacity="0.8"/>
   <text x="90" y="574" font-family="Arial, sans-serif" font-size="14" fill="#94a3b8">February 20, 2026</text>

--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -3689,6 +3689,7 @@ def _match_svg_icon(label: str) -> str:
 
 
 def _select_svg_template(news_items: List[Dict], focus_labels: List[str]) -> str:
+    title_joined = " ".join(item.get("title", "") for item in news_items[:8]).lower()
     joined = " ".join(
         f"{item.get('title', '')} {item.get('summary', '')}" for item in news_items[:8]
     ).lower()
@@ -3742,10 +3743,12 @@ def _select_svg_template(news_items: List[Dict], focus_labels: List[str]) -> str
         r"\bbreach\b",
         r"\bincident\b",
         r"\bthreat\b",
+        r"\bbotnet\b",
         r"제로데이",
         r"패치",
         r"랜섬웨어",
         r"악성코드",
+        r"봇넷",
         r"공격",
         r"침해",
         r"위협",
@@ -3785,6 +3788,9 @@ def _select_svg_template(news_items: List[Dict], focus_labels: List[str]) -> str
     incident_score = sum(
         1 for pattern in incident_patterns if re.search(pattern, joined)
     )
+    title_incident_score = sum(
+        1 for pattern in incident_patterns if re.search(pattern, title_joined)
+    )
     hub_score = sum(1 for pattern in hub_patterns if re.search(pattern, joined))
     risk_focus_score = sum(
         1 for label in focus_labels if label in {"PATCH", "ZERO DAY", "RANSOM"}
@@ -3792,7 +3798,14 @@ def _select_svg_template(news_items: List[Dict], focus_labels: List[str]) -> str
 
     if timeline_score >= 1:
         return SVG_TEMPLATE_TIMELINE
-    if digest_score >= 1 and (incident_score >= 1 or risk_focus_score >= 1):
+    if (
+        digest_score >= 1
+        and hub_score >= 3
+        and title_incident_score == 0
+        and incident_score <= 1
+    ):
+        return SVG_TEMPLATE_HUB_SPOKE
+    if digest_score >= 1 and (incident_score >= 2 or title_incident_score >= 1):
         return SVG_TEMPLATE_TIMELINE
     if incident_score >= 2 and hub_score <= 2:
         return SVG_TEMPLATE_TIMELINE

--- a/scripts/tests/test_news_templates.py
+++ b/scripts/tests/test_news_templates.py
@@ -2430,7 +2430,7 @@ class TestSelectSvgTemplate:
 
         result = _select_svg_template(items, focus_labels=["AI AGENT", "CLOUD"])
 
-        assert result == SVG_TEMPLATE_TIMELINE
+        assert result != SVG_TEMPLATE_BEFORE_AFTER
 
     def test_focus_labels_can_force_timeline_without_keyword(self):
         items = [_item(title="Security digest", summary="executive risk briefing")]
@@ -2472,5 +2472,29 @@ class TestSelectSvgTemplate:
         ]
 
         result = _select_svg_template(items, focus_labels=["AI AGENT", "CLOUD", "K8S"])
+
+        assert result == SVG_TEMPLATE_HUB_SPOKE
+
+    def test_real_mixed_platform_digest_prefers_hub_spoke(self):
+        items = [
+            _item(
+                title="AI 정렬 연구, EKS Flyte 워크플로, Docker 보안, Cloud Native 동향",
+                summary="AI 정렬 연구·EKS Flyte·Docker 보안·Cloud Native를 기준으로 기술 관점과 경영진 관점을 함께 정리한 2월 하순 주간 다이제스트입니다.",
+            )
+        ]
+
+        result = _select_svg_template(items, focus_labels=["AI AGENT", "CLOUD", "K8S"])
+
+        assert result == SVG_TEMPLATE_HUB_SPOKE
+
+    def test_real_security_cloud_digest_prefers_hub_spoke(self):
+        items = [
+            _item(
+                title="2026-02-09 보안 & 클라우드 다이제스트: AI 공급망 보안, AWS Agentic AI",
+                summary="AI VirusTotal 통합으로 AI 에이전트 공급망 보안 강화, SK쉴더스 BlackField 랜섬웨어 리포트, AWS Agentic AI 보안 동향을 함께 다룹니다.",
+            )
+        ]
+
+        result = _select_svg_template(items, focus_labels=["RANSOM", "CLOUD", "AWS"])
 
         assert result == SVG_TEMPLATE_HUB_SPOKE


### PR DESCRIPTION
## Summary
- reduce two remaining mixed-topic digest mismatches by preferring `hub-spoke` when digest wording is present but the title is still primarily multi-platform rather than incident-led
- keep `timeline` for titles that are clearly driven by zero-day, patch, ransomware, malware, or botnet signals
- regenerate the two affected SVGs that changed after the selector update

## Linked issue
- follow-up validation issue: #186

## Validation
- `.venv/bin/python -m pytest scripts/tests/test_news_templates.py -k TestSelectSvgTemplate`
- `python3 -m py_compile scripts/auto_publish_news.py scripts/tests/test_news_templates.py`
- re-checked 10 sample digest posts and updated the issue notes in #186

## Files
- `scripts/auto_publish_news.py`
- `scripts/tests/test_news_templates.py`
- `assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg`
- `assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg`