### PR TITLE
feat(publish): add digest_quality_report pre-publish gate

### DIFF
--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -227,6 +227,53 @@ sys.modules[__name__] = _ConfigProxy(_this_module)
 
 
 # ---------------------------------------------------------------------------
+# Digest quality gate
+# ---------------------------------------------------------------------------
+
+
+def _run_digest_quality_gate(post_path: Path, strict: bool = True) -> bool:
+    """Run digest_quality_report analysis on a just-written Digest post.
+
+    Returns True when the post is clean (or not a Digest). When issues are
+    found and ``strict`` is True, prints a summary and returns False so the
+    caller can abort. When ``strict`` is False, prints a warning and returns
+    True (issues logged but not blocking).
+    """
+    if "Digest" not in post_path.name:
+        return True
+    try:
+        import importlib
+
+        analyze_post = importlib.import_module("digest_quality_report").analyze_post
+    except Exception as e:
+        logging.warning(f"digest_quality_report import failed: {e}")
+        return True
+
+    issues = analyze_post(post_path)
+    has_issues = bool(
+        issues.get("truncated_cells")
+        or issues.get("english_headers")
+        or issues.get("incomplete_highlights")
+        or (issues.get("summary_quality") not in (None, "ok"))
+    )
+    if not has_issues:
+        return True
+
+    label = "❌ Digest quality gate FAILED" if strict else "⚠️ Digest quality gate WARNING"
+    print(f"{label} for {post_path.name}:")
+    for tc in issues.get("truncated_cells", []):
+        print(f"   - TRUNCATED L{tc['line']}: ...{tc['text']}")
+    for eh in issues.get("english_headers", []):
+        print(f"   - ENGLISH HEADER L{eh['line']}: {eh['text']}")
+    for ih in issues.get("incomplete_highlights", []):
+        print(f"   - INCOMPLETE HIGHLIGHT L{ih['line']}: ...{ih['text']}")
+    if issues.get("summary_quality") not in (None, "ok"):
+        print(f"   - SUMMARY: {issues['summary_quality']}")
+
+    return not strict
+
+
+# ---------------------------------------------------------------------------
 # Main function
 # ---------------------------------------------------------------------------
 
@@ -446,6 +493,10 @@ def main():
     with open(post_path, "w", encoding="utf-8") as f:
         f.write(post_content)
     _run_post_quality_gate(post_path, target=80)
+    if not _run_digest_quality_gate(post_path, strict=not args.force):
+        print("   Hint: re-run with --force to override the digest quality gate.")
+        post_path.unlink(missing_ok=True)
+        sys.exit(1)
     print(f"\u2705 Created post: {post_path}")
 
     # Track published URLs for cross-day dedup

--- a/scripts/tests/test_digest_quality_gate.py
+++ b/scripts/tests/test_digest_quality_gate.py
@@ -1,0 +1,111 @@
+"""Unit tests for the digest quality gate in auto_publish_news.
+
+Covers _run_digest_quality_gate() in isolation using tmp_path fixtures.
+Does NOT invoke main(). Pattern follows test_auto_publish_qa.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts/ is on sys.path so auto_publish_news and digest_quality_report
+# are importable without a package prefix.
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from auto_publish_news import _run_digest_quality_gate  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_DIGEST_NAME = "2026-04-20-Tech_Security_Weekly_Digest_Test.md"
+_NON_DIGEST_NAME = "2026-04-20-Tech_Security_Weekly_Test.md"
+
+_CLEAN_CONTENT = """\
+---
+layout: post
+title: Test Digest
+---
+
+| 영역 | 핵심 내용 | 주요 키워드 |
+|------|-----------|-------------|
+| AI/LLM | 공격자가 LLM 프롬프트 인젝션 취약점을 악용해 민감한 데이터를 탈취했습니다. | CVE-2026-0001 |
+"""
+
+_TRUNCATED_CONTENT = """\
+---
+layout: post
+title: Test Digest
+---
+
+| 영역 | 핵심 내용 | 주요 키워드 |
+|------|-----------|-------------|
+| AI/LLM | 공격자가 LLM 프롬프트 인젝션을 통해 민감한 데이터를 탈취하기 위한 | CVE-2026-0001 |
+"""
+
+_ENGLISH_HEADER_CONTENT = """\
+---
+layout: post
+title: Test Digest
+---
+
+| 영역 | 핵심 내용 | 주요 키워드 |
+|------|-----------|-------------|
+| **Random Header** | 관련 시스템에서 보안 패치가 배포되었습니다. | CVE-2026-0002 |
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDigestQualityGate:
+    def test_non_digest_post_skipped(self, tmp_path, capsys):
+        """Files without 'Digest' in name are skipped entirely (always True)."""
+        p = tmp_path / _NON_DIGEST_NAME
+        p.write_text(_TRUNCATED_CONTENT, encoding="utf-8")
+        result = _run_digest_quality_gate(p, strict=True)
+        assert result is True
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+    def test_clean_digest_passes(self, tmp_path):
+        """A well-formed Digest post returns True with no output."""
+        p = tmp_path / _DIGEST_NAME
+        p.write_text(_CLEAN_CONTENT, encoding="utf-8")
+        result = _run_digest_quality_gate(p, strict=True)
+        assert result is True
+
+    def test_truncated_cell_strict_fails(self, tmp_path, capsys):
+        """Truncated table cell causes strict gate to return False."""
+        p = tmp_path / _DIGEST_NAME
+        p.write_text(_TRUNCATED_CONTENT, encoding="utf-8")
+        result = _run_digest_quality_gate(p, strict=True)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
+        assert "TRUNCATED" in captured.out
+
+    def test_truncated_cell_force_warns(self, tmp_path, capsys):
+        """With strict=False the gate warns but returns True (non-blocking)."""
+        p = tmp_path / _DIGEST_NAME
+        p.write_text(_TRUNCATED_CONTENT, encoding="utf-8")
+        result = _run_digest_quality_gate(p, strict=False)
+        assert result is True
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.out
+        assert "TRUNCATED" in captured.out
+
+    def test_english_only_header_fails(self, tmp_path, capsys):
+        """An English-only header not in the allowed list causes strict failure."""
+        p = tmp_path / _DIGEST_NAME
+        p.write_text(_ENGLISH_HEADER_CONTENT, encoding="utf-8")
+        result = _run_digest_quality_gate(p, strict=True)
+        assert result is False
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.out
+        assert "ENGLISH HEADER" in captured.out


### PR DESCRIPTION
## Summary
- New `_run_digest_quality_gate()` in `scripts/auto_publish_news.py` runs `digest_quality_report.analyze_post` on every just-written **Digest** post, after `_run_post_quality_gate` and before SVG generation / URL bookkeeping.
- On issues (truncated table cells, English-only trend headers, incomplete `<li>` highlights, or generic summary fallback), the gate prints a diagnostic block, deletes the half-written post, and `sys.exit(1)` — so the workflow fails loudly instead of shipping a broken digest.
- `--force` downgrades the failure to a warning for operator override.
- Non-Digest posts are a no-op.

## Why
Recent incidents (e.g. the ROCm cell truncation fixed in PR #274 of the notes branch) showed that broken digests were being published end-to-end before the issue was noticed. This adds a self-check in the same process that creates the post, using the existing `digest_quality_report.py` detector.

## Test plan
- [x] `pytest scripts/tests/test_digest_quality_gate.py -v` → 5 passed
- [x] `pytest scripts/tests/ -q` → 781 passed, no regressions
- [x] `ruff check scripts/auto_publish_news.py scripts/tests/test_digest_quality_gate.py` → clean
- [ ] Next weekly-digest run monitored for false positives
- [ ] Operators confirm `--force` override still works in emergency

## Files
- `scripts/auto_publish_news.py` — helper + call site (+51 LoC)
- `scripts/tests/test_digest_quality_gate.py` — 5 new unit tests (+110 LoC)