### PR TITLE
feat: Tags 태그 통계 시각화 바 차트 추가

### DIFF
--- a/_sass/_tags.scss
+++ b/_sass/_tags.scss
@@ -705,6 +705,217 @@
 }
 
 /* ====================================
+   Tag Statistics Chart
+   ==================================== */
+
+.tags-chart-details {
+  margin-bottom: var(--spacing-lg);
+  border: 1px solid rgba(139, 92, 246, 0.15);
+  border-radius: var(--border-radius-xl);
+  background: var(--color-bg-primary);
+  overflow: hidden;
+}
+
+[data-theme="dark"] .tags-chart-details {
+  background: var(--color-bg-secondary);
+  border-color: rgba(139, 92, 246, 0.22);
+}
+
+.tags-chart-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md) var(--spacing-lg);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  border-radius: var(--border-radius-xl);
+  transition: background-color var(--transition-fast);
+
+  &::-webkit-details-marker {
+    display: none;
+  }
+
+  &:hover {
+    background-color: rgba(139, 92, 246, 0.04);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+[data-theme="dark"] .tags-chart-summary:hover {
+  background-color: rgba(139, 92, 246, 0.08);
+}
+
+.tags-chart-summary-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  letter-spacing: 0.01em;
+}
+
+.tags-chart-summary-sub {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  font-weight: var(--font-weight-medium);
+}
+
+.tags-chart-chevron {
+  margin-left: auto;
+  color: var(--color-text-tertiary);
+  flex-shrink: 0;
+  transition: transform 200ms ease;
+}
+
+.tags-chart-details[open] .tags-chart-chevron {
+  transform: rotate(180deg);
+}
+
+.tags-chart {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: var(--spacing-sm) var(--spacing-lg) var(--spacing-lg);
+}
+
+.tags-chart-row {
+  display: grid;
+  grid-template-columns: 120px 1fr 36px;
+  align-items: center;
+  gap: var(--spacing-sm);
+  text-decoration: none;
+  border-radius: var(--border-radius-md);
+  padding: 3px 4px;
+  transition: background-color var(--transition-fast);
+  min-height: 44px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: rgba(139, 92, 246, 0.05);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+}
+
+[data-theme="dark"] .tags-chart-row:hover {
+  background-color: rgba(139, 92, 246, 0.1);
+}
+
+.tags-chart-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+  transition: color var(--transition-fast);
+}
+
+.tags-chart-row:hover .tags-chart-label {
+  color: var(--color-primary);
+}
+
+[data-theme="dark"] .tags-chart-row:hover .tags-chart-label {
+  color: rgba(196, 167, 255, 1);
+}
+
+.tags-chart-track {
+  position: relative;
+  height: 28px;
+  background: var(--color-bg-secondary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+[data-theme="dark"] .tags-chart-track {
+  background: var(--color-bg-tertiary);
+}
+
+.tags-chart-bar {
+  display: block;
+  height: 100%;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #8b5cf6 0%, #3b82f6 60%, #06b6d4 100%);
+  min-width: 4px;
+  transition: transform 150ms ease, filter 150ms ease;
+  transform-origin: left center;
+}
+
+.tags-chart-row:hover .tags-chart-bar {
+  transform: translateX(2px);
+  filter: brightness(1.15);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tags-chart-bar {
+    transition: none;
+  }
+  .tags-chart-chevron {
+    transition: none;
+  }
+}
+
+.tags-chart-count {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-tertiary);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  transition: color var(--transition-fast);
+}
+
+.tags-chart-row:hover .tags-chart-count {
+  color: var(--color-primary);
+}
+
+[data-theme="dark"] .tags-chart-row:hover .tags-chart-count {
+  color: rgba(196, 167, 255, 1);
+}
+
+/* Mobile: tighter label column, smaller font */
+@media (max-width: 767px) {
+  .tags-chart-row {
+    grid-template-columns: 90px 1fr 30px;
+    gap: 6px;
+    min-height: 40px;
+  }
+
+  .tags-chart-label {
+    font-size: 0.6875rem;
+  }
+
+  .tags-chart-bar {
+    height: 22px;
+  }
+
+  .tags-chart-track {
+    height: 22px;
+  }
+}
+
+/* Very small screens: show only top 10 (hide rows 11-15) */
+@media (max-width: 479px) {
+  .tags-chart-row:nth-child(n+11) {
+    display: none;
+  }
+
+  .tags-chart-summary-sub::after {
+    content: " (상위 10개)";
+  }
+
+  .tags-chart-row {
+    grid-template-columns: 80px 1fr 28px;
+  }
+}
+
+/* ====================================
    Tags Toolbar / Search
    ==================================== */
 

--- a/tags.html
+++ b/tags.html
@@ -62,6 +62,64 @@ page_modifier: page--utility
       </div>
     </div>
 
+    <!-- Tag Statistics Chart -->
+    <!-- Build zero-padded entries so lexicographic sort == numeric sort -->
+    {% assign tag_counts = "" | split: "" %}
+    {% assign all_tag_post_counts = "" | split: "" %}
+    {% for tag in all_tags %}
+      {% assign tag_str = tag | append: "" %}
+      {% assign tag_posts = site.posts | where_exp: "post", "post.tags contains tag" %}
+      {% assign tc = tag_posts.size %}
+      {% assign all_tag_post_counts = all_tag_post_counts | push: tc %}
+      {% if tc >= 1000 %}
+        {% assign padded = tc %}
+      {% elsif tc >= 100 %}
+        {% assign padded = tc | prepend: "0" %}
+      {% elsif tc >= 10 %}
+        {% assign padded = tc | prepend: "00" %}
+      {% else %}
+        {% assign padded = tc | prepend: "000" %}
+      {% endif %}
+      {% assign entry = padded | append: ":::" | append: tag_str | append: ":::" | append: tc %}
+      {% assign tag_counts = tag_counts | push: entry %}
+    {% endfor %}
+
+    {% assign sorted_tag_counts = tag_counts | sort | reverse %}
+
+    {% assign sorted_counts_only = all_tag_post_counts | sort | reverse %}
+    {% assign max_count = 1 %}
+    {% for c in sorted_counts_only limit: 1 %}
+      {% assign max_count = c %}
+    {% endfor %}
+
+    <details class="tags-chart-details" open>
+      <summary class="tags-chart-summary" aria-label="태그 통계 펼치기/접기">
+        <span class="tags-chart-summary-label">태그 통계</span>
+        <span class="tags-chart-summary-sub">상위 15개 태그</span>
+        <svg class="tags-chart-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <polyline points="6 9 12 15 18 9"/>
+        </svg>
+      </summary>
+      <div class="tags-chart" role="list" aria-label="태그별 포스트 수 막대 차트">
+        {% for entry in sorted_tag_counts limit: 15 %}
+          {% assign parts = entry | split: ":::" %}
+          {% assign chart_tag = parts[1] %}
+          {% assign chart_count = parts[2] | plus: 0 %}
+          {% assign bar_pct = chart_count | times: 100 | divided_by: max_count %}
+          <a href="#{{ chart_tag | slugify }}"
+             class="tags-chart-row"
+             role="listitem"
+             aria-label="{{ chart_tag }}: {{ chart_count }}개 포스트">
+            <span class="tags-chart-label">{{ chart_tag }}</span>
+            <span class="tags-chart-track" aria-hidden="true">
+              <span class="tags-chart-bar" style="width: {{ bar_pct }}%"></span>
+            </span>
+            <span class="tags-chart-count">{{ chart_count }}</span>
+          </a>
+        {% endfor %}
+      </div>
+    </details>
+
     <!-- Search Toolbar -->
     <div class="tags-toolbar">
       <div class="tags-search-wrap">


### PR DESCRIPTION
## Summary
- 상위 15개 태그별 포스트 수 수평 바 차트 추가
- 순수 CSS + Liquid 기반, JS 불필요
- 클릭 시 해당 태그 섹션으로 스크롤
- details/summary 접기/펼치기, 다크 모드, 모바일 반응형

## Test plan
- [x] Jekyll 빌드 성공 (7.9s, 오류 없음)
- [ ] CI 통과 확인
- [ ] 프로덕션 Tags 페이지 렌더링 확인