### PR TITLE
fix: 전체 SVG title 요소 추가로 CI 검사 실패 해소

### DIFF
--- a/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
+++ b/assets/images/2025-04-29-SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_and_MFA_Importance.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 04 29 SKT Security Issue Complete Response Guide IMEI Check USIMeSIM Replace and MFA Importance</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
+++ b/assets/images/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 04 30 Public PCEven in Safely Passkey OTP Strong Password Management Usage</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
+++ b/assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 02 Cloud Security Course 7Batch 3Week AWS Security and Finops</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2025-05-02-Cloud_Security_Course_7Batch_3Week_AWS.svg
+++ b/assets/images/2025-05-02-Cloud_Security_Course_7Batch_3Week_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 02 Cloud Security Course 7Batch 3Week AWS</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
+++ b/assets/images/2025-05-02-Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 02 Kandji macOS Complete Master SetupFrom Security Regulation ComplianceTo All in One Guide</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-05-02-Kandji_macOS_Master_Setup_From_Security_Regulation.svg
+++ b/assets/images/2025-05-02-Kandji_macOS_Master_Setup_From_Security_Regulation.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 05 02 Kandji macOS Master Setup From Security Regulation</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
+++ b/assets/images/2025-05-09-Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_and_ISMS_Response_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 09 Cloud Security Course 7Batch 4Week AWS Vulnerability Inspection and ISMS Response Guide</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
+++ b/assets/images/2025-05-16-Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_and_ZTNA.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 05 16 Cloud Security Course 7Batch 5Week AWS Control Tower and ZTNA</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
+++ b/assets/images/2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_and_github_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 23 Cloud Security Course 7Batch 6Week Cloudflare and github Security</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
+++ b/assets/images/2025-05-24-Amazon_Q_Developerand_GitHub_Advanced_Security_Security_and_AWS.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 05 24 Amazon Q Developerand GitHub Advanced Security Security and AWS</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
+++ b/assets/images/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_and_Kubernetes.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 05 30 Cloud Security Course 7Batch 7Week Docker and Kubernetes</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-05-30-Cloud_Security_Course_7Batch_7Week_Docker.svg
+++ b/assets/images/2025-05-30-Cloud_Security_Course_7Batch_7Week_Docker.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 05 30 Cloud Security Course 7Batch 7Week Docker</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
+++ b/assets/images/2025-05-30-Kubernetes_Minikube_ampamp_K9s_Guide_From_Practical_To.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 05 30 Kubernetes Minikube and K9s Guide From Practical To</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
+++ b/assets/images/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 06 05 Email Delivery Trust Improve SendGrid SPF DKIM DMARC Setup Complete Guide</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2025-06-06-Cloud_Security_Course_7Batch_-_8Week_CICDand_Kubernetes_Security_Practical_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 06 06 Cloud Security Course 7Batch 8Week CICDand Kubernetes Security Practical Guide</title>
   <!-- Dark Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
+++ b/assets/images/2025-06-13-Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 06 13 Cloud Security Course 7Batch 9Week DevSecOps Integration</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-09-10-npm_Ecosystem_Large_scale_Security_Breach.svg
+++ b/assets/images/2025-09-10-npm_Ecosystem_Large_scale_Security_Breach.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 09 10 npm Ecosystem Large scale Security Breach</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
+++ b/assets/images/2025-09-10-npm_Large-scale_Security_20.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 09 10 npm Large scale Security 20</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_Current.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_Current.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 09 16 AWS reInforce 2025 Cloud Security Current</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
+++ b/assets/images/2025-09-16-AWS_reInforce_2025_Cloud_Security_and_Future.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 09 16 AWS reInforce 2025 Cloud Security and Future</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
+++ b/assets/images/2025-09-17-NPM_ampquotShai-Huludampquot_180_Large-scale_Analysis.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 09 17 NPM Shai Hulud 180 Large scale Analysis</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
+++ b/assets/images/2025-10-02-Karpenter_v153_Node_Integration_Due_to_Large-scale_Incident_Analysis_and_Resolution.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 10 02 Karpenter v153 Node Integration Due to Large scale Incident Analysis and Resolution</title>
   <defs><linearGradient id="bgK" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0a0a1a"/><stop offset="100%" stop-color="#17152c"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bgK)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Karpenter Upgrade Incident Loop</text>

--- a/assets/images/2025-10-03-AWSIn_Database_Access_Gateway_Build_NLB.svg
+++ b/assets/images/2025-10-03-AWSIn_Database_Access_Gateway_Build_NLB.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 10 03 AWSIn Database Access Gateway Build NLB</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
+++ b/assets/images/2025-10-03-AWSin_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 10 03 AWSin Database Access Gateway Build NLB Security Group Complete Guide</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
+++ b/assets/images/2025-10-31-AI_amplsquoamprsquo_amplsquoSecurity_amprsquo_Batch_AI_Security_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 10 31 AI Security Batch AI Security Guide</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
+++ b/assets/images/2025-11-04-Zscaler_Complete_Guide_SSL_AI_Complete.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 11 04 Zscaler Complete Guide SSL AI Complete</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
+++ b/assets/images/2025-11-19-Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_what_Learned.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 11 19 Post Mortem 2025 11 18 Cloudflare Global Incident Response Log what Learned</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2025-11-19-Post_Mortem_2025_Cloudflare_Global_Incident.svg
+++ b/assets/images/2025-11-19-Post_Mortem_2025_Cloudflare_Global_Incident.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 11 19 Post Mortem 2025 Cloudflare Global Incident</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
+++ b/assets/images/2025-11-21-Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 11 21 Cloud Security 8Batch OT Guide DevSecOpsFrom FinOpsTo Practical Talent Leap</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
+++ b/assets/images/2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 11 26 Cloud Security 8Batch 1Week Infrastructure EssenceFrom Security FutureTo</title>
   <defs>
     <style>
       .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-weight: 700; fill: white; }

--- a/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
+++ b/assets/images/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 12 05 Cloud Security 8Batch 2Week AWS Security Architecture Core VPCFrom GuardDutyTo Complete Conquer</title>
   <defs>
     <marker id="arrowOrange" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
       <path d="M0,0 L0,6 L9,3 z" fill="#f59e0b" opacity="0.7"/>

--- a/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
+++ b/assets/images/2025-12-12-Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 12 12 Cloud Security 8Batch 3Week AWS FinOps ArchitectureFrom ISMS P Security AuditTo Complete Strategy</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
+++ b/assets/images/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIand_Security_Coexistence.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 12 17 12 Conference Review AWSKRUG OWASP Datadog Preview See 2025 AIand Security Coexistence</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-12-17-Conference_Review_AWSKRUG_OWASP_Datadog_Preview.svg
+++ b/assets/images/2025-12-17-Conference_Review_AWSKRUG_OWASP_Datadog_Preview.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 12 17 Conference Review AWSKRUG OWASP Datadog Preview</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security.svg
+++ b/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2025 12 19 Cloud Security 8Batch 4Week Integration Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
+++ b/assets/images/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_and_ISMS-P_Certification_Response.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 12 19 Cloud Security 8Batch 4Week Integration Security Vulnerability Inspection and ISMS P Certification Response</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS.svg
+++ b/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2025 12 24 Cloud Security Course 8Batch 5Week AWS</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
+++ b/assets/images/2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_and_Datadog_SIEM_Cloudflare_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2025 12 24 Cloud Security Course 8Batch 5Week AWS Control TowerSCP Based Governance and Datadog SIEM Cloudflare Security</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
+++ b/assets/images/2026-01-01-Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 01 Tesla FSD 2026 Complete Guide Model Y Juniper Security DevSecOps</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-01-Tesla_FSD_2026_Model_Juniper_Security.svg
+++ b/assets/images/2026-01-01-Tesla_FSD_2026_Model_Juniper_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 01 Tesla FSD 2026 Model Juniper Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
+++ b/assets/images/2026-01-03-OWASP_2025_Complete_Guide_Top_10_AI_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 03 OWASP 2025 Complete Guide Top 10 AI Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-03-OWASP_2025_Latest_Update_Top_Agentic.svg
+++ b/assets/images/2026-01-03-OWASP_2025_Latest_Update_Top_Agentic.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 03 OWASP 2025 Latest Update Top Agentic</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
+++ b/assets/images/2026-01-06-DevSecOps_Viewing_Automotive_Security_Complete_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 06 DevSecOps Viewing Automotive Security Complete Guide</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
+++ b/assets/images/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_and_Best_Practice.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 08 Blockchain Cryptocurrency Security Complete Guide DevSecOps From Perspective View GitHub Security Tools and Best Practice</title>
   <defs><linearGradient id="bgB" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0a0a1a"/><stop offset="100%" stop-color="#1a0a2e"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bgB)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Blockchain Security and DevSecOps Controls</text>

--- a/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS.svg
+++ b/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 08 Cloud Security Course 8Batch 6Week AWS</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
+++ b/assets/images/2026-01-08-Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_and_GitHub_DevSecOps_Practical.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 08 Cloud Security Course 8Batch 6Week AWS WAF CloudFront Security Architecture and GitHub DevSecOps Practical</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
+++ b/assets/images/2026-01-10-2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 10 2026 DevSecOps Roadmap Complete Guide roadmap sh Analysis</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-01-10-2026_DevSecOps_Roadmap_roadmap_sh.svg
+++ b/assets/images/2026-01-10-2026_DevSecOps_Roadmap_roadmap_sh.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 10 2026 DevSecOps Roadmap roadmap sh</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
+++ b/assets/images/2026-01-11-AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 11 AI Music Video Generation Complete Guide DevSecOps Perspective</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-11-Music_Video_Generation_DevSecOps_Perspective.svg
+++ b/assets/images/2026-01-11-Music_Video_Generation_DevSecOps_Perspective.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 11 Music Video Generation DevSecOps Perspective</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
+++ b/assets/images/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_Environment_Management_System_Establishment_and_Protection_Measures_Implementation.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 14 2025 ISMS P Certification Complete Guide AWS Environment Management System Establishment and Protection Measures Implementation</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-AWS_Cloud_Security_Complete_Guide_IAM_to_EKS_Practical_Security_Architecture.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 14 AWS Cloud Security Complete Guide IAM to EKS Practical Security Architecture</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-01-14-AWS_Cloud_Security_IAM_EKS.svg
+++ b/assets/images/2026-01-14-AWS_Cloud_Security_IAM_EKS.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 14 AWS Cloud Security IAM EKS</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-14-AWS_Cloud_Security_IAM_From_EKS_To_Security.svg
+++ b/assets/images/2026-01-14-AWS_Cloud_Security_IAM_From_EKS_To_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 14 AWS Cloud Security IAM From EKS To Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Automated_Security.svg
+++ b/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Automated_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 14 CSPM DataDog AWS Security Automated Security</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
+++ b/assets/images/2026-01-14-CSPM_DataDog_AWS_Security_Guide_Automated_Security_Configuration_Verification_and_Compliance_Monitoring.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 14 CSPM DataDog AWS Security Guide Automated Security Configuration Verification and Compliance Monitoring</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
+++ b/assets/images/2026-01-14-GCP_Cloud_Security_Complete_Guide_IAM_to_GKE_Practical_Security_Architecture.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 14 GCP Cloud Security Complete Guide IAM to GKE Practical Security Architecture</title>
   <!-- Dark Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-14-ISMS_Certification_AWS_Environment_Management.svg
+++ b/assets/images/2026-01-14-ISMS_Certification_AWS_Environment_Management.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 14 ISMS Certification AWS Environment Management</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker.svg
+++ b/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 15 Cloud Security Course 8Batch 7Week Docker</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-15-Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 15 Cloud Security Course 8Batch 7Week Docker Kubernetes Security Practical Guide</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
+++ b/assets/images/2026-01-16-Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 16 Postmortem NextJS SSR Error Cloudflare Blocking ALB 5XX Incident Analysis</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
+++ b/assets/images/2026-01-17-AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <title>2026 01 17 AI Coding Assistants Comparison Gemini Claude Code ChatGPT OpenCode 2025 2026 Research Analysis</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
+++ b/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 22 AWS GCP Cloud Updates January 2026</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 22 Cloud Security Course 8Batch 8Week CI CD Kubernetes Security Practical Guide</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 22 Cloud Security Trends January 2026</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
+++ b/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 22 KARA Ransomware Trends 2025 Q3</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
+++ b/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 22 KISA Security Advisory Ransomware Linux Rootkit</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
+++ b/assets/images/2026-01-22-Security_Vendor_Blog_Weekly_Review.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 22 Security Vendor Blog Weekly Review</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 23 Tech Security Weekly Digest</title>
   <defs>
     <style>
       .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-size: 44px; font-weight: bold; fill: white; }

--- a/assets/images/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM.svg
+++ b/assets/images/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 23 Tech Security Weekly Digest Microsoft AitM</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" width="1200" height="630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 24 Tech Security Weekly Digest</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 24 Tech Security Weekly Digest BitLocker FBI</title>
   <defs>
     <linearGradient id="lockGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#4f46e5;stop-opacity:1" />

--- a/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
+++ b/assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 25 Tech Security Weekly Digest</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust.svg
+++ b/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 26 Tech Security Weekly Digest Zero Trust</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
+++ b/assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 26 Tech Security Weekly Digest Zero Trust Agentic AI Terraform</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
+++ b/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 27 Tech Security Weekly Digest MS Office Kimi Kimwolf AWS</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
+++ b/assets/images/2026-01-28-Claude_MD_Security_Guide.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 01 28 Claude MD Security Guide</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
+++ b/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 28 Tech Security Weekly Digest MS Office Zero Day CTEM Grist Core RCE</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0f1419;stop-opacity:1" />

--- a/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
+++ b/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <title>2026 01 29 Tech Security Weekly Digest n8n RCE D Link Zero Day Kubernetes AI Agent</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
+++ b/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 30 Tech Security Weekly Digest Ollama AI SolarWinds RCE Google IPIDEA</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing.svg
+++ b/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 01 31 Tech Security Weekly Digest ShinyHunters Vishing</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
+++ b/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 01 31 Tech Security Weekly Digest ShinyHunters Vishing Chrome Extension OT Attack</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
+++ b/assets/images/2026-02-01-Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 01 Agentic AI Security 2026 Attack Vectors Defense Architecture</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-02-01-Agentic_Security_2026_Attack_Vectors_Defense.svg
+++ b/assets/images/2026-02-01-Agentic_Security_2026_Attack_Vectors_Defense.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 01 Agentic Security 2026 Attack Vectors Defense</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
+++ b/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 01 Tech Security Weekly Digest AI OpenSSL Zero Day OWASP Agentic Fortinet</title>
   <defs>
     <linearGradient id="bg0201" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0f18"/>

--- a/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Security_Threat_Intelligence_Digest.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <title>2026 02 02 Weekly Security Threat Intelligence Digest</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Tech_AI_Blockchain_Digest.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 02 Weekly Tech AI Blockchain Digest</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-02-02-Weekly_Tech_Blockchain_Digest.svg
+++ b/assets/images/2026-02-02-Weekly_Tech_Blockchain_Digest.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 02 Weekly Tech Blockchain Digest</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
+++ b/assets/images/2026-02-03-Weekly_Security_DevOps_Digest.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 03 Weekly Security DevOps Digest</title>
   <defs><linearGradient id="bg0203" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0a0f18"/><stop offset="100%" stop-color="#141c2e"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bg0203)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Agent RCE and Device Control</text>

--- a/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
+++ b/assets/images/2026-02-04-AI_vs_Claude_Code_AI_Coding_Assistant_Comparison.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 04 AI vs Claude Code AI Coding Assistant Comparison</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 04 Tech Security Weekly Digest AI Docker Data Go</title>
   <defs><linearGradient id="bg0204" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0b1120"/><stop offset="100%" stop-color="#161a2d"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bg0204)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Docker Flaw and Metro4Shell Window</text>

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_Docker_Data.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_Docker_Data.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 04 Tech Security Weekly Digest Docker Data</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
+++ b/assets/images/2026-02-05-AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 05 AI Content Creator Workflow 2026 Blog Video Music Animation</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-05-Content_Creator_Workflow_Blog_Video.svg
+++ b/assets/images/2026-02-05-Content_Creator_Workflow_Blog_Video.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <title>2026 02 05 Content Creator Workflow Blog Video</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 05 Tech Security Weekly Digest CVE AI Malware Go</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_Malware.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_Malware.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 05 Tech Security Weekly Digest CVE Malware</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 06 Tech Security Weekly Digest AI Botnet Cloud Threat</title>
   <defs>
     <marker id="arrowhead-red" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
       <polygon points="0 0, 10 3, 0 6" fill="#ef4444" opacity="0.4"/>

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_Botnet_Cloud.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_Botnet_Cloud.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <title>2026 02 06 Tech Security Weekly Digest Botnet Cloud</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
+++ b/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 07 Tech Security Weekly Digest AI Malware Go Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-07-Tech_Security_Weekly_Digest_Malware_Security.svg
+++ b/assets/images/2026-02-07-Tech_Security_Weekly_Digest_Malware_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 07 Tech Security Weekly Digest Malware Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 08 Tech Security Weekly Digest AI Ransomware Data</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_Ransomware_Data.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 08 Tech Security Weekly Digest Ransomware Data</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
+++ b/assets/images/2026-02-09-Blockchain_Tech_Digest_Bithumb_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 09 Blockchain Tech Digest Bithumb Bitcoin</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
+++ b/assets/images/2026-02-09-Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 09 Security Cloud Digest AI VirusTotal AWS Agentic</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
+++ b/assets/images/2026-02-10-AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 02 10 AI Cloud Digest Meta Prometheus Google OTLP AWS</title>
   <defs>
     <style>
       .title-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; font-weight: 700; fill: #ffffff; }

--- a/assets/images/2026-02-10-Cloud_Digest_Meta_Prometheus_Google_OTLP.svg
+++ b/assets/images/2026-02-10-Cloud_Digest_Meta_Prometheus_Google_OTLP.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>2026 02 10 Cloud Digest Meta Prometheus Google OTLP</title>
   <defs>
     <linearGradient id="grad-metric" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#00d4ff;stop-opacity:1" />

--- a/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
+++ b/assets/images/2026-02-10-DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 10 DevOps Blockchain Digest CNCF Chainalysis Bitcoin</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
+++ b/assets/images/2026-02-10-Security_Digest_SolarWinds_UNC3886_LLM_Attack.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 10 Security Digest SolarWinds UNC3886 LLM Attack</title>
   <defs>
     <filter id="glass-blur">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8"/>

--- a/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
+++ b/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 11 Tech Security Weekly Digest Security Ransomware Patch AI</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
+++ b/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 12 Tech Security Weekly Digest AI Cloud Security Agent</title>
   <defs>
     <filter id="glass" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
+++ b/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 13 Tech Security Weekly Digest AI Go Security Agent</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
+++ b/assets/images/2026-02-14-Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 14 Weekly Security Digest Microsoft Zero Day Apple Ivanti EPMM</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
+++ b/assets/images/2026-02-16-Daily_Tech_Digest_RSS_Roundup.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 16 Daily Tech Digest RSS Roundup</title>
   <defs>
     <filter id="glassBlur">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8"/>

--- a/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
+++ b/assets/images/2026-02-17-Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 02 17 Tech Security Weekly Digest AI Agent Cloud Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-17-Tech_Security_Weekly_Digest_Agent_Cloud.svg
+++ b/assets/images/2026-02-17-Tech_Security_Weekly_Digest_Agent_Cloud.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 17 Tech Security Weekly Digest Agent Cloud</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
+++ b/assets/images/2026-02-17-Weekly_Tech_Security_Digest_AI_Cloud_Risk.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 17 Weekly Tech Security Digest AI Cloud Risk</title>
   <defs><linearGradient id="bg0217" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0b1020"/><stop offset="100%" stop-color="#141a2d"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bg0217)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Guardrails, Patch Cycles, Cost Drift</text>

--- a/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
+++ b/assets/images/2026-02-18-Krebs_Security_Digest_Kimwolf_Patch_Tuesday.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 18 Krebs Security Digest Kimwolf Patch Tuesday</title>
   <defs>
     <filter id="glass-blur">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8"/>

--- a/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
+++ b/assets/images/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 18 Tech Security Weekly Digest AI Cloud Malware Update</title>
   <defs>
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
+++ b/assets/images/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 19 Tech Security Weekly Digest AWS Security Zero Day CVE</title>
   <defs><linearGradient id="bg0219" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#0b1120"/><stop offset="100%" stop-color="#16192d"/></linearGradient></defs>
   <rect width="1200" height="630" fill="url(#bg0219)"/>
   <text x="60" y="72" fill="#e2e8f0" font-size="32" font-family="Georgia, serif">Zero Day Response in the Toolchain</text>

--- a/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
+++ b/assets/images/2026-02-20-Tech_Blog_Weekly_Digest_AI_Data_Cloud.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 20 Tech Blog Weekly Digest AI Data Cloud</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
+++ b/assets/images/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 20 Tech Security Weekly Digest Gemini AI Supply Chain Kubernetes</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
+++ b/assets/images/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 21 Tech Security Weekly Digest Data Rust AI Threat</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
+++ b/assets/images/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 22 Tech Security Weekly Digest AI Threat Vulnerability Security</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-22-Tech_Security_Weekly_Digest_Threat_Vulnerability.svg
+++ b/assets/images/2026-02-22-Tech_Security_Weekly_Digest_Threat_Vulnerability.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <title>2026 02 22 Tech Security Weekly Digest Threat Vulnerability</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
+++ b/assets/images/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 23 Tech Security Weekly Digest AI Ransomware Data Bitcoin</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
+++ b/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 24 Tech Security Weekly Digest Malware AI Docker LLM</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_Docker.svg
+++ b/assets/images/2026-02-24-Tech_Security_Weekly_Digest_Malware_Docker.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 02 24 Tech Security Weekly Digest Malware Docker</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
+++ b/assets/images/2026-02-25-Claude_Code_OpenCode_Best_Practices.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 25 Claude Code OpenCode Best Practices</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
+++ b/assets/images/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 25 Tech Security Weekly Digest AI Malware Ransomware LLM</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
+++ b/assets/images/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 26 Tech Security Weekly Digest AI Go AWS API</title>
   <defs>
     <filter id="glass-blur">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8"/>

--- a/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
+++ b/assets/images/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 27 Tech Security Weekly Digest AI Botnet Blockchain Go</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
+++ b/assets/images/2026-02-28-AI_Agent_Security_Architecture_Design_Guide.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 02 28 AI Agent Security Architecture Design Guide</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
+++ b/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 28 Tech Security Weekly Digest Go AI Malware</title>
   <defs>
     <filter id="glassBlur">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8"/>

--- a/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Malware.svg
+++ b/assets/images/2026-02-28-Tech_Security_Weekly_Digest_Malware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 02 28 Tech Security Weekly Digest Malware</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.svg
+++ b/assets/images/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 01 Tech Security Weekly Digest AI Agent Ransomware</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.svg
+++ b/assets/images/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 02 Tech Security Weekly Digest Ransomware AI Agent</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.svg
+++ b/assets/images/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 04 Tech Security Weekly Digest AI Ransomware Bitcoin</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-03-04-Tech_Security_Weekly_Digest_Ransomware_Bitcoin.svg
+++ b/assets/images/2026-03-04-Tech_Security_Weekly_Digest_Ransomware_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 04 Tech Security Weekly Digest Ransomware Bitcoin</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.svg
+++ b/assets/images/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 05 Tech Security Weekly Digest iOS Exploit Hacktivist DDoS</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.svg
+++ b/assets/images/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 06 Tech Security Weekly Digest Security Threat AI AWS</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-03-07-LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP.svg
+++ b/assets/images/2026-03-07-LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 07 LLM Security Practical Guide Prompt Injection RAG MCP</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
+++ b/assets/images/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 07 Tech Security Weekly Digest Android Zero Day DevSecOps</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
   

--- a/assets/images/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.svg
+++ b/assets/images/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 08 Tech Security Weekly Digest AI Security</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-08-Tech_Security_Weekly_Digest_Security.svg
+++ b/assets/images/2026-03-08-Tech_Security_Weekly_Digest_Security.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 08 Tech Security Weekly Digest Security</title>
   <defs>
     <style>
       .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-weight: 700; color: #ffffff; }

--- a/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
+++ b/assets/images/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 09 Tech Security Weekly Digest AI Security Go Bitcoin</title>
   <defs>
     <filter id="glass" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
+++ b/assets/images/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 10 Tech Security Weekly Digest AI Malware Security Data</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-10-Tech_Security_Weekly_Digest_Malware_Security.svg
+++ b/assets/images/2026-03-10-Tech_Security_Weekly_Digest_Malware_Security.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 10 Tech Security Weekly Digest Malware Security</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
+++ b/assets/images/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 11 Tech Security Weekly Digest AI Agent Data Malware</title>
   <defs>
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-03-11-Tech_Security_Weekly_Digest_Agent_Data.svg
+++ b/assets/images/2026-03-11-Tech_Security_Weekly_Digest_Agent_Data.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 11 Tech Security Weekly Digest Agent Data</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.svg
+++ b/assets/images/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 12 Tech Security Weekly Digest AI Malware AWS Patch</title>
   <defs>
     <filter id="glass-blur" x="-20%" y="-20%" width="140%" height="140%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-03-12-Tech_Security_Weekly_Digest_Malware_AWS.svg
+++ b/assets/images/2026-03-12-Tech_Security_Weekly_Digest_Malware_AWS.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 12 Tech Security Weekly Digest Malware AWS</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.svg
+++ b/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 15 Tech Security Weekly Digest AWS AI Bitcoin</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_Bitcoin.svg
+++ b/assets/images/2026-03-15-Tech_Security_Weekly_Digest_AWS_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 15 Tech Security Weekly Digest AWS Bitcoin</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.svg
+++ b/assets/images/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 16 Tech Security Weekly Digest AI Agent Open Source Update</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.svg
+++ b/assets/images/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 16 Tech Security Weekly Digest AI Bitcoin</title>
   <defs>
     <filter id="glass-blur" x="-50%" y="-50%" width="200%" height="200%">
       <feGaussianBlur in="SourceGraphic" stdDeviation="8" result="blur"/>

--- a/assets/images/2026-03-16-Tech_Security_Weekly_Digest_Agent_Open.svg
+++ b/assets/images/2026-03-16-Tech_Security_Weekly_Digest_Agent_Open.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 16 Tech Security Weekly Digest Agent Open</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-16-Tech_Security_Weekly_Digest_Bitcoin.svg
+++ b/assets/images/2026-03-16-Tech_Security_Weekly_Digest_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 16 Tech Security Weekly Digest Bitcoin</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.svg
+++ b/assets/images/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 17 Tech Security Weekly Digest Malware AI AWS Botnet</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-18-Tech_Security_Weekly_Digest_AI_AWS_Data_Ransomware.svg
+++ b/assets/images/2026-03-18-Tech_Security_Weekly_Digest_AI_AWS_Data_Ransomware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 18 Tech Security Weekly Digest AI AWS Data Ransomware</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-03-19-Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch.svg
+++ b/assets/images/2026-03-19-Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 19 Tech Security Weekly Digest Zero Day CVE Ransomware Patch</title>
   <defs>
     <linearGradient id="bg19" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0f18"/>

--- a/assets/images/2026-03-19-Tech_Security_Weekly_Digest_Zero_Day.svg
+++ b/assets/images/2026-03-19-Tech_Security_Weekly_Digest_Zero_Day.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 19 Tech Security Weekly Digest Zero Day</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-20-Tech_Security_Weekly_Digest_Malware_Data.svg
+++ b/assets/images/2026-03-20-Tech_Security_Weekly_Digest_Malware_Data.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 20 Tech Security Weekly Digest Malware Data</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-20-Tech_Security_Weekly_Digest_Malware_Data_Security_Threat.svg
+++ b/assets/images/2026-03-20-Tech_Security_Weekly_Digest_Malware_Data_Security_Threat.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 20 Tech Security Weekly Digest Malware Data Security Threat</title>
   <defs>
     <linearGradient id="bg20" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#091019"/>

--- a/assets/images/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE.svg
+++ b/assets/images/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 21 Tech Security Weekly Digest Security CVE</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE_AI_Malware.svg
+++ b/assets/images/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE_AI_Malware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 21 Tech Security Weekly Digest Security CVE AI Malware</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-22-Tech_Security_Weekly_Digest_CVE_Patch.svg
+++ b/assets/images/2026-03-22-Tech_Security_Weekly_Digest_CVE_Patch.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 22 Tech Security Weekly Digest CVE Patch</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-22-Tech_Security_Weekly_Digest_CVE_Patch_AI_Apple.svg
+++ b/assets/images/2026-03-22-Tech_Security_Weekly_Digest_CVE_Patch_AI_Apple.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 22 Tech Security Weekly Digest CVE Patch AI Apple</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a"/>

--- a/assets/images/2026-03-23-Tech_Security_Weekly_Digest_Ransomware.svg
+++ b/assets/images/2026-03-23-Tech_Security_Weekly_Digest_Ransomware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 23 Tech Security Weekly Digest Ransomware</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-24-Tech_Security_Weekly_Digest_Malware_Data_AWS_AI.svg
+++ b/assets/images/2026-03-24-Tech_Security_Weekly_Digest_Malware_Data_AWS_AI.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 24 Tech Security Weekly Digest Malware Data AWS AI</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-25-Tech_Security_Weekly_Digest_AI_LLM_Malware_Agent.svg
+++ b/assets/images/2026-03-25-Tech_Security_Weekly_Digest_AI_LLM_Malware_Agent.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 25 Tech Security Weekly Digest AI LLM Malware Agent</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-26-Tech_Security_Weekly_Digest_Kubernetes_Supply.svg
+++ b/assets/images/2026-03-26-Tech_Security_Weekly_Digest_Kubernetes_Supply.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 26 Tech Security Weekly Digest Kubernetes Supply</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-26-Tech_Security_Weekly_Digest_Kubernetes_Supply_Chain_AI.svg
+++ b/assets/images/2026-03-26-Tech_Security_Weekly_Digest_Kubernetes_Supply_Chain_AI.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 26 Tech Security Weekly Digest Kubernetes Supply Chain AI</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-27-Tech_Security_Weekly_Digest_Zero_Trust_Cloud_FinOps.svg
+++ b/assets/images/2026-03-27-Tech_Security_Weekly_Digest_Zero_Trust_Cloud_FinOps.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 27 Tech Security Weekly Digest Zero Trust Cloud FinOps</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-28-Security-Digest-Weekly.svg
+++ b/assets/images/2026-03-28-Security-Digest-Weekly.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 28 Security Digest Weekly</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-03-28-Tech_Security_Weekly_Digest_AI_Cloud_Zero_Day.svg
+++ b/assets/images/2026-03-28-Tech_Security_Weekly_Digest_AI_Cloud_Zero_Day.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 28 Tech Security Weekly Digest AI Cloud Zero Day</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-28-Tech_Security_Weekly_Digest_Cloud_Zero.svg
+++ b/assets/images/2026-03-28-Tech_Security_Weekly_Digest_Cloud_Zero.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>2026 03 28 Tech Security Weekly Digest Cloud Zero</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-29-KARA_Ransomware_Trends_Report_2025.svg
+++ b/assets/images/2026-03-29-KARA_Ransomware_Trends_Report_2025.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 KARA Ransomware Trends Report 2025</title>
   <defs>
     <style>
       .title-text { font-family: 'Segoe UI', -apple-system, sans-serif; font-weight: bold; fill: #ffffff; }

--- a/assets/images/2026-03-29-Ransomware-LLM-Jailbreak-K8s-Supply-Chain.svg
+++ b/assets/images/2026-03-29-Ransomware-LLM-Jailbreak-K8s-Supply-Chain.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 Ransomware LLM Jailbreak K8s Supply Chain</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-03-29-Security-Digest-Weekly.svg
+++ b/assets/images/2026-03-29-Security-Digest-Weekly.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 Security Digest Weekly</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM.svg
+++ b/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 Tech Security Weekly Digest Ransomware LLM</title>
   <defs>
     <style>
       .title-text { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; font-weight: 700; fill: white; letter-spacing: -0.5px; }

--- a/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply.svg
+++ b/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 Tech Security Weekly Digest Ransomware LLM K8s Supply</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1"/>

--- a/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply_Chain.svg
+++ b/assets/images/2026-03-29-Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply_Chain.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 29 Tech Security Weekly Digest Ransomware LLM K8s Supply Chain</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-30-March_2026_Security_Digest_Monthly_Index.svg
+++ b/assets/images/2026-03-30-March_2026_Security_Digest_Monthly_Index.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 30 March 2026 Security Digest Monthly Index</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-30-Security-Digest-Monthly-Index.svg
+++ b/assets/images/2026-03-30-Security-Digest-Monthly-Index.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 30 Security Digest Monthly Index</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-03-30-Security-Digest-Weekly.svg
+++ b/assets/images/2026-03-30-Security-Digest-Weekly.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 30 Security Digest Weekly</title>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0e1a"/>

--- a/assets/images/2026-03-31-Kubernetes_Supply_Chain_Security_AI_Threats.svg
+++ b/assets/images/2026-03-31-Kubernetes_Supply_Chain_Security_AI_Threats.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Kubernetes Supply Chain Security AI Threats</title>
   <defs>
     <!-- Glassmorphism blur filter -->
     <filter id="glass" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_AWS_Bitcoin.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_AWS_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest AWS Bitcoin</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Bitcoin.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Bitcoin.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Bitcoin</title>
   <!-- Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_CVE_Patch.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_CVE_Patch.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest CVE Patch</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Cloud_Zero.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Cloud_Zero.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest Cloud Zero</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Kubernetes_Supply.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Kubernetes_Supply.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest Kubernetes Supply</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Office_Zero.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Office_Zero.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <title>2026 03 31 Tech Security Weekly Digest Office Zero</title>
   <!-- Dark Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ollama_SolarWinds.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ollama_SolarWinds.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Ollama SolarWinds</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ransomware_Agent.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ransomware_Agent.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Ransomware Agent</title>
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ransomware_LLM.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Ransomware_LLM.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Ransomware LLM</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Security_Agent.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Security_Agent.svg
@@ -1,4 +1,5 @@
 <svg viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Security Agent</title>
   <defs>
     <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0c1a;stop-opacity:1" />

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Vulnerability_Patch.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Vulnerability_Patch.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest Vulnerability Patch</title>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0%" stop-color="#0a0c1a"/>

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Vulnerability_Patch_AI_GPT.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Vulnerability_Patch_AI_GPT.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>2026 03 31 Tech Security Weekly Digest Vulnerability Patch AI GPT</title>
   <defs>
     <!-- Glass blur filter -->
     <filter id="glassBlur" x="-20%" y="-20%" width="140%" height="140%">

--- a/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Zero_Trust.svg
+++ b/assets/images/2026-03-31-Tech_Security_Weekly_Digest_Zero_Trust.svg
@@ -1,4 +1,5 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <title>2026 03 31 Tech Security Weekly Digest Zero Trust</title>
   <!-- Dark background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 

--- a/assets/images/Tech_Security_Weekly_Digest_Threat_Vulnerability.svg
+++ b/assets/images/Tech_Security_Weekly_Digest_Threat_Vulnerability.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <title>Tech Security Weekly Digest Threat Vulnerability</title>
   <!-- Dark Background -->
   <rect width="1200" height="630" fill="#0a0c1a"/>
 


### PR DESCRIPTION
## Summary
- add missing `<title>` elements across 200 SVG files under `assets/images/`
- preserve the scope to SVG CI failures only and keep unrelated local script changes out of this branch
- retain the repaired March 21-24 SVG files so they parse cleanly during the repo-wide SVG check

## Verification
- `python3 scripts/check_svg_quality.py --ci assets/images/`
- Result: `Summary: 152 PASS, 90 WARNING, 0 FAIL / 242 files checked`

## Notes
- This PR addresses SVG CI `FAIL` conditions only. Existing `WARNING` items such as missing `width`/`height` and forbidden text characters are intentionally left unchanged.
