### PR TITLE
refactor(scripts): add extract_front_matter_image helper and migrate 4 callers

### DIFF
--- a/scripts/generate_svg_with_ai.py
+++ b/scripts/generate_svg_with_ai.py
@@ -9,6 +9,10 @@ import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.lib.image_utils import extract_front_matter_image
+
 POSTS_DIR = Path("_posts")
 IMAGES_DIR = Path("assets/images")
 
@@ -104,8 +108,7 @@ def parse_post(filepath: Path) -> dict:
     result["categories"] = cats
 
     # Image path
-    m = re.search(r"^image:\s*(.*?)$", fm, re.MULTILINE)
-    result["image"] = m.group(1).strip() if m else ""
+    result["image"] = extract_front_matter_image(fm) or ""
 
     # Excerpt
     m = re.search(r'^excerpt:\s*["\']?(.*?)["\']?\s*$', fm, re.MULTILINE)

--- a/scripts/lib/image_utils.py
+++ b/scripts/lib/image_utils.py
@@ -8,11 +8,13 @@
 사용 예시::
 
     from scripts.lib.image_utils import (
+        extract_front_matter_image,
         extract_image_paths,
         check_image_exists,
         has_korean,
     )
 
+    image = extract_front_matter_image(content)  # '/assets/images/foo.svg' or None
     paths = extract_image_paths(content)  # ['2025-01-01-diagram.svg', ...]
     exists, resolved = check_image_exists("/assets/images/diagram.svg")
 """
@@ -80,6 +82,26 @@ def _normalize_extracted_path(path: str) -> Optional[str]:
     if "assets/images/" in normalized:
         return normalized.split("assets/images/", 1)[-1]
     return None
+
+
+def extract_front_matter_image(text: str) -> Optional[str]:
+    """Front matter 블록(또는 full content)에서 ``image:`` 값을 원본 그대로 추출.
+
+    - 주변 공백과 단일/이중 따옴표를 제거한 값을 그대로 반환한다.
+    - 값이 없으면 ``None``.
+    - 복수 개가 있을 경우 첫 번째 매치만 반환(front matter 표준 가정).
+
+    >>> extract_front_matter_image("---\\nimage: /assets/images/foo.svg\\n---\\n")
+    '/assets/images/foo.svg'
+    >>> extract_front_matter_image('image: "/assets/images/bar.png"')
+    '/assets/images/bar.png'
+    >>> extract_front_matter_image("no front matter here") is None
+    True
+    """
+    match = _FRONT_MATTER_IMAGE_RE.search(text)
+    if not match:
+        return None
+    return match.group(1).strip().strip("\"'")
 
 
 def extract_image_paths(content: str, *, include_attr_refs: bool = False) -> List[str]:
@@ -218,6 +240,7 @@ __all__ = [
     "PROJECT_ROOT",
     "check_image_exists",
     "check_image_references",
+    "extract_front_matter_image",
     "extract_image_paths",
     "has_korean",
     "image_exists",

--- a/scripts/regenerate_all_svgs.py
+++ b/scripts/regenerate_all_svgs.py
@@ -15,6 +15,11 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.lib.image_utils import extract_front_matter_image
 
 POSTS_DIR = "/Users/yong/Desktop/personal/tech-blog/_posts"
 IMAGES_DIR = "/Users/yong/Desktop/personal/tech-blog/assets/images"
@@ -550,8 +555,7 @@ def parse_post(filepath):
     fm = fm_match.group(1)
 
     # Parse image path
-    img_match = re.search(r"image:\s*(.+)", fm)
-    image_path = img_match.group(1).strip().strip("\"'") if img_match else None
+    image_path = extract_front_matter_image(fm)
 
     # Parse categories
     categories = []

--- a/scripts/rename_images_to_english.py
+++ b/scripts/rename_images_to_english.py
@@ -11,6 +11,10 @@ import unicodedata
 from pathlib import Path
 from typing import Dict, List
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.lib.image_utils import extract_front_matter_image
+
 # Korean to English translation dictionary for common terms
 KOREAN_TO_ENGLISH = {
     "클라우드": "Cloud",
@@ -219,9 +223,8 @@ def get_post_image_mapping(blog_dir: Path) -> Dict[str, str]:
                 content = f.read()
 
             # Extract image path from frontmatter
-            image_match = re.search(r"^image:\s*(.+)$", content, re.MULTILINE)
-            if image_match:
-                image_path = image_match.group(1).strip().strip("\"'")
+            image_path = extract_front_matter_image(content)
+            if image_path:
                 image_filename = Path(image_path).name
 
                 # Extract date from post filename

--- a/scripts/tests/test_image_utils.py
+++ b/scripts/tests/test_image_utils.py
@@ -12,6 +12,7 @@ from scripts.lib.image_utils import (
     ImageIssue,
     check_image_exists,
     check_image_references,
+    extract_front_matter_image,
     extract_image_paths,
     has_korean,
     image_exists,
@@ -225,6 +226,38 @@ def test_image_issue_is_hashable():
     # dataclass(frozen=True) 덕분에 set/dict key로 사용 가능
     issue = ImageIssue(post=Path("a.md"), image="x.svg", reason="missing")
     assert {issue} == {issue}
+
+
+# ---------------------------------------------------------------------------
+# extract_front_matter_image
+# ---------------------------------------------------------------------------
+
+
+def test_extract_fm_image_basic_path():
+    content = "---\nimage: /assets/images/2025-01-01-diagram.svg\n---\n"
+    assert extract_front_matter_image(content) == "/assets/images/2025-01-01-diagram.svg"
+
+
+def test_extract_fm_image_strips_double_quotes():
+    content = 'image: "/assets/images/bar.png"'
+    assert extract_front_matter_image(content) == "/assets/images/bar.png"
+
+
+def test_extract_fm_image_strips_single_quotes():
+    content = "image: '/assets/images/baz.svg'"
+    assert extract_front_matter_image(content) == "/assets/images/baz.svg"
+
+
+def test_extract_fm_image_returns_none_when_missing():
+    assert extract_front_matter_image("---\ntitle: No image here\n---\n") is None
+
+
+def test_extract_fm_image_stops_at_newline():
+    # 값이 첫 줄에서만 캡처되어야 함 — 줄바꿈 이후 내용 포함 안 됨
+    content = "image: /assets/images/first.svg\nsome other line"
+    result = extract_front_matter_image(content)
+    assert result == "/assets/images/first.svg"
+    assert "\n" not in (result or "")
 
 
 if __name__ == "__main__":

--- a/scripts/upgrade_posts_quality_batch.py
+++ b/scripts/upgrade_posts_quality_batch.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import re
+import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.lib.image_utils import extract_front_matter_image
 from validate_post_quality import validate_post
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -21,10 +24,7 @@ def split_front_matter(content: str) -> tuple[str, str, str]:
 
 
 def extract_image(front_matter: str) -> str:
-    match = re.search(r"^image:\s*(.+)$", front_matter, re.MULTILINE)
-    if not match:
-        return "/assets/images/og-default.svg"
-    return match.group(1).strip()
+    return extract_front_matter_image(front_matter) or "/assets/images/og-default.svg"
 
 
 def ensure_ai_summary(content: str) -> str:


### PR DESCRIPTION
## Summary

- `image_utils`: new `extract_front_matter_image(text) -> Optional[str]` public helper reusing the existing `_FRONT_MATTER_IMAGE_RE` regex — returns the raw path value with surrounding whitespace and quotes stripped, or `None` if absent
- Migrated 4 ad-hoc `re.search(r"^image:\s*(.+)$", ...)` callers to the shared helper: `rename_images_to_english`, `upgrade_posts_quality_batch`, `generate_svg_with_ai`, `regenerate_all_svgs`
- `upgrade_posts_quality_batch`: `import re` removed (was the only usage)
- Tests: 5 new cases covering basic path, double/single quote stripping, missing value → None, newline boundary

## Changes

| File | Change |
|------|--------|
| `scripts/lib/image_utils.py` | Add `extract_front_matter_image()`, add to `__all__`, update module docstring |
| `scripts/rename_images_to_english.py` | Add `sys.path.insert` + import, replace ad-hoc regex |
| `scripts/upgrade_posts_quality_batch.py` | Drop `import re`, add import, simplify `extract_image()` to one-liner |
| `scripts/generate_svg_with_ai.py` | Add `sys.path.insert` + import, replace ad-hoc regex |
| `scripts/regenerate_all_svgs.py` | Add `sys.path.insert` + import, replace ad-hoc regex |
| `scripts/tests/test_image_utils.py` | Add 5 `extract_front_matter_image` test cases (34 total, all passing) |

Related: follows pattern established in #243–#246.

## Test plan

- [x] `pytest scripts/tests/test_image_utils.py -v` — 34 passed
- [x] `pytest scripts/tests/` — 741 passed, 0 failed
- [x] `python3 scripts/rename_images_to_english.py --help` — no import error
- [x] `python3 scripts/generate_svg_with_ai.py --help` — no import error
- [x] Smoke: `extract_front_matter_image('image: /a.svg')` → `'/a.svg'`