### PR TITLE
Prevent VS Code false positives in digest SVG routing

### DIFF
--- a/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
+++ b/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
@@ -18,24 +18,24 @@
   <circle cx="930" cy="500" r="180" fill="#f59e0b" opacity="0.1" filter="url(#glow)"/>
   <text x="90" y="164" font-family="Arial, sans-serif" font-size="52" font-weight="700" fill="#f8fafc">THREAT SIGNAL MAP</text>
   <text x="92" y="204" font-family="Arial, sans-serif" font-size="20" fill="#cbd5e1">ZERO DAY  CLOUD  ZERO-DAY</text>
-
+  <line x1="180" y1="340" x2="1020" y2="340" stroke="#475569" stroke-width="4" stroke-dasharray="14 10" opacity="0.8"/>
   <g transform="translate(250 340)" filter="url(#shadow)">
-    <rect x="-85" y="-85" width="170" height="170" rx="28" fill="#0f172a" stroke="#ef4444" stroke-width="2.5"/>
-    <rect x="-20" y="-16" width="40" height="32" rx="6" fill="#1a1020" stroke="#ef4444" stroke-width="2"/><text x="0" y="-2" font-family="Courier New" font-size="11" font-weight="700" fill="#ef4444" text-anchor="middle">CVE</text><text x="0" y="12" font-family="Courier New" font-size="8" fill="#ef4444" text-anchor="middle" opacity="0.7">PATCH</text>
-  </g>
-  <g transform="translate(600 340)" filter="url(#shadow)">
-    <circle r="62" fill="#111827" stroke="#dc2626" stroke-width="2.5"/>
+    <circle r="56" fill="#0f172a" stroke="#dc2626" stroke-width="2.5"/>
     <rect x="-20" y="-16" width="40" height="32" rx="6" fill="#1a1020" stroke="#dc2626" stroke-width="2"/><text x="0" y="-2" font-family="Courier New" font-size="11" font-weight="700" fill="#dc2626" text-anchor="middle">CVE</text><text x="0" y="12" font-family="Courier New" font-size="8" fill="#dc2626" text-anchor="middle" opacity="0.7">PATCH</text>
   </g>
-  <g transform="translate(950 340)" filter="url(#shadow)">
-    <rect x="-85" y="-85" width="170" height="170" rx="28" fill="#0f172a" stroke="#22c55e" stroke-width="2.5"/>
-    <path d="M-16 10 C-28 10 -32 -2 -32 -10 C-32 -20 -24 -26 -14 -26 C-10 -36 0 -42 10 -42 C24 -42 32 -32 32 -26 C40 -26 44 -20 44 -10 C44 -2 40 10 28 10 Z" fill="#0b1628" stroke="#22c55e" stroke-width="2" transform="scale(0.7)"/>
+  <text x="250" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#dc2626" text-anchor="middle">ZERO DAY</text>
+
+  <g transform="translate(600 340)" filter="url(#shadow)">
+    <circle r="56" fill="#0f172a" stroke="#67e8f9" stroke-width="2.5"/>
+    <path d="M-16 10 C-28 10 -32 -2 -32 -10 C-32 -20 -24 -26 -14 -26 C-10 -36 0 -42 10 -42 C24 -42 32 -32 32 -26 C40 -26 44 -20 44 -10 C44 -2 40 10 28 10 Z" fill="#0b1628" stroke="#67e8f9" stroke-width="2" transform="scale(0.7)"/>
   </g>
-  <path d="M340 340 C430 300 500 300 538 340" fill="none" stroke="#ef4444" stroke-width="3" stroke-dasharray="12 10"/>
-  <path d="M662 340 C720 300 820 300 860 340" fill="none" stroke="#22c55e" stroke-width="3" stroke-dasharray="12 10"/>
-  <text x="250" y="458" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#ef4444" text-anchor="middle">ZERO DAY</text>
-  <text x="600" y="458" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#dc2626" text-anchor="middle">ZERO-DAY</text>
-  <text x="950" y="458" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#22c55e" text-anchor="middle">CLOUD</text>
+  <text x="600" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#67e8f9" text-anchor="middle">CLOUD</text>
+
+  <g transform="translate(950 340)" filter="url(#shadow)">
+    <circle r="56" fill="#0f172a" stroke="#f59e0b" stroke-width="2.5"/>
+    <rect x="-20" y="-16" width="40" height="32" rx="6" fill="#1a1020" stroke="#f59e0b" stroke-width="2"/><text x="0" y="-2" font-family="Courier New" font-size="11" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE</text><text x="0" y="12" font-family="Courier New" font-size="8" fill="#f59e0b" text-anchor="middle" opacity="0.7">PATCH</text>
+  </g>
+  <text x="950" y="448" font-family="Arial, sans-serif" font-size="16" font-weight="700" fill="#f59e0b" text-anchor="middle">ZERO-DAY</text>
 
   <rect x="70" y="532" width="1060" height="1.5" fill="#334155" opacity="0.8"/>
   <text x="90" y="574" font-family="Arial, sans-serif" font-size="14" fill="#94a3b8">February 19, 2026</text>

--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -3699,7 +3699,7 @@ def _select_svg_template(news_items: List[Dict], focus_labels: List[str]) -> str
         r"\bfrom\b.{0,80}\bto\b",
         r"\b(?:replace|replaced|replacing|migration|migrate|migrates|migrating)\b",
         r"\b(?:upgrade|downgrade|rollback|rollbacks|rollbacked|rollbacking|swap|swaps|swapped|transition|transitions|transitioning)\b",
-        r"\bvs\.?\b",
+        r"\bvs\.?(?!\s*code\b)\b",
         r"\bversus\b",
         r"비교",
         r"전환",

--- a/scripts/tests/test_news_templates.py
+++ b/scripts/tests/test_news_templates.py
@@ -2498,3 +2498,17 @@ class TestSelectSvgTemplate:
         result = _select_svg_template(items, focus_labels=["RANSOM", "CLOUD", "AWS"])
 
         assert result == SVG_TEMPLATE_HUB_SPOKE
+
+    def test_vs_code_does_not_trigger_before_after(self):
+        items = [
+            _item(
+                title="AWS 보안 업데이트, Zero-Day 패치, CVE-2026-2329 분석",
+                summary="Dell RecoverPoint VM 제로데이 악용과 VS Code 확장 취약점, 포렌식 도구 오남용 사례를 함께 다룹니다.",
+            )
+        ]
+
+        result = _select_svg_template(
+            items, focus_labels=["ZERO DAY", "PATCH", "CLOUD"]
+        )
+
+        assert result == SVG_TEMPLATE_TIMELINE


### PR DESCRIPTION
## Summary
- prevent the `before-after` selector from treating `VS Code` as a comparison-style `vs` signal
- add a regression test for the real 2026-02-19 digest case that previously rendered with the wrong template
- regenerate the affected digest SVG so the merged asset now stays on the intended `timeline` layout

## Linked issue
- follow-up validation issue: #186

## Validation
- `.venv/bin/python -m pytest scripts/tests/test_news_templates.py -k TestSelectSvgTemplate`
- `python3 -m py_compile scripts/auto_publish_news.py scripts/tests/test_news_templates.py`

## Files
- `scripts/auto_publish_news.py`
- `scripts/tests/test_news_templates.py`
- `assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg`