### PR TITLE
fix(ads): graceful fallback for adsbygoogle.js 403 errors

### DIFF
--- a/assets/js/adsense-init.js
+++ b/assets/js/adsense-init.js
@@ -5,8 +5,52 @@
     return;
   }
 
+  var AD_LOAD_TIMEOUT = 5000;
+  var AD_CHECK_INTERVAL = 200;
+  var _fallbackTimer = null;
+  var _checkInterval = null;
+
+  function hideAdSlots() {
+    var slots = document.querySelectorAll('ins.adsbygoogle');
+    for (var i = 0; i < slots.length; i += 1) {
+      slots[i].style.display = 'none';
+      slots[i].style.minHeight = '0';
+      slots[i].setAttribute('data-ad-load-failed', 'true');
+    }
+  }
+
+  function isAdsenseReady() {
+    return (
+      typeof window.adsbygoogle !== 'undefined' &&
+      typeof window.adsbygoogle.push === 'function'
+    );
+  }
+
+  function startFallbackGuard() {
+    if (_fallbackTimer !== null) {
+      return;
+    }
+
+    _fallbackTimer = setTimeout(function () {
+      clearInterval(_checkInterval);
+      _checkInterval = null;
+      if (!isAdsenseReady()) {
+        hideAdSlots();
+      }
+    }, AD_LOAD_TIMEOUT);
+
+    _checkInterval = setInterval(function () {
+      if (isAdsenseReady()) {
+        clearTimeout(_fallbackTimer);
+        clearInterval(_checkInterval);
+        _fallbackTimer = null;
+        _checkInterval = null;
+      }
+    }, AD_CHECK_INTERVAL);
+  }
+
   function initializeAdsenseSlots() {
-    if (!window.adsbygoogle || !window.adsbygoogle.push) {
+    if (!isAdsenseReady()) {
       return;
     }
 
@@ -22,6 +66,7 @@
   window.__adsenseSlotInitializer = initializeAdsenseSlots;
   window.addEventListener('adsense:ready', initializeAdsenseSlots);
   window.addEventListener('load', function () {
+    startFallbackGuard();
     setTimeout(initializeAdsenseSlots, 300);
   }, { once: true });
 })();


### PR DESCRIPTION
## Summary

Adds a 5-second timeout guard to \`assets/js/adsense-init.js\` that detects when \`adsbygoogle.js\` fails to load (e.g., production 403 Forbidden from Google) and gracefully hides all ad slots to eliminate:

- Empty layout gaps caused by unrendered \`<ins.adsbygoogle>\` elements
- Console noise from failed ad pushes

## Root cause (not fixable in code)

Production console shows:
\`\`\`
GET https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6788271437088974 net::ERR_ABORTED 403 (Forbidden)
\`\`\`

The 403 is server-side at Google — likely caused by AdSense account/domain approval status. **This PR does not fix the 403** — it only masks the UX impact when the script fails to load.

## Mechanism

- \`startFallbackGuard()\` starts a 5s timer + 200ms polling after page \`load\`
- If \`window.adsbygoogle.push\` exists → clear timer, do nothing (ads work normally)
- If timeout fires → apply \`display:none; minHeight:0\` to all \`ins.adsbygoogle\` + \`data-ad-load-failed=\"true\"\` attribute

## Files changed

- \`assets/js/adsense-init.js\`: +46 lines, -1 line

## Test plan

- [ ] Verify ads still load normally when AdSense 403 is resolved
- [ ] Verify slots hide cleanly on simulated script block (e.g., adblocker)
- [ ] Monitor production CLS after deploy — should improve slightly (no empty ad reservations)

## Follow-up

AdSense account/domain approval status check is required on the Google AdSense dashboard (not fixable via code).