### PR TITLE
refactor(scripts): migrate cleanup_unused_images to image_utils with extended patterns

### DIFF
--- a/scripts/cleanup_unused_images.py
+++ b/scripts/cleanup_unused_images.py
@@ -13,11 +13,13 @@ assets/images/ 디렉토리의 미사용 이미지와 누락된 이미지를 분
 """
 
 import argparse
-import os
-import re
 import sys
 from collections import defaultdict
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.lib.image_utils import extract_image_paths
 
 REPO_ROOT = Path(__file__).parent.parent
 POSTS_DIR = REPO_ROOT / "_posts"
@@ -43,56 +45,12 @@ STATIC_IMAGES = {
 
 def extract_image_refs_from_file(filepath: Path) -> set[str]:
     """파일에서 이미지 참조 경로를 추출합니다."""
-    refs = set()
     try:
         content = filepath.read_text(encoding="utf-8", errors="ignore")
     except OSError:
-        return refs
+        return set()
 
-    # front matter image: /assets/images/...
-    for match in re.finditer(
-        r"^image\s*:\s*['\"]?(/assets/images/[^\s'\"]+)['\"]?", content, re.MULTILINE
-    ):
-        refs.add(match.group(1))
-
-    # Markdown image syntax: ![alt](path)
-    for match in re.finditer(r"!\[[^\]]*\]\((/assets/images/[^\s)]+)\)", content):
-        refs.add(match.group(1))
-
-    # HTML img src: <img src="/assets/images/...">
-    for match in re.finditer(
-        r'<img[^>]+src=["\']([^"\']*assets/images/[^"\']+)["\']', content
-    ):
-        refs.add(match.group(1))
-
-    # HTML picture source srcset: <source srcset="...">
-    for match in re.finditer(
-        r'<source[^>]+srcset=["\']([^"\']*assets/images/[^"\']+)["\']', content
-    ):
-        path = match.group(1).split()[0]  # srcset에서 첫 URL만
-        refs.add(path)
-
-    # src= 또는 href= 패턴 (레이아웃/인클루드용)
-    for match in re.finditer(
-        r'(?:src|href)=["\']([^"\']*assets/images/[^"\']+)["\']', content
-    ):
-        refs.add(match.group(1))
-
-    # Liquid {{ ... }} 내부 assets/images 참조
-    for match in re.finditer(r"\{%[^%]*%\}|{{[^}]*}}", content):
-        inner = match.group(0)
-        for m2 in re.finditer(r"['\"]([^'\"]*assets/images/[^'\"]+)['\"]", inner):
-            refs.add(m2.group(1))
-
-    # {% raw %}{{ '/assets/images/...' | filter }}{% endraw %} 패턴
-    for match in re.finditer(
-        r"\{%-?\s*raw\s*-?%\}(.*?)\{%-?\s*endraw\s*-?%\}", content, re.DOTALL
-    ):
-        inner = match.group(1)
-        for m2 in re.finditer(r"['\"]([^'\"]*assets/images/[^'\"]+)['\"]", inner):
-            refs.add(m2.group(1))
-
-    return refs
+    return set(extract_image_paths(content, include_attr_refs=True))
 
 
 def normalize_ref(ref: str) -> str:

--- a/scripts/lib/image_utils.py
+++ b/scripts/lib/image_utils.py
@@ -34,6 +34,9 @@ _KOREAN_RE = re.compile(r"[가-힣]")
 _FRONT_MATTER_IMAGE_RE = re.compile(r"^image:\s*(.+)$", re.MULTILINE)
 _HTML_IMG_RE = re.compile(r'<img[^>]+src=["\']([^"\']+)["\']')
 _MD_IMG_RE = re.compile(r"!\[.*?\]\(([^)]+)\)")
+_HTML_SOURCE_SRCSET_RE = re.compile(r'<source[^>]+srcset=["\']([^"\']+)["\']')
+_GENERIC_ATTR_RE = re.compile(r'(?:src|href)=["\']([^"\']*assets/images/[^"\']+)["\']')
+_QUOTED_ASSET_RE = re.compile(r"['\"]([^'\"]*assets/images/[^'\"]+)['\"]")
 
 
 @dataclass(frozen=True)
@@ -63,14 +66,33 @@ def _strip_relative_url(path: str) -> str:
     return path
 
 
-def extract_image_paths(content: str) -> List[str]:
+def _normalize_extracted_path(path: str) -> Optional[str]:
+    """추출된 이미지 참조를 `assets/images/` 기준 상대 경로로 정규화합니다."""
+    if not path:
+        return None
+
+    normalized = _strip_relative_url(path).strip()
+    normalized = normalized.split(",", 1)[0].strip()
+    normalized = normalized.split()[0].strip()
+
+    if "/assets/images/" in normalized:
+        return normalized.split("/assets/images/", 1)[-1]
+    if "assets/images/" in normalized:
+        return normalized.split("assets/images/", 1)[-1]
+    return None
+
+
+def extract_image_paths(content: str, *, include_attr_refs: bool = False) -> List[str]:
     """포스트 본문에서 이미지 파일명(assets/images 기준)을 추출합니다.
 
     다음을 모두 스캔합니다:
       - Front matter의 ``image:`` 필드
       - HTML ``<img src="...">`` 태그
+      - HTML ``<source srcset="...">`` 태그 (첫 URL 사용)
       - Markdown ``![alt](src)`` 문법
       - Jekyll ``| relative_url`` 필터 사용 경로
+      - Liquid / raw 블록 내부의 quoted image path
+      - 선택적으로 일반 ``src=`` / ``href=`` 속성 경로
 
     반환값은 `assets/images/` 뒤의 상대 경로만 포함하며 중복이 제거됩니다.
 
@@ -84,17 +106,18 @@ def extract_image_paths(content: str) -> List[str]:
         raw.append(fm.group(1).strip())
 
     raw.extend(_HTML_IMG_RE.findall(content))
+    raw.extend(_HTML_SOURCE_SRCSET_RE.findall(content))
     raw.extend(_MD_IMG_RE.findall(content))
+    raw.extend(_QUOTED_ASSET_RE.findall(content))
+
+    if include_attr_refs:
+        raw.extend(_GENERIC_ATTR_RE.findall(content))
 
     cleaned: List[str] = []
     for item in raw:
-        path = _strip_relative_url(item)
-        if "/assets/images/" in path:
-            cleaned.append(path.split("/assets/images/")[-1])
-        elif "assets/images/" in path:
-            cleaned.append(path.split("assets/images/")[-1])
-        elif path.startswith("/assets/images/"):
-            cleaned.append(path.replace("/assets/images/", ""))
+        normalized = _normalize_extracted_path(item)
+        if normalized:
+            cleaned.append(normalized)
 
     # 중복 제거 (순서는 보장하지 않음 — 기존 verify_images_unified.py와 동일)
     return list(set(cleaned))

--- a/scripts/tests/test_image_utils.py
+++ b/scripts/tests/test_image_utils.py
@@ -60,9 +60,32 @@ def test_extract_html_img():
     assert "logo.webp" in extract_image_paths(content)
 
 
+def test_extract_source_srcset_uses_first_candidate():
+    content = '<source srcset="/assets/images/card.avif 1x, /assets/images/card@2x.avif 2x">'
+    assert "card.avif" in extract_image_paths(content)
+
+
 def test_extract_relative_url_filter():
     content = "![img]({{ '/assets/images/banner.svg' | relative_url }})"
     assert "banner.svg" in extract_image_paths(content)
+
+
+def test_extract_liquid_assign_path():
+    content = "{% assign hero_image = '/assets/images/hero/banner.png' %}"
+    assert "hero/banner.png" in extract_image_paths(content)
+
+
+def test_extract_raw_wrapped_liquid_path():
+    content = (
+        "{% raw %}{{ '/assets/images/diagrams/architecture.svg' | relative_url }}"
+        "{% endraw %}"
+    )
+    assert "diagrams/architecture.svg" in extract_image_paths(content)
+
+
+def test_extract_include_attr_refs_for_href():
+    content = '<a href="/assets/images/og/preview.png">preview</a>'
+    assert "og/preview.png" in extract_image_paths(content, include_attr_refs=True)
 
 
 def test_extract_deduplicates():


### PR DESCRIPTION
## Summary
- Follow-up to #245 / #246 — completes the `image_utils` migration by porting `cleanup_unused_images.py` (deferred from #246 per `notes/per-pr/PR-243-244-245-246.md`)
- Extends `image_utils.extract_image_paths` with srcset / quoted-asset / raw-Liquid / generic attr scanning so the single entry point covers all prior local regexes
- Deletes 7 local regex blocks in `cleanup_unused_images.py`, leaving a one-liner delegation to `extract_image_paths(content, include_attr_refs=True)`

## Changes
- `scripts/lib/image_utils.py`: +39 / -15
  - New regexes: `_HTML_SOURCE_SRCSET_RE`, `_GENERIC_ATTR_RE`, `_QUOTED_ASSET_RE`
  - Extract `_normalize_extracted_path` helper (used for all sources)
  - `extract_image_paths(..., include_attr_refs: bool = False)` opt-in for href/src attr scanning
- `scripts/cleanup_unused_images.py`: +7 / -49 (removed duplicate scanners)
- `scripts/tests/test_image_utils.py`: +23 (5 new cases)

## Test plan
- [x] `pytest scripts/tests/test_image_utils.py -v` — 29 passed in 0.04s
- [ ] `pytest scripts/tests/` — full suite (pre-commit hook covers this)
- [ ] `python3 scripts/cleanup_unused_images.py --help` smoke check
- [ ] CI (Jekyll build / security audit) green