### PR TITLE
fix(cls): eliminate 0.79 CLS from home post-card initial hide-all

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ title: Home
         {% elsif age_days == age_under_180 %}
           {% assign popularity = popularity | plus: 8 %}
         {% endif %}
-        <article class="post-card card" data-category="{{ post_cats }}" data-date="{{ post.date | date: '%Y%m%d' }}" data-popularity="{{ popularity }}">
+        <article class="post-card card" data-category="{{ post_cats }}" data-date="{{ post.date | date: '%Y%m%d' }}" data-popularity="{{ popularity }}"{% if forloop.index > 12 %} style="display:none"{% endif %}>
           <a href="{{ post.url | relative_url }}" class="post-card-inner" aria-label="{{ post.title | escape }}">
             {% if post.image and post.image != "" %}
             <div class="post-card-image">


### PR DESCRIPTION
## Summary

Home page reports CLS 0.793 from `DIV#posts-panel.posts-list` causing 4+ ARTICLE.post-card shifts per user console output. Root-caused to the fact that home page SSR renders 30 post cards (3 cols × 10 rows) but \`assets/js/home-posts-filter.js\` then hides all and shows only the first 12 on initial paint — collapsing 6 rows in a single layout shift.

## Fix

Emit \`style=\"display:none\"\` inline on cards at positions > 12 at Jekyll render time so the initial paint already shows exactly 12 cards. JS continues to toggle display as today (inline style takes precedence over CSS, and \`style.display = ''\` correctly clears it for reveals).

## Files changed

- \`index.html\` — one-line change adding \`{% if forloop.index > 12 %} style=\"display:none\"{% endif %}\` to the \`<article class=\"post-card ...\">\` element inside the main posts loop.

## Test plan

- [ ] Local Jekyll build renders the post-card loop with \`style=\"display:none\"\` on cards 13–30 (inspect HTML output)
- [ ] Initial page load shows 12 cards in default (latest) tab — no visible flicker or shift
- [ ] Clicking a category tab (Security, DevSecOps, etc.) still filters and sorts correctly
- [ ] \"More\" button still reveals next 12 filtered cards
- [ ] Performance monitor console no longer logs \`CLS is high: 0.79\` — expect CLS < 0.1

## Not in scope

- \`adsbygoogle.js\` 403 — already covered by PR #278 (graceful fallback merged)
- Other layout-shift sources (lazy-loaded images have explicit \`width/height\` and \`aspect-ratio\` via CSS)

## Root cause reference

- \`assets/js/home-posts-filter.js:79-85\` — \`allCards.forEach(c => c.style.display = 'none')\` unconditionally, then \`filtered.slice(0, 12).forEach(c => c.style.display = '')\`
- \`assets/js/home-posts-filter.js:181\` — calls \`renderPosts()\` on initial load
- \`index.html:94\` — \`{% for post in site.posts limit: 30 %}\` outputs 30 cards