### PR TITLE
chore(gitignore): ignore .coverage and .omx local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,12 @@ USER.md
 _data/processed_news_ids.json
 _drafts/prompts/
 .venv/
+
+# Coverage artifacts (pytest-cov)
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
+# OMX (oh-my-codex) local state - not for commit
+.omx/


### PR DESCRIPTION
## Summary
- `.coverage`, `.coverage.*`, `coverage.xml`, `htmlcov/` — pytest-cov output that surfaces in `git status` every test run
- `.omx/` — oh-my-codex local session state, not for commit
- `.omc/` was already ignored (line 103); this PR closes the remaining gap

No tracked files needed `git rm --cached` — both paths were untracked.

## Test plan
- [x] `git check-ignore -v .coverage .omx/` confirms both patterns active (lines 122, 128)
- [x] `pytest scripts/tests/ -q` → 776 passed in 0.71s
- [x] Only `.gitignore` modified — no scripts or production code touched