### PR TITLE
fix(posts): escape inner single quotes in ai-summary-card include tag

### DIFF
--- a/_posts/2026-04-20-Tech_Security_Weekly_Digest_AI_Apple_AWS_Palantir.md
+++ b/_posts/2026-04-20-Tech_Security_Weekly_Digest_AI_Apple_AWS_Palantir.md
@@ -15,7 +15,7 @@ toc: true
 ---
 
 {% include ai-summary-card.html
-  title='Apple 계정 변경 알림을 악용한 피싱 이메일, NIST, 증가하는 취약점 수로 인해 비우선순위, Palantir, 포용성과 '퇴행적''
+  title="Apple 계정 변경 알림을 악용한 피싱 이메일, NIST, 증가하는 취약점 수로 인해 비우선순위, Palantir, 포용성과 &#x27;퇴행적&#x27;"
   categories_html='<span class="category-tag security">보안</span> <span class="category-tag devsecops">DevSecOps</span>'
   tags_html='<span class="tag">Security-Weekly</span>
       <span class="tag">AI</span>


### PR DESCRIPTION
## Summary
Follow-up to PR #267. Fixes Liquid syntax error discovered during PR #267's build verification.

## Problem
`_posts/2026-04-20-Tech_Security_Weekly_Digest_AI_Apple_AWS_Palantir.md:18` wrapped its \`{% include ai-summary-card.html title='…' %}\` argument in single quotes, but the title contained `'퇴행적'`. Liquid's argument parser terminated on the first inner single quote, leaving `퇴행적'` as an unrecognised token — Vercel production build failed.

## Fix
- Outer quote switched to double quote
- Inner `'퇴행적'` encoded as `&#x27;퇴행적&#x27;` (matches the style already used in the sibling \`highlights_html\` on line 28)
- Single-line change: 1 insertion, 1 deletion

## Test plan
- [x] \`bundle exec jekyll build --destination _site\` completes with no errors/warnings about the Palantir post
- [ ] CI green
- [ ] Vercel production deploy succeeds (follow-up after merge)

## Follow-up (not in this PR)
\`scripts/auto_publish_news.py\` emits the buggy pattern when a headline contains single quotes — should audit the template and emit double-quoted outer or pre-escape inner single quotes to prevent recurrence.