### PR TITLE
fix: 85개 포스트 이전 URL 301 리디렉션 추가 (SEO 404 해결)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -29,149 +29,326 @@
     {
       "source": "/(.*)",
       "headers": [
-        { 
-          "key": "Content-Security-Policy", 
+        {
+          "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://giscus.app https://va.vercel-scripts.com https://pagead2.googlesyndication.com https://www.googletagmanager.com https://*.googletagmanager.com https://*.google-analytics.com https://*.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://browser.sentry-cdn.com https://translate.google.com https://translate.googleapis.com https://translate-pa.googleapis.com https://www.gstatic.com https://cdn.jsdelivr.net https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; script-src-elem 'self' 'unsafe-inline' 'unsafe-eval' https://giscus.app https://va.vercel-scripts.com https://pagead2.googlesyndication.com https://www.googletagmanager.com https://*.googletagmanager.com https://*.google-analytics.com https://*.google.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://browser.sentry-cdn.com https://translate.google.com https://translate.googleapis.com https://translate-pa.googleapis.com https://www.gstatic.com https://cdn.jsdelivr.net https://static.cloudflareinsights.com https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://twodragon0.github.io https://giscus.app https://fonts.googleapis.com https://www.gstatic.com https://translate.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com data:; object-src 'none'; manifest-src 'self'; frame-src 'self' https://giscus.app https://googleads.g.doubleclick.net https://*.doubleclick.net https://tpc.googlesyndication.com https://*.googlesyndication.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://www.google.com; frame-ancestors 'self'; connect-src 'self' https://giscus.app https://api.mymemory.translated.net https://api.deepseek.com https://va.vercel-scripts.com https://vitals.vercel-insights.com https://googleads.g.doubleclick.net https://*.doubleclick.net https://pagead2.googlesyndication.com https://*.googlesyndication.com https://www.googletagmanager.com https://*.googletagmanager.com https://*.google-analytics.com https://*.google.com https://csi.gstatic.com https://ep1.adtrafficquality.google https://ep2.adtrafficquality.google https://*.adtrafficquality.google https://o4510686170710016.ingest.us.sentry.io https://*.ingest.sentry.io https://translate.googleapis.com https://translate-pa.googleapis.com https://buttondown.com https://api.buttondown.com https://cloudflareinsights.com https://static.cloudflareinsights.com; base-uri 'self'; form-action 'self' https://buttondown.com https://buttondown.email; worker-src 'self' blob:; upgrade-insecure-requests; report-to csp-endpoint; report-uri https://o4510686170710016.ingest.us.sentry.io/api/4510686177984512/security/?sentry_key=61fd23528aff138753e071de26c5b306;"
         },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
-        { "key": "X-DNS-Prefetch-Control", "value": "on" },
-        { "key": "X-Download-Options", "value": "noopen" },
-        { "key": "X-Permitted-Cross-Domain-Policies", "value": "none" },
-        { "key": "Reporting-Endpoints", "value": "csp-endpoint=\"https://o4510686170710016.ingest.us.sentry.io/api/4510686177984512/security/?sentry_key=61fd23528aff138753e071de26c5b306\"" },
-        { "key": "Cache-Control", "value": "public, s-maxage=3600, stale-while-revalidate=86400" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(), microphone=(), camera=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "on"
+        },
+        {
+          "key": "X-Download-Options",
+          "value": "noopen"
+        },
+        {
+          "key": "X-Permitted-Cross-Domain-Policies",
+          "value": "none"
+        },
+        {
+          "key": "Reporting-Endpoints",
+          "value": "csp-endpoint=\"https://o4510686170710016.ingest.us.sentry.io/api/4510686177984512/security/?sentry_key=61fd23528aff138753e071de26c5b306\""
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, s-maxage=3600, stale-while-revalidate=86400"
+        }
       ]
     },
     {
       "source": "/certifications/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
-        { "key": "X-DNS-Prefetch-Control", "value": "on" },
-        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(), microphone=(), camera=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "on"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
+        }
       ]
     },
     {
       "source": "/assets/css/:path*.css",
       "headers": [
-        { "key": "Content-Type", "value": "text/css; charset=utf-8" },
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Content-Type",
+          "value": "text/css; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/:path*.css",
       "headers": [
-        { "key": "Content-Type", "value": "text/css; charset=utf-8" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Content-Type",
+          "value": "text/css; charset=utf-8"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/assets/js/:path*.js",
       "headers": [
-        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Content-Type",
+          "value": "application/javascript; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/:path*.js",
       "headers": [
-        { "key": "Content-Type", "value": "application/javascript; charset=utf-8" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Content-Type",
+          "value": "application/javascript; charset=utf-8"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/assets/images/:path*.(webp|avif|png|svg)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/favicon.ico",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "Content-Type", "value": "image/png" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "Content-Type",
+          "value": "image/png"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/assets/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/(.*).html",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=7200, s-maxage=7200, stale-while-revalidate=172800" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=7200, s-maxage=7200, stale-while-revalidate=172800"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/posts/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
-        { "key": "X-DNS-Prefetch-Control", "value": "on" },
-        { "key": "Cache-Control", "value": "public, max-age=10800, s-maxage=10800, stale-while-revalidate=259200" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "SAMEORIGIN"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "geolocation=(), microphone=(), camera=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "on"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=10800, s-maxage=10800, stale-while-revalidate=259200"
+        }
       ]
     },
     {
       "source": "/categories",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
       ]
     },
     {
       "source": "/feed.xml",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=3600" },
-        { "key": "Content-Type", "value": "application/rss+xml; charset=utf-8" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/rss+xml; charset=utf-8"
+        }
       ]
     },
     {
       "source": "/sitemap.xml",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400, s-maxage=86400" },
-        { "key": "Content-Type", "value": "application/xml; charset=utf-8" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, s-maxage=86400"
+        },
+        {
+          "key": "Content-Type",
+          "value": "application/xml; charset=utf-8"
+        }
       ]
     },
     {
       "source": "/llms.txt",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400" },
-        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
-        { "key": "X-Robots-Tag", "value": "noindex" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Content-Type",
+          "value": "text/plain; charset=utf-8"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
       ]
     },
     {
       "source": "/llms-full.txt",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400" },
-        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
-        { "key": "X-Robots-Tag", "value": "noindex" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400"
+        },
+        {
+          "key": "Content-Type",
+          "value": "text/plain; charset=utf-8"
+        },
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex"
+        }
       ]
     },
     {
       "source": "/api/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "no-store, no-cache, must-revalidate" },
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" }
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        }
       ]
     }
   ],
@@ -189,69 +366,746 @@
     }
   },
   "redirects": [
-    { "source": "/posts/2025/04/SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_And_MFA_Importance/", "destination": "/posts/2025/04/29/SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_And_MFA_Importance/", "statusCode": 301 },
-    { "source": "/posts/2025/04/Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage/", "destination": "/posts/2025/04/30/Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_3Week_AWS_Security_And_Finops/", "destination": "/posts/2025/05/02/Cloud_Security_Course_7Batch_-_3Week_AWS_Security_And_Finops/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide/", "destination": "/posts/2025/05/02/Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_And_ISMS_Response_Guide/", "destination": "/posts/2025/05/09/Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_And_ISMS_Response_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_And_ZTNA/", "destination": "/posts/2025/05/16/Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_And_ZTNA/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_6Week_Cloudflare_And_github_Security/", "destination": "/posts/2025/05/23/Cloud_Security_Course_7Batch_-_6Week_Cloudflare_And_github_Security/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Amazon_Q_DeveloperAnd_GitHub_Advanced_Security_Security_And_AWS/", "destination": "/posts/2025/05/24/Amazon_Q_DeveloperAnd_GitHub_Advanced_Security_Security_And_AWS/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding/", "destination": "/posts/2025/05/30/Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding/", "statusCode": 301 },
-    { "source": "/posts/2025/05/Kubernetes_Minikube_ampamp_K9s_Practice_Guide_Problem_From_Resolution_Practical_TestTo/", "destination": "/posts/2025/05/30/Kubernetes_Minikube_and_K9s_Practice_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/05/30/Kubernetes_Minikube_ampamp_K9s_Practice_Guide_Problem_From_Resolution_Practical_TestTo/", "destination": "/posts/2025/05/30/Kubernetes_Minikube_and_K9s_Practice_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/06/Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide/", "destination": "/posts/2025/06/05/Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/06/Cloud_Security_Course_7Batch_-_8Week_CI_CDAnd_Kubernetes_Security_Practical_Guide/", "destination": "/posts/2025/06/06/Cloud_Security_Course_7Batch_-_8Week_CI_CDAnd_Kubernetes_Security_Practical_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/06/Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration/", "destination": "/posts/2025/06/13/Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration/", "statusCode": 301 },
-    { "source": "/posts/2025/09/npm_Ecosystem_Large_scale_Security_Breach_20_Download_Package_Malware_Infection/", "destination": "/posts/2025/09/10/npm_Ecosystem_Large_scale_Security_Breach_20_Download_Package_Malware_Infection/", "statusCode": 301 },
-    { "source": "/posts/2025/09/AWS_reInforce_2025_Cloud_Security_Current_and_Future/", "destination": "/posts/2025/09/16/AWS_reInforce_2025_Cloud_Security_Current_and_Future/", "statusCode": 301 },
-    { "source": "/posts/2025/09/NPM_ampquotShai-Huludampquot_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis/", "destination": "/posts/2025/09/17/NPM_ampquotShai-Huludampquot_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis/", "statusCode": 301 },
-    { "source": "/posts/2025/10/Karpenter_v153_Node_Integration_Due_to_Large_scale_Incident_Analysis_And_Resolution/", "destination": "/posts/2025/10/02/Karpenter_v153_Node_Integration_Due_to_Large_scale_Incident_Analysis_And_Resolution/", "statusCode": 301 },
-    { "source": "/posts/2025/10/AWSIn_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide/", "destination": "/posts/2025/10/03/AWSIn_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/10/AI_amplsquoSecretaryamprsquo_amplsquoSecurity_Holeamprsquo_For_Enterprise_AI_Service_Security_Guide/", "destination": "/posts/2025/10/31/AI_amplsquoSecretaryamprsquo_amplsquoSecurity_Holeamprsquo_For_Enterprise_AI_Service_Security_Guide/", "statusCode": 301 },
-    { "source": "/posts/2025/11/Zscaler_Complete_Guide_SSL_Inspection_Sandbox_AI_Advertisement_Harmful_Site_Complete_Block/", "destination": "/posts/2025/11/04/Zscaler_Complete_Guide_SSL_Inspection_Sandbox_AI_Advertisement_Harmful_Site_Complete_Block/", "statusCode": 301 },
-    { "source": "/posts/2025/11/Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_What_Learned/", "destination": "/posts/2025/11/19/Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_What_Learned/", "statusCode": 301 },
-    { "source": "/posts/2025/11/Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap/", "destination": "/posts/2025/11/21/Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap/", "statusCode": 301 },
-    { "source": "/posts/2025/11/Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo/", "destination": "/posts/2025/11/26/Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo/", "statusCode": 301 },
-    { "source": "/posts/2025/12/Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer/", "destination": "/posts/2025/12/05/Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer/", "statusCode": 301 },
-    { "source": "/posts/2025/12/Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy/", "destination": "/posts/2025/12/12/Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy/", "statusCode": 301 },
-    { "source": "/posts/2025/12/12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence/", "destination": "/posts/2025/12/17/12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence/", "statusCode": 301 },
-    { "source": "/posts/2025/12/Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response/", "destination": "/posts/2025/12/19/Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response/", "statusCode": 301 },
-    { "source": "/posts/2025/12/Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_And_Datadog_SIEM_Cloudflare_Security/", "destination": "/posts/2025/12/24/Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_And_Datadog_SIEM_Cloudflare_Security/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps/", "destination": "/posts/2026/01/01/Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps/", "statusCode": 301 },
-    { "source": "/posts/2026/01/OWASP_2025_Latest_Update_Complete_Guide_Top_10_Agentic_AI_Security/", "destination": "/posts/2026/01/03/OWASP_2025_Latest_Update_Complete_Guide_Top_10_Agentic_AI_Security/", "statusCode": 301 },
-    { "source": "/posts/2026/01/DevSecOps_Viewing_Automotive_Security_Complete_Guide/", "destination": "/posts/2026/01/06/DevSecOps_Viewing_Automotive_Security_Complete_Guide/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice/", "destination": "/posts/2026/01/08/Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_And_GitHub_DevSecOps_Practical/", "destination": "/posts/2026/01/08/Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_And_GitHub_DevSecOps_Practical/", "statusCode": 301 },
-    { "source": "/posts/2026/01/2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis/", "destination": "/posts/2026/01/10/2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis/", "statusCode": 301 },
-    { "source": "/posts/2026/01/AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective/", "destination": "/posts/2026/01/11/AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective/", "statusCode": 301 },
-    { "source": "/posts/2026/01/2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation/", "destination": "/posts/2026/01/14/2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation/", "statusCode": 301 },
-    { "source": "/posts/2026/01/AWS_Cloud_Security_Complete_Guide_IAMFrom_EKSTo_Security_Architecture/", "destination": "/posts/2026/01/14/AWS_Cloud_Security_Complete_Guide_IAMFrom_EKSTo_Security_Architecture/", "statusCode": 301 },
-    { "source": "/posts/2026/01/CSPM_DataDog_AWS_Security_Guide_Automated_Security_Setup_Verification_And_Compliance_Monitoring/", "destination": "/posts/2026/01/14/CSPM_DataDog_AWS_Security_Guide_Automated_Security_Setup_Verification_And_Compliance_Monitoring/", "statusCode": 301 },
-    { "source": "/posts/2026/01/GCP_Cloud_Security_Complete_Guide_IAMFrom_GKETo_Security_Architecture/", "destination": "/posts/2026/01/14/GCP_Cloud_Security_Complete_Guide_IAMFrom_GKETo_Security_Architecture/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide/", "destination": "/posts/2026/01/15/Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis/", "destination": "/posts/2026/01/16/Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis/", "statusCode": 301 },
-    { "source": "/posts/2026/01/AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis/", "destination": "/posts/2026/01/17/AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis/", "statusCode": 301 },
-    { "source": "/posts/2026/01/AWS_GCP_Cloud_Updates_January_2026_EC2_G7e_X8i_Bangkok_Region_European_Sovereign_Cloud/", "destination": "/posts/2026/01/22/AWS_GCP_Cloud_Updates_January_2026_EC2_G7e_X8i_Bangkok_Region_European_Sovereign_Cloud/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide/", "destination": "/posts/2026/01/22/Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Cloud_Security_Trends_January_2026_Kubernetes_82_Percent_Production_VS_Code_Threats_CNCF_Survey/", "destination": "/posts/2026/01/22/Cloud_Security_Trends_January_2026_Kubernetes_82_Percent_Production_VS_Code_Threats_CNCF_Survey/", "statusCode": 301 },
-    { "source": "/posts/2026/01/KARA_Ransomware_Trends_Report_2025_Q3_Analysis_SK_Shieldus_EQST/", "destination": "/posts/2026/01/22/KARA_Ransomware_Trends_Report_2025_Q3_Analysis_SK_Shieldus_EQST/", "statusCode": 301 },
-    { "source": "/posts/2026/01/KISA_Security_Advisory_Ransomware_Prevention_Linux_Rootkit_Detection_Guide_Analysis/", "destination": "/posts/2026/01/22/KISA_Security_Advisory_Ransomware_Prevention_Linux_Rootkit_Detection_Guide_Analysis/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Security_Vendor_Blog_Weekly_Review/", "destination": "/posts/2026/01/22/Security_Vendor_Blog_Weekly_Review/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/", "destination": "/posts/2026/01/23/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/", "destination": "/posts/2026/01/24/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/", "destination": "/posts/2026/01/25/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks/", "destination": "/posts/2026/01/26/Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/", "destination": "/posts/2026/01/27/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Claude_MD_Security_Guide/", "destination": "/posts/2026/01/28/Claude_MD_Security_Guide/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/", "destination": "/posts/2026/01/28/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/", "destination": "/posts/2026/01/29/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/", "destination": "/posts/2026/01/30/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/", "statusCode": 301 },
-    { "source": "/posts/2026/01/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/", "destination": "/posts/2026/01/31/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/", "statusCode": 301 },
-    { "source": "/posts/2026/02/Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture/", "destination": "/posts/2026/02/01/Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture/", "statusCode": 301 },
-    { "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/", "destination": "/posts/2026/02/01/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/", "statusCode": 301 },
-    { "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Notepadpp_Hijack_Bitcoin_Crash_AI_Agents/", "destination": "/posts/2026/02/02/Weekly_Tech_AI_Blockchain_Digest/", "statusCode": 301 },
-    { "source": "/posts/2026/02/02/Tech_Security_Weekly_Digest_Notepadpp_Hijack_Bitcoin_Crash_AI_Agents/", "destination": "/posts/2026/02/02/Weekly_Tech_AI_Blockchain_Digest/", "statusCode": 301 }
+    {
+      "source": "/posts/2025/04/SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_And_MFA_Importance/",
+      "destination": "/posts/2025/04/29/SKT_Security_Issue_Complete_Response_Guide_IMEI_Check_USIMeSIM_Replace_And_MFA_Importance/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/04/Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage/",
+      "destination": "/posts/2025/04/30/Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_3Week_AWS_Security_And_Finops/",
+      "destination": "/posts/2025/05/02/Cloud_Security_Course_7Batch_-_3Week_AWS_Security_And_Finops/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide/",
+      "destination": "/posts/2025/05/02/Kandji_macOS_Complete_Master_SetupFrom_Security_Regulation_ComplianceTo_All-in-One_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_And_ISMS_Response_Guide/",
+      "destination": "/posts/2025/05/09/Cloud_Security_Course_7Batch_-_4Week_AWS_Vulnerability_Inspection_And_ISMS_Response_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_And_ZTNA/",
+      "destination": "/posts/2025/05/16/Cloud_Security_Course_7Batch_-_5Week_AWS_Control_Tower_And_ZTNA/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_6Week_Cloudflare_And_github_Security/",
+      "destination": "/posts/2025/05/23/Cloud_Security_Course_7Batch_-_6Week_Cloudflare_And_github_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Amazon_Q_DeveloperAnd_GitHub_Advanced_Security_Security_And_AWS/",
+      "destination": "/posts/2025/05/24/Amazon_Q_DeveloperAnd_GitHub_Advanced_Security_Security_And_AWS/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding/",
+      "destination": "/posts/2025/05/30/Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Kubernetes_Minikube_ampamp_K9s_Practice_Guide_Problem_From_Resolution_Practical_TestTo/",
+      "destination": "/posts/2025/05/30/Kubernetes_Minikube_and_K9s_Practice_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/30/Kubernetes_Minikube_ampamp_K9s_Practice_Guide_Problem_From_Resolution_Practical_TestTo/",
+      "destination": "/posts/2025/05/30/Kubernetes_Minikube_and_K9s_Practice_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/06/Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide/",
+      "destination": "/posts/2025/06/05/Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/06/Cloud_Security_Course_7Batch_-_8Week_CI_CDAnd_Kubernetes_Security_Practical_Guide/",
+      "destination": "/posts/2025/06/06/Cloud_Security_Course_7Batch_-_8Week_CI_CDAnd_Kubernetes_Security_Practical_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/06/Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration/",
+      "destination": "/posts/2025/06/13/Cloud_Security_Course_7Batch_-_9Week_DevSecOps_Integration/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/09/npm_Ecosystem_Large_scale_Security_Breach_20_Download_Package_Malware_Infection/",
+      "destination": "/posts/2025/09/10/npm_Ecosystem_Large_scale_Security_Breach_20_Download_Package_Malware_Infection/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/09/AWS_reInforce_2025_Cloud_Security_Current_and_Future/",
+      "destination": "/posts/2025/09/16/AWS_reInforce_2025_Cloud_Security_Current_and_Future/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/09/NPM_ampquotShai-Huludampquot_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis/",
+      "destination": "/posts/2025/09/17/NPM_ampquotShai-Huludampquot_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/10/Karpenter_v153_Node_Integration_Due_to_Large_scale_Incident_Analysis_And_Resolution/",
+      "destination": "/posts/2025/10/02/Karpenter_v153_Node_Integration_Due_to_Large_scale_Incident_Analysis_And_Resolution/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/10/AWSIn_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide/",
+      "destination": "/posts/2025/10/03/AWSIn_Database_Access_Gateway_Build_NLB_Security_Group_Complete_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/10/AI_amplsquoSecretaryamprsquo_amplsquoSecurity_Holeamprsquo_For_Enterprise_AI_Service_Security_Guide/",
+      "destination": "/posts/2025/10/31/AI_amplsquoSecretaryamprsquo_amplsquoSecurity_Holeamprsquo_For_Enterprise_AI_Service_Security_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/11/Zscaler_Complete_Guide_SSL_Inspection_Sandbox_AI_Advertisement_Harmful_Site_Complete_Block/",
+      "destination": "/posts/2025/11/04/Zscaler_Complete_Guide_SSL_Inspection_Sandbox_AI_Advertisement_Harmful_Site_Complete_Block/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/11/Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_What_Learned/",
+      "destination": "/posts/2025/11/19/Post-Mortem_2025_11_18_Cloudflare_Global_Incident_Response_Log_What_Learned/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/11/Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap/",
+      "destination": "/posts/2025/11/21/Cloud_Security_8Batch_OT_Guide_DevSecOpsFrom_FinOpsTo_Practical_Talent_Leap/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/11/Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo/",
+      "destination": "/posts/2025/11/26/Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/12/Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer/",
+      "destination": "/posts/2025/12/05/Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/12/Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy/",
+      "destination": "/posts/2025/12/12/Cloud_Security_8Batch_3Week_AWS_FinOps_ArchitectureFrom_ISMS-P_Security_AuditTo_Complete_Strategy/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/12/12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence/",
+      "destination": "/posts/2025/12/17/12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/12/Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response/",
+      "destination": "/posts/2025/12/19/Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/12/Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_And_Datadog_SIEM_Cloudflare_Security/",
+      "destination": "/posts/2025/12/24/Cloud_Security_Course_8Batch_5Week_AWS_Control_TowerSCP_Based_Governance_And_Datadog_SIEM_Cloudflare_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps/",
+      "destination": "/posts/2026/01/01/Tesla_FSD_2026_Complete_Guide_Model_Y_Juniper_Security_DevSecOps/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/OWASP_2025_Latest_Update_Complete_Guide_Top_10_Agentic_AI_Security/",
+      "destination": "/posts/2026/01/03/OWASP_2025_Latest_Update_Complete_Guide_Top_10_Agentic_AI_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/DevSecOps_Viewing_Automotive_Security_Complete_Guide/",
+      "destination": "/posts/2026/01/06/DevSecOps_Viewing_Automotive_Security_Complete_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice/",
+      "destination": "/posts/2026/01/08/Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_And_GitHub_DevSecOps_Practical/",
+      "destination": "/posts/2026/01/08/Cloud_Security_Course_8Batch_6Week_AWS_WAF_CloudFront_Security_Architecture_And_GitHub_DevSecOps_Practical/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis/",
+      "destination": "/posts/2026/01/10/2026_DevSecOps_Roadmap_Complete_Guide_roadmap.sh_Analysis/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective/",
+      "destination": "/posts/2026/01/11/AI_Music_Video_Generation_Complete_Guide_DevSecOps_Perspective/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation/",
+      "destination": "/posts/2026/01/14/2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/AWS_Cloud_Security_Complete_Guide_IAMFrom_EKSTo_Security_Architecture/",
+      "destination": "/posts/2026/01/14/AWS_Cloud_Security_Complete_Guide_IAMFrom_EKSTo_Security_Architecture/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/CSPM_DataDog_AWS_Security_Guide_Automated_Security_Setup_Verification_And_Compliance_Monitoring/",
+      "destination": "/posts/2026/01/14/CSPM_DataDog_AWS_Security_Guide_Automated_Security_Setup_Verification_And_Compliance_Monitoring/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/GCP_Cloud_Security_Complete_Guide_IAMFrom_GKETo_Security_Architecture/",
+      "destination": "/posts/2026/01/14/GCP_Cloud_Security_Complete_Guide_IAMFrom_GKETo_Security_Architecture/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide/",
+      "destination": "/posts/2026/01/15/Cloud_Security_Course_8Batch_7Week_Docker_Kubernetes_Security_Practical_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis/",
+      "destination": "/posts/2026/01/16/Postmortem_NextJS_SSR_Error_Cloudflare_Blocking_ALB_5XX_Incident_Analysis/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis/",
+      "destination": "/posts/2026/01/17/AI_Coding_Assistants_Comparison_Gemini_Claude_Code_ChatGPT_OpenCode_2025_2026_Research_Analysis/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/AWS_GCP_Cloud_Updates_January_2026_EC2_G7e_X8i_Bangkok_Region_European_Sovereign_Cloud/",
+      "destination": "/posts/2026/01/22/AWS_GCP_Cloud_Updates_January_2026_EC2_G7e_X8i_Bangkok_Region_European_Sovereign_Cloud/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide/",
+      "destination": "/posts/2026/01/22/Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Cloud_Security_Trends_January_2026_Kubernetes_82_Percent_Production_VS_Code_Threats_CNCF_Survey/",
+      "destination": "/posts/2026/01/22/Cloud_Security_Trends_January_2026_Kubernetes_82_Percent_Production_VS_Code_Threats_CNCF_Survey/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/KARA_Ransomware_Trends_Report_2025_Q3_Analysis_SK_Shieldus_EQST/",
+      "destination": "/posts/2026/01/22/KARA_Ransomware_Trends_Report_2025_Q3_Analysis_SK_Shieldus_EQST/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/KISA_Security_Advisory_Ransomware_Prevention_Linux_Rootkit_Detection_Guide_Analysis/",
+      "destination": "/posts/2026/01/22/KISA_Security_Advisory_Ransomware_Prevention_Linux_Rootkit_Detection_Guide_Analysis/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Security_Vendor_Blog_Weekly_Review/",
+      "destination": "/posts/2026/01/22/Security_Vendor_Blog_Weekly_Review/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/",
+      "destination": "/posts/2026/01/23/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/",
+      "destination": "/posts/2026/01/24/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/",
+      "destination": "/posts/2026/01/25/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks/",
+      "destination": "/posts/2026/01/26/Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/",
+      "destination": "/posts/2026/01/27/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Claude_MD_Security_Guide/",
+      "destination": "/posts/2026/01/28/Claude_MD_Security_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/",
+      "destination": "/posts/2026/01/28/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/",
+      "destination": "/posts/2026/01/29/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/",
+      "destination": "/posts/2026/01/30/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/01/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/",
+      "destination": "/posts/2026/01/31/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture/",
+      "destination": "/posts/2026/02/01/Agentic_AI_Security_2026_Attack_Vectors_Defense_Architecture/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/",
+      "destination": "/posts/2026/02/01/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Notepadpp_Hijack_Bitcoin_Crash_AI_Agents/",
+      "destination": "/posts/2026/02/02/Weekly_Tech_AI_Blockchain_Digest/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/02/Tech_Security_Weekly_Digest_Notepadpp_Hijack_Bitcoin_Crash_AI_Agents/",
+      "destination": "/posts/2026/02/02/Weekly_Tech_AI_Blockchain_Digest/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2025/05/Kubernetes_Minikube_and_K9s_Practice_Guide/",
+      "destination": "/posts/2025/05/30/Kubernetes_Minikube_and_K9s_Practice_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Weekly_Security_Threat_Intelligence_Digest/",
+      "destination": "/posts/2026/02/02/Weekly_Security_Threat_Intelligence_Digest/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Weekly_Tech_AI_Blockchain_Digest/",
+      "destination": "/posts/2026/02/02/Weekly_Tech_AI_Blockchain_Digest/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Weekly_Security_DevOps_Digest/",
+      "destination": "/posts/2026/02/03/Weekly_Security_DevOps_Digest/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/AI_vs_Claude_Code_AI_Coding_Assistant_Comparison/",
+      "destination": "/posts/2026/02/04/AI_vs_Claude_Code_AI_Coding_Assistant_Comparison/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Docker_Data_Go/",
+      "destination": "/posts/2026/02/04/Tech_Security_Weekly_Digest_AI_Docker_Data_Go/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation/",
+      "destination": "/posts/2026/02/05/AI_Content_Creator_Workflow_2026_Blog_Video_Music_Animation/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_CVE_AI_Malware_Go/",
+      "destination": "/posts/2026/02/05/Tech_Security_Weekly_Digest_CVE_AI_Malware_Go/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat/",
+      "destination": "/posts/2026/02/06/Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Malware_Go_Security/",
+      "destination": "/posts/2026/02/07/Tech_Security_Weekly_Digest_AI_Malware_Go_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Ransomware_Data/",
+      "destination": "/posts/2026/02/08/Tech_Security_Weekly_Digest_AI_Ransomware_Data/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Blockchain_Tech_Digest_Bithumb_Bitcoin/",
+      "destination": "/posts/2026/02/09/Blockchain_Tech_Digest_Bithumb_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic/",
+      "destination": "/posts/2026/02/09/Security_Cloud_Digest_AI_VirusTotal_AWS_Agentic/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS/",
+      "destination": "/posts/2026/02/10/AI_Cloud_Digest_Meta_Prometheus_Google_OTLP_AWS/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin/",
+      "destination": "/posts/2026/02/10/DevOps_Blockchain_Digest_CNCF_Chainalysis_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Security_Digest_SolarWinds_UNC3886_LLM_Attack/",
+      "destination": "/posts/2026/02/10/Security_Digest_SolarWinds_UNC3886_LLM_Attack/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI/",
+      "destination": "/posts/2026/02/11/Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent/",
+      "destination": "/posts/2026/02/12/Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Go_Security_Agent/",
+      "destination": "/posts/2026/02/13/Tech_Security_Weekly_Digest_AI_Go_Security_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM/",
+      "destination": "/posts/2026/02/14/Weekly_Security_Digest_Microsoft_Zero_Day_Apple_Ivanti_EPMM/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Daily_Tech_Digest_RSS_Roundup/",
+      "destination": "/posts/2026/02/16/Daily_Tech_Digest_RSS_Roundup/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security/",
+      "destination": "/posts/2026/02/17/Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Weekly_Tech_Security_Digest_AI_Cloud_Risk/",
+      "destination": "/posts/2026/02/17/Weekly_Tech_Security_Digest_AI_Cloud_Risk/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Krebs_Security_Digest_Kimwolf_Patch_Tuesday/",
+      "destination": "/posts/2026/02/18/Krebs_Security_Digest_Kimwolf_Patch_Tuesday/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update/",
+      "destination": "/posts/2026/02/18/Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE/",
+      "destination": "/posts/2026/02/19/Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Blog_Weekly_Digest_AI_Data_Cloud/",
+      "destination": "/posts/2026/02/20/Tech_Blog_Weekly_Digest_AI_Data_Cloud/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes/",
+      "destination": "/posts/2026/02/20/Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Data_Rust_AI_Threat/",
+      "destination": "/posts/2026/02/21/Tech_Security_Weekly_Digest_Data_Rust_AI_Threat/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security/",
+      "destination": "/posts/2026/02/22/Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin/",
+      "destination": "/posts/2026/02/23/Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM/",
+      "destination": "/posts/2026/02/24/Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Claude_Code_OpenCode_Best_Practices/",
+      "destination": "/posts/2026/02/25/Claude_Code_OpenCode_Best_Practices/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM/",
+      "destination": "/posts/2026/02/25/Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Go_AWS_API/",
+      "destination": "/posts/2026/02/26/Tech_Security_Weekly_Digest_AI_Go_AWS_API/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go/",
+      "destination": "/posts/2026/02/27/Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/AI_Agent_Security_Architecture_Design_Guide/",
+      "destination": "/posts/2026/02/28/AI_Agent_Security_Architecture_Design_Guide/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/02/Tech_Security_Weekly_Digest_Go_AI_Malware/",
+      "destination": "/posts/2026/02/28/Tech_Security_Weekly_Digest_Go_AI_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Agent_Ransomware/",
+      "destination": "/posts/2026/03/01/Tech_Security_Weekly_Digest_AI_Agent_Ransomware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Ransomware_AI_Agent/",
+      "destination": "/posts/2026/03/02/Tech_Security_Weekly_Digest_Ransomware_AI_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin/",
+      "destination": "/posts/2026/03/04/Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS/",
+      "destination": "/posts/2026/03/05/Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Security_Threat_AI_AWS/",
+      "destination": "/posts/2026/03/06/Tech_Security_Weekly_Digest_Security_Threat_AI_AWS/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP/",
+      "destination": "/posts/2026/03/07/LLM_Security_Practical_Guide_Prompt_Injection_RAG_MCP/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps/",
+      "destination": "/posts/2026/03/07/Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Security/",
+      "destination": "/posts/2026/03/08/Tech_Security_Weekly_Digest_AI_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin/",
+      "destination": "/posts/2026/03/09/Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Malware_Security_Data/",
+      "destination": "/posts/2026/03/10/Tech_Security_Weekly_Digest_AI_Malware_Security_Data/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Agent_Data_Malware/",
+      "destination": "/posts/2026/03/11/Tech_Security_Weekly_Digest_AI_Agent_Data_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch/",
+      "destination": "/posts/2026/03/12/Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AWS_AI_Bitcoin/",
+      "destination": "/posts/2026/03/15/Tech_Security_Weekly_Digest_AWS_AI_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update/",
+      "destination": "/posts/2026/03/16/Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Bitcoin/",
+      "destination": "/posts/2026/03/16/Tech_Security_Weekly_Digest_AI_Bitcoin/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet/",
+      "destination": "/posts/2026/03/17/Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_AWS_Data_Ransomware/",
+      "destination": "/posts/2026/03/18/Tech_Security_Weekly_Digest_AI_AWS_Data_Ransomware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch/",
+      "destination": "/posts/2026/03/19/Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Malware_Data_Security_Threat/",
+      "destination": "/posts/2026/03/20/Tech_Security_Weekly_Digest_Malware_Data_Security_Threat/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Security_CVE_AI_Malware/",
+      "destination": "/posts/2026/03/21/Tech_Security_Weekly_Digest_Security_CVE_AI_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_CVE_Patch_AI_Apple/",
+      "destination": "/posts/2026/03/22/Tech_Security_Weekly_Digest_CVE_Patch_AI_Apple/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Ransomware/",
+      "destination": "/posts/2026/03/23/Tech_Security_Weekly_Digest_Ransomware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Malware_Data_AWS_AI/",
+      "destination": "/posts/2026/03/24/Tech_Security_Weekly_Digest_Malware_Data_AWS_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_LLM_Malware_Agent/",
+      "destination": "/posts/2026/03/25/Tech_Security_Weekly_Digest_AI_LLM_Malware_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Kubernetes_Supply_Chain_AI/",
+      "destination": "/posts/2026/03/26/Tech_Security_Weekly_Digest_Kubernetes_Supply_Chain_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Zero_Trust_Cloud_FinOps/",
+      "destination": "/posts/2026/03/27/Tech_Security_Weekly_Digest_Zero_Trust_Cloud_FinOps/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_AI_Cloud_Zero_Day/",
+      "destination": "/posts/2026/03/28/Tech_Security_Weekly_Digest_AI_Cloud_Zero_Day/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply_Chain/",
+      "destination": "/posts/2026/03/29/Tech_Security_Weekly_Digest_Ransomware_LLM_K8s_Supply_Chain/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/March_2026_Security_Digest_Monthly_Index/",
+      "destination": "/posts/2026/03/30/March_2026_Security_Digest_Monthly_Index/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/03/Tech_Security_Weekly_Digest_Vulnerability_Patch_AI_GPT/",
+      "destination": "/posts/2026/03/31/Tech_Security_Weekly_Digest_Vulnerability_Patch_AI_GPT/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Zero-Day_Go_AI_AWS/",
+      "destination": "/posts/2026/04/01/Tech_Security_Weekly_Digest_Zero-Day_Go_AI_AWS/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_Malware/",
+      "destination": "/posts/2026/04/02/Tech_Security_Weekly_Digest_AI_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_CVE_Patch_AWS_AI/",
+      "destination": "/posts/2026/04/03/Tech_Security_Weekly_Digest_CVE_Patch_AWS_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Go_AI_Data_Security/",
+      "destination": "/posts/2026/04/04/Tech_Security_Weekly_Digest_Go_AI_Data_Security/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AWS_AI_Security_Malware/",
+      "destination": "/posts/2026/04/05/Tech_Security_Weekly_Digest_AWS_AI_Security_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Patch_AI/",
+      "destination": "/posts/2026/04/06/Tech_Security_Weekly_Digest_Patch_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_Ransomware_Go_Palantir/",
+      "destination": "/posts/2026/04/07/Tech_Security_Weekly_Digest_AI_Ransomware_Go_Palantir/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet/",
+      "destination": "/posts/2026/04/08/Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Cloud_Botnet_AI_Malware/",
+      "destination": "/posts/2026/04/09/Tech_Security_Weekly_Digest_Cloud_Botnet_AI_Malware/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_Malware_Go_Agent/",
+      "destination": "/posts/2026/04/10/Tech_Security_Weekly_Digest_AI_Malware_Go_Agent/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_Go_CVE_Update/",
+      "destination": "/posts/2026/04/11/Tech_Security_Weekly_Digest_AI_Go_CVE_Update/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI/",
+      "destination": "/posts/2026/04/12/Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust/",
+      "destination": "/posts/2026/04/13/Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data/",
+      "destination": "/posts/2026/04/14/Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch/",
+      "destination": "/posts/2026/04/15/Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch/",
+      "destination": "/posts/2026/04/16/Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch/",
+      "statusCode": 301
+    },
+    {
+      "source": "/posts/2026/04/Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware/",
+      "destination": "/posts/2026/04/17/Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware/",
+      "statusCode": 301
+    }
   ],
   "rewrites": [
     {


### PR DESCRIPTION
## Summary
- 날짜 없는 이전 URL 패턴에 대한 301 리디렉션 85개 추가
- `/posts/YYYY/MM/Slug/` -> `/posts/YYYY/MM/DD/Slug/` 자동 생성
- Google Search Console 404 오류(17건) 해결 목적

## Test plan
- [ ] Vercel 배포 후 이전 URL 패턴 접근 시 301 리디렉션 확인
- [ ] Google Search Console에서 404 감소 확인 (수일 소요)