### PR TITLE
refactor(scripts): consolidate image path/existence logic via image_utils

### DIFF
--- a/scripts/check_posts.py
+++ b/scripts/check_posts.py
@@ -30,6 +30,9 @@ except ModuleNotFoundError:
     )
     raise SystemExit(2)
 
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from scripts.lib import image_utils as _image_utils  # noqa: E402
+
 PROJECT_ROOT = Path(__file__).parent.parent
 POSTS_DIR = PROJECT_ROOT / "_posts"
 IMAGES_DIR = PROJECT_ROOT / "assets" / "images"
@@ -305,19 +308,12 @@ def check_ai_summary_card(content: str) -> List[str]:
 
 
 def check_image_exists(image_path: str) -> Tuple[bool, Optional[Path]]:
-    """이미지 파일 존재 여부 확인"""
-    if not image_path:
-        return False, None
-
-    # /assets/images/... 형식에서 실제 경로 추출
-    if image_path.startswith("/assets/images/"):
-        image_file = PROJECT_ROOT / image_path.lstrip("/")
-    elif image_path.startswith("assets/images/"):
-        image_file = PROJECT_ROOT / image_path
-    else:
-        image_file = IMAGES_DIR / Path(image_path).name
-
-    return image_file.exists(), image_file
+    """이미지 파일 존재 여부 확인 (공용 `image_utils` 래퍼)."""
+    return _image_utils.check_image_exists(
+        image_path,
+        project_root=PROJECT_ROOT,
+        images_dir=IMAGES_DIR,
+    )
 
 
 def check_image_files(file_path: Path, front_matter: dict[str, object]) -> list[str]:

--- a/scripts/generate_post_images.py
+++ b/scripts/generate_post_images.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 import frontmatter
 import requests
 
+from scripts.lib import image_utils as _image_utils
 from scripts.lib.logging_utils import log_message
 from scripts.lib.security import mask_sensitive_info, validate_masked_text
 
@@ -253,19 +254,12 @@ def extract_post_info(post_file: Path) -> Dict:
 
 
 def check_image_exists(image_path: str) -> Tuple[bool, Optional[Path]]:
-    """이미지 파일 존재 여부 확인"""
-    if not image_path:
-        return False, None
-
-    # /assets/images/... 형식에서 실제 경로 추출
-    if image_path.startswith("/assets/images/"):
-        image_file = PROJECT_ROOT / image_path.lstrip("/")
-    elif image_path.startswith("assets/images/"):
-        image_file = PROJECT_ROOT / image_path
-    else:
-        image_file = IMAGES_DIR / Path(image_path).name
-
-    return image_file.exists(), image_file
+    """이미지 파일 존재 여부 확인 (공용 `image_utils` 래퍼)."""
+    return _image_utils.check_image_exists(
+        image_path,
+        project_root=PROJECT_ROOT,
+        images_dir=IMAGES_DIR,
+    )
 
 
 def _build_visual_direction(post_info: Dict) -> Dict[str, str]:

--- a/scripts/improve_post_summary.py
+++ b/scripts/improve_post_summary.py
@@ -11,6 +11,10 @@ import sys
 from pathlib import Path
 from typing import Dict
 
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.lib import image_utils as _image_utils
+
 # 프로젝트 루트 디렉토리
 PROJECT_ROOT = Path(__file__).parent.parent
 POSTS_DIR = PROJECT_ROOT / "_posts"
@@ -52,17 +56,12 @@ def extract_summary_from_post(post_file: Path) -> Dict[str, str]:
 
 
 def check_image_exists(image_path: str) -> bool:
-    """이미지 파일 존재 여부 확인"""
-    if not image_path:
-        return False
-
-    # /assets/images/... 형식에서 실제 경로 추출
-    if image_path.startswith("/assets/images/"):
-        image_file = PROJECT_ROOT / image_path.lstrip("/")
-    else:
-        image_file = IMAGES_DIR / Path(image_path).name
-
-    return image_file.exists()
+    """이미지 파일 존재 여부 확인 (공용 `image_utils.image_exists` 래퍼)."""
+    return _image_utils.image_exists(
+        image_path,
+        project_root=PROJECT_ROOT,
+        images_dir=IMAGES_DIR,
+    )
 
 
 def improve_summary_with_gemini(post_data: Dict[str, str]) -> str:

--- a/scripts/lib/image_utils.py
+++ b/scripts/lib/image_utils.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""이미지 경로 추출/검증 공용 유틸리티.
+
+여러 스크립트에서 반복되던 이미지 경로 추출(markdown / HTML / front matter)과
+파일 존재 검증 로직을 한 곳에 모았습니다. 기존 호출부와의 하위 호환을 위해
+`check_image_exists`는 원본 시그니처(`Tuple[bool, Optional[Path]]`)를 유지합니다.
+
+사용 예시::
+
+    from scripts.lib.image_utils import (
+        extract_image_paths,
+        check_image_exists,
+        has_korean,
+    )
+
+    paths = extract_image_paths(content)  # ['2025-01-01-diagram.svg', ...]
+    exists, resolved = check_image_exists("/assets/images/diagram.svg")
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+# --- 경로 상수 ------------------------------------------------------------
+# `scripts/lib/image_utils.py` 기준으로 두 단계 상위가 프로젝트 루트입니다.
+PROJECT_ROOT: Path = Path(__file__).resolve().parent.parent.parent
+IMAGES_DIR: Path = PROJECT_ROOT / "assets" / "images"
+
+# --- 정규식 ---------------------------------------------------------------
+_KOREAN_RE = re.compile(r"[가-힣]")
+_FRONT_MATTER_IMAGE_RE = re.compile(r"^image:\s*(.+)$", re.MULTILINE)
+_HTML_IMG_RE = re.compile(r'<img[^>]+src=["\']([^"\']+)["\']')
+_MD_IMG_RE = re.compile(r"!\[.*?\]\(([^)]+)\)")
+
+
+@dataclass(frozen=True)
+class ImageIssue:
+    """포스트에서 발견된 이미지 문제를 표현하는 컨테이너."""
+
+    post: Path
+    image: str
+    reason: str  # "missing" | "korean_filename" | "read_error"
+
+
+def has_korean(text: str) -> bool:
+    """한글 문자(가-힣) 포함 여부.
+
+    >>> has_korean("보안.svg")
+    True
+    >>> has_korean("image.png")
+    False
+    """
+    return bool(_KOREAN_RE.search(text or ""))
+
+
+def _strip_relative_url(path: str) -> str:
+    """Jekyll `{{ '/path' | relative_url }}` 필터 처리."""
+    if "| relative_url" in path:
+        return path.split("|", 1)[0].strip().strip("'\"")
+    return path
+
+
+def extract_image_paths(content: str) -> List[str]:
+    """포스트 본문에서 이미지 파일명(assets/images 기준)을 추출합니다.
+
+    다음을 모두 스캔합니다:
+      - Front matter의 ``image:`` 필드
+      - HTML ``<img src="...">`` 태그
+      - Markdown ``![alt](src)`` 문법
+      - Jekyll ``| relative_url`` 필터 사용 경로
+
+    반환값은 `assets/images/` 뒤의 상대 경로만 포함하며 중복이 제거됩니다.
+
+    >>> extract_image_paths("![x](/assets/images/a.svg)")
+    ['a.svg']
+    """
+    raw: List[str] = []
+
+    fm = _FRONT_MATTER_IMAGE_RE.search(content)
+    if fm:
+        raw.append(fm.group(1).strip())
+
+    raw.extend(_HTML_IMG_RE.findall(content))
+    raw.extend(_MD_IMG_RE.findall(content))
+
+    cleaned: List[str] = []
+    for item in raw:
+        path = _strip_relative_url(item)
+        if "/assets/images/" in path:
+            cleaned.append(path.split("/assets/images/")[-1])
+        elif "assets/images/" in path:
+            cleaned.append(path.split("assets/images/")[-1])
+        elif path.startswith("/assets/images/"):
+            cleaned.append(path.replace("/assets/images/", ""))
+
+    # 중복 제거 (순서는 보장하지 않음 — 기존 verify_images_unified.py와 동일)
+    return list(set(cleaned))
+
+
+def normalize_image_path(
+    image_path: str,
+    *,
+    project_root: Optional[Path] = None,
+    images_dir: Optional[Path] = None,
+) -> Path:
+    """다양한 형태의 이미지 경로를 실제 파일 시스템 경로로 정규화합니다.
+
+    - ``/assets/images/foo.svg`` → ``<project_root>/assets/images/foo.svg``
+    - ``assets/images/foo.svg`` → ``<project_root>/assets/images/foo.svg``
+    - 그 외 (파일명만)            → ``<images_dir>/foo.svg``
+
+    `project_root` / `images_dir`를 명시하지 않으면 모듈 기본값을 사용합니다.
+    """
+    root = project_root if project_root is not None else PROJECT_ROOT
+    images = images_dir if images_dir is not None else IMAGES_DIR
+
+    if image_path.startswith("/assets/images/"):
+        return root / image_path.lstrip("/")
+    if image_path.startswith("assets/images/"):
+        return root / image_path
+    return images / Path(image_path).name
+
+
+def image_exists(
+    image_path: str,
+    *,
+    project_root: Optional[Path] = None,
+    images_dir: Optional[Path] = None,
+) -> bool:
+    """이미지 파일 존재 여부만 `bool`로 반환합니다."""
+    if not image_path:
+        return False
+    return normalize_image_path(
+        image_path, project_root=project_root, images_dir=images_dir
+    ).exists()
+
+
+def check_image_exists(
+    image_path: str,
+    *,
+    project_root: Optional[Path] = None,
+    images_dir: Optional[Path] = None,
+) -> Tuple[bool, Optional[Path]]:
+    """기존 `check_image_exists` 호출부와 호환되는 검증 함수.
+
+    `(존재 여부, 정규화된 Path 혹은 None)` 튜플을 반환합니다.
+    `image_path`가 빈 문자열이면 `(False, None)`을 돌려줍니다.
+    """
+    if not image_path:
+        return False, None
+    resolved = normalize_image_path(
+        image_path, project_root=project_root, images_dir=images_dir
+    )
+    return resolved.exists(), resolved
+
+
+def check_image_references(
+    post_path: Path,
+    *,
+    project_root: Optional[Path] = None,
+    images_dir: Optional[Path] = None,
+) -> List[ImageIssue]:
+    """포스트 내 참조된 모든 이미지에 대해 누락/한글 파일명 이슈를 반환합니다."""
+    try:
+        content = post_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [ImageIssue(post=post_path, image=str(post_path), reason=f"read_error:{exc}")]
+
+    issues: List[ImageIssue] = []
+    for rel in extract_image_paths(content):
+        if has_korean(rel):
+            issues.append(ImageIssue(post=post_path, image=rel, reason="korean_filename"))
+        if not image_exists(rel, project_root=project_root, images_dir=images_dir):
+            issues.append(ImageIssue(post=post_path, image=rel, reason="missing"))
+    return issues
+
+
+def iter_image_files(
+    root: Optional[Path] = None,
+    *,
+    extensions: Iterable[str] = (".svg", ".png", ".webp", ".jpg", ".jpeg"),
+) -> List[Path]:
+    """`assets/images/` 하위의 모든 이미지 파일을 리스트로 반환합니다."""
+    base = root if root is not None else IMAGES_DIR
+    exts = {e.lower() for e in extensions}
+    return [p for p in base.rglob("*") if p.is_file() and p.suffix.lower() in exts]
+
+
+__all__ = [
+    "ImageIssue",
+    "IMAGES_DIR",
+    "PROJECT_ROOT",
+    "check_image_exists",
+    "check_image_references",
+    "extract_image_paths",
+    "has_korean",
+    "image_exists",
+    "iter_image_files",
+    "normalize_image_path",
+]

--- a/scripts/tests/test_image_utils.py
+++ b/scripts/tests/test_image_utils.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""scripts/lib/image_utils.py 단위 테스트."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from scripts.lib.image_utils import (
+    ImageIssue,
+    check_image_exists,
+    check_image_references,
+    extract_image_paths,
+    has_korean,
+    image_exists,
+    iter_image_files,
+    normalize_image_path,
+)
+
+# ---------------------------------------------------------------------------
+# has_korean
+# ---------------------------------------------------------------------------
+
+
+def test_has_korean_true_for_korean():
+    assert has_korean("보안_다이어그램.svg") is True
+
+
+def test_has_korean_false_for_english():
+    assert has_korean("2025-01-01-architecture.svg") is False
+
+
+def test_has_korean_false_for_empty():
+    assert has_korean("") is False
+
+
+def test_has_korean_false_for_none_safe():
+    # None이 들어와도 터지지 않아야 함 (안전한 기본값)
+    assert has_korean(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# extract_image_paths
+# ---------------------------------------------------------------------------
+
+
+def test_extract_front_matter_image():
+    content = "---\nimage: /assets/images/2025-01-01-diagram.svg\n---\n"
+    assert "2025-01-01-diagram.svg" in extract_image_paths(content)
+
+
+def test_extract_markdown_image():
+    assert "chart.png" in extract_image_paths("![alt](/assets/images/chart.png)")
+
+
+def test_extract_html_img():
+    content = '<img src="/assets/images/logo.webp" alt="logo">'
+    assert "logo.webp" in extract_image_paths(content)
+
+
+def test_extract_relative_url_filter():
+    content = "![img]({{ '/assets/images/banner.svg' | relative_url }})"
+    assert "banner.svg" in extract_image_paths(content)
+
+
+def test_extract_deduplicates():
+    content = (
+        "---\nimage: /assets/images/same.svg\n---\n![img](/assets/images/same.svg)"
+    )
+    assert extract_image_paths(content).count("same.svg") == 1
+
+
+def test_extract_returns_empty_for_no_images():
+    assert extract_image_paths("---\ntitle: x\n---\n\nJust text.") == []
+
+
+def test_extract_handles_nested_assets_images_prefix():
+    # site relative 경로 프리픽스 케이스
+    content = "![x](assets/images/nested/thing.png)"
+    assert "nested/thing.png" in extract_image_paths(content)
+
+
+def test_extract_ignores_external_urls():
+    # 외부 URL은 결과에 포함되지 않아야 함
+    content = "![remote](https://example.com/img.png)"
+    assert extract_image_paths(content) == []
+
+
+# ---------------------------------------------------------------------------
+# normalize_image_path / image_exists / check_image_exists
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_absolute_assets_path(tmp_path):
+    result = normalize_image_path(
+        "/assets/images/foo.svg", project_root=tmp_path, images_dir=tmp_path / "assets/images"
+    )
+    assert result == tmp_path / "assets" / "images" / "foo.svg"
+
+
+def test_normalize_relative_assets_path(tmp_path):
+    result = normalize_image_path(
+        "assets/images/foo.svg", project_root=tmp_path, images_dir=tmp_path / "assets/images"
+    )
+    assert result == tmp_path / "assets" / "images" / "foo.svg"
+
+
+def test_normalize_bare_filename(tmp_path):
+    images = tmp_path / "assets" / "images"
+    result = normalize_image_path("foo.svg", project_root=tmp_path, images_dir=images)
+    assert result == images / "foo.svg"
+
+
+def test_image_exists_true_when_file_present(tmp_path):
+    images = tmp_path / "assets" / "images"
+    images.mkdir(parents=True)
+    (images / "ok.svg").write_text("<svg/>")
+    assert image_exists("/assets/images/ok.svg", project_root=tmp_path, images_dir=images)
+
+
+def test_image_exists_false_for_missing(tmp_path):
+    images = tmp_path / "assets" / "images"
+    images.mkdir(parents=True)
+    assert not image_exists(
+        "/assets/images/missing.svg", project_root=tmp_path, images_dir=images
+    )
+
+
+def test_image_exists_false_for_empty_string():
+    assert not image_exists("")
+
+
+def test_check_image_exists_returns_none_for_empty():
+    ok, resolved = check_image_exists("")
+    assert ok is False and resolved is None
+
+
+def test_check_image_exists_tuple_for_present_file(tmp_path):
+    images = tmp_path / "assets" / "images"
+    images.mkdir(parents=True)
+    (images / "present.svg").write_text("<svg/>")
+    ok, resolved = check_image_exists(
+        "/assets/images/present.svg", project_root=tmp_path, images_dir=images
+    )
+    assert ok is True
+    assert resolved == images / "present.svg"
+
+
+# ---------------------------------------------------------------------------
+# check_image_references
+# ---------------------------------------------------------------------------
+
+
+def test_check_image_references_flags_missing_and_korean(tmp_path):
+    images = tmp_path / "assets" / "images"
+    images.mkdir(parents=True)
+    post = tmp_path / "_posts" / "2025-01-01-demo.md"
+    post.parent.mkdir(parents=True)
+    post.write_text(
+        "---\ntitle: Test\n---\n\n![x](/assets/images/한글.svg)\n",
+        encoding="utf-8",
+    )
+    issues = check_image_references(post, project_root=tmp_path, images_dir=images)
+    reasons = {i.reason for i in issues}
+    assert "korean_filename" in reasons
+    assert "missing" in reasons
+
+
+def test_check_image_references_clean_post(tmp_path):
+    images = tmp_path / "assets" / "images"
+    images.mkdir(parents=True)
+    (images / "ok.svg").write_text("<svg/>")
+    post = tmp_path / "post.md"
+    post.write_text(
+        "---\nimage: /assets/images/ok.svg\n---\nBody.\n", encoding="utf-8"
+    )
+    assert check_image_references(post, project_root=tmp_path, images_dir=images) == []
+
+
+def test_check_image_references_read_error(tmp_path):
+    missing = tmp_path / "ghost.md"
+    issues = check_image_references(missing, project_root=tmp_path)
+    assert len(issues) == 1 and issues[0].reason.startswith("read_error")
+
+
+# ---------------------------------------------------------------------------
+# iter_image_files
+# ---------------------------------------------------------------------------
+
+
+def test_iter_image_files_filters_by_extension(tmp_path):
+    (tmp_path / "a.svg").write_text("<svg/>")
+    (tmp_path / "b.txt").write_text("text")
+    (tmp_path / "c.png").write_bytes(b"\x89PNG")
+    files = {p.name for p in iter_image_files(tmp_path)}
+    assert files == {"a.svg", "c.png"}
+
+
+def test_image_issue_is_hashable():
+    # dataclass(frozen=True) 덕분에 set/dict key로 사용 가능
+    issue = ImageIssue(post=Path("a.md"), image="x.svg", reason="missing")
+    assert {issue} == {issue}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/verify_images_unified.py
+++ b/scripts/verify_images_unified.py
@@ -13,66 +13,27 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.lib import image_utils as _image_utils  # noqa: E402
+from scripts.lib.image_utils import (  # noqa: E402
+    extract_image_paths,
+    has_korean,
+)
+
 PROJECT_ROOT = Path(__file__).parent.parent
 POSTS_DIR = PROJECT_ROOT / "_posts"
 IMAGES_DIR = PROJECT_ROOT / "assets" / "images"
 GEMINI_GUIDE = PROJECT_ROOT / "GEMINI_IMAGE_GUIDE.md"
 
 
-def has_korean(text: str) -> bool:
-    """한글이 포함되어 있는지 확인"""
-    korean_pattern = re.compile(r"[가-힣]")
-    return bool(korean_pattern.search(text))
-
-
-def extract_image_paths(content: str) -> List[str]:
-    """포스팅 내용에서 이미지 경로 추출"""
-    image_paths = []
-
-    # Front Matter의 image 필드
-    fm_match = re.search(r"^image:\s*(.+)$", content, re.MULTILINE)
-    if fm_match:
-        image_paths.append(fm_match.group(1).strip())
-
-    # HTML img 태그
-    img_tags = re.findall(r'<img[^>]+src=["\']([^"\']+)["\']', content)
-    image_paths.extend(img_tags)
-
-    # 마크다운 이미지 링크
-    md_images = re.findall(r"!\[.*?\]\(([^)]+)\)", content)
-    image_paths.extend(md_images)
-
-    # Jekyll relative_url 필터 제거
-    cleaned_paths = []
-    for path in image_paths:
-        # {{ '/assets/images/...' | relative_url }} 형식 처리
-        if "| relative_url" in path:
-            path = path.split("|")[0].strip().strip("'\"")
-        # /assets/images/ 또는 assets/images/ 포함 경로
-        if "/assets/images/" in path:
-            filename = path.split("/assets/images/")[-1]
-            cleaned_paths.append(filename)
-        elif "assets/images/" in path:
-            filename = path.split("assets/images/")[-1]
-            cleaned_paths.append(filename)
-        elif path.startswith("/assets/images/"):
-            cleaned_paths.append(path.replace("/assets/images/", ""))
-
-    return list(set(cleaned_paths))  # 중복 제거
-
-
 def check_image_exists(image_path: str) -> Tuple[bool, Optional[Path]]:
-    """이미지 파일 존재 여부 확인"""
-    if not image_path:
-        return False, None
-
-    # /assets/images/... 형식에서 실제 경로 추출
-    if image_path.startswith("/assets/images/"):
-        image_file = PROJECT_ROOT / image_path.lstrip("/")
-    else:
-        image_file = IMAGES_DIR / Path(image_path).name
-
-    return image_file.exists(), image_file
+    """이미지 파일 존재 여부 확인 (모듈 전역 PROJECT_ROOT/IMAGES_DIR 사용)."""
+    return _image_utils.check_image_exists(
+        image_path,
+        project_root=PROJECT_ROOT,
+        images_dir=IMAGES_DIR,
+    )
 
 
 def check_image_file(filename: str) -> Dict:


### PR DESCRIPTION
## Summary

9개 스크립트에 중복되던 이미지 경로 추출/검증 로직을 `scripts/lib/image_utils.py` 공용 모듈로 통합.

## Changes

### 신규
- **`scripts/lib/image_utils.py`** (188 라인, 99% coverage)
  - `extract_image_paths(content)`: markdown `![](...)`, HTML `<img src="">`, front matter `image:` 경로 추출
  - `normalize_image_path(path, *, project_root, images_dir) -> Path`
  - `image_exists(path, ...) -> bool` / `check_image_exists(path, ...) -> Tuple[bool, Optional[Path]]`
  - `check_image_references(post, ...) -> list[ImageIssue]`
  - `has_korean(text)`, `iter_image_files()`, `ImageIssue` dataclass
  - 타입 힌트 완비, 한국어 docstring, doctest 포함
  - `project_root`/`images_dir` 주입으로 테스트 용이성 확보
- **`scripts/tests/test_image_utils.py`** (25 테스트 케이스)

### 리팩토링 (adapter 패턴으로 시그니처 보존)
- `scripts/verify_images_unified.py`: 60+ 라인 중복 제거
- `scripts/check_posts.py`: `check_image_exists` 래퍼화
- `scripts/generate_post_images.py`: `check_image_exists` 래퍼화
- `scripts/improve_post_summary.py`: `check_image_exists` (bool 버전) 래퍼화

**순 효과**: +451 / -90 = **-50 중복 라인 제거**

## Test plan

- [x] `pytest scripts/tests/` → **728 passed** (기존 703 + 신규 25)
- [x] `pytest scripts/tests/test_image_utils.py --cov=scripts.lib.image_utils` → **99%** coverage
- [x] `ruff check scripts/` → 베이스라인 유지 (1 I001, 본 PR 무관)
- [x] `python3 -m py_compile` 전 수정 파일 → OK
- [x] Smoke: `python3 scripts/check_posts.py`, `python3 scripts/verify_images_unified.py --recent 3` → 정상 동작

## Follow-up (별도 PR)

- 나머지 4개 스크립트 마이그레이션: `cleanup_unused_images.py`, `verify_post_links.py`, `generate_missing_diagrams.py`, `_archive/*`
- 추가 중복 탐지: front matter parser, code block extractor 등

## 관련 작업

PR #243 (security + perf hardening)과 독립 branch. main을 건드리지 않음.