### PR TITLE
docs(notes): PR #243-#246 session record

### DIFF
--- a/notes/per-pr/PR-243-244-245-246.md
+++ b/notes/per-pr/PR-243-244-245-246.md
@@ -1,0 +1,46 @@
+# PR #243-#246 세션 기록
+
+## 세션 개요
+- 대상: PR #243, #244, #245, #246
+- 범위: 보안 하드닝, 의존성 자동화, 이미지 경로/존재 로직 통합, 후속 마이그레이션 정리
+- 결과: 4개 PR 모두 병합 완료
+
+## PR별 결과
+
+### PR #243
+- 제목: `feat: security hardening + performance + dependency automation (7 atomic commits)`
+- 병합 시각: 2026-04-17T08:55:10Z
+- URL: https://github.com/Twodragon0/tech-blog/pull/243
+- 핵심: `api/chat.js` 로그 sanitizer, CSP 정리, 4개 생태계 Dependabot 구성, Jekyll lazy-loading 플러그인, 콘텐츠 2건 수정, `check_posts` uniqueness cutoff 및 테스트 보강
+- 검증: `pytest scripts/tests/` 707 passed, `node api tests` 77 passed, `bundle exec jekyll build` 성공
+
+### PR #244
+- 제목: `deps(actions)(deps): bump ruby/setup-ruby from 1.301.0 to 1.302.0`
+- 병합 시각: 2026-04-17T09:10:06Z
+- URL: https://github.com/Twodragon0/tech-blog/pull/244
+- 핵심: `deploy-pages`, `jekyll`, `lighthouse`, `security-audit` 워크플로우의 `ruby/setup-ruby` Dependabot 업데이트
+
+### PR #245
+- 제목: `refactor(scripts): consolidate image path/existence logic via image_utils`
+- 병합 시각: 2026-04-17T09:36:51Z
+- URL: https://github.com/Twodragon0/tech-blog/pull/245
+- 핵심: `scripts/lib/image_utils.py` 및 테스트 추가, `check_posts`, `generate_post_images`, `improve_post_summary`, `verify_images_unified` 이관
+- 검증: `pytest scripts/tests/` 728 passed, `image_utils` coverage 99%, smoke checks OK
+
+### PR #246
+- 제목: `refactor(scripts): P2 follow-up image_utils migration (2 files)`
+- 병합 시각: 2026-04-17T09:44:02Z
+- URL: https://github.com/Twodragon0/tech-blog/pull/246
+- 핵심: `generate_missing_diagrams.py`, `verify_post_links.py` 를 `image_utils` 기반으로 이관
+- 보류: `cleanup_unused_images.py` 는 더 넓은 패턴 정리가 필요해 다음 세션으로 연기
+- 상태 메모: 오늘 auto-merge 요청을 시도했지만, `gh pr view` 기준 PR #246 는 이미 `MERGED` 상태였고 `mergeStateStatus` 는 `UNKNOWN`, `autoMergeRequest` 는 `null`
+- 검증: `pytest scripts/tests/` 732 passed, `cleanup_unused_images` / `verify_post_links` / `generate_missing_diagrams` smoke checks OK
+
+## 검증 요약
+- `pytest scripts/tests/`: 707 → 728 → 732 passed
+- `node api tests`: 77 passed
+- `bundle exec jekyll build`: 성공
+- 이미지 유틸 이관 후 smoke checks: 정상
+
+## 다음 단계
+- `cleanup_unused_images` 를 `image_utils` 로 이관하는 후속 작업을 이어서 진행한다.


### PR DESCRIPTION
## Summary

- Retroactive commit of session notes left untracked after merging 4 PRs on 2026-04-17
- No code changes — documentation only

## Included PRs

- #243 security hardening + performance + dependency automation
- #244 bump ruby/setup-ruby 1.301.0 → 1.302.0
- #245 consolidate image path/existence logic via image_utils
- #246 P2 follow-up image_utils migration (2 files)

## Rationale

`notes/per-pr/PR-243-244-245-246.md` was created during the session but never staged/committed. This PR commits it as-is (no content modifications) to keep the notes directory consistent with the existing per-PR record pattern (e.g. PR-255 already merged).