### PR TITLE
fix(perf): CLS/LCP 3대 수정 - aspect-ratio, Fonts display=swap, giscus min-height

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -153,8 +153,8 @@
   <!-- Fonts: Noto Sans KR (CSP-safe non-blocking load via JS) -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=optional" rel="stylesheet" media="print" id="gfonts">
-  <noscript><link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=optional" rel="stylesheet"></noscript>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet" media="print" id="gfonts">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap" rel="stylesheet"></noscript>
   <script>
     // CSP-safe deferred CSS/font loading (replaces inline onload handlers)
     // NOTE: .deferred-css links are defined *below* this script; query them after DOM is ready.

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -13,7 +13,7 @@
       <picture>
         <source srcset="{{ card_sm_avif }} 525w, {{ card_avif }} 1120w" type="image/avif" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
         <source srcset="{{ card_sm_webp }} 525w, {{ card_webp }} 1120w" type="image/webp" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
-        <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="525" height="276" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
+        <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="525" height="276" style="aspect-ratio: 525/276" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
       </picture>
     </div>
     {% endif %}

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -1985,7 +1985,8 @@
 
 .giscus-wrapper {
   position: relative;
-  min-height: 200px;
+  min-height: 400px;
+  contain-intrinsic-size: auto 500px;
 }
 
 .giscus-loading {


### PR DESCRIPTION
## Summary

성능 감사 보고서 기반 Critical/High CLS·LCP 항목 3건 수정.

| # | 파일 | 변경 내용 | 예상 효과 |
|---|------|-----------|-----------|
| 1 | `_includes/post-card.html` | `<img>`에 `style="aspect-ratio: 525/276"` 인라인 추가 | CSS `aspect-ratio` 미지원 구형 브라우저에서도 이미지 공간 예약 → CLS 감소 |
| 2 | `_includes/head.html` | Google Fonts URL `display=optional` → `display=swap` | 폰트 로드 전 폴백 폰트 표시 → LCP 텍스트 지연 없음, FOIT 제거 |
| 3 | `_sass/_post.scss` | `.giscus-wrapper` `min-height: 200px → 400px` + `contain-intrinsic-size: auto 500px` 추가 | Giscus 댓글 로드 전 공간 충분히 예약 → 댓글 영역 CLS 대폭 감소 |

## Before / After (감사 보고서 기반 추정)

| 지표 | Before | After (추정) |
|------|--------|--------------|
| CLS (post page) | ~0.08–0.12 | ~0.02–0.04 |
| LCP (post page) | 텍스트 FOIT 발생 | FOIT 없음, swap으로 즉시 표시 |
| CLS (home card) | 이미지 리플로우 있음 | aspect-ratio fallback으로 안정 |
| Giscus CLS | 레이아웃 시프트 큼 | 400px 예약으로 최소화 |

## Test plan

- [ ] Lighthouse 재측정: Home 페이지 (`/`)
- [ ] Lighthouse 재측정: Post 페이지 (임의 포스트 1건)
- [ ] Lighthouse 재측정: Category 페이지 (`/devsecops/`)
- [ ] 구형 브라우저(Safari 14 이하) post-card 이미지 레이아웃 확인
- [ ] 폰트 swap 동작 확인 (Network throttle → 폴백 폰트 → 스왑 확인)
- [ ] Giscus 섹션 스크롤 시 CLS 미발생 확인 (WebPageTest 영상)