### PR TITLE
docs(notes): PR #254 session record

### DIFF
--- a/notes/per-pr/PR-254.md
+++ b/notes/per-pr/PR-254.md
@@ -1,0 +1,45 @@
+# PR #254 세션 기록
+
+## 세션 개요
+- 대상: PR #254
+- 범위: `cleanup_unused_images.py` 의 `image_utils` 이관 완료 + 확장 패턴 추가
+- 배경: PR #246 에서 `cleanup_unused_images.py` 이관이 더 넓은 패턴 정리가 필요하다는 이유로 다음 세션으로 연기되었으며, 이번 PR 에서 완료
+- 결과: PR 병합 완료 (squash merge, 브랜치 자동 삭제)
+
+## 변경 요약
+
+### PR #254
+- 제목: `refactor(scripts): migrate cleanup_unused_images to image_utils with extended patterns`
+- 병합 시각: 2026-04-18T04:27:21Z
+- Squash merge commit: `a39e0e61`
+- URL: https://github.com/Twodragon0/tech-blog/pull/254
+
+#### `scripts/lib/image_utils.py` (+39 / -15)
+- 새 regex 3종 추가
+  - `_HTML_SOURCE_SRCSET_RE`: `<source>` 태그의 `srcset` 속성 스캔
+  - `_GENERIC_ATTR_RE`: href/src 속성 내 이미지 경로 범용 스캔
+  - `_QUOTED_ASSET_RE`: 큰따옴표/작은따옴표로 감싸인 assets 경로 스캔
+- `_normalize_extracted_path` helper 추출 (중복 경로 정규화 로직 통합)
+- `extract_image_paths(content, *, include_attr_refs=False)` — 선택적 href/src attr scanning 옵션 추가
+
+#### `scripts/cleanup_unused_images.py` (+7 / -49)
+- 자체 정의하던 regex 7개 블록 제거
+- `image_utils.extract_image_paths()` 단일 호출로 위임
+- 순 감소: -42 lines (복잡도 대폭 감소)
+
+#### `scripts/tests/test_image_utils.py` (+23)
+- 테스트 5개 추가
+  - srcset 첫 번째 후보 추출 검증
+  - Liquid `assign` 구문 내 이미지 경로 추출
+  - `{% raw %}` 로 감싸인 Liquid 경로 추출
+  - href attr 스캔 (include_attr_refs=True)
+  - 기존 패턴과의 회귀 방지
+
+## 검증 요약
+- `pytest scripts/tests/test_image_utils.py -v` → 29 passed in 0.04s (로컬)
+- CI auto-merge 성공 (squash + delete-branch)
+- 누적 테스트 수: 732 → 737 (5개 신규)
+
+## 다음 단계
+- 나머지 `scripts/` 내 ad-hoc 이미지 regex 호출부 sanity check (별도 세션 예정)
+- `image_utils` coverage 유지 확인 (현재 99%)


### PR DESCRIPTION
## Summary
- `notes/per-pr/PR-254.md` 신규 작성: PR #254 세션 기록
- PR #254(`cleanup_unused_images` → `image_utils` 이관 완료 + 확장 패턴 추가)의 변경 내용, 검증 결과, 다음 단계 정리
- 스타일: `notes/per-pr/PR-243-244-245-246.md` 형식 준수 (한국어, 세션 개요/변경 요약/검증 요약/다음 단계)

## Test plan
- [ ] `notes/per-pr/PR-254.md` 파일 내용 정확성 확인
- [ ] 다른 스크립트 파일 변경 없음 확인 (`git diff main...HEAD` 에 노트 파일만 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)