### PR TITLE
fix: 테이블 좌우 스크롤 버튼 제거

### DIFF
--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -512,69 +512,6 @@
   background: var(--color-primary-hover, #1d4ed8);
 }
 
-/* ===== PC 테이블 좌우 스크롤 버튼 ===== */
-.table-scroll-btn {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 32px;
-  height: 32px;
-  border: 1px solid var(--color-border);
-  border-radius: 50%;
-  background: var(--color-bg-primary);
-  color: var(--color-text-secondary);
-  font-size: 14px;
-  cursor: pointer;
-  z-index: 10;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
-  transition: opacity 0.2s, background-color 0.2s, color 0.2s;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.table-scroll-btn:hover {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
-}
-
-.table-scroll-btn--left {
-  left: -16px;
-}
-
-.table-scroll-btn--right {
-  right: -16px;
-}
-
-.table-wrapper.can-scroll-left .table-scroll-btn--left,
-.table-wrapper.can-scroll-right .table-scroll-btn--right {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-/* 모바일에서는 버튼 숨김 (터치 스크롤 사용) */
-@media (max-width: 768px) {
-  .table-scroll-btn {
-    display: none;
-  }
-}
-
-[data-theme="dark"] .table-scroll-btn {
-  background: var(--color-bg-secondary);
-  border-color: var(--color-border);
-  color: var(--color-text-secondary);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme="dark"] .table-scroll-btn:hover {
-  background: var(--color-primary);
-  color: #fff;
-  border-color: var(--color-primary);
-}
-
 /* ===== 태블릿 (768px ~ 1024px) ===== */
 @media (max-width: 1024px) and (min-width: 769px) {
   .post-content table {

--- a/assets/js/main-post.js
+++ b/assets/js/main-post.js
@@ -357,44 +357,6 @@
         addCellStateClasses(table, context);
       };
       
-      // PC 좌우 스크롤 버튼 생성
-      const setupScrollButtons = (wrapper) => {
-        if (wrapper.querySelector('.table-scroll-btn')) return;
-
-        const btnLeft = document.createElement('button');
-        btnLeft.className = 'table-scroll-btn table-scroll-btn--left';
-        btnLeft.setAttribute('aria-label', 'Scroll table left');
-        btnLeft.innerHTML = '&#9664;';
-        btnLeft.addEventListener('click', () => {
-          wrapper.scrollBy({ left: -200, behavior: 'smooth' });
-        });
-
-        const btnRight = document.createElement('button');
-        btnRight.className = 'table-scroll-btn table-scroll-btn--right';
-        btnRight.setAttribute('aria-label', 'Scroll table right');
-        btnRight.innerHTML = '&#9654;';
-        btnRight.addEventListener('click', () => {
-          wrapper.scrollBy({ left: 200, behavior: 'smooth' });
-        });
-
-        wrapper.appendChild(btnLeft);
-        wrapper.appendChild(btnRight);
-      };
-
-      // 스크롤 위치에 따라 버튼 표시/숨김
-      const updateScrollBtnState = (wrapper) => {
-        const scrollLeft = wrapper.scrollLeft;
-        const maxScroll = wrapper.scrollWidth - wrapper.clientWidth;
-
-        if (maxScroll <= 0) {
-          wrapper.classList.remove('can-scroll-left', 'can-scroll-right');
-          return;
-        }
-
-        wrapper.classList.toggle('can-scroll-left', scrollLeft > 2);
-        wrapper.classList.toggle('can-scroll-right', scrollLeft < maxScroll - 2);
-      };
-
       // 테이블 래퍼 생성 및 스크롤 이벤트 설정
       const wrapTables = () => {
         const postContent = document.querySelector('.post-content');
@@ -471,16 +433,7 @@
           } else {
             wrapper.classList.remove('no-scroll-hint');
           }
-          updateScrollBtnState(wrapper);
         };
-
-        // PC 좌우 스크롤 버튼 추가
-        setupScrollButtons(wrapper);
-
-        // 스크롤 시 버튼 상태 업데이트
-        wrapper.addEventListener('scroll', () => {
-          updateScrollBtnState(wrapper);
-        }, { passive: true });
 
         // 초기 체크 (약간 지연)
         setTimeout(checkScrollable, 100);


### PR DESCRIPTION
## Summary
- 테이블 좌우 스크롤 버튼(◀▶) JS/CSS 코드 완전 제거
- blockquote 내 테이블에 불필요한 버튼이 표시되던 문제 해결
- 테이블 래퍼의 자연 스크롤(터치/마우스) 기능은 유지

## Test plan
- [ ] 포스트 페이지에서 테이블에 ◀▶ 버튼이 없는지 확인
- [ ] 넓은 테이블에서 자연 스크롤 동작 확인