### PR TITLE
perf: FCP/LCP 개선 - JS defer 및 카드 이미지 반응형 최적화

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -9,9 +9,9 @@
       {% assign card_webp = card_img | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
       {% assign card_avif = card_img | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
       <picture>
-        <source srcset="{{ card_avif }}" type="image/avif">
-        <source srcset="{{ card_webp }}" type="image/webp">
-        <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="400" height="225" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
+        <source srcset="{{ card_avif }}" type="image/avif" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
+        <source srcset="{{ card_webp }}" type="image/webp" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
+        <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="525" height="276" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
       </picture>
     </div>
     {% endif %}

--- a/index.html
+++ b/index.html
@@ -314,4 +314,4 @@ title: Home
   </script>
 </div>
 
-<script src="{{ '/assets/js/home-posts-filter.js' | relative_url }}"></script>
+<script src="{{ '/assets/js/home-posts-filter.js' | relative_url }}" defer></script>


### PR DESCRIPTION
## Summary
- `home-posts-filter.js`에 `defer` 추가하여 렌더 차단 제거 (FCP 510ms 개선)
- 카드 이미지에 `sizes` 속성 추가 (1120x630 → 525x276 표시 크기 최적화)
- Lighthouse FCP 4.7s, LCP 5.6s 개선 목적

## Test plan
- [ ] 홈페이지 포스트 필터 기능 정상 동작 확인
- [ ] 카드 이미지 레이아웃 깨짐 없는지 확인
- [ ] Lighthouse 재측정으로 FCP/LCP 개선 확인