### PR TITLE
feat(images): Style A v4c pure-visual (April 01-19 backfill)

### DIFF
--- a/assets/images/2026-04-01-Tech_Security_Weekly_Digest_Zero-Day_Go_AI_AWS.svg
+++ b/assets/images/2026-04-01-Tech_Security_Weekly_Digest_Zero-Day_Go_AI_AWS.svg
@@ -1,145 +1,424 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 01 2026 ZERO DAY">
-  <title>Style A v3 APR 01 2026 ZERO DAY</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#040b1a"/><stop offset="100%" stop-color="#081029"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#081029"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.34"/><stop offset="100%" stop-color="#040b1a" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.32"/><stop offset="100%" stop-color="#081029" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"><animate attributeName="stop-color" values="#3b82f6;#60a5fa;#06b6d4;#3b82f6" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#60a5fa"><animate attributeName="stop-color" values="#60a5fa;#22d3ee;#3b82f6;#60a5fa" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#22d3ee"><animate attributeName="stop-color" values="#22d3ee;#06b6d4;#60a5fa;#22d3ee" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.9"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#040b1a" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="50%" stop-color="#06b6d4" stop-opacity="0.7"/><stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="1"/><stop offset="55%" stop-color="#3b82f6" stop-opacity="0.75"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.5"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a5f3fc" stop-opacity="0.85"/><stop offset="100%" stop-color="#a5f3fc" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0.45"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.85"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.4"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="35%" stop-color="#06b6d4" stop-opacity="0.95"/><stop offset="65%" stop-color="#3b82f6" stop-opacity="0.95"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0"/><stop offset="40%" stop-color="#60a5fa" stop-opacity="0.55"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#60a5fa"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#3b82f6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="728.5" y1="491.3" x2="755.4" y2="410.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="728.5" y1="491.3" x2="795.1" y2="180.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="755.4" y1="410.6" x2="795.1" y2="180.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="755.4" y1="410.6" x2="765.4" y2="238.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="795.1" y1="180.6" x2="765.4" y2="238.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="795.1" y1="180.6" x2="937.9" y2="331.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="765.4" y1="238.8" x2="937.9" y2="331.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="765.4" y1="238.8" x2="550.1" y2="374.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="937.9" y1="331.1" x2="550.1" y2="374.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="937.9" y1="331.1" x2="591.7" y2="188.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="550.1" y1="374.5" x2="591.7" y2="188.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="550.1" y1="374.5" x2="580.5" y2="217.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="591.7" y1="188.8" x2="580.5" y2="217.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="591.7" y1="188.8" x2="754.6" y2="421.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="580.5" y1="217.2" x2="754.6" y2="421.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="580.5" y1="217.2" x2="584.6" y2="439.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="754.6" y1="421.9" x2="584.6" y2="439.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="754.6" y1="421.9" x2="893.5" y2="444.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="584.6" y1="439.4" x2="893.5" y2="444.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="584.6" y1="439.4" x2="791.2" y2="398.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="893.5" y1="444.6" x2="791.2" y2="398.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="893.5" y1="444.6" x2="575.9" y2="361.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="791.2" y1="398.5" x2="575.9" y2="361.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="791.2" y1="398.5" x2="569.0" y2="281.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="575.9" y1="361.7" x2="569.0" y2="281.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="575.9" y1="361.7" x2="928.2" y2="334.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="569.0" y1="281.4" x2="928.2" y2="334.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="569.0" y1="281.4" x2="802.5" y2="163.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="928.2" y1="334.7" x2="802.5" y2="163.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="928.2" y1="334.7" x2="938.2" y2="351.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="802.5" y1="163.6" x2="938.2" y2="351.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="802.5" y1="163.6" x2="519.5" y2="295.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="938.2" y1="351.8" x2="519.5" y2="295.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <circle cx="728.5" cy="491.3" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="728.5" cy="491.3" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="755.4" cy="410.6" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="755.4" cy="410.6" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="795.1" cy="180.6" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="795.1" cy="180.6" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="765.4" cy="238.8" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="765.4" cy="238.8" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="937.9" cy="331.1" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="937.9" cy="331.1" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="550.1" cy="374.5" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="550.1" cy="374.5" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="591.7" cy="188.8" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="591.7" cy="188.8" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="580.5" cy="217.2" r="14.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="580.5" cy="217.2" r="8.6" fill="url(#nodeCore)"><animate attributeName="r" values="8.6;10.6;8.6" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="754.6" cy="421.9" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="754.6" cy="421.9" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="584.6" cy="439.4" r="14.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="584.6" cy="439.4" r="8.3" fill="url(#nodeCore)"><animate attributeName="r" values="8.3;10.3;8.3" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="893.5" cy="444.6" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="893.5" cy="444.6" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="791.2" cy="398.5" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="791.2" cy="398.5" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="575.9" cy="361.7" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="575.9" cy="361.7" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="569.0" cy="281.4" r="14.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="569.0" cy="281.4" r="8.3" fill="url(#nodeCore)"><animate attributeName="r" values="8.3;10.3;8.3" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="928.2" cy="334.7" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="928.2" cy="334.7" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="802.5" cy="163.6" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="802.5" cy="163.6" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="938.2" cy="351.8" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="938.2" cy="351.8" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="519.5" cy="295.3" r="13.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="519.5" cy="295.3" r="7.4" fill="url(#nodeCore)"><animate attributeName="r" values="7.4;9.4;7.4" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1042.6" cy="435.9" r="1.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="435.9;369.9;435.9" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="1113.8" cy="374.7" r="2.7" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="374.7;292.9;374.7" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="598.7" cy="64.1" r="1.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="64.1;-16.3;64.1" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="561.8" cy="558.0" r="2.8" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="558.0;505.1;558.0" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="848.1" cy="466.0" r="1.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="466.0;390.6;466.0" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="548.0" cy="432.5" r="2.3" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="432.5;356.6;432.5" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="930.4" cy="548.2" r="2.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="548.2;488.4;548.2" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1022.2" cy="192.7" r="1.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="192.7;126.6;192.7" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="997.1" cy="432.4" r="2.3" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="432.4;392.7;432.4" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="983.5" cy="433.5" r="2.5" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="433.5;382.5;433.5" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="912.9" cy="252.8" r="2.5" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="252.8;210.7;252.8" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1019.7" cy="166.5" r="1.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="166.5;114.2;166.5" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="819.9" cy="473.7" r="1.5" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="473.7;433.2;473.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="593.0" cy="434.4" r="1.8" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="434.4;395.2;434.4" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#06b6d4" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#60a5fa" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#3b82f6" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#3b82f6" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#60a5fa"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">ZERO<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">DAY<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">APT</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">AWS</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">ANDROID</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#06b6d4" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#60a5fa"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#a5f3fc" letter-spacing="3.5" opacity="0.9">APR 01 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">ZERO</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">DAY</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#06b6d4" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#3b82f6" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#60a5fa" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#06b6d4" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#a5f3fc" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#60a5fa" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6.4,2.4H6.8V2.8H6.4zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.4,4.4H16.8V4.8H16.4zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM2,6.4H2.4V6.8H2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM5.2,6.8H5.6V7.2H5.2zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM2.8,7.6H3.2V8H2.8zM4.8,7.6H5.2V8H4.8zM6.4,7.6H6.8V8H6.4zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM8.4,8.4H8.8V8.8H8.4zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM1.6,8.8H2V9.2H1.6zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM6.4,8.8H6.8V9.2H6.4zM8.4,8.8H8.8V9.2H8.4zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM1.2,10.4H1.6V10.8H1.2zM2,10.4H2.4V10.8H2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM6,10.8H6.4V11.2H6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4.8,11.2H5.2V11.6H4.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM4,11.6H4.4V12H4zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM0.8,12H1.2V12.4H0.8zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM3.6,13.2H4V13.6H3.6zM5.2,13.2H5.6V13.6H5.2zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM6.4,13.6H6.8V14H6.4zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM5.6,14H6V14.4H5.6zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM6,14.4H6.4V14.8H6zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.6,14.8H6V15.2H5.6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM6,15.6H6.4V16H6zM6.4,15.6H6.8V16H6.4zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.8,16H5.2V16.4H4.8zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: device verification, CVE triage, cloud compliance">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Industrial rack -->
+  <g transform="translate(-60,-100)">
+    <rect x="0" y="0" width="120" height="150" rx="4" fill="#0B132B" stroke="#E63946" stroke-width="2.4"/>
+    <!-- 1U rows -->
+    <rect x="6" y="8" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="30" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="52" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="74" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="96" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="118" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <!-- row LEDs blinking (red = vulnerable) -->
+    <circle cx="14" cy="17" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="17" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="61" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="61" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="105" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="105" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.5s" repeatCount="indefinite"/></circle>
+    <!-- serial ports (right side of each row) -->
+    <rect x="90" y="14" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="36" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="58" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="80" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="102" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="124" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <!-- progress bars of each row -->
+    <rect x="34" y="15" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="15" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="37" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="37" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="59" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="59" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="81" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="81" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="103" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="103" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="125" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="125" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2.5s" repeatCount="indefinite"/></rect>
   </g>
+  <!-- Serial cable snaking out -->
+  <path d="M 70 -30 Q 100 -30 100 0 Q 100 30 70 30 Q 40 30 40 60" fill="none" stroke="#E63946" stroke-width="3" stroke-linecap="round">
+    <animate attributeName="stroke-dasharray" values="0 300;300 0" dur="4s" repeatCount="indefinite"/>
+  </path>
+  <circle cx="40" cy="60" r="4" fill="#E63946">
+    <animate attributeName="r" values="4;6;4" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Glowing vulnerability burst -->
+  <g transform="translate(-100,60)">
+    <circle cx="0" cy="0" r="10" fill="url(#glowRed)" opacity="0.7">
+      <animate attributeName="r" values="10;20;10" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <!-- crack star burst -->
+    <path d="M 0 -14 L 0 14 M -14 0 L 14 0 M -10 -10 L 10 10 M 10 -10 L -10 10"
+          stroke="#E63946" stroke-width="1.8" fill="none">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.5s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Exposure count beads (3 small circles, visual-only) -->
+  <circle cx="90" cy="-80" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.6s" repeatCount="indefinite"/></circle>
+  <circle cx="96" cy="-72" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="102" cy="-64" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="2.0s" repeatCount="indefinite"/></circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">ANDROID</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Developer verification rollout begins</text>
+<g transform="translate(576,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">TRUECONF</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Zero-day exploited against governments</text>
+<g transform="translate(936,330)">
+  <!-- Shield silhouette -->
+  <g transform="translate(-70,-100)">
+    <path d="M 0 0 L 60 0 L 60 60 Q 60 100 30 120 Q 0 100 0 60 Z"
+          fill="#0B132B" stroke="#3A86FF" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.9;1;0.9" dur="3.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- inner pulse -->
+    <path d="M 10 10 L 50 10 L 50 58 Q 50 92 30 108 Q 10 92 10 58 Z"
+          fill="url(#glowBlue)" opacity="0.35">
+      <animate attributeName="opacity" values="0.2;0.55;0.2" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- big checkmark inside -->
+    <path d="M 14 58 L 26 74 L 48 40" fill="none" stroke="#3A86FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Clipboard (right) -->
+  <g transform="translate(10,-90)">
+    <rect x="0" y="0" width="90" height="120" rx="6" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- clip -->
+    <rect x="32" y="-8" width="26" height="14" rx="3" fill="#3A86FF"/>
+    <!-- checklist rows appearing -->
+    <g>
+      <circle cx="14" cy="24" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 24 L 13 26 L 17 22" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="22" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="28" width="42" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="44" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 44 L 13 46 L 17 42" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="1s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="42" width="58" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="48" width="46" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="64" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 64 L 13 66 L 17 62" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="2s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="62" width="50" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="68" width="38" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="84" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 84 L 13 86 L 17 82" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="3s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="82" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="88" width="44" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="104" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 104 L 13 106 L 17 102" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="4s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="102" width="60" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="108" width="48" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+  </g>
+  <!-- Growing service nodes around shield -->
+  <circle cx="-90" cy="40" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="60;40;40;20" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- progress bar bottom -->
+  <rect x="-60" y="56" width="120" height="6" rx="3" fill="#2A3256"/>
+  <rect x="-60" y="56" width="20" height="6" rx="3" fill="#3A86FF">
+    <animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/>
+  </rect>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AWS</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="13" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">New compliance guide published</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM6.8,0.8H7.2V1.2H6.8zM8,0.8H8.4V1.2H8zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM6,1.6H6.4V2H6zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM16.4,4.8H16.8V5.2H16.4zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM5.6,5.2H6V5.6H5.6zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4,6H4.4V6.4H4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM5.2,6.4H5.6V6.8H5.2zM6.4,6.4H6.8V6.8H6.4zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM7.6,7.2H8V7.6H7.6zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM2.8,7.6H3.2V8H2.8zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM6,8H6.4V8.4H6zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM1.6,8.4H2V8.8H1.6zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM8.4,8.4H8.8V8.8H8.4zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM1.6,8.8H2V9.2H1.6zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM6,8.8H6.4V9.2H6zM6.8,8.8H7.2V9.2H6.8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.8,9.2H9.2V9.6H8.8zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM5.2,9.6H5.6V10H5.2zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16.8,9.6H17.2V10H16.8zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2.4,10H2.8V10.4H2.4zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM4.4,10H4.8V10.4H4.4zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM0.8,10.4H1.2V10.8H0.8zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2,10.8H2.4V11.2H2zM2.8,10.8H3.2V11.2H2.8zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM6.4,11.2H6.8V11.6H6.4zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM0.8,12H1.2V12.4H0.8zM1.6,12H2V12.4H1.6zM2,12H2.4V12.4H2zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM2,12.4H2.4V12.8H2zM3.6,12.4H4V12.8H3.6zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM6.4,12.8H6.8V13.2H6.4zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM3.6,13.2H4V13.6H3.6zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM6.8,13.2H7.2V13.6H6.8zM7.6,13.2H8V13.6H7.6zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM6.8,13.6H7.2V14H6.8zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM11.6,14H12V14.4H11.6zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM6,15.6H6.4V16H6zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-02-Tech_Security_Weekly_Digest_AI_Malware.svg
+++ b/assets/images/2026-04-02-Tech_Security_Weekly_Digest_AI_Malware.svg
@@ -1,145 +1,473 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 02 2026 AI MALWARE">
-  <title>Style A v3 APR 02 2026 AI MALWARE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#04120b"/><stop offset="100%" stop-color="#071a14"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#071a14"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.34"/><stop offset="100%" stop-color="#04120b" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.32"/><stop offset="100%" stop-color="#071a14" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"><animate attributeName="stop-color" values="#84cc16;#bef264;#10b981;#84cc16" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#bef264"><animate attributeName="stop-color" values="#bef264;#34d399;#84cc16;#bef264" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#34d399"><animate attributeName="stop-color" values="#34d399;#10b981;#bef264;#34d399" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.9"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#04120b" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="50%" stop-color="#10b981" stop-opacity="0.7"/><stop offset="100%" stop-color="#10b981" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#bef264" stop-opacity="1"/><stop offset="55%" stop-color="#84cc16" stop-opacity="0.75"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#34d399" stop-opacity="0.5"/><stop offset="100%" stop-color="#34d399" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#d9f99d" stop-opacity="0.85"/><stop offset="100%" stop-color="#d9f99d" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#bef264" stop-opacity="0.45"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.85"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.4"/><stop offset="100%" stop-color="#bef264" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="35%" stop-color="#10b981" stop-opacity="0.95"/><stop offset="65%" stop-color="#84cc16" stop-opacity="0.95"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#bef264" stop-opacity="0"/><stop offset="40%" stop-color="#bef264" stop-opacity="0.55"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"/><stop offset="100%" stop-color="#bef264"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#84cc16" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="827.6" y1="170.8" x2="951.7" y2="331.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="827.6" y1="170.8" x2="891.2" y2="287.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="951.7" y1="331.2" x2="891.2" y2="287.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="951.7" y1="331.2" x2="758.6" y2="460.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="891.2" y1="287.8" x2="758.6" y2="460.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="891.2" y1="287.8" x2="721.3" y2="239.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="758.6" y1="460.1" x2="721.3" y2="239.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="758.6" y1="460.1" x2="625.2" y2="371.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="721.3" y1="239.0" x2="625.2" y2="371.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="721.3" y1="239.0" x2="727.0" y2="403.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="625.2" y1="371.2" x2="727.0" y2="403.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="625.2" y1="371.2" x2="832.5" y2="472.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="727.0" y1="403.2" x2="832.5" y2="472.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="727.0" y1="403.2" x2="576.7" y2="416.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="832.5" y1="472.7" x2="576.7" y2="416.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="832.5" y1="472.7" x2="764.8" y2="192.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="576.7" y1="416.8" x2="764.8" y2="192.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="576.7" y1="416.8" x2="891.5" y2="283.4" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="764.8" y1="192.5" x2="891.5" y2="283.4" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="764.8" y1="192.5" x2="791.3" y2="238.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="891.5" y1="283.4" x2="791.3" y2="238.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="891.5" y1="283.4" x2="762.6" y2="414.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="791.3" y1="238.7" x2="762.6" y2="414.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="791.3" y1="238.7" x2="837.7" y2="407.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="762.6" y1="414.5" x2="837.7" y2="407.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="762.6" y1="414.5" x2="730.7" y2="136.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="837.7" y1="407.7" x2="730.7" y2="136.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="837.7" y1="407.7" x2="668.9" y2="180.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="730.7" y1="136.5" x2="668.9" y2="180.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="730.7" y1="136.5" x2="598.0" y2="169.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="668.9" y1="180.7" x2="598.0" y2="169.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="668.9" y1="180.7" x2="629.0" y2="382.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="598.0" y1="169.9" x2="629.0" y2="382.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <circle cx="827.6" cy="170.8" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="827.6" cy="170.8" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="951.7" cy="331.2" r="13.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="951.7" cy="331.2" r="7.1" fill="url(#nodeCore)"><animate attributeName="r" values="7.1;9.1;7.1" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="891.2" cy="287.8" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="891.2" cy="287.8" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="758.6" cy="460.1" r="12.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="758.6" cy="460.1" r="6.2" fill="url(#nodeCore)"><animate attributeName="r" values="6.2;8.2;6.2" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="721.3" cy="239.0" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="721.3" cy="239.0" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="625.2" cy="371.2" r="11.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="625.2" cy="371.2" r="5.7" fill="url(#nodeCore)"><animate attributeName="r" values="5.7;7.7;5.7" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="727.0" cy="403.2" r="10.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="727.0" cy="403.2" r="4.7" fill="url(#nodeCore)"><animate attributeName="r" values="4.7;6.7;4.7" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="832.5" cy="472.7" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="832.5" cy="472.7" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="576.7" cy="416.8" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="576.7" cy="416.8" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="764.8" cy="192.5" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="764.8" cy="192.5" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="891.5" cy="283.4" r="10.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="891.5" cy="283.4" r="4.7" fill="url(#nodeCore)"><animate attributeName="r" values="4.7;6.7;4.7" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="791.3" cy="238.7" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="791.3" cy="238.7" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="762.6" cy="414.5" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="762.6" cy="414.5" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="837.7" cy="407.7" r="11.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="837.7" cy="407.7" r="5.0" fill="url(#nodeCore)"><animate attributeName="r" values="5.0;7.0;5.0" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="730.7" cy="136.5" r="10.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="730.7" cy="136.5" r="4.0" fill="url(#nodeCore)"><animate attributeName="r" values="4.0;6.0;4.0" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="668.9" cy="180.7" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="668.9" cy="180.7" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="598.0" cy="169.9" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="598.0" cy="169.9" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="629.0" cy="382.1" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="629.0" cy="382.1" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="855.6" cy="211.7" r="2.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="211.7;144.8;211.7" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="764.1" cy="472.6" r="1.7" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="472.6;398.7;472.6" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="690.3" cy="350.7" r="2.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="350.7;306.4;350.7" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="889.2" cy="95.3" r="3.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="95.3;13.2;95.3" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1052.7" cy="535.2" r="2.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="535.2;467.7;535.2" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="656.4" cy="558.7" r="1.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="558.7;522.6;558.7" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="577.7" cy="348.6" r="2.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="348.6;290.6;348.6" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="824.7" cy="356.3" r="1.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="356.3;280.4;356.3" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="695.7" cy="131.2" r="1.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="131.2;84.6;131.2" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1105.4" cy="291.0" r="2.3" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="291.0;231.8;291.0" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="861.2" cy="469.3" r="2.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="469.3;407.5;469.3" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="554.8" cy="516.9" r="3.0" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="516.9;462.4;516.9" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="865.3" cy="332.2" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="332.2;290.0;332.2" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="642.7" cy="254.6" r="2.2" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="254.6;171.1;254.6" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#10b981" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#bef264" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#84cc16" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#84cc16" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#bef264"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">AI<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">MALWARE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">MODEL</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">THREAT</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">AGENT</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#10b981" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#bef264"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#d9f99d" letter-spacing="3.5" opacity="0.9">APR 02 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">AI</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">MALWARE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#10b981" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#84cc16" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#bef264" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#10b981" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#d9f99d" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#bef264" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.8293)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.6,0.8H12V1.2H11.6zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14,0.8H14.4V1.2H14zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.4,1.2H4.8V1.6H4.4zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM15.2,1.2H15.6V1.6H15.2zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14,1.6H14.4V2H14zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14,2H14.4V2.4H14zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM12,2.4H12.4V2.8H12zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14,2.4H14.4V2.8H14zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM8.8,2.8H9.2V3.2H8.8zM10.4,2.8H10.8V3.2H10.4zM10.8,2.8H11.2V3.2H10.8zM11.2,2.8H11.6V3.2H11.2zM12.8,2.8H13.2V3.2H12.8zM15.2,2.8H15.6V3.2H15.2zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.2,3.2H13.6V3.6H13.2zM13.6,3.2H14V3.6H13.6zM14,3.2H14.4V3.6H14zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM8.4,3.6H8.8V4H8.4zM9.6,3.6H10V4H9.6zM10,3.6H10.4V4H10zM11.2,3.6H11.6V4H11.2zM12,3.6H12.4V4H12zM0.8,4H1.2V4.4H0.8zM3.2,4H3.6V4.4H3.2zM4,4H4.4V4.4H4zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM0.8,4.4H1.2V4.8H0.8zM2,4.4H2.4V4.8H2zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM9.2,4.4H9.6V4.8H9.2zM9.6,4.4H10V4.8H9.6zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM0.8,4.8H1.2V5.2H0.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM5.2,4.8H5.6V5.2H5.2zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.8,4.8H11.2V5.2H10.8zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.4,4.8H12.8V5.2H12.4zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM4,5.2H4.4V5.6H4zM5.2,5.2H5.6V5.6H5.2zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.2,5.2H7.6V5.6H7.2zM8,5.2H8.4V5.6H8zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM11.2,5.2H11.6V5.6H11.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM14,5.2H14.4V5.6H14zM15.2,5.2H15.6V5.6H15.2zM2,5.6H2.4V6H2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM6,5.6H6.4V6H6zM7.2,5.6H7.6V6H7.2zM8,5.6H8.4V6H8zM10.4,5.6H10.8V6H10.4zM11.6,5.6H12V6H11.6zM12.8,5.6H13.2V6H12.8zM14.4,5.6H14.8V6H14.4zM15.2,5.6H15.6V6H15.2zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM8.4,6H8.8V6.4H8.4zM8.8,6H9.2V6.4H8.8zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM0.8,6.4H1.2V6.8H0.8zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.8,6.4H7.2V6.8H6.8zM8,6.4H8.4V6.8H8zM9.6,6.4H10V6.8H9.6zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM11.2,6.4H11.6V6.8H11.2zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM15.2,6.4H15.6V6.8H15.2zM1.2,6.8H1.6V7.2H1.2zM2.4,6.8H2.8V7.2H2.4zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM10,6.8H10.4V7.2H10zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM14,6.8H14.4V7.2H14zM14.4,6.8H14.8V7.2H14.4zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12,7.2H12.4V7.6H12zM12.4,7.2H12.8V7.6H12.4zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM14.4,7.2H14.8V7.6H14.4zM15.2,7.2H15.6V7.6H15.2zM1.2,7.6H1.6V8H1.2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM6.8,7.6H7.2V8H6.8zM8,7.6H8.4V8H8zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM13.2,7.6H13.6V8H13.2zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM7.6,8H8V8.4H7.6zM8,8H8.4V8.4H8zM8.4,8H8.8V8.4H8.4zM9.2,8H9.6V8.4H9.2zM10,8H10.4V8.4H10zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM7.2,8.4H7.6V8.8H7.2zM8,8.4H8.4V8.8H8zM9.6,8.4H10V8.8H9.6zM10.4,8.4H10.8V8.8H10.4zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.2,8.4H13.6V8.8H13.2zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM1.2,9.2H1.6V9.6H1.2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM11.6,9.2H12V9.6H11.6zM12,9.2H12.4V9.6H12zM13.6,9.2H14V9.6H13.6zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM4.8,9.6H5.2V10H4.8zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.8,9.6H13.2V10H12.8zM13.2,9.6H13.6V10H13.2zM13.6,9.6H14V10H13.6zM14,9.6H14.4V10H14zM15.2,9.6H15.6V10H15.2zM1.2,10H1.6V10.4H1.2zM2.4,10H2.8V10.4H2.4zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM11.2,10H11.6V10.4H11.2zM11.6,10H12V10.4H11.6zM12,10H12.4V10.4H12zM12.4,10H12.8V10.4H12.4zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM15.2,10H15.6V10.4H15.2zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM12,10.4H12.4V10.8H12zM12.8,10.4H13.2V10.8H12.8zM13.6,10.4H14V10.8H13.6zM14.8,10.4H15.2V10.8H14.8zM15.2,10.4H15.6V10.8H15.2zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM14,10.8H14.4V11.2H14zM0.8,11.2H1.2V11.6H0.8zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM5.2,11.2H5.6V11.6H5.2zM6.8,11.2H7.2V11.6H6.8zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.6,11.2H10V11.6H9.6zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.6,11.2H12V11.6H11.6zM12.8,11.2H13.2V11.6H12.8zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM5.6,11.6H6V12H5.6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM15.2,11.6H15.6V12H15.2zM0.8,12H1.2V12.4H0.8zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.4,12H14.8V12.4H14.4zM14.8,12H15.2V12.4H14.8zM15.2,12H15.6V12.4H15.2zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6.8,12.4H7.2V12.8H6.8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.6,12.4H10V12.8H9.6zM10,12.4H10.4V12.8H10zM12,12.4H12.4V12.8H12zM13.6,12.4H14V12.8H13.6zM14.8,12.4H15.2V12.8H14.8zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM8.4,12.8H8.8V13.2H8.4zM9.6,12.8H10V13.2H9.6zM10,12.8H10.4V13.2H10zM10.8,12.8H11.2V13.2H10.8zM12,12.8H12.4V13.2H12zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14.8,12.8H15.2V13.2H14.8zM15.2,12.8H15.6V13.2H15.2zM0.8,13.2H1.2V13.6H0.8zM3.2,13.2H3.6V13.6H3.2zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM12,13.2H12.4V13.6H12zM13.6,13.2H14V13.6H13.6zM14.8,13.2H15.2V13.6H14.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10.4,13.6H10.8V14H10.4zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM0.8,14H1.2V14.4H0.8zM1.6,14H2V14.4H1.6zM2,14H2.4V14.4H2zM2.4,14H2.8V14.4H2.4zM3.2,14H3.6V14.4H3.2zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM8,14H8.4V14.4H8zM10,14H10.4V14.4H10zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM14.4,14H14.8V14.4H14.4zM14.8,14H15.2V14.4H14.8zM15.2,14H15.6V14.4H15.2zM0.8,14.4H1.2V14.8H0.8zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM3.2,14.4H3.6V14.8H3.2zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM14.4,14.4H14.8V14.8H14.4zM14.8,14.4H15.2V14.8H14.8zM15.2,14.4H15.6V14.8H15.2zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.6,14.8H6V15.2H5.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM14,14.8H14.4V15.2H14zM15.2,14.8H15.6V15.2H15.2zM0.8,15.2H1.2V15.6H0.8zM1.2,15.2H1.6V15.6H1.2zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM2.8,15.2H3.2V15.6H2.8zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM10.4,15.2H10.8V15.6H10.4zM12,15.2H12.4V15.6H12zM12.8,15.2H13.2V15.6H12.8zM13.2,15.2H13.6V15.6H13.2zM14,15.2H14.4V15.6H14zM15.2,15.2H15.6V15.6H15.2z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: phishing campaign, supply-chain breach, C2 malware">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Device frame (phone outline) -->
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="#0B132B" stroke="#3A86FF" stroke-width="2.4" opacity="0.95"/>
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="url(#glowBlue)" opacity="0.28">
+    <animate attributeName="opacity" values="0.18;0.42;0.18" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="-126" width="40" height="6" rx="3" fill="#2A3256"/>
+  <!-- Notification stack (3 mini rows appearing) -->
+  <g transform="translate(-54,-92)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;6.4;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="54" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
   </g>
+  <g transform="translate(-54,-62)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="48" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-32)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="58" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Bell (top right of phone) pulsing -->
+  <g transform="translate(46,-104)">
+    <path d="M -10 6 Q -10 -8 0 -8 Q 10 -8 10 6 L 12 10 L -12 10 Z"
+          fill="#FFB703" opacity="0.95"/>
+    <circle cx="0" cy="-10" r="2.2" fill="#FFB703"/>
+    <path d="M -3 12 Q 0 16 3 12" fill="none" stroke="#FFB703" stroke-width="1.5"/>
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-12 0 -8; 12 0 -8; -12 0 -8"
+                      dur="1.6s" repeatCount="indefinite" additive="sum"/>
+  </g>
+  <!-- Fishhook swinging below phone -->
+  <g transform="translate(0,108)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-10 0 -40; 10 0 -40; -10 0 -40"
+                      dur="3.2s" repeatCount="indefinite" additive="sum"/>
+    <line x1="0" y1="-40" x2="0" y2="6" stroke="#FFB703" stroke-width="2.4"/>
+    <path d="M 0 6 Q 0 22 -12 22 Q -22 22 -22 12" fill="none"
+          stroke="#FFB703" stroke-width="2.6" stroke-linecap="round"/>
+    <circle cx="-22" cy="12" r="2.6" fill="#FFB703"/>
+    <path d="M -22 12 L -18 18 L -26 18 Z" fill="#FFB703"/>
+  </g>
+  <!-- Phishing particles flying toward hook -->
+  <circle cx="-90" cy="40" r="3" fill="#E63946">
+    <animate attributeName="cx" values="-90;-22" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="40;100" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="10" r="2.4" fill="#FFB703">
+    <animate attributeName="cx" values="-100;-22" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="10;100" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-88" cy="70" r="2.8" fill="#E63946">
+    <animate attributeName="cx" values="-88;-22" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="70;100" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- brand noun at bottom -->
+  <text x="0" y="164" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CERTUA</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Million phishing emails impersonate agency</text>
+<g transform="translate(576,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
+  </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AXIOS</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">npm supply chain breach mitigated</text>
+<g transform="translate(936,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">MALWARE</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Bypass loader hides persistent implant</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(6.097561)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14,0.8H14.4V1.2H14zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.4,1.2H4.8V1.6H4.4zM5.6,1.2H6V1.6H5.6zM7.6,1.2H8V1.6H7.6zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM15.2,1.2H15.6V1.6H15.2zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM10.8,1.6H11.2V2H10.8zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14,1.6H14.4V2H14zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14,2H14.4V2.4H14zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM6.8,2.4H7.2V2.8H6.8zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM12,2.4H12.4V2.8H12zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14,2.4H14.4V2.8H14zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM9.6,2.8H10V3.2H9.6zM10,2.8H10.4V3.2H10zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM15.2,2.8H15.6V3.2H15.2zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.2,3.2H13.6V3.6H13.2zM13.6,3.2H14V3.6H13.6zM14,3.2H14.4V3.6H14zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM6.8,3.6H7.2V4H6.8zM8.8,3.6H9.2V4H8.8zM9.6,3.6H10V4H9.6zM10,3.6H10.4V4H10zM10.8,3.6H11.2V4H10.8zM12,3.6H12.4V4H12zM0.8,4H1.2V4.4H0.8zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM6.4,4H6.8V4.4H6.4zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM8.8,4.4H9.2V4.8H8.8zM9.2,4.4H9.6V4.8H9.2zM9.6,4.4H10V4.8H9.6zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM0.8,4.8H1.2V5.2H0.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM8,4.8H8.4V5.2H8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM10.8,4.8H11.2V5.2H10.8zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14.4,4.8H14.8V5.2H14.4zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM10,5.2H10.4V5.6H10zM11.2,5.2H11.6V5.6H11.2zM12.4,5.2H12.8V5.6H12.4zM12.8,5.2H13.2V5.6H12.8zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM2,5.6H2.4V6H2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM7.2,5.6H7.6V6H7.2zM8,5.6H8.4V6H8zM10.4,5.6H10.8V6H10.4zM11.6,5.6H12V6H11.6zM12.8,5.6H13.2V6H12.8zM15.2,5.6H15.6V6H15.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM6.8,6H7.2V6.4H6.8zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10.4,6.4H10.8V6.8H10.4zM11.2,6.4H11.6V6.8H11.2zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM2.4,6.8H2.8V7.2H2.4zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM6.4,6.8H6.8V7.2H6.4zM10,6.8H10.4V7.2H10zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM14,6.8H14.4V7.2H14zM14.4,6.8H14.8V7.2H14.4zM1.2,7.2H1.6V7.6H1.2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6.8,7.2H7.2V7.6H6.8zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12,7.2H12.4V7.6H12zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM14.4,7.2H14.8V7.6H14.4zM14.8,7.2H15.2V7.6H14.8zM15.2,7.2H15.6V7.6H15.2zM2.4,7.6H2.8V8H2.4zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM9.6,7.6H10V8H9.6zM10.4,7.6H10.8V8H10.4zM11.6,7.6H12V8H11.6zM12.4,7.6H12.8V8H12.4zM13.2,7.6H13.6V8H13.2zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM1.2,8H1.6V8.4H1.2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4.4,8H4.8V8.4H4.4zM5.6,8H6V8.4H5.6zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM7.6,8H8V8.4H7.6zM8,8H8.4V8.4H8zM8.4,8H8.8V8.4H8.4zM9.2,8H9.6V8.4H9.2zM10,8H10.4V8.4H10zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM0.8,8.4H1.2V8.8H0.8zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8,8.4H8.4V8.8H8zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.6,8.4H10V8.8H9.6zM10.4,8.4H10.8V8.8H10.4zM10.8,8.4H11.2V8.8H10.8zM11.2,8.4H11.6V8.8H11.2zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM1.2,8.8H1.6V9.2H1.2zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.2,8.8H5.6V9.2H5.2zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM9.6,8.8H10V9.2H9.6zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM11.2,8.8H11.6V9.2H11.2zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM1.2,9.2H1.6V9.6H1.2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM11.6,9.2H12V9.6H11.6zM12,9.2H12.4V9.6H12zM13.6,9.2H14V9.6H13.6zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM0.8,9.6H1.2V10H0.8zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.2,9.6H13.6V10H13.2zM14,9.6H14.4V10H14zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM2.4,10H2.8V10.4H2.4zM2.8,10H3.2V10.4H2.8zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM11.2,10H11.6V10.4H11.2zM11.6,10H12V10.4H11.6zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM0.8,10.4H1.2V10.8H0.8zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM12,10.4H12.4V10.8H12zM12.8,10.4H13.2V10.8H12.8zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.2,10.4H15.6V10.8H15.2zM0.8,10.8H1.2V11.2H0.8zM1.6,10.8H2V11.2H1.6zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM11.6,10.8H12V11.2H11.6zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM6,11.2H6.4V11.6H6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.2,11.2H13.6V11.6H13.2zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM5.2,11.6H5.6V12H5.2zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM8,11.6H8.4V12H8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM15.2,11.6H15.6V12H15.2zM0.8,12H1.2V12.4H0.8zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.4,12H14.8V12.4H14.4zM15.2,12H15.6V12.4H15.2zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM12,12.4H12.4V12.8H12zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM8.4,12.8H8.8V13.2H8.4zM9.6,12.8H10V13.2H9.6zM10,12.8H10.4V13.2H10zM10.8,12.8H11.2V13.2H10.8zM12,12.8H12.4V13.2H12zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14.8,12.8H15.2V13.2H14.8zM15.2,12.8H15.6V13.2H15.2zM0.8,13.2H1.2V13.6H0.8zM3.2,13.2H3.6V13.6H3.2zM4,13.2H4.4V13.6H4zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM10.8,13.2H11.2V13.6H10.8zM12,13.2H12.4V13.6H12zM13.6,13.2H14V13.6H13.6zM14.8,13.2H15.2V13.6H14.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM7.6,13.6H8V14H7.6zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14.8,13.6H15.2V14H14.8zM0.8,14H1.2V14.4H0.8zM1.6,14H2V14.4H1.6zM2,14H2.4V14.4H2zM2.4,14H2.8V14.4H2.4zM3.2,14H3.6V14.4H3.2zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM6.8,14H7.2V14.4H6.8zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM14.4,14H14.8V14.4H14.4zM14.8,14H15.2V14.4H14.8zM15.2,14H15.6V14.4H15.2zM0.8,14.4H1.2V14.8H0.8zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM3.2,14.4H3.6V14.8H3.2zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM10,14.4H10.4V14.8H10zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.8,14.8H5.2V15.2H4.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM14,14.8H14.4V15.2H14zM14.4,14.8H14.8V15.2H14.4zM14.8,14.8H15.2V15.2H14.8zM15.2,14.8H15.6V15.2H15.2zM0.8,15.2H1.2V15.6H0.8zM1.2,15.2H1.6V15.6H1.2zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM2.8,15.2H3.2V15.6H2.8zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM10.4,15.2H10.8V15.6H10.4zM12,15.2H12.4V15.6H12zM12.8,15.2H13.2V15.6H12.8zM13.2,15.2H13.6V15.6H13.2zM14,15.2H14.4V15.6H14zM15.2,15.2H15.6V15.6H15.2z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-03-Tech_Security_Weekly_Digest_CVE_Patch_AWS_AI.svg
+++ b/assets/images/2026-04-03-Tech_Security_Weekly_Digest_CVE_Patch_AWS_AI.svg
@@ -1,145 +1,478 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 03 2026 CVE PATCH">
-  <title>Style A v3 APR 03 2026 CVE PATCH</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0b0420"/><stop offset="100%" stop-color="#160829"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#160829"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.34"/><stop offset="100%" stop-color="#0b0420" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.32"/><stop offset="100%" stop-color="#160829" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"><animate attributeName="stop-color" values="#d946ef;#f0abfc;#8b5cf6;#d946ef" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#f0abfc"><animate attributeName="stop-color" values="#f0abfc;#a78bfa;#d946ef;#f0abfc" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#a78bfa"><animate attributeName="stop-color" values="#a78bfa;#8b5cf6;#f0abfc;#a78bfa" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.9"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0b0420" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="50%" stop-color="#8b5cf6" stop-opacity="0.7"/><stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="1"/><stop offset="55%" stop-color="#d946ef" stop-opacity="0.75"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.5"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.85"/><stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0.45"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.85"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.4"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="35%" stop-color="#8b5cf6" stop-opacity="0.95"/><stop offset="65%" stop-color="#d946ef" stop-opacity="0.95"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0"/><stop offset="40%" stop-color="#f0abfc" stop-opacity="0.55"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"/><stop offset="100%" stop-color="#f0abfc"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#d946ef" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="698.9" y1="408.5" x2="900.4" y2="331.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="698.9" y1="408.5" x2="842.8" y2="174.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="900.4" y1="331.0" x2="842.8" y2="174.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="900.4" y1="331.0" x2="616.7" y2="335.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="842.8" y1="174.0" x2="616.7" y2="335.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="842.8" y1="174.0" x2="787.2" y2="240.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="616.7" y1="335.5" x2="787.2" y2="240.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="616.7" y1="335.5" x2="926.0" y2="421.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="787.2" y1="240.6" x2="926.0" y2="421.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="787.2" y1="240.6" x2="791.9" y2="149.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="926.0" y1="421.7" x2="791.9" y2="149.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="926.0" y1="421.7" x2="698.5" y2="492.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="791.9" y1="149.5" x2="698.5" y2="492.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="791.9" y1="149.5" x2="847.1" y2="205.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="698.5" y1="492.4" x2="847.1" y2="205.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="698.5" y1="492.4" x2="509.1" y2="272.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="847.1" y1="205.7" x2="509.1" y2="272.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="847.1" y1="205.7" x2="892.6" y2="454.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="509.1" y1="272.0" x2="892.6" y2="454.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="509.1" y1="272.0" x2="659.3" y2="269.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="892.6" y1="454.8" x2="659.3" y2="269.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="892.6" y1="454.8" x2="1004.3" y2="402.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="659.3" y1="269.5" x2="1004.3" y2="402.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="659.3" y1="269.5" x2="699.3" y2="442.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="1004.3" y1="402.0" x2="699.3" y2="442.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="1004.3" y1="402.0" x2="874.7" y2="224.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="699.3" y1="442.4" x2="874.7" y2="224.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="699.3" y1="442.4" x2="616.7" y2="329.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="874.7" y1="224.4" x2="616.7" y2="329.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="874.7" y1="224.4" x2="779.4" y2="243.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="616.7" y1="329.7" x2="779.4" y2="243.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="616.7" y1="329.7" x2="620.3" y2="379.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="779.4" y1="243.0" x2="620.3" y2="379.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <circle cx="698.9" cy="408.5" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="698.9" cy="408.5" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="900.4" cy="331.0" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="900.4" cy="331.0" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="842.8" cy="174.0" r="14.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="842.8" cy="174.0" r="8.9" fill="url(#nodeCore)"><animate attributeName="r" values="8.9;10.9;8.9" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="616.7" cy="335.5" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="616.7" cy="335.5" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="787.2" cy="240.6" r="13.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="787.2" cy="240.6" r="7.8" fill="url(#nodeCore)"><animate attributeName="r" values="7.8;9.8;7.8" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="926.0" cy="421.7" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="926.0" cy="421.7" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="791.9" cy="149.5" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="791.9" cy="149.5" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="698.5" cy="492.4" r="12.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="698.5" cy="492.4" r="6.2" fill="url(#nodeCore)"><animate attributeName="r" values="6.2;8.2;6.2" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="847.1" cy="205.7" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="847.1" cy="205.7" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="509.1" cy="272.0" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="509.1" cy="272.0" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="892.6" cy="454.8" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="892.6" cy="454.8" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="659.3" cy="269.5" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="659.3" cy="269.5" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1004.3" cy="402.0" r="11.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1004.3" cy="402.0" r="5.0" fill="url(#nodeCore)"><animate attributeName="r" values="5.0;7.0;5.0" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="699.3" cy="442.4" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="699.3" cy="442.4" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="874.7" cy="224.4" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="874.7" cy="224.4" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.6s" repeatCount="indefinite"/></circle>
-  <circle cx="616.7" cy="329.7" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="616.7" cy="329.7" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="779.4" cy="243.0" r="13.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="779.4" cy="243.0" r="7.3" fill="url(#nodeCore)"><animate attributeName="r" values="7.3;9.3;7.3" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="620.3" cy="379.1" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="620.3" cy="379.1" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="621.0" cy="300.9" r="2.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="300.9;259.9;300.9" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="780.7" cy="463.4" r="2.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="463.4;400.9;463.4" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="789.3" cy="466.3" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="466.3;417.6;466.3" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="802.0" cy="150.5" r="3.1" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="150.5;75.9;150.5" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="939.2" cy="511.0" r="1.6" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="511.0;460.6;511.0" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="414.2" cy="304.4" r="2.4" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="304.4;261.1;304.4" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="461.0" cy="306.2" r="2.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="306.2;265.6;306.2" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="422.4" cy="105.9" r="1.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="105.9;56.1;105.9" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="1119.0" cy="143.4" r="1.7" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="143.4;88.3;143.4" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="731.0" cy="76.9" r="2.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="76.9;18.9;76.9" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="1104.1" cy="396.8" r="2.3" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="396.8;324.5;396.8" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="652.1" cy="296.5" r="2.5" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="296.5;256.9;296.5" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="617.7" cy="564.3" r="2.5" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="564.3;528.1;564.3" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="884.7" cy="457.9" r="2.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="457.9;390.9;457.9" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#8b5cf6" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#f0abfc" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#d946ef" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#d946ef" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#f0abfc"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">CVE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">PATCH<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">AWS</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">CLOUD</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#8b5cf6" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#f0abfc"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fbcfe8" letter-spacing="3.5" opacity="0.9">APR 03 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">CVE</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">PATCH</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#8b5cf6" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#d946ef" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#f0abfc" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#8b5cf6" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fbcfe8" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#f0abfc" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM8.4,0.8H8.8V1.2H8.4zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6.8,1.6H7.2V2H6.8zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6.4,2.4H6.8V2.8H6.4zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM7.2,5.2H7.6V5.6H7.2zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.8,5.6H5.2V6H4.8zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM4,6H4.4V6.4H4zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM3.6,6.8H4V7.2H3.6zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM2.8,8.4H3.2V8.8H2.8zM4.8,8.4H5.2V8.8H4.8zM6,8.4H6.4V8.8H6zM7.2,8.4H7.6V8.8H7.2zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8.4,8.8H8.8V9.2H8.4zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.8,9.2H17.2V9.6H16.8zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM5.2,9.6H5.6V10H5.2zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM4,10.8H4.4V11.2H4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM1.2,11.6H1.6V12H1.2zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM16.8,11.6H17.2V12H16.8zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4.8,12H5.2V12.4H4.8zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM6,12.4H6.4V12.8H6zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM4.4,12.8H4.8V13.2H4.4zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.6,13.2H6V13.6H5.6zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6.4,13.6H6.8V14H6.4zM6.8,13.6H7.2V14H6.8zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM6.4,14H6.8V14.4H6.4zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.2,14.8H5.6V15.2H5.2zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM7.2,15.6H7.6V16H7.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM6.4,16.8H6.8V17.2H6.4zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: CVE triage, agent AI cloud, organisational announcement">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
   </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CISCO</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Urgent patches land across products</text>
+<g transform="translate(576,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AGENT</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Agentic AI design principles shared</text>
+<g transform="translate(936,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AWS</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">New Amazon training series announced</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM5.2,1.6H5.6V2H5.2zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8.8,1.6H9.2V2H8.8zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM6,2.4H6.4V2.8H6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM5.2,2.8H5.6V3.2H5.2zM6,2.8H6.4V3.2H6zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.6,3.6H6V4H5.6zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.8,4.4H5.2V4.8H4.8zM6,4.4H6.4V4.8H6zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6.4,5.2H6.8V5.6H6.4zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.4,5.2H14.8V5.6H14.4zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM6,5.6H6.4V6H6zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM1.2,6H1.6V6.4H1.2zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM5.6,6H6V6.4H5.6zM8,6H8.4V6.4H8zM8.8,6H9.2V6.4H8.8zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM7.2,6.4H7.6V6.8H7.2zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM1.6,7.2H2V7.6H1.6zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM0.8,7.6H1.2V8H0.8zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM4.4,7.6H4.8V8H4.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.4,8H12.8V8.4H12.4zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM2.4,8.4H2.8V8.8H2.4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM0.8,8.8H1.2V9.2H0.8zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM4.8,8.8H5.2V9.2H4.8zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM9.2,8.8H9.6V9.2H9.2zM10.4,8.8H10.8V9.2H10.4zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM1.6,10.8H2V11.2H1.6zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM6,11.2H6.4V11.6H6zM6.8,11.2H7.2V11.6H6.8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM4.4,11.6H4.8V12H4.4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM5.6,12H6V12.4H5.6zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM8,12.4H8.4V12.8H8zM9.2,12.4H9.6V12.8H9.2zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM2.4,13.2H2.8V13.6H2.4zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.8,13.2H13.2V13.6H12.8zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM5.2,14.4H5.6V14.8H5.2zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM8,14.4H8.4V14.8H8zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM5.2,14.8H5.6V15.2H5.2zM6,14.8H6.4V15.2H6zM7.2,14.8H7.6V15.2H7.2zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM11.2,15.6H11.6V16H11.2zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-04-Tech_Security_Weekly_Digest_Go_AI_Data_Security.svg
+++ b/assets/images/2026-04-04-Tech_Security_Weekly_Digest_Go_AI_Data_Security.svg
@@ -1,145 +1,450 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 04 2026 DATA LEAK">
-  <title>Style A v3 APR 04 2026 DATA LEAK</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#160605"/><stop offset="100%" stop-color="#220708"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#220708"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.34"/><stop offset="100%" stop-color="#160605" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.32"/><stop offset="100%" stop-color="#220708" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ef4444"><animate attributeName="stop-color" values="#ef4444;#fb7185;#f97316;#ef4444" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fb7185"><animate attributeName="stop-color" values="#fb7185;#fb923c;#ef4444;#fb7185" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#fb923c"><animate attributeName="stop-color" values="#fb923c;#f97316;#fb7185;#fb923c" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.9"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#160605" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0"/><stop offset="50%" stop-color="#f97316" stop-opacity="0.7"/><stop offset="100%" stop-color="#f97316" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fb7185" stop-opacity="1"/><stop offset="55%" stop-color="#ef4444" stop-opacity="0.75"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fb923c" stop-opacity="0.5"/><stop offset="100%" stop-color="#fb923c" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fecaca" stop-opacity="0.85"/><stop offset="100%" stop-color="#fecaca" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fb7185" stop-opacity="0.45"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.85"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.4"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0"/><stop offset="35%" stop-color="#f97316" stop-opacity="0.95"/><stop offset="65%" stop-color="#ef4444" stop-opacity="0.95"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fb7185" stop-opacity="0"/><stop offset="40%" stop-color="#fb7185" stop-opacity="0.55"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ef4444"/><stop offset="100%" stop-color="#fb7185"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#f97316" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#ef4444" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#f97316" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="559.9" y1="219.7" x2="616.1" y2="200.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="559.9" y1="219.7" x2="663.3" y2="258.0" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="616.1" y1="200.3" x2="663.3" y2="258.0" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="616.1" y1="200.3" x2="635.5" y2="322.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="663.3" y1="258.0" x2="635.5" y2="322.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="663.3" y1="258.0" x2="751.5" y2="397.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="635.5" y1="322.8" x2="751.5" y2="397.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="635.5" y1="322.8" x2="667.7" y2="169.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="751.5" y1="397.6" x2="667.7" y2="169.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="751.5" y1="397.6" x2="915.9" y2="419.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="667.7" y1="169.1" x2="915.9" y2="419.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="667.7" y1="169.1" x2="1010.2" y2="321.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="915.9" y1="419.6" x2="1010.2" y2="321.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="915.9" y1="419.6" x2="522.9" y2="397.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="1010.2" y1="321.8" x2="522.9" y2="397.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="1010.2" y1="321.8" x2="633.8" y2="206.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="522.9" y1="397.7" x2="633.8" y2="206.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="522.9" y1="397.7" x2="619.7" y2="437.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="633.8" y1="206.9" x2="619.7" y2="437.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="633.8" y1="206.9" x2="504.2" y2="371.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="619.7" y1="437.3" x2="504.2" y2="371.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="619.7" y1="437.3" x2="904.9" y2="259.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="504.2" y1="371.9" x2="904.9" y2="259.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="504.2" y1="371.9" x2="576.0" y2="350.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="904.9" y1="259.1" x2="576.0" y2="350.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="904.9" y1="259.1" x2="975.6" y2="236.2" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="576.0" y1="350.8" x2="975.6" y2="236.2" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="576.0" y1="350.8" x2="1027.3" y2="365.0" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="975.6" y1="236.2" x2="1027.3" y2="365.0" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="975.6" y1="236.2" x2="905.2" y2="190.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="1027.3" y1="365.0" x2="905.2" y2="190.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="1027.3" y1="365.0" x2="1024.7" y2="321.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="905.2" y1="190.9" x2="1024.7" y2="321.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <circle cx="559.9" cy="219.7" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="559.9" cy="219.7" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="616.1" cy="200.3" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="616.1" cy="200.3" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="663.3" cy="258.0" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="663.3" cy="258.0" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="635.5" cy="322.8" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="635.5" cy="322.8" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="751.5" cy="397.6" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="751.5" cy="397.6" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="667.7" cy="169.1" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="667.7" cy="169.1" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="915.9" cy="419.6" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="915.9" cy="419.6" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="1010.2" cy="321.8" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1010.2" cy="321.8" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="522.9" cy="397.7" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="522.9" cy="397.7" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="633.8" cy="206.9" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="633.8" cy="206.9" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="619.7" cy="437.3" r="11.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="619.7" cy="437.3" r="5.9" fill="url(#nodeCore)"><animate attributeName="r" values="5.9;7.9;5.9" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="504.2" cy="371.9" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="504.2" cy="371.9" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="904.9" cy="259.1" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="904.9" cy="259.1" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="576.0" cy="350.8" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="576.0" cy="350.8" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="975.6" cy="236.2" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="975.6" cy="236.2" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1027.3" cy="365.0" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1027.3" cy="365.0" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="905.2" cy="190.9" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="905.2" cy="190.9" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1024.7" cy="321.1" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1024.7" cy="321.1" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="507.4" cy="516.3" r="2.3" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="516.3;461.8;516.3" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="574.9" cy="169.7" r="2.8" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="169.7;87.5;169.7" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="898.2" cy="285.0" r="1.5" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="285.0;217.5;285.0" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="694.0" cy="458.9" r="3.0" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="458.9;382.6;458.9" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="741.4" cy="553.1" r="1.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="553.1;473.4;553.1" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="896.9" cy="267.4" r="2.5" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="267.4;223.1;267.4" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="915.2" cy="352.6" r="2.4" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="352.6;278.3;352.6" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="845.8" cy="418.0" r="1.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="418.0;373.7;418.0" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="901.5" cy="213.8" r="2.5" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="213.8;134.5;213.8" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="733.7" cy="514.1" r="2.9" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="514.1;466.0;514.1" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1078.2" cy="212.1" r="3.1" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="212.1;135.4;212.1" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="1053.4" cy="139.9" r="1.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="139.9;69.3;139.9" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="979.8" cy="323.6" r="1.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="323.6;271.1;323.6" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="940.9" cy="496.8" r="2.9" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="496.8;413.8;496.8" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#f97316" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fb7185" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#ef4444" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#ef4444" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fb7185"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">DATA<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">LEAK<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">GO</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">CRYPTO</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#f97316" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fb7185"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fecaca" letter-spacing="3.5" opacity="0.9">APR 04 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">DATA</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">LEAK</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#f97316" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#ef4444" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fb7185" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#f97316" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fecaca" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fb7185" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.4,1.6H4.8V2H4.4zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6.8,1.6H7.2V2H6.8zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM10.8,1.6H11.2V2H10.8zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM7.2,2H7.6V2.4H7.2zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM8,3.6H8.4V4H8zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM5.6,4H6V4.4H5.6zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM6.4,4.8H6.8V5.2H6.4zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM5.6,5.2H6V5.6H5.6zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.4,5.2H14.8V5.6H14.4zM15.6,5.2H16V5.6H15.6zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.6,6.4H2V6.8H1.6zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM7.2,6.8H7.6V7.2H7.2zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM2,7.2H2.4V7.6H2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.8,7.2H5.2V7.6H4.8zM7.2,7.2H7.6V7.6H7.2zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM2.4,7.6H2.8V8H2.4zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM7.2,7.6H7.6V8H7.2zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM7.2,8.4H7.6V8.8H7.2zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.2,8.4H11.6V8.8H11.2zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM3.2,8.8H3.6V9.2H3.2zM6,8.8H6.4V9.2H6zM6.8,8.8H7.2V9.2H6.8zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM15.2,8.8H15.6V9.2H15.2zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM6.4,9.6H6.8V10H6.4zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM5.6,10H6V10.4H5.6zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM3.6,10.8H4V11.2H3.6zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM5.6,11.2H6V11.6H5.6zM6.8,11.2H7.2V11.6H6.8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM0.8,12H1.2V12.4H0.8zM2,12H2.4V12.4H2zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.8,12H11.2V12.4H10.8zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8.4,12.8H8.8V13.2H8.4zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM5.6,13.2H6V13.6H5.6zM6.8,13.2H7.2V13.6H6.8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.8,13.2H13.2V13.6H12.8zM13.2,13.2H13.6V13.6H13.2zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM6.8,14H7.2V14.4H6.8zM7.6,14H8V14.4H7.6zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM10.8,14.4H11.2V14.8H10.8zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM5.6,14.8H6V15.2H5.6zM6.4,14.8H6.8V15.2H6.4zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.8,14.8H11.2V15.2H10.8zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM7.2,15.2H7.6V15.6H7.2zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM5.2,15.6H5.6V16H5.2zM6.4,15.6H6.8V16H6.4zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM7.6,16.8H8V17.2H7.6zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: APT C2, phishing targets, compliance posture">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">PLUGX</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">China-linked actor targets European governments</text>
+<g transform="translate(576,330)">
+  <!-- Device frame (phone outline) -->
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="#0B132B" stroke="#3A86FF" stroke-width="2.4" opacity="0.95"/>
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="url(#glowBlue)" opacity="0.28">
+    <animate attributeName="opacity" values="0.18;0.42;0.18" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="-126" width="40" height="6" rx="3" fill="#2A3256"/>
+  <!-- Notification stack (3 mini rows appearing) -->
+  <g transform="translate(-54,-92)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;6.4;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="54" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-62)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="48" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-32)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="58" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Bell (top right of phone) pulsing -->
+  <g transform="translate(46,-104)">
+    <path d="M -10 6 Q -10 -8 0 -8 Q 10 -8 10 6 L 12 10 L -12 10 Z"
+          fill="#FFB703" opacity="0.95"/>
+    <circle cx="0" cy="-10" r="2.2" fill="#FFB703"/>
+    <path d="M -3 12 Q 0 16 3 12" fill="none" stroke="#FFB703" stroke-width="1.5"/>
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-12 0 -8; 12 0 -8; -12 0 -8"
+                      dur="1.6s" repeatCount="indefinite" additive="sum"/>
+  </g>
+  <!-- Fishhook swinging below phone -->
+  <g transform="translate(0,108)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-10 0 -40; 10 0 -40; -10 0 -40"
+                      dur="3.2s" repeatCount="indefinite" additive="sum"/>
+    <line x1="0" y1="-40" x2="0" y2="6" stroke="#FFB703" stroke-width="2.4"/>
+    <path d="M 0 6 Q 0 22 -12 22 Q -22 22 -22 12" fill="none"
+          stroke="#FFB703" stroke-width="2.6" stroke-linecap="round"/>
+    <circle cx="-22" cy="12" r="2.6" fill="#FFB703"/>
+    <path d="M -22 12 L -18 18 L -26 18 Z" fill="#FFB703"/>
+  </g>
+  <!-- Phishing particles flying toward hook -->
+  <circle cx="-90" cy="40" r="3" fill="#E63946">
+    <animate attributeName="cx" values="-90;-22" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="40;100" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="10" r="2.4" fill="#FFB703">
+    <animate attributeName="cx" values="-100;-22" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="10;100" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-88" cy="70" r="2.8" fill="#E63946">
+    <animate attributeName="cx" values="-88;-22" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="70;100" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- brand noun at bottom -->
+  <text x="0" y="164" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">LINKEDIN</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Thousands of executive accounts impersonated</text>
+<g transform="translate(936,330)">
+  <!-- Shield silhouette -->
+  <g transform="translate(-70,-100)">
+    <path d="M 0 0 L 60 0 L 60 60 Q 60 100 30 120 Q 0 100 0 60 Z"
+          fill="#0B132B" stroke="#3A86FF" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.9;1;0.9" dur="3.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- inner pulse -->
+    <path d="M 10 10 L 50 10 L 50 58 Q 50 92 30 108 Q 10 92 10 58 Z"
+          fill="url(#glowBlue)" opacity="0.35">
+      <animate attributeName="opacity" values="0.2;0.55;0.2" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- big checkmark inside -->
+    <path d="M 14 58 L 26 74 L 48 40" fill="none" stroke="#3A86FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Clipboard (right) -->
+  <g transform="translate(10,-90)">
+    <rect x="0" y="0" width="90" height="120" rx="6" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- clip -->
+    <rect x="32" y="-8" width="26" height="14" rx="3" fill="#3A86FF"/>
+    <!-- checklist rows appearing -->
+    <g>
+      <circle cx="14" cy="24" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 24 L 13 26 L 17 22" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="22" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="28" width="42" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="44" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 44 L 13 46 L 17 42" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="1s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="42" width="58" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="48" width="46" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="64" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 64 L 13 66 L 17 62" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="2s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="62" width="50" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="68" width="38" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="84" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 84 L 13 86 L 17 82" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="3s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="82" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="88" width="44" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="104" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 104 L 13 106 L 17 102" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="4s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="102" width="60" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="108" width="48" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+  </g>
+  <!-- Growing service nodes around shield -->
+  <circle cx="-90" cy="40" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="60;40;40;20" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- progress bar bottom -->
+  <rect x="-60" y="56" width="120" height="6" rx="3" fill="#2A3256"/>
+  <rect x="-60" y="56" width="20" height="6" rx="3" fill="#3A86FF">
+    <animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/>
+  </rect>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">WEBSHELL</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Persistent Linux web shell detailed</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.4,0.8H10.8V1.2H10.4zM11.2,0.8H11.6V1.2H11.2zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.6,1.2H8V1.6H7.6zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM5.2,1.6H5.6V2H5.2zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM10,1.6H10.4V2H10zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.2,1.6H13.6V2H13.2zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM10.4,2H10.8V2.4H10.4zM11.2,2H11.6V2.4H11.2zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM8,2.4H8.4V2.8H8zM9.2,2.4H9.6V2.8H9.2zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM12,2.4H12.4V2.8H12zM12.4,2.4H12.8V2.8H12.4zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.8,2.8H5.2V3.2H4.8zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM10.4,2.8H10.8V3.2H10.4zM10.8,2.8H11.2V3.2H10.8zM12.8,2.8H13.2V3.2H12.8zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM6,3.6H6.4V4H6zM8.8,3.6H9.2V4H8.8zM10,3.6H10.4V4H10zM10.4,3.6H10.8V4H10.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM8.8,4H9.2V4.4H8.8zM11.6,4H12V4.4H11.6zM13.2,4H13.6V4.4H13.2zM14.8,4H15.2V4.4H14.8zM16,4H16.4V4.4H16zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8.4,4.4H8.8V4.8H8.4zM10,4.4H10.4V4.8H10zM10.4,4.4H10.8V4.8H10.4zM11.2,4.4H11.6V4.8H11.2zM11.6,4.4H12V4.8H11.6zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.4,4.4H14.8V4.8H14.4zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM8,4.8H8.4V5.2H8zM8.4,4.8H8.8V5.2H8.4zM8.8,4.8H9.2V5.2H8.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM10.4,4.8H10.8V5.2H10.4zM10.8,4.8H11.2V5.2H10.8zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM15.2,4.8H15.6V5.2H15.2zM15.6,4.8H16V5.2H15.6zM16,4.8H16.4V5.2H16zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4.8,5.2H5.2V5.6H4.8zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.2,5.2H7.6V5.6H7.2zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM10.4,5.2H10.8V5.6H10.4zM11.6,5.2H12V5.6H11.6zM12,5.2H12.4V5.6H12zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM5.6,5.6H6V6H5.6zM10,5.6H10.4V6H10zM10.4,5.6H10.8V6H10.4zM11.2,5.6H11.6V6H11.2zM12,5.6H12.4V6H12zM12.8,5.6H13.2V6H12.8zM14.4,5.6H14.8V6H14.4zM16.4,5.6H16.8V6H16.4zM16.8,5.6H17.2V6H16.8zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM4.8,6H5.2V6.4H4.8zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM12.4,6H12.8V6.4H12.4zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM11.2,6.4H11.6V6.8H11.2zM11.6,6.4H12V6.8H11.6zM12.8,6.4H13.2V6.8H12.8zM13.2,6.4H13.6V6.8H13.2zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM16.8,6.4H17.2V6.8H16.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM4.8,6.8H5.2V7.2H4.8zM6.4,6.8H6.8V7.2H6.4zM7.2,6.8H7.6V7.2H7.2zM8,6.8H8.4V7.2H8zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14,6.8H14.4V7.2H14zM14.4,6.8H14.8V7.2H14.4zM15.6,6.8H16V7.2H15.6zM16.4,6.8H16.8V7.2H16.4zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM7.2,7.2H7.6V7.6H7.2zM8,7.2H8.4V7.6H8zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM12,7.2H12.4V7.6H12zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14,7.2H14.4V7.6H14zM14.4,7.2H14.8V7.6H14.4zM16.8,7.2H17.2V7.6H16.8zM1.2,7.6H1.6V8H1.2zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM6,7.6H6.4V8H6zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM16.8,7.6H17.2V8H16.8zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8,8H8.4V8.4H8zM8.4,8H8.8V8.4H8.4zM10,8H10.4V8.4H10zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.2,8H13.6V8.4H13.2zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM15.2,8H15.6V8.4H15.2zM15.6,8H16V8.4H15.6zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM2,8.4H2.4V8.8H2zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10,8.4H10.4V8.8H10zM11.2,8.4H11.6V8.8H11.2zM12,8.4H12.4V8.8H12zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM15.6,8.4H16V8.8H15.6zM16.4,8.4H16.8V8.8H16.4zM0.8,8.8H1.2V9.2H0.8zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM5.2,8.8H5.6V9.2H5.2zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM9.2,8.8H9.6V9.2H9.2zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM13.2,8.8H13.6V9.2H13.2zM14.4,8.8H14.8V9.2H14.4zM15.6,8.8H16V9.2H15.6zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2,9.2H2.4V9.6H2zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM10,9.2H10.4V9.6H10zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.6,9.2H16V9.6H15.6zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM5.2,9.6H5.6V10H5.2zM6,9.6H6.4V10H6zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM10.8,9.6H11.2V10H10.8zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM13.2,9.6H13.6V10H13.2zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6.8,10H7.2V10.4H6.8zM8,10H8.4V10.4H8zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM11.6,10H12V10.4H11.6zM12,10H12.4V10.4H12zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM1.6,10.4H2V10.8H1.6zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM8.8,10.4H9.2V10.8H8.8zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM12,10.4H12.4V10.8H12zM13.6,10.4H14V10.8H13.6zM14.4,10.4H14.8V10.8H14.4zM15.6,10.4H16V10.8H15.6zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM10,10.8H10.4V11.2H10zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM11.6,10.8H12V11.2H11.6zM13.2,10.8H13.6V11.2H13.2zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.6,10.8H16V11.2H15.6zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8.4,11.2H8.8V11.6H8.4zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.2,11.2H13.6V11.6H13.2zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM15.6,11.2H16V11.6H15.6zM16,11.2H16.4V11.6H16zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM2,11.6H2.4V12H2zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.8,11.6H15.2V12H14.8zM15.6,11.6H16V12H15.6zM2,12H2.4V12.4H2zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM7.2,12H7.6V12.4H7.2zM8.8,12H9.2V12.4H8.8zM11.2,12H11.6V12.4H11.2zM12,12H12.4V12.4H12zM12.8,12H13.2V12.4H12.8zM14.4,12H14.8V12.4H14.4zM16.8,12H17.2V12.4H16.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6,12.4H6.4V12.8H6zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8.8,12.4H9.2V12.8H8.8zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM7.6,12.8H8V13.2H7.6zM8.8,12.8H9.2V13.2H8.8zM10,12.8H10.4V13.2H10zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM13.2,12.8H13.6V13.2H13.2zM14,12.8H14.4V13.2H14zM15.6,12.8H16V13.2H15.6zM16,12.8H16.4V13.2H16zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4.4,13.2H4.8V13.6H4.4zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM8,13.2H8.4V13.6H8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.6,13.2H10V13.6H9.6zM11.2,13.2H11.6V13.6H11.2zM13.2,13.2H13.6V13.6H13.2zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6,13.6H6.4V14H6zM6.4,13.6H6.8V14H6.4zM7.2,13.6H7.6V14H7.2zM8.8,13.6H9.2V14H8.8zM10,13.6H10.4V14H10zM12,13.6H12.4V14H12zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16.4,13.6H16.8V14H16.4zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM7.6,14H8V14.4H7.6zM8.4,14H8.8V14.4H8.4zM10,14H10.4V14.4H10zM10.4,14H10.8V14.4H10.4zM10.8,14H11.2V14.4H10.8zM11.6,14H12V14.4H11.6zM12.8,14H13.2V14.4H12.8zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM8.4,14.4H8.8V14.8H8.4zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10,14.4H10.4V14.8H10zM11.6,14.4H12V14.8H11.6zM12.4,14.4H12.8V14.8H12.4zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM16,14.4H16.4V14.8H16zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM6.4,14.8H6.8V15.2H6.4zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.4,14.8H16.8V15.2H16.4zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM6.8,15.2H7.2V15.6H6.8zM7.6,15.2H8V15.6H7.6zM8.8,15.2H9.2V15.6H8.8zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM10,15.2H10.4V15.6H10zM10.8,15.2H11.2V15.6H10.8zM12,15.2H12.4V15.6H12zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM5.6,15.6H6V16H5.6zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14.8,15.6H15.2V16H14.8zM15.2,15.6H15.6V16H15.2zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM8,16H8.4V16.4H8zM8.4,16H8.8V16.4H8.4zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM12.8,16H13.2V16.4H12.8zM13.6,16H14V16.4H13.6zM14,16H14.4V16.4H14zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.6,16.4H10V16.8H9.6zM11.2,16.4H11.6V16.8H11.2zM11.6,16.4H12V16.8H11.6zM12,16.4H12.4V16.8H12zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM5.2,16.8H5.6V17.2H5.2zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM10,16.8H10.4V17.2H10zM10.4,16.8H10.8V17.2H10.4zM11.6,16.8H12V17.2H11.6zM12,16.8H12.4V17.2H12zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.8,16.8H17.2V17.2H16.8z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-05-Tech_Security_Weekly_Digest_AWS_AI_Security_Malware.svg
+++ b/assets/images/2026-04-05-Tech_Security_Weekly_Digest_AWS_AI_Security_Malware.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 05 2026 AWS SECURITY">
-  <title>Style A v3 APR 05 2026 AWS SECURITY</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#021218"/><stop offset="100%" stop-color="#03171e"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#03171e"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.34"/><stop offset="100%" stop-color="#021218" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.32"/><stop offset="100%" stop-color="#03171e" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0ea5e9"><animate attributeName="stop-color" values="#0ea5e9;#7dd3fc;#14b8a6;#0ea5e9" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#7dd3fc"><animate attributeName="stop-color" values="#7dd3fc;#2dd4bf;#0ea5e9;#7dd3fc" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#2dd4bf"><animate attributeName="stop-color" values="#2dd4bf;#14b8a6;#7dd3fc;#2dd4bf" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.9"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#021218" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0"/><stop offset="50%" stop-color="#14b8a6" stop-opacity="0.7"/><stop offset="100%" stop-color="#14b8a6" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="1"/><stop offset="55%" stop-color="#0ea5e9" stop-opacity="0.75"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.5"/><stop offset="100%" stop-color="#2dd4bf" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#bae6fd" stop-opacity="0.85"/><stop offset="100%" stop-color="#bae6fd" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="0.45"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.85"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.4"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0"/><stop offset="35%" stop-color="#14b8a6" stop-opacity="0.95"/><stop offset="65%" stop-color="#0ea5e9" stop-opacity="0.95"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="0"/><stop offset="40%" stop-color="#7dd3fc" stop-opacity="0.55"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#7dd3fc"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#14b8a6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#0ea5e9" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#14b8a6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="823.6" y1="148.2" x2="484.4" y2="317.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="823.6" y1="148.2" x2="523.2" y2="382.3" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="484.4" y1="317.5" x2="523.2" y2="382.3" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="484.4" y1="317.5" x2="820.2" y2="240.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="523.2" y1="382.3" x2="820.2" y2="240.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="523.2" y1="382.3" x2="633.7" y2="228.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="820.2" y1="240.2" x2="633.7" y2="228.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="820.2" y1="240.2" x2="749.6" y2="239.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="633.7" y1="228.2" x2="749.6" y2="239.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="633.7" y1="228.2" x2="576.2" y2="312.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="749.6" y1="239.9" x2="576.2" y2="312.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="749.6" y1="239.9" x2="717.9" y2="484.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="576.2" y1="312.5" x2="717.9" y2="484.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="576.2" y1="312.5" x2="835.1" y2="196.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="717.9" y1="484.0" x2="835.1" y2="196.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="717.9" y1="484.0" x2="731.7" y2="245.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="835.1" y1="196.1" x2="731.7" y2="245.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="835.1" y1="196.1" x2="515.5" y2="316.6" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="731.7" y1="245.7" x2="515.5" y2="316.6" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="731.7" y1="245.7" x2="889.5" y2="181.4" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="515.5" y1="316.6" x2="889.5" y2="181.4" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="515.5" y1="316.6" x2="902.7" y2="212.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="889.5" y1="181.4" x2="902.7" y2="212.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.2s" repeatCount="indefinite"/></line>
-  <line x1="889.5" y1="181.4" x2="988.3" y2="311.3" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="902.7" y1="212.8" x2="988.3" y2="311.3" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="902.7" y1="212.8" x2="567.8" y2="229.6" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="988.3" y1="311.3" x2="567.8" y2="229.6" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="988.3" y1="311.3" x2="877.0" y2="470.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="567.8" y1="229.6" x2="877.0" y2="470.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="567.8" y1="229.6" x2="798.4" y2="486.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="877.0" y1="470.1" x2="798.4" y2="486.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="877.0" y1="470.1" x2="856.0" y2="219.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="798.4" y1="486.5" x2="856.0" y2="219.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <circle cx="823.6" cy="148.2" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="823.6" cy="148.2" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="484.4" cy="317.5" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="484.4" cy="317.5" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="523.2" cy="382.3" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="523.2" cy="382.3" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="820.2" cy="240.2" r="15.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="820.2" cy="240.2" r="9.0" fill="url(#nodeCore)"><animate attributeName="r" values="9.0;11.0;9.0" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="633.7" cy="228.2" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="633.7" cy="228.2" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="749.6" cy="239.9" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="749.6" cy="239.9" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="576.2" cy="312.5" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="576.2" cy="312.5" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="717.9" cy="484.0" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="717.9" cy="484.0" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="835.1" cy="196.1" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="835.1" cy="196.1" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="731.7" cy="245.7" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="731.7" cy="245.7" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="515.5" cy="316.6" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="515.5" cy="316.6" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="889.5" cy="181.4" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="889.5" cy="181.4" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="902.7" cy="212.8" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="902.7" cy="212.8" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="988.3" cy="311.3" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="988.3" cy="311.3" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="567.8" cy="229.6" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="567.8" cy="229.6" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="877.0" cy="470.1" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="877.0" cy="470.1" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="798.4" cy="486.5" r="13.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="798.4" cy="486.5" r="7.1" fill="url(#nodeCore)"><animate attributeName="r" values="7.1;9.1;7.1" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="856.0" cy="219.9" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="856.0" cy="219.9" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1052.3" cy="168.2" r="2.3" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="168.2;128.2;168.2" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="817.0" cy="406.6" r="2.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="406.6;344.4;406.6" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="541.9" cy="287.6" r="2.4" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="287.6;225.1;287.6" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="523.1" cy="458.4" r="1.8" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="458.4;393.5;458.4" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="407.7" cy="128.5" r="1.8" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="128.5;58.6;128.5" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="991.6" cy="362.1" r="3.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="362.1;323.6;362.1" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="605.2" cy="314.9" r="1.7" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="314.9;259.1;314.9" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="485.2" cy="273.3" r="2.6" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="273.3;220.6;273.3" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1002.6" cy="390.9" r="3.0" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="390.9;330.8;390.9" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="730.9" cy="147.9" r="1.7" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="147.9;78.7;147.9" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="506.3" cy="132.3" r="2.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="132.3;83.5;132.3" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="559.1" cy="80.5" r="1.6" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="80.5;30.9;80.5" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="987.1" cy="567.1" r="2.5" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="567.1;519.7;567.1" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="565.5" cy="502.1" r="2.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="502.1;437.6;502.1" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#14b8a6" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#7dd3fc" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#0ea5e9" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#0ea5e9" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#7dd3fc"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">AWS<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="82" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">SECURITY<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">MALWARE</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">CLOUD</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#14b8a6" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#7dd3fc"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#bae6fd" letter-spacing="3.5" opacity="0.9">APR 05 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">AWS</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">SECURITY</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#14b8a6" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#0ea5e9" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#7dd3fc" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#14b8a6" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#bae6fd" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#7dd3fc" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM6,1.6H6.4V2H6zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM7.2,2H7.6V2.4H7.2zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM6,2.4H6.4V2.8H6zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM6,3.6H6.4V4H6zM6.8,3.6H7.2V4H6.8zM8,3.6H8.4V4H8zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM6.4,4.8H6.8V5.2H6.4zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.2,5.2H1.6V5.6H1.2zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM5.2,5.2H5.6V5.6H5.2zM6.4,5.2H6.8V5.6H6.4zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM7.2,6.4H7.6V6.8H7.2zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM0.8,7.6H1.2V8H0.8zM2,7.6H2.4V8H2zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8,7.6H8.4V8H8zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8.4,8.4H8.8V8.8H8.4zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM5.2,9.2H5.6V9.6H5.2zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM1.6,10H2V10.4H1.6zM4.8,10H5.2V10.4H4.8zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM0.8,10.4H1.2V10.8H0.8zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM0.8,11.2H1.2V11.6H0.8zM3.2,11.2H3.6V11.6H3.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM15.2,11.2H15.6V11.6H15.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM3.6,11.6H4V12H3.6zM4.4,11.6H4.8V12H4.4zM5.6,11.6H6V12H5.6zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM8,12.8H8.4V13.2H8zM8.4,12.8H8.8V13.2H8.4zM9.2,12.8H9.6V13.2H9.2zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM7.2,13.2H7.6V13.6H7.2zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM6,14.8H6.4V15.2H6zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM7.2,15.2H7.6V15.6H7.2zM9.2,15.2H9.6V15.6H9.2zM10.8,15.2H11.2V15.6H10.8zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM5.6,15.6H6V16H5.6zM6.4,15.6H6.8V16H6.4zM7.2,15.6H7.6V16H7.2zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.2,16.8H5.6V17.2H5.2zM7.2,16.8H7.6V17.2H7.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: cloud compliance, supply-chain hijack, device phishing">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Shield silhouette -->
+  <g transform="translate(-70,-100)">
+    <path d="M 0 0 L 60 0 L 60 60 Q 60 100 30 120 Q 0 100 0 60 Z"
+          fill="#0B132B" stroke="#3A86FF" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.9;1;0.9" dur="3.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- inner pulse -->
+    <path d="M 10 10 L 50 10 L 50 58 Q 50 92 30 108 Q 10 92 10 58 Z"
+          fill="url(#glowBlue)" opacity="0.35">
+      <animate attributeName="opacity" values="0.2;0.55;0.2" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- big checkmark inside -->
+    <path d="M 14 58 L 26 74 L 48 40" fill="none" stroke="#3A86FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
   </g>
+  <!-- Clipboard (right) -->
+  <g transform="translate(10,-90)">
+    <rect x="0" y="0" width="90" height="120" rx="6" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- clip -->
+    <rect x="32" y="-8" width="26" height="14" rx="3" fill="#3A86FF"/>
+    <!-- checklist rows appearing -->
+    <g>
+      <circle cx="14" cy="24" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 24 L 13 26 L 17 22" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="22" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="28" width="42" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="44" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 44 L 13 46 L 17 42" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="1s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="42" width="58" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="48" width="46" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="64" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 64 L 13 66 L 17 62" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="2s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="62" width="50" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="68" width="38" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="84" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 84 L 13 86 L 17 82" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="3s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="82" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="88" width="44" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="104" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 104 L 13 106 L 17 102" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="4s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="102" width="60" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="108" width="48" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+  </g>
+  <!-- Growing service nodes around shield -->
+  <circle cx="-90" cy="40" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="60;40;40;20" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- progress bar bottom -->
+  <rect x="-60" y="56" width="120" height="6" rx="3" fill="#2A3256"/>
+  <rect x="-60" y="56" width="20" height="6" rx="3" fill="#3A86FF">
+    <animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/>
+  </rect>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AWS</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Landing zone accelerator workbook released</text>
+<g transform="translate(576,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
+  </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">NPM</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Axios maintainer account hijacked</text>
+<g transform="translate(936,330)">
+  <!-- Device frame (phone outline) -->
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="#0B132B" stroke="#3A86FF" stroke-width="2.4" opacity="0.95"/>
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="url(#glowBlue)" opacity="0.28">
+    <animate attributeName="opacity" values="0.18;0.42;0.18" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="-126" width="40" height="6" rx="3" fill="#2A3256"/>
+  <!-- Notification stack (3 mini rows appearing) -->
+  <g transform="translate(-54,-92)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;6.4;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="54" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-62)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="48" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-32)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="58" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Bell (top right of phone) pulsing -->
+  <g transform="translate(46,-104)">
+    <path d="M -10 6 Q -10 -8 0 -8 Q 10 -8 10 6 L 12 10 L -12 10 Z"
+          fill="#FFB703" opacity="0.95"/>
+    <circle cx="0" cy="-10" r="2.2" fill="#FFB703"/>
+    <path d="M -3 12 Q 0 16 3 12" fill="none" stroke="#FFB703" stroke-width="1.5"/>
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-12 0 -8; 12 0 -8; -12 0 -8"
+                      dur="1.6s" repeatCount="indefinite" additive="sum"/>
+  </g>
+  <!-- Fishhook swinging below phone -->
+  <g transform="translate(0,108)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-10 0 -40; 10 0 -40; -10 0 -40"
+                      dur="3.2s" repeatCount="indefinite" additive="sum"/>
+    <line x1="0" y1="-40" x2="0" y2="6" stroke="#FFB703" stroke-width="2.4"/>
+    <path d="M 0 6 Q 0 22 -12 22 Q -22 22 -22 12" fill="none"
+          stroke="#FFB703" stroke-width="2.6" stroke-linecap="round"/>
+    <circle cx="-22" cy="12" r="2.6" fill="#FFB703"/>
+    <path d="M -22 12 L -18 18 L -26 18 Z" fill="#FFB703"/>
+  </g>
+  <!-- Phishing particles flying toward hook -->
+  <circle cx="-90" cy="40" r="3" fill="#E63946">
+    <animate attributeName="cx" values="-90;-22" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="40;100" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="10" r="2.4" fill="#FFB703">
+    <animate attributeName="cx" values="-100;-22" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="10;100" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-88" cy="70" r="2.8" fill="#E63946">
+    <animate attributeName="cx" values="-88;-22" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="70;100" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- brand noun at bottom -->
+  <text x="0" y="164" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">DEVICE</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Device code phishing hits enterprises</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM6,0.8H6.4V1.2H6zM6.8,0.8H7.2V1.2H6.8zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM9.6,0.8H10V1.2H9.6zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM8.8,1.6H9.2V2H8.8zM10,1.6H10.4V2H10zM11.2,1.6H11.6V2H11.2zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.8,2H13.2V2.4H12.8zM13.2,2H13.6V2.4H13.2zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4,4H4.4V4.4H4zM5.2,4H5.6V4.4H5.2zM7.2,4H7.6V4.4H7.2zM8.4,4H8.8V4.4H8.4zM9.2,4H9.6V4.4H9.2zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.8,4H15.2V4.4H14.8zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM7.6,4.4H8V4.8H7.6zM9.2,4.4H9.6V4.8H9.2zM10.4,4.4H10.8V4.8H10.4zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12.4,4.4H12.8V4.8H12.4zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM14.8,4.4H15.2V4.8H14.8zM15.6,4.4H16V4.8H15.6zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.4,4.8H8.8V5.2H8.4zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM10.8,4.8H11.2V5.2H10.8zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM15.6,4.8H16V5.2H15.6zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM5.6,5.2H6V5.6H5.6zM6.4,5.2H6.8V5.6H6.4zM7.2,5.2H7.6V5.6H7.2zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.2,5.2H11.6V5.6H11.2zM12,5.2H12.4V5.6H12zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16,5.2H16.4V5.6H16zM16.8,5.2H17.2V5.6H16.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.2,5.6H9.6V6H9.2zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16.8,5.6H17.2V6H16.8zM0.8,6H1.2V6.4H0.8zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.6,6H6V6.4H5.6zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.6,6H8V6.4H7.6zM9.6,6H10V6.4H9.6zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM10.4,6.4H10.8V6.8H10.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM10.8,6.8H11.2V7.2H10.8zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM14.4,6.8H14.8V7.2H14.4zM14.8,6.8H15.2V7.2H14.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM3.6,7.6H4V8H3.6zM4.8,7.6H5.2V8H4.8zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM6.4,8H6.8V8.4H6.4zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM6.8,8.4H7.2V8.8H6.8zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.4,8.4H8.8V8.8H8.4zM9.6,8.4H10V8.8H9.6zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM2,8.8H2.4V9.2H2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8,9.2H8.4V9.6H8zM9.2,9.2H9.6V9.6H9.2zM10.8,9.2H11.2V9.6H10.8zM12.4,9.2H12.8V9.6H12.4zM14.4,9.2H14.8V9.6H14.4zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM10.8,9.6H11.2V10H10.8zM12,9.6H12.4V10H12zM13.2,9.6H13.6V10H13.2zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.4,9.6H16.8V10H16.4zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM8.8,10H9.2V10.4H8.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM10.8,10H11.2V10.4H10.8zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.8,10H13.2V10.4H12.8zM14.8,10H15.2V10.4H14.8zM16,10H16.4V10.4H16zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM2,10.4H2.4V10.8H2zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.6,10.4H12V10.8H11.6zM12,10.4H12.4V10.8H12zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.4,10.4H14.8V10.8H14.4zM14.8,10.4H15.2V10.8H14.8zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.6,10.8H2V11.2H1.6zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM15.6,10.8H16V11.2H15.6zM2,11.2H2.4V11.6H2zM3.2,11.2H3.6V11.6H3.2zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8.8,11.2H9.2V11.6H8.8zM10,11.2H10.4V11.6H10zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM1.6,11.6H2V12H1.6zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM5.2,11.6H5.6V12H5.2zM6,11.6H6.4V12H6zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10.4,11.6H10.8V12H10.4zM10.8,11.6H11.2V12H10.8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM0.8,12H1.2V12.4H0.8zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM6.4,12H6.8V12.4H6.4zM7.6,12H8V12.4H7.6zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.4,12.8H8.8V13.2H8.4zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14.8,12.8H15.2V13.2H14.8zM16,12.8H16.4V13.2H16zM16.4,12.8H16.8V13.2H16.4zM16.8,12.8H17.2V13.2H16.8zM2,13.2H2.4V13.6H2zM4.4,13.2H4.8V13.6H4.4zM5.6,13.2H6V13.6H5.6zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6.8,13.6H7.2V14H6.8zM8,13.6H8.4V14H8zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10.4,14H10.8V14.4H10.4zM10.8,14H11.2V14.4H10.8zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.4,14.4H8.8V14.8H8.4zM10.8,14.4H11.2V14.8H10.8zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16,14.8H16.4V15.2H16zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12,15.2H12.4V15.6H12zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16.4,15.2H16.8V15.6H16.4zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM6.4,15.6H6.8V16H6.4zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM12,15.6H12.4V16H12zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.4,15.6H14.8V16H14.4zM15.2,15.6H15.6V16H15.2zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM8,16.4H8.4V16.8H8zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10,16.4H10.4V16.8H10zM10.8,16.4H11.2V16.8H10.8zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.2,16.4H13.6V16.8H13.2zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.8,16.4H15.2V16.8H14.8zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM5.2,16.8H5.6V17.2H5.2zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-06-Tech_Security_Weekly_Digest_Patch_AI.svg
+++ b/assets/images/2026-04-06-Tech_Security_Weekly_Digest_Patch_AI.svg
@@ -1,145 +1,448 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 06 2026 PATCH STORM">
-  <title>Style A v3 APR 06 2026 PATCH STORM</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#120d04"/><stop offset="100%" stop-color="#1c1608"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#1c1608"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.34"/><stop offset="100%" stop-color="#120d04" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#ca8a04" stop-opacity="0.32"/><stop offset="100%" stop-color="#1c1608" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ca8a04"><animate attributeName="stop-color" values="#ca8a04;#fde047;#eab308;#ca8a04" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fde047"><animate attributeName="stop-color" values="#fde047;#facc15;#ca8a04;#fde047" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#facc15"><animate attributeName="stop-color" values="#facc15;#eab308;#fde047;#facc15" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.9"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#120d04" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0"/><stop offset="50%" stop-color="#eab308" stop-opacity="0.7"/><stop offset="100%" stop-color="#eab308" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fde047" stop-opacity="1"/><stop offset="55%" stop-color="#ca8a04" stop-opacity="0.75"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#facc15" stop-opacity="0.5"/><stop offset="100%" stop-color="#facc15" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fef08a" stop-opacity="0.85"/><stop offset="100%" stop-color="#fef08a" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fde047" stop-opacity="0.45"/><stop offset="100%" stop-color="#fde047" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.85"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ca8a04" stop-opacity="0.4"/><stop offset="100%" stop-color="#fde047" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0"/><stop offset="35%" stop-color="#eab308" stop-opacity="0.95"/><stop offset="65%" stop-color="#ca8a04" stop-opacity="0.95"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fde047" stop-opacity="0"/><stop offset="40%" stop-color="#fde047" stop-opacity="0.55"/><stop offset="100%" stop-color="#fde047" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ca8a04"/><stop offset="100%" stop-color="#fde047"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#eab308" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#ca8a04" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#eab308" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="724.6" y1="432.8" x2="960.0" y2="369.3" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="724.6" y1="432.8" x2="716.0" y2="217.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="960.0" y1="369.3" x2="716.0" y2="217.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="960.0" y1="369.3" x2="958.7" y2="422.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="716.0" y1="217.1" x2="958.7" y2="422.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="716.0" y1="217.1" x2="938.0" y2="318.3" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="958.7" y1="422.6" x2="938.0" y2="318.3" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="958.7" y1="422.6" x2="555.8" y2="251.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="938.0" y1="318.3" x2="555.8" y2="251.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="938.0" y1="318.3" x2="600.4" y2="327.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="555.8" y1="251.9" x2="600.4" y2="327.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="555.8" y1="251.9" x2="807.3" y2="466.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="600.4" y1="327.1" x2="807.3" y2="466.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="600.4" y1="327.1" x2="609.4" y2="253.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="807.3" y1="466.4" x2="609.4" y2="253.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="807.3" y1="466.4" x2="821.3" y2="440.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="609.4" y1="253.7" x2="821.3" y2="440.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="609.4" y1="253.7" x2="791.5" y2="184.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="821.3" y1="440.8" x2="791.5" y2="184.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="821.3" y1="440.8" x2="632.7" y2="175.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="791.5" y1="184.1" x2="632.7" y2="175.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="791.5" y1="184.1" x2="873.1" y2="357.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="632.7" y1="175.5" x2="873.1" y2="357.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="632.7" y1="175.5" x2="655.3" y2="472.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="873.1" y1="357.9" x2="655.3" y2="472.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="873.1" y1="357.9" x2="731.8" y2="226.3" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="655.3" y1="472.1" x2="731.8" y2="226.3" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="655.3" y1="472.1" x2="576.6" y2="255.0" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="731.8" y1="226.3" x2="576.6" y2="255.0" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="731.8" y1="226.3" x2="715.9" y2="392.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="576.6" y1="255.0" x2="715.9" y2="392.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="576.6" y1="255.0" x2="579.4" y2="450.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="715.9" y1="392.4" x2="579.4" y2="450.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <circle cx="724.6" cy="432.8" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="724.6" cy="432.8" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="960.0" cy="369.3" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="960.0" cy="369.3" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="716.0" cy="217.1" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="716.0" cy="217.1" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="958.7" cy="422.6" r="13.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="958.7" cy="422.6" r="7.9" fill="url(#nodeCore)"><animate attributeName="r" values="7.9;9.9;7.9" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="938.0" cy="318.3" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="938.0" cy="318.3" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="555.8" cy="251.9" r="11.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="555.8" cy="251.9" r="5.9" fill="url(#nodeCore)"><animate attributeName="r" values="5.9;7.9;5.9" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="600.4" cy="327.1" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="600.4" cy="327.1" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="807.3" cy="466.4" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="807.3" cy="466.4" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="609.4" cy="253.7" r="10.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="609.4" cy="253.7" r="4.7" fill="url(#nodeCore)"><animate attributeName="r" values="4.7;6.7;4.7" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="821.3" cy="440.8" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="821.3" cy="440.8" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="791.5" cy="184.1" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="791.5" cy="184.1" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="632.7" cy="175.5" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="632.7" cy="175.5" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="873.1" cy="357.9" r="14.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="873.1" cy="357.9" r="8.9" fill="url(#nodeCore)"><animate attributeName="r" values="8.9;10.9;8.9" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="655.3" cy="472.1" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="655.3" cy="472.1" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="731.8" cy="226.3" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="731.8" cy="226.3" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="576.6" cy="255.0" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="576.6" cy="255.0" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="715.9" cy="392.4" r="15.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="715.9" cy="392.4" r="9.0" fill="url(#nodeCore)"><animate attributeName="r" values="9.0;11.0;9.0" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="579.4" cy="450.8" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="579.4" cy="450.8" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="959.2" cy="370.5" r="2.2" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="370.5;306.3;370.5" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="580.8" cy="352.4" r="2.5" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="352.4;288.8;352.4" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="930.6" cy="441.4" r="2.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="441.4;403.0;441.4" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="854.0" cy="269.6" r="3.2" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="269.6;193.2;269.6" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1040.0" cy="149.3" r="2.0" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="149.3;65.3;149.3" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="918.4" cy="360.4" r="2.7" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="360.4;322.6;360.4" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="980.7" cy="555.4" r="2.7" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="555.4;478.5;555.4" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="684.5" cy="525.6" r="1.7" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="525.6;482.0;525.6" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1029.9" cy="240.2" r="2.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="240.2;157.2;240.2" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="500.6" cy="519.9" r="2.5" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="519.9;461.1;519.9" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.5s" repeatCount="indefinite"/></circle>
-  <circle cx="808.3" cy="513.4" r="2.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="513.4;457.2;513.4" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1122.6" cy="474.4" r="3.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="474.4;436.1;474.4" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="735.0" cy="434.2" r="2.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="434.2;381.8;434.2" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="1121.0" cy="82.8" r="2.8" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="82.8;36.4;82.8" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#eab308" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fde047" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#ca8a04" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#ca8a04" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fde047"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">PATCH<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">STORM<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">CVE</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">FIX</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#eab308" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fde047"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fef08a" letter-spacing="3.5" opacity="0.9">APR 06 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">PATCH</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">STORM</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#eab308" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#ca8a04" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fde047" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#eab308" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fef08a" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fde047" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.8293)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM6,0.8H6.4V1.2H6zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14,0.8H14.4V1.2H14zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM7.6,1.2H8V1.6H7.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM15.2,1.2H15.6V1.6H15.2zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14,1.6H14.4V2H14zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM9.6,2H10V2.4H9.6zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM12,2H12.4V2.4H12zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14,2H14.4V2.4H14zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM6,2.4H6.4V2.8H6zM7.2,2.4H7.6V2.8H7.2zM8.4,2.4H8.8V2.8H8.4zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM12,2.4H12.4V2.8H12zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14,2.4H14.4V2.8H14zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM10.4,2.8H10.8V3.2H10.4zM10.8,2.8H11.2V3.2H10.8zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM15.2,2.8H15.6V3.2H15.2zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.2,3.2H13.6V3.6H13.2zM13.6,3.2H14V3.6H13.6zM14,3.2H14.4V3.6H14zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.6,3.6H6V4H5.6zM6.4,3.6H6.8V4H6.4zM8.4,3.6H8.8V4H8.4zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10,3.6H10.4V4H10zM11.2,3.6H11.6V4H11.2zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM5.6,4.4H6V4.8H5.6zM6.8,4.4H7.2V4.8H6.8zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM8.8,4.4H9.2V4.8H8.8zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12,4.4H12.4V4.8H12zM13.2,4.4H13.6V4.8H13.2zM14.4,4.4H14.8V4.8H14.4zM14.8,4.4H15.2V4.8H14.8zM0.8,4.8H1.2V5.2H0.8zM1.6,4.8H2V5.2H1.6zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.8,4.8H11.2V5.2H10.8zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.4,4.8H12.8V5.2H12.4zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM5.2,5.2H5.6V5.6H5.2zM5.6,5.2H6V5.6H5.6zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM11.2,5.2H11.6V5.6H11.2zM11.6,5.2H12V5.6H11.6zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM15.2,5.2H15.6V5.6H15.2zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8,5.6H8.4V6H8zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10,5.6H10.4V6H10zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.2,5.6H15.6V6H15.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM8.4,6H8.8V6.4H8.4zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM12,6H12.4V6.4H12zM13.2,6H13.6V6.4H13.2zM0.8,6.4H1.2V6.8H0.8zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.8,6.4H7.2V6.8H6.8zM8,6.4H8.4V6.8H8zM9.6,6.4H10V6.8H9.6zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM11.2,6.4H11.6V6.8H11.2zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM15.2,6.4H15.6V6.8H15.2zM0.8,6.8H1.2V7.2H0.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM5.6,6.8H6V7.2H5.6zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM8,6.8H8.4V7.2H8zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM6.8,7.2H7.2V7.6H6.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12,7.2H12.4V7.6H12zM12.4,7.2H12.8V7.6H12.4zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM14.4,7.2H14.8V7.6H14.4zM14.8,7.2H15.2V7.6H14.8zM15.2,7.2H15.6V7.6H15.2zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM12,7.6H12.4V8H12zM13.2,7.6H13.6V8H13.2zM14.8,7.6H15.2V8H14.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4.4,8H4.8V8.4H4.4zM6,8H6.4V8.4H6zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.2,8H13.6V8.4H13.2zM13.6,8H14V8.4H13.6zM14,8H14.4V8.4H14zM14.8,8H15.2V8.4H14.8zM15.2,8H15.6V8.4H15.2zM0.8,8.4H1.2V8.8H0.8zM2.8,8.4H3.2V8.8H2.8zM5.2,8.4H5.6V8.8H5.2zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8,8.4H8.4V8.8H8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10.4,8.4H10.8V8.8H10.4zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.2,8.4H13.6V8.8H13.2zM13.6,8.4H14V8.8H13.6zM15.2,8.4H15.6V8.8H15.2zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM7.2,8.8H7.6V9.2H7.2zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM4.4,9.2H4.8V9.6H4.4zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM7.6,9.2H8V9.6H7.6zM8.4,9.2H8.8V9.6H8.4zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM11.2,9.2H11.6V9.6H11.2zM14,9.2H14.4V9.6H14zM14.8,9.2H15.2V9.6H14.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM8.8,9.6H9.2V10H8.8zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.8,9.6H13.2V10H12.8zM13.2,9.6H13.6V10H13.2zM13.6,9.6H14V10H13.6zM14,9.6H14.4V10H14zM15.2,9.6H15.6V10H15.2zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM4.8,10H5.2V10.4H4.8zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM8.4,10H8.8V10.4H8.4zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.4,10H12.8V10.4H12.4zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.4,10.4H4.8V10.8H4.4zM4.8,10.4H5.2V10.8H4.8zM6,10.4H6.4V10.8H6zM6.8,10.4H7.2V10.8H6.8zM8.8,10.4H9.2V10.8H8.8zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM12.8,10.4H13.2V10.8H12.8zM13.2,10.4H13.6V10.8H13.2zM14.4,10.4H14.8V10.8H14.4zM15.2,10.4H15.6V10.8H15.2zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.8,10.8H9.2V11.2H8.8zM9.6,10.8H10V11.2H9.6zM10,10.8H10.4V11.2H10zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM0.8,11.2H1.2V11.6H0.8zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM5.6,11.2H6V11.6H5.6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.6,11.2H10V11.6H9.6zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.6,11.2H12V11.6H11.6zM12.8,11.2H13.2V11.6H12.8zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM3.6,11.6H4V12H3.6zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM0.8,12H1.2V12.4H0.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.4,12H14.8V12.4H14.4zM15.2,12H15.6V12.4H15.2zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM9.6,12.4H10V12.8H9.6zM10,12.4H10.4V12.8H10zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.4,12.8H4.8V13.2H4.4zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM11.2,12.8H11.6V13.2H11.2zM12,12.8H12.4V13.2H12zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14.4,12.8H14.8V13.2H14.4zM15.2,12.8H15.6V13.2H15.2zM0.8,13.2H1.2V13.6H0.8zM3.2,13.2H3.6V13.6H3.2zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.8,13.2H15.2V13.6H14.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10.4,13.6H10.8V14H10.4zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM0.8,14H1.2V14.4H0.8zM1.6,14H2V14.4H1.6zM2,14H2.4V14.4H2zM2.4,14H2.8V14.4H2.4zM3.2,14H3.6V14.4H3.2zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM13.6,14H14V14.4H13.6zM14,14H14.4V14.4H14zM14.8,14H15.2V14.4H14.8zM15.2,14H15.6V14.4H15.2zM0.8,14.4H1.2V14.8H0.8zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM14.4,14.4H14.8V14.8H14.4zM14.8,14.4H15.2V14.8H14.8zM15.2,14.4H15.6V14.8H15.2zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.2,14.8H5.6V15.2H5.2zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM0.8,15.2H1.2V15.6H0.8zM1.2,15.2H1.6V15.6H1.2zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM2.8,15.2H3.2V15.6H2.8zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM7.6,15.2H8V15.6H7.6zM8,15.2H8.4V15.6H8zM9.6,15.2H10V15.6H9.6zM10,15.2H10.4V15.6H10zM10.4,15.2H10.8V15.6H10.4zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: heist breach, phishing lure, CVE triage">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Vault door -->
+  <g transform="translate(-70,-100)">
+    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
+    <!-- vault handle spokes rotating -->
+    <g transform="translate(60,60)">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="6s" repeatCount="indefinite"/>
+      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
+    </g>
+    <!-- crack in door -->
+    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
+    </path>
   </g>
+  <!-- Coins flying out -->
+  <g>
+    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Masked figure silhouette (right) -->
+  <g transform="translate(90,-20)">
+    <!-- head -->
+    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- mask band -->
+    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
+    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
+    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
+    <!-- body -->
+    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- arm reaching down -->
+    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="d"
+               values="M -14 -2 Q -30 20 -28 34;
+                       M -14 -2 Q -34 22 -36 38;
+                       M -14 -2 Q -30 20 -28 34"
+               dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <!-- holding coin -->
+    <circle cx="-28" cy="34" r="4" fill="#FFB703">
+      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Down arrow stream (loss) -->
+  <g transform="translate(-30,60)">
+    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="15" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">DRIFT</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Large breach traced to social engineering</text>
+<g transform="translate(576,330)">
+  <!-- Device frame (phone outline) -->
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="#0B132B" stroke="#3A86FF" stroke-width="2.4" opacity="0.95"/>
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="url(#glowBlue)" opacity="0.28">
+    <animate attributeName="opacity" values="0.18;0.42;0.18" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="-126" width="40" height="6" rx="3" fill="#2A3256"/>
+  <!-- Notification stack (3 mini rows appearing) -->
+  <g transform="translate(-54,-92)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;6.4;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="54" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-62)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="48" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-32)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="58" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Bell (top right of phone) pulsing -->
+  <g transform="translate(46,-104)">
+    <path d="M -10 6 Q -10 -8 0 -8 Q 10 -8 10 6 L 12 10 L -12 10 Z"
+          fill="#FFB703" opacity="0.95"/>
+    <circle cx="0" cy="-10" r="2.2" fill="#FFB703"/>
+    <path d="M -3 12 Q 0 16 3 12" fill="none" stroke="#FFB703" stroke-width="1.5"/>
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-12 0 -8; 12 0 -8; -12 0 -8"
+                      dur="1.6s" repeatCount="indefinite" additive="sum"/>
+  </g>
+  <!-- Fishhook swinging below phone -->
+  <g transform="translate(0,108)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-10 0 -40; 10 0 -40; -10 0 -40"
+                      dur="3.2s" repeatCount="indefinite" additive="sum"/>
+    <line x1="0" y1="-40" x2="0" y2="6" stroke="#FFB703" stroke-width="2.4"/>
+    <path d="M 0 6 Q 0 22 -12 22 Q -22 22 -22 12" fill="none"
+          stroke="#FFB703" stroke-width="2.6" stroke-linecap="round"/>
+    <circle cx="-22" cy="12" r="2.6" fill="#FFB703"/>
+    <path d="M -22 12 L -18 18 L -26 18 Z" fill="#FFB703"/>
+  </g>
+  <!-- Phishing particles flying toward hook -->
+  <circle cx="-90" cy="40" r="3" fill="#E63946">
+    <animate attributeName="cx" values="-90;-22" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="40;100" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="10" r="2.4" fill="#FFB703">
+    <animate attributeName="cx" values="-100;-22" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="10;100" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-88" cy="70" r="2.8" fill="#E63946">
+    <animate attributeName="cx" values="-88;-22" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="70;100" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- brand noun at bottom -->
+  <text x="0" y="164" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">QR</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">QR codes drive traffic fine fraud</text>
+<g transform="translate(936,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">FORTINET</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Urgent appliance flaws under exploitation</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(6.097561)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14,0.8H14.4V1.2H14zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM7.6,1.2H8V1.6H7.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM15.2,1.2H15.6V1.6H15.2zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14,1.6H14.4V2H14zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM9.6,2H10V2.4H9.6zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM12,2H12.4V2.4H12zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14,2H14.4V2.4H14zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM7.2,2.4H7.6V2.8H7.2zM8.4,2.4H8.8V2.8H8.4zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM12,2.4H12.4V2.8H12zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14,2.4H14.4V2.8H14zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM5.2,2.8H5.6V3.2H5.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM15.2,2.8H15.6V3.2H15.2zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.2,3.2H13.6V3.6H13.2zM13.6,3.2H14V3.6H13.6zM14,3.2H14.4V3.6H14zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.6,3.6H6V4H5.6zM8.4,3.6H8.8V4H8.4zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10,3.6H10.4V4H10zM11.2,3.6H11.6V4H11.2zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM6.4,4H6.8V4.4H6.4zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM1.6,4.4H2V4.8H1.6zM2.4,4.4H2.8V4.8H2.4zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12,4.4H12.4V4.8H12zM13.2,4.4H13.6V4.8H13.2zM14.4,4.4H14.8V4.8H14.4zM14.8,4.4H15.2V4.8H14.8zM0.8,4.8H1.2V5.2H0.8zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM5.2,4.8H5.6V5.2H5.2zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.8,4.8H11.2V5.2H10.8zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.4,4.8H12.8V5.2H12.4zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM11.2,5.2H11.6V5.6H11.2zM11.6,5.2H12V5.6H11.6zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM15.2,5.2H15.6V5.6H15.2zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4.8,5.6H5.2V6H4.8zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8,5.6H8.4V6H8zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10,5.6H10.4V6H10zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.2,5.6H15.6V6H15.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM7.6,6H8V6.4H7.6zM8.4,6H8.8V6.4H8.4zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM12,6H12.4V6.4H12zM13.2,6H13.6V6.4H13.2zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.8,6.4H7.2V6.8H6.8zM8,6.4H8.4V6.8H8zM9.6,6.4H10V6.8H9.6zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM11.2,6.4H11.6V6.8H11.2zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM15.2,6.4H15.6V6.8H15.2zM1.2,6.8H1.6V7.2H1.2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM8,6.8H8.4V7.2H8zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8,7.2H8.4V7.6H8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12,7.2H12.4V7.6H12zM12.4,7.2H12.8V7.6H12.4zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.4,7.2H14.8V7.6H14.4zM14.8,7.2H15.2V7.6H14.8zM15.2,7.2H15.6V7.6H15.2zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM12,7.6H12.4V8H12zM13.2,7.6H13.6V8H13.2zM14.8,7.6H15.2V8H14.8zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.2,8H13.6V8.4H13.2zM14,8H14.4V8.4H14zM14.8,8H15.2V8.4H14.8zM15.2,8H15.6V8.4H15.2zM0.8,8.4H1.2V8.8H0.8zM2.8,8.4H3.2V8.8H2.8zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8,8.4H8.4V8.8H8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10.4,8.4H10.8V8.8H10.4zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.2,8.4H13.6V8.8H13.2zM13.6,8.4H14V8.8H13.6zM15.2,8.4H15.6V8.8H15.2zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM7.2,8.8H7.6V9.2H7.2zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM4.4,9.2H4.8V9.6H4.4zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM7.6,9.2H8V9.6H7.6zM8.4,9.2H8.8V9.6H8.4zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM11.2,9.2H11.6V9.6H11.2zM14,9.2H14.4V9.6H14zM14.8,9.2H15.2V9.6H14.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.8,9.6H13.2V10H12.8zM13.2,9.6H13.6V10H13.2zM13.6,9.6H14V10H13.6zM14,9.6H14.4V10H14zM15.2,9.6H15.6V10H15.2zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM8.4,10H8.8V10.4H8.4zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.4,10H12.8V10.4H12.4zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM1.2,10.4H1.6V10.8H1.2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM12.8,10.4H13.2V10.8H12.8zM13.6,10.4H14V10.8H13.6zM14.4,10.4H14.8V10.8H14.4zM15.2,10.4H15.6V10.8H15.2zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.6,10.8H10V11.2H9.6zM10,10.8H10.4V11.2H10zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM0.8,11.2H1.2V11.6H0.8zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.6,11.2H10V11.6H9.6zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.6,11.2H12V11.6H11.6zM12.8,11.2H13.2V11.6H12.8zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM0.8,12H1.2V12.4H0.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.4,12H14.8V12.4H14.4zM15.2,12H15.6V12.4H15.2zM4,12.4H4.4V12.8H4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM9.6,12.4H10V12.8H9.6zM10,12.4H10.4V12.8H10zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.8,12.8H5.2V13.2H4.8zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM11.2,12.8H11.6V13.2H11.2zM12,12.8H12.4V13.2H12zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14.4,12.8H14.8V13.2H14.4zM15.2,12.8H15.6V13.2H15.2zM0.8,13.2H1.2V13.6H0.8zM3.2,13.2H3.6V13.6H3.2zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.8,13.2H15.2V13.6H14.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10.4,13.6H10.8V14H10.4zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM0.8,14H1.2V14.4H0.8zM1.6,14H2V14.4H1.6zM2,14H2.4V14.4H2zM2.4,14H2.8V14.4H2.4zM3.2,14H3.6V14.4H3.2zM4,14H4.4V14.4H4zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM13.6,14H14V14.4H13.6zM14,14H14.4V14.4H14zM14.8,14H15.2V14.4H14.8zM15.2,14H15.6V14.4H15.2zM0.8,14.4H1.2V14.8H0.8zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM14.4,14.4H14.8V14.8H14.4zM14.8,14.4H15.2V14.8H14.8zM15.2,14.4H15.6V14.8H15.2zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.2,14.8H5.6V15.2H5.2zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM0.8,15.2H1.2V15.6H0.8zM1.2,15.2H1.6V15.6H1.2zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM2.8,15.2H3.2V15.6H2.8zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM7.6,15.2H8V15.6H7.6zM8,15.2H8.4V15.6H8zM9.6,15.2H10V15.6H9.6zM10,15.2H10.4V15.6H10zM10.4,15.2H10.8V15.6H10.4zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-07-Tech_Security_Weekly_Digest_AI_Ransomware_Go_Palantir.svg
+++ b/assets/images/2026-04-07-Tech_Security_Weekly_Digest_AI_Ransomware_Go_Palantir.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 07 2026 RANSOM WARE">
-  <title>Style A v3 APR 07 2026 RANSOM WARE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#100415"/><stop offset="100%" stop-color="#190622"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#190622"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.34"/><stop offset="100%" stop-color="#100415" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#c026d3" stop-opacity="0.32"/><stop offset="100%" stop-color="#190622" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#c026d3"><animate attributeName="stop-color" values="#c026d3;#f472b6;#dc2626;#c026d3" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#f472b6"><animate attributeName="stop-color" values="#f472b6;#e11d48;#c026d3;#f472b6" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#e11d48"><animate attributeName="stop-color" values="#e11d48;#dc2626;#f472b6;#e11d48" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.9"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#100415" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="50%" stop-color="#dc2626" stop-opacity="0.7"/><stop offset="100%" stop-color="#dc2626" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#f472b6" stop-opacity="1"/><stop offset="55%" stop-color="#c026d3" stop-opacity="0.75"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#e11d48" stop-opacity="0.5"/><stop offset="100%" stop-color="#e11d48" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.85"/><stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#f472b6" stop-opacity="0.45"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.85"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#c026d3" stop-opacity="0.4"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="35%" stop-color="#dc2626" stop-opacity="0.95"/><stop offset="65%" stop-color="#c026d3" stop-opacity="0.95"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#f472b6" stop-opacity="0"/><stop offset="40%" stop-color="#f472b6" stop-opacity="0.55"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#c026d3"/><stop offset="100%" stop-color="#f472b6"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#c026d3" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="946.7" y1="281.6" x2="930.5" y2="229.6" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="946.7" y1="281.6" x2="540.7" y2="376.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="930.5" y1="229.6" x2="540.7" y2="376.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="930.5" y1="229.6" x2="899.1" y2="235.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="540.7" y1="376.2" x2="899.1" y2="235.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="540.7" y1="376.2" x2="687.1" y2="165.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="899.1" y1="235.5" x2="687.1" y2="165.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="899.1" y1="235.5" x2="920.4" y2="370.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="687.1" y1="165.1" x2="920.4" y2="370.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="687.1" y1="165.1" x2="569.8" y2="358.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="920.4" y1="370.5" x2="569.8" y2="358.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="920.4" y1="370.5" x2="814.8" y2="190.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="569.8" y1="358.9" x2="814.8" y2="190.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="569.8" y1="358.9" x2="764.3" y2="407.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="814.8" y1="190.4" x2="764.3" y2="407.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="814.8" y1="190.4" x2="800.3" y2="454.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="764.3" y1="407.8" x2="800.3" y2="454.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="764.3" y1="407.8" x2="648.0" y2="463.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="800.3" y1="454.2" x2="648.0" y2="463.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="800.3" y1="454.2" x2="981.6" y2="307.3" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="648.0" y1="463.1" x2="981.6" y2="307.3" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="648.0" y1="463.1" x2="670.2" y2="171.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="981.6" y1="307.3" x2="670.2" y2="171.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="981.6" y1="307.3" x2="625.6" y2="457.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="670.2" y1="171.1" x2="625.6" y2="457.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="670.2" y1="171.1" x2="975.6" y2="203.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="625.6" y1="457.4" x2="975.6" y2="203.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="625.6" y1="457.4" x2="663.4" y2="212.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="975.6" y1="203.4" x2="663.4" y2="212.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="975.6" y1="203.4" x2="642.9" y2="390.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="663.4" y1="212.4" x2="642.9" y2="390.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="663.4" y1="212.4" x2="1013.5" y2="286.7" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="642.9" y1="390.9" x2="1013.5" y2="286.7" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <circle cx="946.7" cy="281.6" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="946.7" cy="281.6" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="930.5" cy="229.6" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="930.5" cy="229.6" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="540.7" cy="376.2" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="540.7" cy="376.2" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="899.1" cy="235.5" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="899.1" cy="235.5" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="687.1" cy="165.1" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="687.1" cy="165.1" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="920.4" cy="370.5" r="10.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="920.4" cy="370.5" r="4.4" fill="url(#nodeCore)"><animate attributeName="r" values="4.4;6.4;4.4" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="569.8" cy="358.9" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="569.8" cy="358.9" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="814.8" cy="190.4" r="13.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="814.8" cy="190.4" r="7.1" fill="url(#nodeCore)"><animate attributeName="r" values="7.1;9.1;7.1" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="764.3" cy="407.8" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="764.3" cy="407.8" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="800.3" cy="454.2" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="800.3" cy="454.2" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="648.0" cy="463.1" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="648.0" cy="463.1" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="981.6" cy="307.3" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="981.6" cy="307.3" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="670.2" cy="171.1" r="11.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="670.2" cy="171.1" r="5.0" fill="url(#nodeCore)"><animate attributeName="r" values="5.0;7.0;5.0" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="625.6" cy="457.4" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="625.6" cy="457.4" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="975.6" cy="203.4" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="975.6" cy="203.4" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="663.4" cy="212.4" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="663.4" cy="212.4" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="642.9" cy="390.9" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="642.9" cy="390.9" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1013.5" cy="286.7" r="13.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1013.5" cy="286.7" r="7.4" fill="url(#nodeCore)"><animate attributeName="r" values="7.4;9.4;7.4" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="706.0" cy="566.9" r="1.7" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="566.9;512.2;566.9" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="649.1" cy="154.1" r="2.9" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="154.1;72.4;154.1" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="567.9" cy="166.6" r="1.8" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="166.6;91.1;166.6" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="426.2" cy="142.1" r="2.9" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="142.1;92.8;142.1" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="698.7" cy="144.2" r="2.6" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="144.2;68.3;144.2" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="997.6" cy="263.1" r="1.9" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="263.1;224.6;263.1" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="404.2" cy="120.4" r="2.5" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="120.4;43.3;120.4" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="711.6" cy="545.4" r="2.7" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="545.4;505.9;545.4" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="835.3" cy="107.3" r="2.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="107.3;36.6;107.3" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="576.4" cy="445.2" r="2.5" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="445.2;361.1;445.2" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1138.7" cy="110.5" r="1.6" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="110.5;30.1;110.5" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1025.1" cy="415.2" r="3.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="415.2;350.9;415.2" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="559.4" cy="393.9" r="2.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="393.9;338.0;393.9" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="831.4" cy="375.6" r="2.6" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="375.6;334.7;375.6" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#dc2626" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#f472b6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#c026d3" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#c026d3" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#f472b6"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">RANSOM<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">WARE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">GO</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">PALANTIR</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#dc2626" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#f472b6"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fbcfe8" letter-spacing="3.5" opacity="0.9">APR 07 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">RANSOM</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">WARE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#dc2626" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#c026d3" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#f472b6" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#dc2626" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fbcfe8" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#f472b6" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM9.2,0.8H9.6V1.2H9.2zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM5.6,1.2H6V1.6H5.6zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM10,1.2H10.4V1.6H10zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM10,1.6H10.4V2H10zM11.2,1.6H11.6V2H11.2zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.4,2H4.8V2.4H4.4zM5.6,2H6V2.4H5.6zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.2,2H13.6V2.4H13.2zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM6,2.4H6.4V2.8H6zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM6.4,3.6H6.8V4H6.4zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM8.4,4H8.8V4.4H8.4zM9.2,4H9.6V4.4H9.2zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.8,4H15.2V4.4H14.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM4.4,4.4H4.8V4.8H4.4zM6,4.4H6.4V4.8H6zM7.2,4.4H7.6V4.8H7.2zM7.6,4.4H8V4.8H7.6zM9.2,4.4H9.6V4.8H9.2zM10.4,4.4H10.8V4.8H10.4zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12.4,4.4H12.8V4.8H12.4zM13.6,4.4H14V4.8H13.6zM15.6,4.4H16V4.8H15.6zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.4,4.8H8.8V5.2H8.4zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM10.8,4.8H11.2V5.2H10.8zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM15.6,4.8H16V5.2H15.6zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM3.6,5.2H4V5.6H3.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.2,5.2H7.6V5.6H7.2zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.2,5.2H11.6V5.6H11.2zM12,5.2H12.4V5.6H12zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16,5.2H16.4V5.6H16zM16.8,5.2H17.2V5.6H16.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.2,5.6H9.6V6H9.2zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16.4,5.6H16.8V6H16.4zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM3.6,6H4V6.4H3.6zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM9.6,6H10V6.4H9.6zM10.8,6H11.2V6.4H10.8zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.8,6.8H11.2V7.2H10.8zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM14.8,6.8H15.2V7.2H14.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM4.4,7.6H4.8V8H4.4zM5.2,7.6H5.6V8H5.2zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM12.4,8H12.8V8.4H12.4zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.6,8.4H10V8.8H9.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.6,9.2H6V9.6H5.6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM12.4,9.2H12.8V9.6H12.4zM12.8,9.2H13.2V9.6H12.8zM14.4,9.2H14.8V9.6H14.4zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM10.8,9.6H11.2V10H10.8zM12,9.6H12.4V10H12zM13.2,9.6H13.6V10H13.2zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2.4,10H2.8V10.4H2.4zM2.8,10H3.2V10.4H2.8zM4.8,10H5.2V10.4H4.8zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM8.8,10H9.2V10.4H8.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM10.4,10H10.8V10.4H10.4zM10.8,10H11.2V10.4H10.8zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.8,10H13.2V10.4H12.8zM14.4,10H14.8V10.4H14.4zM16,10H16.4V10.4H16zM16.8,10H17.2V10.4H16.8zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.6,10.4H12V10.8H11.6zM12,10.4H12.4V10.8H12zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.4,10.4H14.8V10.8H14.4zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2.8,10.8H3.2V11.2H2.8zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8.8,11.2H9.2V11.6H8.8zM10,11.2H10.4V11.6H10zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10.4,11.6H10.8V12H10.4zM10.8,11.6H11.2V12H10.8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM16.8,11.6H17.2V12H16.8zM1.2,12H1.6V12.4H1.2zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM9.2,12.4H9.6V12.8H9.2zM10,12.4H10.4V12.8H10zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.2,12.4H13.6V12.8H13.2zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM7.6,12.8H8V13.2H7.6zM8.4,12.8H8.8V13.2H8.4zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM14.8,12.8H15.2V13.2H14.8zM16,12.8H16.4V13.2H16zM16.4,12.8H16.8V13.2H16.4zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM6.4,13.2H6.8V13.6H6.4zM7.6,13.2H8V13.6H7.6zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6.4,13.6H6.8V14H6.4zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10.4,14H10.8V14.4H10.4zM10.8,14H11.2V14.4H10.8zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM8.4,14.4H8.8V14.8H8.4zM10.8,14.4H11.2V14.8H10.8zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16,14.8H16.4V15.2H16zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.6,15.2H12V15.6H11.6zM12,15.2H12.4V15.6H12zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16.4,15.2H16.8V15.6H16.4zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM12,15.6H12.4V16H12zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.4,15.6H14.8V16H14.4zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10,16.4H10.4V16.8H10zM10.8,16.4H11.2V16.8H10.8zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.2,16.4H13.6V16.8H13.2zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.8,16.4H15.2V16.8H14.8zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: APT C2, ransomware return, organisational announcement">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">LAZARUS</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">GitHub abused as covert channel</text>
+<g transform="translate(576,330)">
+  <!-- Vault door -->
+  <g transform="translate(-70,-100)">
+    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
+    <!-- vault handle spokes rotating -->
+    <g transform="translate(60,60)">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="6s" repeatCount="indefinite"/>
+      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
+    </g>
+    <!-- crack in door -->
+    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Coins flying out -->
+  <g>
+    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Masked figure silhouette (right) -->
+  <g transform="translate(90,-20)">
+    <!-- head -->
+    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- mask band -->
+    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
+    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
+    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
+    <!-- body -->
+    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- arm reaching down -->
+    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="d"
+               values="M -14 -2 Q -30 20 -28 34;
+                       M -14 -2 Q -34 22 -36 38;
+                       M -14 -2 Q -30 20 -28 34"
+               dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <!-- holding coin -->
+    <circle cx="-28" cy="34" r="4" fill="#FFB703">
+      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Down arrow stream (loss) -->
+  <g transform="translate(-30,60)">
+    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="15" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">REVIL</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Ransomware brand returns to leak sites</text>
+<g transform="translate(936,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">PALANTIR</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Company posts controversial culture memo</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.4,1.2H8.8V1.6H8.4zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.4,1.2H12.8V1.6H12.4zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8.4,1.6H8.8V2H8.4zM9.2,1.6H9.6V2H9.2zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM6.4,3.6H6.8V4H6.4zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM6.4,4.8H6.8V5.2H6.4zM7.2,4.8H7.6V5.2H7.2zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM3.6,5.2H4V5.6H3.6zM4.4,5.2H4.8V5.6H4.4zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM6,5.6H6.4V6H6zM7.6,5.6H8V6H7.6zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.4,5.6H16.8V6H16.4zM16.8,5.6H17.2V6H16.8zM2.4,6H2.8V6.4H2.4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM6.4,6.4H6.8V6.8H6.4zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM6,6.8H6.4V7.2H6zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM9.2,6.8H9.6V7.2H9.2zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM8,7.6H8.4V8H8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.6,8.4H10V8.8H9.6zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM1.2,9.2H1.6V9.6H1.2zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.6,9.2H12V9.6H11.6zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM1.6,9.6H2V10H1.6zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.6,9.6H16V10H15.6zM16.8,9.6H17.2V10H16.8zM1.2,10H1.6V10.4H1.2zM2.4,10H2.8V10.4H2.4zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10.4,10H10.8V10.4H10.4zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM1.6,10.4H2V10.8H1.6zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM2,10.8H2.4V11.2H2zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4.8,12H5.2V12.4H4.8zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM2.8,12.4H3.2V12.8H2.8zM4,12.4H4.4V12.8H4zM4.8,12.4H5.2V12.8H4.8zM6,12.4H6.4V12.8H6zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM10,12.4H10.4V12.8H10zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM1.6,12.8H2V13.2H1.6zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.4,12.8H8.8V13.2H8.4zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM11.6,14H12V14.4H11.6zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12.4,14.4H12.8V14.8H12.4zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM9.2,14.8H9.6V15.2H9.2zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM8.8,15.2H9.2V15.6H8.8zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM6,15.6H6.4V16H6zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM8,15.6H8.4V16H8zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.2,15.6H11.6V16H11.2zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16,15.6H16.4V16H16zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-08-Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet.svg
+++ b/assets/images/2026-04-08-Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 08 2026 BOTNET CVE">
-  <title>Style A v3 APR 08 2026 BOTNET CVE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0d0613"/><stop offset="100%" stop-color="#1a0a14"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#1a0a14"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.34"/><stop offset="100%" stop-color="#0d0613" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#f59e0b" stop-opacity="0.32"/><stop offset="100%" stop-color="#1a0a14" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"><animate attributeName="stop-color" values="#f59e0b;#fbbf24;#dc2626;#f59e0b" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fbbf24"><animate attributeName="stop-color" values="#fbbf24;#ef4444;#f59e0b;#fbbf24" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#ef4444"><animate attributeName="stop-color" values="#ef4444;#dc2626;#fbbf24;#ef4444" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.9"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0d0613" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="50%" stop-color="#dc2626" stop-opacity="0.7"/><stop offset="100%" stop-color="#dc2626" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="1"/><stop offset="55%" stop-color="#f59e0b" stop-opacity="0.75"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.5"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fca5a5" stop-opacity="0.85"/><stop offset="100%" stop-color="#fca5a5" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="0.45"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.85"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f59e0b" stop-opacity="0.4"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="35%" stop-color="#dc2626" stop-opacity="0.95"/><stop offset="65%" stop-color="#f59e0b" stop-opacity="0.95"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="40%" stop-color="#fbbf24" stop-opacity="0.55"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#fbbf24"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#f59e0b" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="799.7" y1="387.0" x2="676.5" y2="207.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="799.7" y1="387.0" x2="922.1" y2="220.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="676.5" y1="207.9" x2="922.1" y2="220.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <line x1="676.5" y1="207.9" x2="658.3" y2="207.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="922.1" y1="220.7" x2="658.3" y2="207.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="922.1" y1="220.7" x2="692.7" y2="195.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="658.3" y1="207.8" x2="692.7" y2="195.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.2s" repeatCount="indefinite"/></line>
-  <line x1="658.3" y1="207.8" x2="727.3" y2="390.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="692.7" y1="195.3" x2="727.3" y2="390.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="692.7" y1="195.3" x2="814.8" y2="164.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="727.3" y1="390.2" x2="814.8" y2="164.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="727.3" y1="390.2" x2="716.7" y2="388.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="814.8" y1="164.4" x2="716.7" y2="388.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="814.8" y1="164.4" x2="997.3" y2="401.1" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="716.7" y1="388.7" x2="997.3" y2="401.1" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="716.7" y1="388.7" x2="922.2" y2="428.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="997.3" y1="401.1" x2="922.2" y2="428.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="997.3" y1="401.1" x2="1016.3" y2="268.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="922.2" y1="428.4" x2="1016.3" y2="268.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="922.2" y1="428.4" x2="983.0" y2="267.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="1016.3" y1="268.4" x2="983.0" y2="267.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="1016.3" y1="268.4" x2="665.3" y2="235.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="983.0" y1="267.2" x2="665.3" y2="235.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="983.0" y1="267.2" x2="856.9" y2="254.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="665.3" y1="235.3" x2="856.9" y2="254.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="665.3" y1="235.3" x2="889.5" y2="173.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="856.9" y1="254.4" x2="889.5" y2="173.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="856.9" y1="254.4" x2="797.9" y2="172.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="889.5" y1="173.2" x2="797.9" y2="172.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="889.5" y1="173.2" x2="615.0" y2="261.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="797.9" y1="172.3" x2="615.0" y2="261.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="797.9" y1="172.3" x2="721.5" y2="204.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="615.0" y1="261.4" x2="721.5" y2="204.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <circle cx="799.7" cy="387.0" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="799.7" cy="387.0" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="676.5" cy="207.9" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="676.5" cy="207.9" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="922.1" cy="220.7" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="922.1" cy="220.7" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="658.3" cy="207.8" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="658.3" cy="207.8" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="692.7" cy="195.3" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="692.7" cy="195.3" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="727.3" cy="390.2" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="727.3" cy="390.2" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="814.8" cy="164.4" r="11.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="814.8" cy="164.4" r="5.9" fill="url(#nodeCore)"><animate attributeName="r" values="5.9;7.9;5.9" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="716.7" cy="388.7" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="716.7" cy="388.7" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="997.3" cy="401.1" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="997.3" cy="401.1" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="922.2" cy="428.4" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="922.2" cy="428.4" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1016.3" cy="268.4" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1016.3" cy="268.4" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="983.0" cy="267.2" r="14.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="983.0" cy="267.2" r="8.6" fill="url(#nodeCore)"><animate attributeName="r" values="8.6;10.6;8.6" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="665.3" cy="235.3" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="665.3" cy="235.3" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.6s" repeatCount="indefinite"/></circle>
-  <circle cx="856.9" cy="254.4" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="856.9" cy="254.4" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="889.5" cy="173.2" r="12.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="889.5" cy="173.2" r="6.9" fill="url(#nodeCore)"><animate attributeName="r" values="6.9;8.9;6.9" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="797.9" cy="172.3" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="797.9" cy="172.3" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="615.0" cy="261.4" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="615.0" cy="261.4" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="721.5" cy="204.9" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="721.5" cy="204.9" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="904.5" cy="153.4" r="1.5" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="153.4;83.0;153.4" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1049.9" cy="259.2" r="1.9" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="259.2;196.4;259.2" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="946.2" cy="176.6" r="2.9" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="176.6;135.8;176.6" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="1022.2" cy="158.5" r="3.2" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="158.5;102.0;158.5" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="570.4" cy="398.8" r="2.2" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="398.8;352.0;398.8" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="556.2" cy="277.6" r="1.7" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="277.6;224.9;277.6" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="619.3" cy="106.8" r="1.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="106.8;29.1;106.8" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="663.0" cy="486.9" r="3.1" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="486.9;446.3;486.9" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="645.4" cy="244.2" r="2.9" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="244.2;176.8;244.2" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="603.4" cy="541.2" r="2.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="541.2;474.9;541.2" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1025.8" cy="465.8" r="2.2" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="465.8;408.8;465.8" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="516.4" cy="267.8" r="3.2" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="267.8;230.1;267.8" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.5s" repeatCount="indefinite"/></circle>
-  <circle cx="710.2" cy="149.5" r="3.0" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="149.5;101.4;149.5" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="495.0" cy="176.7" r="2.7" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="176.7;115.7;176.7" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#dc2626" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fbbf24" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#f59e0b" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#f59e0b" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fbbf24"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">BOTNET<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">CVE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">DOCKER</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">SPREAD</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#dc2626" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fbbf24"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fca5a5" letter-spacing="3.5" opacity="0.9">APR 08 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">BOTNET</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">CVE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#dc2626" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#f59e0b" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fbbf24" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#dc2626" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fca5a5" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fbbf24" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM8.8,0.8H9.2V1.2H8.8zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.8,1.2H5.2V1.6H4.8zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM12.8,1.2H13.2V1.6H12.8zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM10.4,1.6H10.8V2H10.4zM10.8,1.6H11.2V2H10.8zM11.2,1.6H11.6V2H11.2zM12.8,1.6H13.2V2H12.8zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.6,2H6V2.4H5.6zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM5.6,2.4H6V2.8H5.6zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM8,2.4H8.4V2.8H8zM10,2.4H10.4V2.8H10zM10.4,2.4H10.8V2.8H10.4zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM6,2.8H6.4V3.2H6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.6,3.6H6V4H5.6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2.4,4.8H2.8V5.2H2.4zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM7.2,4.8H7.6V5.2H7.2zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM14,4.8H14.4V5.2H14zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16.8,5.2H17.2V5.6H16.8zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM4,6H4.4V6.4H4zM4.8,6H5.2V6.4H4.8zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.8,6.4H5.2V6.8H4.8zM6,6.4H6.4V6.8H6zM6.8,6.4H7.2V6.8H6.8zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM9.2,6.4H9.6V6.8H9.2zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM5.6,6.8H6V7.2H5.6zM6.8,6.8H7.2V7.2H6.8zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM13.2,6.8H13.6V7.2H13.2zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4.8,7.2H5.2V7.6H4.8zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8,7.2H8.4V7.6H8zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM12.8,7.2H13.2V7.6H12.8zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4.8,8H5.2V8.4H4.8zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8.4,8.4H8.8V8.8H8.4zM9.6,8.4H10V8.8H9.6zM10.8,8.4H11.2V8.8H10.8zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM5.2,8.8H5.6V9.2H5.2zM5.6,8.8H6V9.2H5.6zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM9.6,8.8H10V9.2H9.6zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM3.6,9.2H4V9.6H3.6zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM5.2,10H5.6V10.4H5.2zM6.4,10H6.8V10.4H6.4zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM15.2,10H15.6V10.4H15.2zM2,10.4H2.4V10.8H2zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM1.2,12H1.6V12.4H1.2zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM6.4,12.4H6.8V12.8H6.4zM8.4,12.4H8.8V12.8H8.4zM9.6,12.4H10V12.8H9.6zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.8,13.2H9.2V13.6H8.8zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6.4,13.6H6.8V14H6.4zM6.8,13.6H7.2V14H6.8zM8,13.6H8.4V14H8zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM10,13.6H10.4V14H10zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.2,14.4H11.6V14.8H11.2zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM6,14.8H6.4V15.2H6zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM11.2,14.8H11.6V15.2H11.2zM12,14.8H12.4V15.2H12zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM6,16.8H6.4V17.2H6zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: APT router C2, AI cloud risk, container triage">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">APT</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Routers hijacked in global DNS campaign</text>
+<g transform="translate(576,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AI</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Identity gaps widen with autonomous agents</text>
+<g transform="translate(936,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">DOCKER</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Container runtime flaws require patches</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.6,1.2H6V1.6H5.6zM6.8,1.2H7.2V1.6H6.8zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM12.4,1.2H12.8V1.6H12.4zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM7.6,2H8V2.4H7.6zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.6,2.4H8V2.8H7.6zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM3.6,4.4H4V4.8H3.6zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM3.2,5.6H3.6V6H3.2zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.4,5.6H16.8V6H16.4zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12.4,6H12.8V6.4H12.4zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM3.6,6.8H4V7.2H3.6zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.6,6.8H8V7.2H7.6zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.2,7.6H1.6V8H1.2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM5.2,7.6H5.6V8H5.2zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM2,8.4H2.4V8.8H2zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM8.8,8.8H9.2V9.2H8.8zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM2,9.2H2.4V9.6H2zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM5.6,9.2H6V9.6H5.6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.8,9.2H9.2V9.6H8.8zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6,10.4H6.4V10.8H6zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM0.8,12H1.2V12.4H0.8zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.8,13.6H5.2V14H4.8zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM11.6,14H12V14.4H11.6zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.2,16H7.6V16.4H7.2zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM7.2,16.8H7.6V17.2H7.2zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-09-Tech_Security_Weekly_Digest_Cloud_Botnet_AI_Malware.svg
+++ b/assets/images/2026-04-09-Tech_Security_Weekly_Digest_Cloud_Botnet_AI_Malware.svg
@@ -1,145 +1,442 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 09 2026 BOTNET CLOUD">
-  <title>Style A v3 APR 09 2026 BOTNET CLOUD</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#040b1a"/><stop offset="100%" stop-color="#081029"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#081029"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.34"/><stop offset="100%" stop-color="#040b1a" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.32"/><stop offset="100%" stop-color="#081029" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"><animate attributeName="stop-color" values="#3b82f6;#60a5fa;#06b6d4;#3b82f6" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#60a5fa"><animate attributeName="stop-color" values="#60a5fa;#22d3ee;#3b82f6;#60a5fa" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#22d3ee"><animate attributeName="stop-color" values="#22d3ee;#06b6d4;#60a5fa;#22d3ee" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.9"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#040b1a" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="50%" stop-color="#06b6d4" stop-opacity="0.7"/><stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="1"/><stop offset="55%" stop-color="#3b82f6" stop-opacity="0.75"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.5"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a5f3fc" stop-opacity="0.85"/><stop offset="100%" stop-color="#a5f3fc" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0.45"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.85"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.4"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="35%" stop-color="#06b6d4" stop-opacity="0.95"/><stop offset="65%" stop-color="#3b82f6" stop-opacity="0.95"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0"/><stop offset="40%" stop-color="#60a5fa" stop-opacity="0.55"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#60a5fa"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#3b82f6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="692.1" y1="461.3" x2="810.3" y2="487.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="692.1" y1="461.3" x2="881.3" y2="216.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="810.3" y1="487.5" x2="881.3" y2="216.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <line x1="810.3" y1="487.5" x2="800.4" y2="429.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="881.3" y1="216.9" x2="800.4" y2="429.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="881.3" y1="216.9" x2="643.2" y2="368.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="800.4" y1="429.3" x2="643.2" y2="368.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="800.4" y1="429.3" x2="642.6" y2="268.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="643.2" y1="368.0" x2="642.6" y2="268.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="643.2" y1="368.0" x2="924.6" y2="338.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="642.6" y1="268.0" x2="924.6" y2="338.0" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="642.6" y1="268.0" x2="847.0" y2="228.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="924.6" y1="338.0" x2="847.0" y2="228.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="924.6" y1="338.0" x2="567.3" y2="328.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="847.0" y1="228.4" x2="567.3" y2="328.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="847.0" y1="228.4" x2="923.7" y2="352.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="567.3" y1="328.5" x2="923.7" y2="352.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="567.3" y1="328.5" x2="1007.6" y2="279.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="923.7" y1="352.7" x2="1007.6" y2="279.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="923.7" y1="352.7" x2="818.7" y2="245.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="1007.6" y1="279.5" x2="818.7" y2="245.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="1007.6" y1="279.5" x2="964.2" y2="314.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="818.7" y1="245.4" x2="964.2" y2="314.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="818.7" y1="245.4" x2="759.2" y2="402.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="964.2" y1="314.7" x2="759.2" y2="402.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="964.2" y1="314.7" x2="551.0" y2="370.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="759.2" y1="402.4" x2="551.0" y2="370.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="759.2" y1="402.4" x2="632.4" y2="318.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="551.0" y1="370.7" x2="632.4" y2="318.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="551.0" y1="370.7" x2="805.0" y2="243.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="632.4" y1="318.4" x2="805.0" y2="243.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="632.4" y1="318.4" x2="671.8" y2="463.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="805.0" y1="243.8" x2="671.8" y2="463.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <circle cx="692.1" cy="461.3" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="692.1" cy="461.3" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="810.3" cy="487.5" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="810.3" cy="487.5" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="881.3" cy="216.9" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="881.3" cy="216.9" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="800.4" cy="429.3" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="800.4" cy="429.3" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="643.2" cy="368.0" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="643.2" cy="368.0" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="642.6" cy="268.0" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="642.6" cy="268.0" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="924.6" cy="338.0" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="924.6" cy="338.0" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="847.0" cy="228.4" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="847.0" cy="228.4" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="567.3" cy="328.5" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="567.3" cy="328.5" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="923.7" cy="352.7" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="923.7" cy="352.7" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1007.6" cy="279.5" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1007.6" cy="279.5" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="818.7" cy="245.4" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="818.7" cy="245.4" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="964.2" cy="314.7" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="964.2" cy="314.7" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="759.2" cy="402.4" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="759.2" cy="402.4" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="551.0" cy="370.7" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="551.0" cy="370.7" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="632.4" cy="318.4" r="13.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="632.4" cy="318.4" r="7.1" fill="url(#nodeCore)"><animate attributeName="r" values="7.1;9.1;7.1" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="805.0" cy="243.8" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="805.0" cy="243.8" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="671.8" cy="463.7" r="13.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="671.8" cy="463.7" r="7.8" fill="url(#nodeCore)"><animate attributeName="r" values="7.8;9.8;7.8" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="795.2" cy="493.9" r="2.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="493.9;458.8;493.9" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="755.8" cy="158.6" r="2.0" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="158.6;101.5;158.6" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1085.5" cy="61.0" r="1.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="61.0;4.4;61.0" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="915.1" cy="65.7" r="1.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="65.7;-13.5;65.7" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="601.8" cy="418.7" r="2.7" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="418.7;339.6;418.7" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="741.7" cy="362.9" r="3.1" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="362.9;318.4;362.9" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="457.6" cy="286.3" r="2.3" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="286.3;209.8;286.3" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="424.3" cy="298.4" r="1.7" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="298.4;256.6;298.4" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="729.2" cy="432.6" r="2.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="432.6;384.7;432.6" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="541.9" cy="120.7" r="2.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="120.7;40.9;120.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="876.1" cy="481.4" r="3.0" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="481.4;424.0;481.4" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1030.2" cy="292.5" r="1.5" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="292.5;218.1;292.5" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="1139.5" cy="288.2" r="2.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="288.2;242.1;288.2" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="547.9" cy="351.2" r="1.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="351.2;288.3;351.2" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#06b6d4" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#60a5fa" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#3b82f6" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#3b82f6" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#60a5fa"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">BOTNET<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">CLOUD<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">MALWARE</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">C2</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#06b6d4" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#60a5fa"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#a5f3fc" letter-spacing="3.5" opacity="0.9">APR 09 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">BOTNET</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">CLOUD</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#06b6d4" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#3b82f6" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#60a5fa" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#06b6d4" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#a5f3fc" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#60a5fa" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.6,0.8H6V1.2H5.6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM6.4,1.2H6.8V1.6H6.4zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM7.2,3.6H7.6V4H7.2zM8,3.6H8.4V4H8zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.6,6H14V6.4H13.6zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.8,6.4H5.2V6.8H4.8zM5.6,6.4H6V6.8H5.6zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM8.8,6.4H9.2V6.8H8.8zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM8,6.8H8.4V7.2H8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM2,7.6H2.4V8H2zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM6.8,8H7.2V8.4H6.8zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM2.4,8.4H2.8V8.8H2.4zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM6,8.4H6.4V8.8H6zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.2,8.8H5.6V9.2H5.2zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.8,9.2H3.2V9.6H2.8zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM4,10H4.4V10.4H4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM1.2,10.4H1.6V10.8H1.2zM2,10.4H2.4V10.8H2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM2,11.2H2.4V11.6H2zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM5.6,11.2H6V11.6H5.6zM6.4,11.2H6.8V11.6H6.4zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.2,11.2H15.6V11.6H15.2zM1.2,11.6H1.6V12H1.2zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM5.6,11.6H6V12H5.6zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM16.8,11.6H17.2V12H16.8zM2,12H2.4V12.4H2zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM5.2,12.8H5.6V13.2H5.2zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8.4,12.8H8.8V13.2H8.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM10.8,15.2H11.2V15.6H10.8zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM6.4,15.6H6.8V16H6.4zM7.2,15.6H7.6V16H7.2zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.2,16.8H5.6V17.2H5.2zM7.2,16.8H7.6V17.2H7.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: cloud variant, IoT device botnet, router C2">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
   </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CHAOS</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Variant targets misconfigured cloud deployments</text>
+<g transform="translate(576,330)">
+  <!-- Industrial rack -->
+  <g transform="translate(-60,-100)">
+    <rect x="0" y="0" width="120" height="150" rx="4" fill="#0B132B" stroke="#E63946" stroke-width="2.4"/>
+    <!-- 1U rows -->
+    <rect x="6" y="8" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="30" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="52" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="74" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="96" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="118" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <!-- row LEDs blinking (red = vulnerable) -->
+    <circle cx="14" cy="17" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="17" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="61" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="61" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="105" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="105" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.5s" repeatCount="indefinite"/></circle>
+    <!-- serial ports (right side of each row) -->
+    <rect x="90" y="14" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="36" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="58" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="80" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="102" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="124" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <!-- progress bars of each row -->
+    <rect x="34" y="15" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="15" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="37" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="37" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="59" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="59" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="81" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="81" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="103" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="103" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="125" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="125" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <!-- Serial cable snaking out -->
+  <path d="M 70 -30 Q 100 -30 100 0 Q 100 30 70 30 Q 40 30 40 60" fill="none" stroke="#E63946" stroke-width="3" stroke-linecap="round">
+    <animate attributeName="stroke-dasharray" values="0 300;300 0" dur="4s" repeatCount="indefinite"/>
+  </path>
+  <circle cx="40" cy="60" r="4" fill="#E63946">
+    <animate attributeName="r" values="4;6;4" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Glowing vulnerability burst -->
+  <g transform="translate(-100,60)">
+    <circle cx="0" cy="0" r="10" fill="url(#glowRed)" opacity="0.7">
+      <animate attributeName="r" values="10;20;10" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <!-- crack star burst -->
+    <path d="M 0 -14 L 0 14 M -14 0 L 14 0 M -10 -10 L 10 10 M 10 -10 L -10 10"
+          stroke="#E63946" stroke-width="1.8" fill="none">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.5s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Exposure count beads (3 small circles, visual-only) -->
+  <circle cx="90" cy="-80" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.6s" repeatCount="indefinite"/></circle>
+  <circle cx="96" cy="-72" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="102" cy="-64" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="2.0s" repeatCount="indefinite"/></circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">MASJESU</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Rented botnet recruits home cameras</text>
+<g transform="translate(936,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">PRISMEX</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Router implant enables espionage persistence</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM4.4,4.8H4.8V5.2H4.4zM6.4,4.8H6.8V5.2H6.4zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM4.4,5.2H4.8V5.6H4.4zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM7.2,6.4H7.6V6.8H7.2zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM8,6.8H8.4V7.2H8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM7.6,7.2H8V7.6H7.6zM8,7.2H8.4V7.6H8zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM2,7.6H2.4V8H2zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6.8,7.6H7.2V8H6.8zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM10,7.6H10.4V8H10zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.6,8H6V8.4H5.6zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM2.4,8.4H2.8V8.8H2.4zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM1.2,8.8H1.6V9.2H1.2zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM2.8,9.2H3.2V9.6H2.8zM4,9.2H4.4V9.6H4zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.6,9.6H2V10H1.6zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM5.6,9.6H6V10H5.6zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM1.2,10H1.6V10.4H1.2zM4.8,10H5.2V10.4H4.8zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM0.8,10.4H1.2V10.8H0.8zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM0.8,10.8H1.2V11.2H0.8zM2,10.8H2.4V11.2H2zM2.8,10.8H3.2V11.2H2.8zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM5.6,11.2H6V11.6H5.6zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2.4,11.6H2.8V12H2.4zM4.4,11.6H4.8V12H4.4zM5.6,11.6H6V12H5.6zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM16.8,11.6H17.2V12H16.8zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM7.2,12.8H7.6V13.2H7.2zM8.4,12.8H8.8V13.2H8.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM10.8,15.2H11.2V15.6H10.8zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM6.4,15.6H6.8V16H6.4zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.8,16H5.2V16.4H4.8zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.2,16.8H5.6V17.2H5.2zM7.2,16.8H7.6V17.2H7.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-10-Tech_Security_Weekly_Digest_AI_Malware_Go_Agent.svg
+++ b/assets/images/2026-04-10-Tech_Security_Weekly_Digest_AI_Malware_Go_Agent.svg
@@ -1,145 +1,480 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 10 2026 AI AGENT">
-  <title>Style A v3 APR 10 2026 AI AGENT</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#04120b"/><stop offset="100%" stop-color="#071a14"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#071a14"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.34"/><stop offset="100%" stop-color="#04120b" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.32"/><stop offset="100%" stop-color="#071a14" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"><animate attributeName="stop-color" values="#84cc16;#bef264;#10b981;#84cc16" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#bef264"><animate attributeName="stop-color" values="#bef264;#34d399;#84cc16;#bef264" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#34d399"><animate attributeName="stop-color" values="#34d399;#10b981;#bef264;#34d399" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.9"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#04120b" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="50%" stop-color="#10b981" stop-opacity="0.7"/><stop offset="100%" stop-color="#10b981" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#bef264" stop-opacity="1"/><stop offset="55%" stop-color="#84cc16" stop-opacity="0.75"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#34d399" stop-opacity="0.5"/><stop offset="100%" stop-color="#34d399" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#d9f99d" stop-opacity="0.85"/><stop offset="100%" stop-color="#d9f99d" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#bef264" stop-opacity="0.45"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.85"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.4"/><stop offset="100%" stop-color="#bef264" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="35%" stop-color="#10b981" stop-opacity="0.95"/><stop offset="65%" stop-color="#84cc16" stop-opacity="0.95"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#bef264" stop-opacity="0"/><stop offset="40%" stop-color="#bef264" stop-opacity="0.55"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"/><stop offset="100%" stop-color="#bef264"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#84cc16" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="938.4" y1="427.6" x2="877.8" y2="309.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="938.4" y1="427.6" x2="645.9" y2="203.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="877.8" y1="309.0" x2="645.9" y2="203.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="877.8" y1="309.0" x2="908.4" y2="290.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="645.9" y1="203.0" x2="908.4" y2="290.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="645.9" y1="203.0" x2="723.3" y2="212.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="908.4" y1="290.0" x2="723.3" y2="212.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="908.4" y1="290.0" x2="627.0" y2="280.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="723.3" y1="212.8" x2="627.0" y2="280.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="723.3" y1="212.8" x2="848.8" y2="215.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="627.0" y1="280.8" x2="848.8" y2="215.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="627.0" y1="280.8" x2="568.2" y2="435.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="848.8" y1="215.1" x2="568.2" y2="435.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="848.8" y1="215.1" x2="954.1" y2="235.4" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="568.2" y1="435.6" x2="954.1" y2="235.4" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="568.2" y1="435.6" x2="855.5" y2="378.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="954.1" y1="235.4" x2="855.5" y2="378.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="954.1" y1="235.4" x2="612.8" y2="312.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="855.5" y1="378.0" x2="612.8" y2="312.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="855.5" y1="378.0" x2="972.7" y2="346.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="612.8" y1="312.7" x2="972.7" y2="346.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="612.8" y1="312.7" x2="595.8" y2="364.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="972.7" y1="346.5" x2="595.8" y2="364.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="972.7" y1="346.5" x2="820.7" y2="146.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="595.8" y1="364.3" x2="820.7" y2="146.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="595.8" y1="364.3" x2="868.7" y2="339.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="820.7" y1="146.3" x2="868.7" y2="339.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="820.7" y1="146.3" x2="741.9" y2="469.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="868.7" y1="339.5" x2="741.9" y2="469.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="868.7" y1="339.5" x2="789.6" y2="245.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="741.9" y1="469.3" x2="789.6" y2="245.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="741.9" y1="469.3" x2="956.8" y2="295.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="789.6" y1="245.1" x2="956.8" y2="295.0" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <circle cx="938.4" cy="427.6" r="11.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="938.4" cy="427.6" r="5.7" fill="url(#nodeCore)"><animate attributeName="r" values="5.7;7.7;5.7" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="877.8" cy="309.0" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="877.8" cy="309.0" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="645.9" cy="203.0" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="645.9" cy="203.0" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="908.4" cy="290.0" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="908.4" cy="290.0" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="723.3" cy="212.8" r="14.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="723.3" cy="212.8" r="8.6" fill="url(#nodeCore)"><animate attributeName="r" values="8.6;10.6;8.6" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="627.0" cy="280.8" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="627.0" cy="280.8" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="848.8" cy="215.1" r="13.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="848.8" cy="215.1" r="7.9" fill="url(#nodeCore)"><animate attributeName="r" values="7.9;9.9;7.9" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="568.2" cy="435.6" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="568.2" cy="435.6" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="954.1" cy="235.4" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="954.1" cy="235.4" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="855.5" cy="378.0" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="855.5" cy="378.0" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.6s" repeatCount="indefinite"/></circle>
-  <circle cx="612.8" cy="312.7" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="612.8" cy="312.7" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="972.7" cy="346.5" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="972.7" cy="346.5" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="595.8" cy="364.3" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="595.8" cy="364.3" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="820.7" cy="146.3" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="820.7" cy="146.3" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="868.7" cy="339.5" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="868.7" cy="339.5" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="741.9" cy="469.3" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="741.9" cy="469.3" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="789.6" cy="245.1" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="789.6" cy="245.1" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="956.8" cy="295.0" r="14.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="956.8" cy="295.0" r="8.6" fill="url(#nodeCore)"><animate attributeName="r" values="8.6;10.6;8.6" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="492.8" cy="186.9" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="186.9;116.2;186.9" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1058.7" cy="271.1" r="1.6" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="271.1;205.1;271.1" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1117.6" cy="457.6" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="457.6;397.8;457.6" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="620.2" cy="168.2" r="1.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="168.2;83.6;168.2" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="766.9" cy="340.4" r="2.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="340.4;276.7;340.4" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="599.9" cy="208.0" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="208.0;162.9;208.0" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.5s" repeatCount="indefinite"/></circle>
-  <circle cx="837.4" cy="354.4" r="1.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="354.4;271.0;354.4" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="877.6" cy="555.4" r="3.0" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="555.4;479.8;555.4" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="497.9" cy="252.6" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="252.6;193.4;252.6" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1123.5" cy="411.3" r="2.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="411.3;370.1;411.3" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="838.0" cy="422.3" r="1.6" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="422.3;379.9;422.3" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="832.3" cy="564.8" r="2.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="564.8;507.5;564.8" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="691.5" cy="73.1" r="2.4" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="73.1;23.9;73.1" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="589.7" cy="459.4" r="3.2" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="459.4;406.6;459.4" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#10b981" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#bef264" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#84cc16" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#84cc16" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#bef264"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">AI<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">AGENT<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">MALWARE</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">GO</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">SWARM</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#10b981" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#bef264"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#d9f99d" letter-spacing="3.5" opacity="0.9">APR 10 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">AI</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">AGENT</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#10b981" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#84cc16" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#bef264" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#10b981" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#d9f99d" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#bef264" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.8,1.2H5.2V1.6H4.8zM8,1.2H8.4V1.6H8zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM12.8,1.2H13.2V1.6H12.8zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.8,1.6H7.2V2H6.8zM7.6,1.6H8V2H7.6zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM10.4,1.6H10.8V2H10.4zM12.8,1.6H13.2V2H12.8zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6.4,2H6.8V2.4H6.4zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.8,2.4H5.2V2.8H4.8zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM10.4,2.4H10.8V2.8H10.4zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM5.2,2.8H5.6V3.2H5.2zM6,2.8H6.4V3.2H6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM14,4.8H14.4V5.2H14zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.2,5.2H15.6V5.6H15.2zM16.4,5.2H16.8V5.6H16.4zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6.8,6H7.2V6.4H6.8zM7.6,6H8V6.4H7.6zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM14.4,6H14.8V6.4H14.4zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM8.4,6.4H8.8V6.8H8.4zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.8,6.4H11.2V6.8H10.8zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM6,6.8H6.4V7.2H6zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM8,7.2H8.4V7.6H8zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12.8,7.2H13.2V7.6H12.8zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM2,7.6H2.4V8H2zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM0.8,8H1.2V8.4H0.8zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4.4,8H4.8V8.4H4.4zM5.2,8H5.6V8.4H5.2zM6.4,8H6.8V8.4H6.4zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.4,8.4H8.8V8.8H8.4zM9.2,8.4H9.6V8.8H9.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM5.6,8.8H6V9.2H5.6zM7.2,8.8H7.6V9.2H7.2zM8.8,8.8H9.2V9.2H8.8zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM3.6,10H4V10.4H3.6zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM0.8,10.4H1.2V10.8H0.8zM2,10.4H2.4V10.8H2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM4.8,10.8H5.2V11.2H4.8zM6,10.8H6.4V11.2H6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM6.4,11.2H6.8V11.6H6.4zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM2.4,11.6H2.8V12H2.4zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM16.4,12H16.8V12.4H16.4zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM4,12.4H4.4V12.8H4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.6,12.4H10V12.8H9.6zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM5.6,12.8H6V13.2H5.6zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8.4,12.8H8.8V13.2H8.4zM9.2,12.8H9.6V13.2H9.2zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM2,13.2H2.4V13.6H2zM3.6,13.2H4V13.6H3.6zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8.4,13.2H8.8V13.6H8.4zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM5.2,13.6H5.6V14H5.2zM6,13.6H6.4V14H6zM6.8,13.6H7.2V14H6.8zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM8.8,13.6H9.2V14H8.8zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM8,14.4H8.4V14.8H8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM10.8,14.4H11.2V14.8H10.8zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM10.4,14.8H10.8V15.2H10.4zM12,14.8H12.4V15.2H12zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM9.6,15.6H10V16H9.6zM11.2,15.6H11.6V16H11.2zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM5.2,16H5.6V16.4H5.2zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10.4,16H10.8V16.4H10.4zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM8,16.8H8.4V17.2H8zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: mobile SDK exposure, targeted C2, agentic AI cloud">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
   </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">ENGAGELAB</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">SDK flaw exposes millions of devices</text>
+<g transform="translate(576,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">LUCIDROOK</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Spear phish targets Taiwan nonprofit</text>
+<g transform="translate(936,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">MICROSOFT</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Agentic SOC workflow enters preview</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM12.8,1.2H13.2V1.6H12.8zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6.4,1.6H6.8V2H6.4zM7.6,1.6H8V2H7.6zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM10.4,1.6H10.8V2H10.4zM12.8,1.6H13.2V2H12.8zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM8.4,2.4H8.8V2.8H8.4zM9.6,2.4H10V2.8H9.6zM10.4,2.4H10.8V2.8H10.4zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM5.2,2.8H5.6V3.2H5.2zM6,2.8H6.4V3.2H6zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM14,4.8H14.4V5.2H14zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM6,5.2H6.4V5.6H6zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.2,5.2H15.6V5.6H15.2zM16.4,5.2H16.8V5.6H16.4zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.6,6H8V6.4H7.6zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM14.4,6H14.8V6.4H14.4zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM5.2,6.4H5.6V6.8H5.2zM6.4,6.4H6.8V6.8H6.4zM8.4,6.4H8.8V6.8H8.4zM8.8,6.4H9.2V6.8H8.8zM10,6.4H10.4V6.8H10zM10.8,6.4H11.2V6.8H10.8zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM5.2,6.8H5.6V7.2H5.2zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.2,7.2H1.6V7.6H1.2zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM8,7.2H8.4V7.6H8zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12.8,7.2H13.2V7.6H12.8zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM2,7.6H2.4V8H2zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM11.6,7.6H12V8H11.6zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM0.8,8H1.2V8.4H0.8zM1.6,8H2V8.4H1.6zM3.2,8H3.6V8.4H3.2zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4.8,8.4H5.2V8.8H4.8zM6,8.4H6.4V8.8H6zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM9.2,8.4H9.6V8.8H9.2zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM5.6,8.8H6V9.2H5.6zM7.2,8.8H7.6V9.2H7.2zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM2,9.2H2.4V9.6H2zM4,9.2H4.4V9.6H4zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM16.4,9.6H16.8V10H16.4zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2.4,10H2.8V10.4H2.4zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM16.4,12H16.8V12.4H16.4zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.6,12.4H10V12.8H9.6zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.6,12.4H14V12.8H13.6zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM7.2,12.8H7.6V13.2H7.2zM8.4,12.8H8.8V13.2H8.4zM9.2,12.8H9.6V13.2H9.2zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM3.6,13.2H4V13.6H3.6zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.6,13.2H8V13.6H7.6zM8.4,13.2H8.8V13.6H8.4zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM9.2,13.6H9.6V14H9.2zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.2,14H5.6V14.4H5.2zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM8,14.4H8.4V14.8H8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM10.8,14.4H11.2V14.8H10.8zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM5.2,14.8H5.6V15.2H5.2zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM10.4,14.8H10.8V15.2H10.4zM12,14.8H12.4V15.2H12zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM9.6,15.6H10V16H9.6zM11.2,15.6H11.6V16H11.2zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10.4,16H10.8V16.4H10.4zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM8,16.8H8.4V17.2H8zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-11-Tech_Security_Weekly_Digest_AI_Go_CVE_Update.svg
+++ b/assets/images/2026-04-11-Tech_Security_Weekly_Digest_AI_Go_CVE_Update.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 11 2026 CVE UPDATE">
-  <title>Style A v3 APR 11 2026 CVE UPDATE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0b0420"/><stop offset="100%" stop-color="#160829"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#160829"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.34"/><stop offset="100%" stop-color="#0b0420" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.32"/><stop offset="100%" stop-color="#160829" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"><animate attributeName="stop-color" values="#d946ef;#f0abfc;#8b5cf6;#d946ef" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#f0abfc"><animate attributeName="stop-color" values="#f0abfc;#a78bfa;#d946ef;#f0abfc" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#a78bfa"><animate attributeName="stop-color" values="#a78bfa;#8b5cf6;#f0abfc;#a78bfa" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.9"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0b0420" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="50%" stop-color="#8b5cf6" stop-opacity="0.7"/><stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="1"/><stop offset="55%" stop-color="#d946ef" stop-opacity="0.75"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.5"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.85"/><stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0.45"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.85"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.4"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="35%" stop-color="#8b5cf6" stop-opacity="0.95"/><stop offset="65%" stop-color="#d946ef" stop-opacity="0.95"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0"/><stop offset="40%" stop-color="#f0abfc" stop-opacity="0.55"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"/><stop offset="100%" stop-color="#f0abfc"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#d946ef" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="534.6" y1="347.1" x2="581.3" y2="185.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="534.6" y1="347.1" x2="666.1" y2="366.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="581.3" y1="185.7" x2="666.1" y2="366.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="581.3" y1="185.7" x2="806.2" y2="227.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="666.1" y1="366.5" x2="806.2" y2="227.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="666.1" y1="366.5" x2="882.1" y2="268.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="806.2" y1="227.4" x2="882.1" y2="268.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="806.2" y1="227.4" x2="747.1" y2="491.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="882.1" y1="268.2" x2="747.1" y2="491.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="882.1" y1="268.2" x2="525.4" y2="218.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="747.1" y1="491.4" x2="525.4" y2="218.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="747.1" y1="491.4" x2="924.4" y2="274.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="525.4" y1="218.6" x2="924.4" y2="274.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="525.4" y1="218.6" x2="738.4" y2="450.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="924.4" y1="274.1" x2="738.4" y2="450.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="924.4" y1="274.1" x2="914.1" y2="436.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="738.4" y1="450.2" x2="914.1" y2="436.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="738.4" y1="450.2" x2="814.2" y2="439.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="914.1" y1="436.5" x2="814.2" y2="439.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="914.1" y1="436.5" x2="778.0" y2="422.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="814.2" y1="439.5" x2="778.0" y2="422.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="814.2" y1="439.5" x2="866.7" y2="471.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="778.0" y1="422.7" x2="866.7" y2="471.0" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="778.0" y1="422.7" x2="754.9" y2="238.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="866.7" y1="471.0" x2="754.9" y2="238.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="866.7" y1="471.0" x2="657.9" y2="277.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="754.9" y1="238.5" x2="657.9" y2="277.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="754.9" y1="238.5" x2="824.5" y2="191.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="657.9" y1="277.8" x2="824.5" y2="191.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="657.9" y1="277.8" x2="854.7" y2="395.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="824.5" y1="191.1" x2="854.7" y2="395.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="824.5" y1="191.1" x2="623.7" y2="312.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="854.7" y1="395.2" x2="623.7" y2="312.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <circle cx="534.6" cy="347.1" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="534.6" cy="347.1" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="581.3" cy="185.7" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="581.3" cy="185.7" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="666.1" cy="366.5" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="666.1" cy="366.5" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="806.2" cy="227.4" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="806.2" cy="227.4" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="882.1" cy="268.2" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="882.1" cy="268.2" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="747.1" cy="491.4" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="747.1" cy="491.4" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="525.4" cy="218.6" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="525.4" cy="218.6" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="924.4" cy="274.1" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="924.4" cy="274.1" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="738.4" cy="450.2" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="738.4" cy="450.2" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="914.1" cy="436.5" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="914.1" cy="436.5" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="814.2" cy="439.5" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="814.2" cy="439.5" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="778.0" cy="422.7" r="14.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="778.0" cy="422.7" r="8.9" fill="url(#nodeCore)"><animate attributeName="r" values="8.9;10.9;8.9" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="866.7" cy="471.0" r="10.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="866.7" cy="471.0" r="4.4" fill="url(#nodeCore)"><animate attributeName="r" values="4.4;6.4;4.4" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="754.9" cy="238.5" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="754.9" cy="238.5" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="657.9" cy="277.8" r="13.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="657.9" cy="277.8" r="7.8" fill="url(#nodeCore)"><animate attributeName="r" values="7.8;9.8;7.8" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="824.5" cy="191.1" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="824.5" cy="191.1" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="854.7" cy="395.2" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="854.7" cy="395.2" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="623.7" cy="312.1" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="623.7" cy="312.1" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="609.0" cy="506.4" r="2.9" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="506.4;440.1;506.4" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="756.6" cy="317.3" r="2.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="317.3;236.9;317.3" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="595.9" cy="222.0" r="2.5" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="222.0;164.9;222.0" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="926.8" cy="566.5" r="3.1" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="566.5;529.4;566.5" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="617.6" cy="187.2" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="187.2;150.6;187.2" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="783.3" cy="400.1" r="2.9" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="400.1;333.7;400.1" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="646.0" cy="98.8" r="2.4" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="98.8;44.6;98.8" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1104.4" cy="435.5" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="435.5;372.4;435.5" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1060.1" cy="214.6" r="2.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="214.6;169.0;214.6" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1119.6" cy="173.2" r="2.1" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="173.2;121.3;173.2" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="999.6" cy="133.7" r="1.7" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="133.7;61.1;133.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="432.6" cy="145.6" r="2.6" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="145.6;103.0;145.6" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="797.7" cy="205.4" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="205.4;120.5;205.4" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="485.8" cy="119.7" r="2.3" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="119.7;36.3;119.7" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#8b5cf6" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#f0abfc" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#d946ef" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#d946ef" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#f0abfc"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">CVE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">UPDATE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">GO</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">PATCH</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#8b5cf6" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#f0abfc"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fbcfe8" letter-spacing="3.5" opacity="0.9">APR 11 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">CVE</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">UPDATE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#8b5cf6" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#d946ef" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#f0abfc" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#8b5cf6" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fbcfe8" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#f0abfc" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6.8,0.8H7.2V1.2H6.8zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.6,1.2H6V1.6H5.6zM6.4,1.2H6.8V1.6H6.4zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM2,5.2H2.4V5.6H2zM3.6,5.2H4V5.6H3.6zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM7.2,5.2H7.6V5.6H7.2zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM3.2,5.6H3.6V6H3.2zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.4,5.6H16.8V6H16.4zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.8,6.8H7.2V7.2H6.8zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM2.8,8.4H3.2V8.8H2.8zM4.4,8.4H4.8V8.8H4.4zM6.8,8.4H7.2V8.8H6.8zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM2,8.8H2.4V9.2H2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM7.2,8.8H7.6V9.2H7.2zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.8,9.2H17.2V9.6H16.8zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.6,9.6H16V10H15.6zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM4.4,11.6H4.8V12H4.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2,12.4H2.4V12.8H2zM2.8,12.4H3.2V12.8H2.8zM4.4,12.4H4.8V12.8H4.4zM5.2,12.4H5.6V12.8H5.2zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM5.6,13.2H6V13.6H5.6zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.8,14.8H5.2V15.2H4.8zM6.4,14.8H6.8V15.2H6.4zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM5.2,15.6H5.6V16H5.2zM6,15.6H6.4V16H6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM5.6,16.4H6V16.8H5.6zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: worm C2, browser triage, AI cloud threat">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">GLASSWORM</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Worm spreads through developer toolchains</text>
+<g transform="translate(576,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CHROME</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Browser session binding rollout advances</text>
+<g transform="translate(936,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">AI</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Extensions emerge as new AI channel</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6.4,1.2H6.8V1.6H6.4zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM2,5.2H2.4V5.6H2zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM5.6,5.2H6V5.6H5.6zM6.4,5.2H6.8V5.6H6.4zM7.2,5.2H7.6V5.6H7.2zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.4,5.6H16.8V6H16.4zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.6,6.4H2V6.8H1.6zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8,7.2H8.4V7.6H8zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM2.8,8.4H3.2V8.8H2.8zM4.8,8.4H5.2V8.8H4.8zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8.8,8.8H9.2V9.2H8.8zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.8,9.2H9.2V9.6H8.8zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.8,9.2H17.2V9.6H16.8zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.4,9.6H4.8V10H4.4zM5.2,9.6H5.6V10H5.2zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.6,9.6H16V10H15.6zM16.8,9.6H17.2V10H16.8zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM16.4,10H16.8V10.4H16.4zM1.2,10.4H1.6V10.8H1.2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4.8,12H5.2V12.4H4.8zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM5.2,12.4H5.6V12.8H5.2zM6.4,12.4H6.8V12.8H6.4zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM5.2,13.2H5.6V13.6H5.2zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4.4,13.6H4.8V14H4.4zM6,13.6H6.4V14H6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM11.6,14H12V14.4H11.6zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM6,15.6H6.4V16H6zM6.4,15.6H6.8V16H6.4zM7.2,15.6H7.6V16H7.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM5.2,16.4H5.6V16.8H5.2zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.6,16.8H6V17.2H5.6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-12-Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI.svg
+++ b/assets/images/2026-04-12-Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI.svg
@@ -1,145 +1,471 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 12 2026 GPT CLOUD">
-  <title>Style A v3 APR 12 2026 GPT CLOUD</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#160605"/><stop offset="100%" stop-color="#220708"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#220708"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.34"/><stop offset="100%" stop-color="#160605" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.32"/><stop offset="100%" stop-color="#220708" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ef4444"><animate attributeName="stop-color" values="#ef4444;#fb7185;#f97316;#ef4444" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fb7185"><animate attributeName="stop-color" values="#fb7185;#fb923c;#ef4444;#fb7185" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#fb923c"><animate attributeName="stop-color" values="#fb923c;#f97316;#fb7185;#fb923c" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.9"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#160605" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0"/><stop offset="50%" stop-color="#f97316" stop-opacity="0.7"/><stop offset="100%" stop-color="#f97316" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fb7185" stop-opacity="1"/><stop offset="55%" stop-color="#ef4444" stop-opacity="0.75"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fb923c" stop-opacity="0.5"/><stop offset="100%" stop-color="#fb923c" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fecaca" stop-opacity="0.85"/><stop offset="100%" stop-color="#fecaca" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fb7185" stop-opacity="0.45"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f97316" stop-opacity="0.85"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.4"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f97316" stop-opacity="0"/><stop offset="35%" stop-color="#f97316" stop-opacity="0.95"/><stop offset="65%" stop-color="#ef4444" stop-opacity="0.95"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fb7185" stop-opacity="0"/><stop offset="40%" stop-color="#fb7185" stop-opacity="0.55"/><stop offset="100%" stop-color="#fb7185" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ef4444"/><stop offset="100%" stop-color="#fb7185"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#f97316" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#ef4444" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#f97316" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="651.6" y1="462.7" x2="882.3" y2="263.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="651.6" y1="462.7" x2="877.0" y2="249.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="882.3" y1="263.7" x2="877.0" y2="249.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="882.3" y1="263.7" x2="972.6" y2="279.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="877.0" y1="249.6" x2="972.6" y2="279.9" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="877.0" y1="249.6" x2="592.8" y2="294.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="972.6" y1="279.9" x2="592.8" y2="294.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="972.6" y1="279.9" x2="793.8" y2="423.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="592.8" y1="294.5" x2="793.8" y2="423.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="592.8" y1="294.5" x2="591.8" y2="403.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="793.8" y1="423.5" x2="591.8" y2="403.1" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="793.8" y1="423.5" x2="976.1" y2="243.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="591.8" y1="403.1" x2="976.1" y2="243.6" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="591.8" y1="403.1" x2="520.6" y2="334.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="976.1" y1="243.6" x2="520.6" y2="334.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="976.1" y1="243.6" x2="983.3" y2="351.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="520.6" y1="334.3" x2="983.3" y2="351.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="520.6" y1="334.3" x2="837.2" y2="262.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="983.3" y1="351.3" x2="837.2" y2="262.3" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="983.3" y1="351.3" x2="512.8" y2="274.4" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="837.2" y1="262.3" x2="512.8" y2="274.4" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="837.2" y1="262.3" x2="747.1" y2="392.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="512.8" y1="274.4" x2="747.1" y2="392.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="512.8" y1="274.4" x2="838.8" y2="183.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="747.1" y1="392.8" x2="838.8" y2="183.8" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="747.1" y1="392.8" x2="964.2" y2="329.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="838.8" y1="183.8" x2="964.2" y2="329.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="838.8" y1="183.8" x2="818.1" y2="240.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="964.2" y1="329.5" x2="818.1" y2="240.5" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="964.2" y1="329.5" x2="670.2" y2="405.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="818.1" y1="240.5" x2="670.2" y2="405.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="818.1" y1="240.5" x2="624.2" y2="291.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <line x1="670.2" y1="405.7" x2="624.2" y2="291.7" stroke="#ef4444" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <circle cx="651.6" cy="462.7" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="651.6" cy="462.7" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="882.3" cy="263.7" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="882.3" cy="263.7" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="877.0" cy="249.6" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="877.0" cy="249.6" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="972.6" cy="279.9" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="972.6" cy="279.9" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="592.8" cy="294.5" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="592.8" cy="294.5" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="793.8" cy="423.5" r="11.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="793.8" cy="423.5" r="5.7" fill="url(#nodeCore)"><animate attributeName="r" values="5.7;7.7;5.7" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="591.8" cy="403.1" r="11.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="591.8" cy="403.1" r="5.0" fill="url(#nodeCore)"><animate attributeName="r" values="5.0;7.0;5.0" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="976.1" cy="243.6" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="976.1" cy="243.6" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="520.6" cy="334.3" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="520.6" cy="334.3" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="983.3" cy="351.3" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="983.3" cy="351.3" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="837.2" cy="262.3" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="837.2" cy="262.3" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="512.8" cy="274.4" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="512.8" cy="274.4" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="747.1" cy="392.8" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="747.1" cy="392.8" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="838.8" cy="183.8" r="14.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="838.8" cy="183.8" r="8.5" fill="url(#nodeCore)"><animate attributeName="r" values="8.5;10.5;8.5" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="964.2" cy="329.5" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="964.2" cy="329.5" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="818.1" cy="240.5" r="14.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="818.1" cy="240.5" r="8.3" fill="url(#nodeCore)"><animate attributeName="r" values="8.3;10.3;8.3" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="670.2" cy="405.7" r="10.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="670.2" cy="405.7" r="4.5" fill="url(#nodeCore)"><animate attributeName="r" values="4.5;6.5;4.5" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="624.2" cy="291.7" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="624.2" cy="291.7" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="543.5" cy="202.0" r="2.0" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="202.0;166.5;202.0" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="874.9" cy="120.4" r="1.8" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="120.4;62.8;120.4" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1000.4" cy="461.4" r="1.8" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="461.4;376.9;461.4" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="845.2" cy="61.3" r="2.1" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="61.3;-6.3;61.3" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1080.2" cy="259.6" r="2.0" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="259.6;201.8;259.6" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="805.5" cy="372.4" r="2.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="372.4;331.4;372.4" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="752.9" cy="432.5" r="3.0" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="432.5;374.3;432.5" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="883.2" cy="117.7" r="2.9" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="117.7;59.8;117.7" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="446.4" cy="243.6" r="3.0" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="243.6;184.5;243.6" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="865.1" cy="323.3" r="2.7" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="323.3;273.0;323.3" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="882.9" cy="556.4" r="2.1" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="556.4;509.7;556.4" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="967.9" cy="355.2" r="2.4" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="355.2;320.2;355.2" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="603.2" cy="230.3" r="2.8" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="230.3;167.9;230.3" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="580.0" cy="229.1" r="2.8" fill="#fb7185" opacity="0.75"><animate attributeName="cy" values="229.1;174.7;229.1" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#f97316" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fb7185" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#ef4444" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#ef4444" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fb7185"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">GPT<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">CLOUD<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">DATA</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#f97316" fill-opacity="0.12" stroke="#f97316" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fb7185" text-anchor="middle" letter-spacing="2">LEAK</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#ef4444" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#f97316" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fb7185"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fecaca" letter-spacing="3.5" opacity="0.9">APR 12 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">GPT</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">CLOUD</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#f97316" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#ef4444" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fb7185" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#ef4444" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#f97316" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#f97316" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fecaca" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fb7185" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM4.8,1.2H5.2V1.6H4.8zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM10,1.6H10.4V2H10zM10.8,1.6H11.2V2H10.8zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6.4,2H6.8V2.4H6.4zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.2,2H13.6V2.4H13.2zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM9.6,2.4H10V2.8H9.6zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM8.4,4H8.8V4.4H8.4zM9.2,4H9.6V4.4H9.2zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.8,4H15.2V4.4H14.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2.8,4.4H3.2V4.8H2.8zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM7.6,4.4H8V4.8H7.6zM9.2,4.4H9.6V4.8H9.2zM10.4,4.4H10.8V4.8H10.4zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12.4,4.4H12.8V4.8H12.4zM13.6,4.4H14V4.8H13.6zM15.6,4.4H16V4.8H15.6zM16,4.4H16.4V4.8H16zM0.8,4.8H1.2V5.2H0.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.4,4.8H8.8V5.2H8.4zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM10.8,4.8H11.2V5.2H10.8zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM15.6,4.8H16V5.2H15.6zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM4.4,5.2H4.8V5.6H4.4zM6.4,5.2H6.8V5.6H6.4zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.2,5.2H11.6V5.6H11.2zM12,5.2H12.4V5.6H12zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16,5.2H16.4V5.6H16zM16.4,5.2H16.8V5.6H16.4zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.2,5.6H9.6V6H9.2zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16.4,5.6H16.8V6H16.4zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM9.6,6H10V6.4H9.6zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.8,6H13.2V6.4H12.8zM13.6,6H14V6.4H13.6zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM0.8,6.4H1.2V6.8H0.8zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.6,6.4H6V6.8H5.6zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM10.4,6.4H10.8V6.8H10.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM4,6.8H4.4V7.2H4zM4.8,6.8H5.2V7.2H4.8zM6,6.8H6.4V7.2H6zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM10.8,6.8H11.2V7.2H10.8zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM14.8,6.8H15.2V7.2H14.8zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM6,7.2H6.4V7.6H6zM6.8,7.2H7.2V7.6H6.8zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM7.2,7.6H7.6V8H7.2zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM11.2,7.6H11.6V8H11.2zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM11.2,8H11.6V8.4H11.2zM12.8,8H13.2V8.4H12.8zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM4.8,8.4H5.2V8.8H4.8zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.6,8.4H10V8.8H9.6zM11.2,8.4H11.6V8.8H11.2zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM4.4,8.8H4.8V9.2H4.4zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM11.6,8.8H12V9.2H11.6zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2,9.2H2.4V9.6H2zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM12.4,9.2H12.8V9.6H12.4zM14.4,9.2H14.8V9.6H14.4zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.6,9.6H6V10H5.6zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM10.4,9.6H10.8V10H10.4zM10.8,9.6H11.2V10H10.8zM12,9.6H12.4V10H12zM13.2,9.6H13.6V10H13.2zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM1.6,10H2V10.4H1.6zM2.4,10H2.8V10.4H2.4zM4.4,10H4.8V10.4H4.4zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM8.8,10H9.2V10.4H8.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM10.8,10H11.2V10.4H10.8zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.8,10H13.2V10.4H12.8zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM16,10H16.4V10.4H16zM16.8,10H17.2V10.4H16.8zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.6,10.4H12V10.8H11.6zM12,10.4H12.4V10.8H12zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.4,10.4H14.8V10.8H14.4zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2,10.8H2.4V11.2H2zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM15.6,10.8H16V11.2H15.6zM16.8,10.8H17.2V11.2H16.8zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8.8,11.2H9.2V11.6H8.8zM10,11.2H10.4V11.6H10zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM3.6,11.6H4V12H3.6zM4.4,11.6H4.8V12H4.4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10.4,11.6H10.8V12H10.4zM10.8,11.6H11.2V12H10.8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM16.4,11.6H16.8V12H16.4zM1.2,12H1.6V12.4H1.2zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM6,12H6.4V12.4H6zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM8.4,12.4H8.8V12.8H8.4zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.2,12.4H13.6V12.8H13.2zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM7.6,12.8H8V13.2H7.6zM8.4,12.8H8.8V13.2H8.4zM8.8,12.8H9.2V13.2H8.8zM10.8,12.8H11.2V13.2H10.8zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14.8,12.8H15.2V13.2H14.8zM16,12.8H16.4V13.2H16zM16.4,12.8H16.8V13.2H16.4zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM6,13.2H6.4V13.6H6zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10.4,14H10.8V14.4H10.4zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.8,14H13.2V14.4H12.8zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM5.2,14.4H5.6V14.8H5.2zM7.6,14.4H8V14.8H7.6zM8.4,14.4H8.8V14.8H8.4zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6,14.8H6.4V15.2H6zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16,14.8H16.4V15.2H16zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM6.8,15.2H7.2V15.6H6.8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM11.6,15.2H12V15.6H11.6zM12,15.2H12.4V15.6H12zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16.4,15.2H16.8V15.6H16.4zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM12,15.6H12.4V16H12zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.4,15.6H14.8V16H14.4zM15.2,15.6H15.6V16H15.2zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10,16.4H10.4V16.8H10zM10.8,16.4H11.2V16.8H10.8zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.2,16.4H13.6V16.8H13.2zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.8,16.4H15.2V16.8H14.8zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: organisational report, crypto heist takedown, cloud AI rivalry">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
   </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CITIZENLAB</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Research ties tracking to ad data</text>
+<g transform="translate(576,330)">
+  <!-- Vault door -->
+  <g transform="translate(-70,-100)">
+    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
+    <!-- vault handle spokes rotating -->
+    <g transform="translate(60,60)">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="6s" repeatCount="indefinite"/>
+      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
+    </g>
+    <!-- crack in door -->
+    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Coins flying out -->
+  <g>
+    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Masked figure silhouette (right) -->
+  <g transform="translate(90,-20)">
+    <!-- head -->
+    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- mask band -->
+    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
+    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
+    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
+    <!-- body -->
+    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- arm reaching down -->
+    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="d"
+               values="M -14 -2 Q -30 20 -28 34;
+                       M -14 -2 Q -34 22 -36 38;
+                       M -14 -2 Q -30 20 -28 34"
+               dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <!-- holding coin -->
+    <circle cx="-28" cy="34" r="4" fill="#FFB703">
+      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Down arrow stream (loss) -->
+  <g transform="translate(-30,60)">
+    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="15" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">CRYPTO</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Thousands of fraud victims identified worldwide</text>
+<g transform="translate(936,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">CHATGPT</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Rival chatbots compete on reasoning</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.6,0.8H6V1.2H5.6zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.6,0.8H10V1.2H9.6zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12,1.2H12.4V1.6H12zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM10,1.6H10.4V2H10zM10.8,1.6H11.2V2H10.8zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6.4,2H6.8V2.4H6.4zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.8,2H13.2V2.4H12.8zM13.2,2H13.6V2.4H13.2zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM6,2.4H6.4V2.8H6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM10.4,2.8H10.8V3.2H10.4zM11.2,2.8H11.6V3.2H11.2zM11.6,2.8H12V3.2H11.6zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM8.4,4H8.8V4.4H8.4zM9.2,4H9.6V4.4H9.2zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM13.6,4H14V4.4H13.6zM14,4H14.4V4.4H14zM14.8,4H15.2V4.4H14.8zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM7.6,4.4H8V4.8H7.6zM9.2,4.4H9.6V4.8H9.2zM10.4,4.4H10.8V4.8H10.4zM10.8,4.4H11.2V4.8H10.8zM11.2,4.4H11.6V4.8H11.2zM12.4,4.4H12.8V4.8H12.4zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM14.8,4.4H15.2V4.8H14.8zM15.6,4.4H16V4.8H15.6zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM8.4,4.8H8.8V5.2H8.4zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM10.8,4.8H11.2V5.2H10.8zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM15.6,4.8H16V5.2H15.6zM16,4.8H16.4V5.2H16zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM6,5.2H6.4V5.6H6zM8,5.2H8.4V5.6H8zM9.2,5.2H9.6V5.6H9.2zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.2,5.2H11.6V5.6H11.2zM12,5.2H12.4V5.6H12zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16,5.2H16.4V5.6H16zM16.4,5.2H16.8V5.6H16.4zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.2,5.6H9.6V6H9.2zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16.4,5.6H16.8V6H16.4zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6.4,6H6.8V6.4H6.4zM7.2,6H7.6V6.4H7.2zM9.6,6H10V6.4H9.6zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM0.8,6.4H1.2V6.8H0.8zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM7.6,6.4H8V6.8H7.6zM8.8,6.4H9.2V6.8H8.8zM10.4,6.4H10.8V6.8H10.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.8,6.8H5.2V7.2H4.8zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM10.8,6.8H11.2V7.2H10.8zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM14.8,6.8H15.2V7.2H14.8zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM11.2,8H11.6V8.4H11.2zM12.8,8H13.2V8.4H12.8zM14,8H14.4V8.4H14zM14.4,8H14.8V8.4H14.4zM15.2,8H15.6V8.4H15.2zM16.8,8H17.2V8.4H16.8zM1.6,8.4H2V8.8H1.6zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.6,8.4H10V8.8H9.6zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.6,8.8H8V9.2H7.6zM8,8.8H8.4V9.2H8zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM11.6,8.8H12V9.2H11.6zM12.8,8.8H13.2V9.2H12.8zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM3.6,9.2H4V9.6H3.6zM5.6,9.2H6V9.6H5.6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM7.6,9.2H8V9.6H7.6zM8,9.2H8.4V9.6H8zM9.2,9.2H9.6V9.6H9.2zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM12.4,9.2H12.8V9.6H12.4zM14.4,9.2H14.8V9.6H14.4zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM10.4,9.6H10.8V10H10.4zM10.8,9.6H11.2V10H10.8zM12,9.6H12.4V10H12zM13.2,9.6H13.6V10H13.2zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM8.8,10H9.2V10.4H8.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM10.8,10H11.2V10.4H10.8zM11.2,10H11.6V10.4H11.2zM12,10H12.4V10.4H12zM12.8,10H13.2V10.4H12.8zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM16,10H16.4V10.4H16zM16.8,10H17.2V10.4H16.8zM1.6,10.4H2V10.8H1.6zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.6,10.4H12V10.8H11.6zM12,10.4H12.4V10.8H12zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.4,10.4H14.8V10.8H14.4zM14.8,10.4H15.2V10.8H14.8zM0.8,10.8H1.2V11.2H0.8zM1.6,10.8H2V11.2H1.6zM2.8,10.8H3.2V11.2H2.8zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM9.6,10.8H10V11.2H9.6zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12,10.8H12.4V11.2H12zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM15.6,10.8H16V11.2H15.6zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8.8,11.2H9.2V11.6H8.8zM10,11.2H10.4V11.6H10zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2.4,11.6H2.8V12H2.4zM4.4,11.6H4.8V12H4.4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10.4,11.6H10.8V12H10.4zM10.8,11.6H11.2V12H10.8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM16.4,11.6H16.8V12H16.4zM1.2,12H1.6V12.4H1.2zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM1.6,12.4H2V12.8H1.6zM2,12.4H2.4V12.8H2zM2.4,12.4H2.8V12.8H2.4zM4.4,12.4H4.8V12.8H4.4zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.8,12.4H7.2V12.8H6.8zM8.4,12.4H8.8V12.8H8.4zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8.4,12.8H8.8V13.2H8.4zM8.8,12.8H9.2V13.2H8.8zM10.8,12.8H11.2V13.2H10.8zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14.8,12.8H15.2V13.2H14.8zM16,12.8H16.4V13.2H16zM16.4,12.8H16.8V13.2H16.4zM16.8,12.8H17.2V13.2H16.8zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6,13.6H6.4V14H6zM6.8,13.6H7.2V14H6.8zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM9.2,13.6H9.6V14H9.2zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10.4,14H10.8V14.4H10.4zM12.8,14H13.2V14.4H12.8zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM8.4,14.4H8.8V14.8H8.4zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.4,14.8H6.8V15.2H6.4zM7.6,14.8H8V15.2H7.6zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16,14.8H16.4V15.2H16zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM6,15.2H6.4V15.6H6zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM11.6,15.2H12V15.6H11.6zM12,15.2H12.4V15.6H12zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16.4,15.2H16.8V15.6H16.4zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6.8,15.6H7.2V16H6.8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM12,15.6H12.4V16H12zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.4,15.6H14.8V16H14.4zM15.2,15.6H15.6V16H15.2zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10,16H10.4V16.4H10zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6,16.4H6.4V16.8H6zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10,16.4H10.4V16.8H10zM10.8,16.4H11.2V16.8H10.8zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.2,16.4H13.6V16.8H13.2zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.8,16.4H15.2V16.8H14.8zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-13-Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust.svg
+++ b/assets/images/2026-04-13-Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust.svg
@@ -1,145 +1,447 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 13 2026 ZERO DAY">
-  <title>Style A v3 APR 13 2026 ZERO DAY</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#021218"/><stop offset="100%" stop-color="#03171e"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#03171e"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.34"/><stop offset="100%" stop-color="#021218" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.32"/><stop offset="100%" stop-color="#03171e" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0ea5e9"><animate attributeName="stop-color" values="#0ea5e9;#7dd3fc;#14b8a6;#0ea5e9" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#7dd3fc"><animate attributeName="stop-color" values="#7dd3fc;#2dd4bf;#0ea5e9;#7dd3fc" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#2dd4bf"><animate attributeName="stop-color" values="#2dd4bf;#14b8a6;#7dd3fc;#2dd4bf" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.9"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#021218" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0"/><stop offset="50%" stop-color="#14b8a6" stop-opacity="0.7"/><stop offset="100%" stop-color="#14b8a6" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="1"/><stop offset="55%" stop-color="#0ea5e9" stop-opacity="0.75"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#2dd4bf" stop-opacity="0.5"/><stop offset="100%" stop-color="#2dd4bf" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#bae6fd" stop-opacity="0.85"/><stop offset="100%" stop-color="#bae6fd" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="0.45"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0.85"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.4"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#14b8a6" stop-opacity="0"/><stop offset="35%" stop-color="#14b8a6" stop-opacity="0.95"/><stop offset="65%" stop-color="#0ea5e9" stop-opacity="0.95"/><stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#7dd3fc" stop-opacity="0"/><stop offset="40%" stop-color="#7dd3fc" stop-opacity="0.55"/><stop offset="100%" stop-color="#7dd3fc" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0ea5e9"/><stop offset="100%" stop-color="#7dd3fc"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#14b8a6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#0ea5e9" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#14b8a6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="758.2" y1="434.8" x2="782.5" y2="185.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="758.2" y1="434.8" x2="774.1" y2="491.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="782.5" y1="185.5" x2="774.1" y2="491.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="782.5" y1="185.5" x2="903.1" y2="197.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="774.1" y1="491.7" x2="903.1" y2="197.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="774.1" y1="491.7" x2="610.9" y2="321.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="903.1" y1="197.0" x2="610.9" y2="321.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="903.1" y1="197.0" x2="673.1" y2="149.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="610.9" y1="321.8" x2="673.1" y2="149.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="610.9" y1="321.8" x2="712.0" y2="246.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="673.1" y1="149.5" x2="712.0" y2="246.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="673.1" y1="149.5" x2="662.2" y2="251.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="712.0" y1="246.9" x2="662.2" y2="251.8" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="712.0" y1="246.9" x2="691.1" y2="239.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="662.2" y1="251.8" x2="691.1" y2="239.9" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="662.2" y1="251.8" x2="671.0" y2="219.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="691.1" y1="239.9" x2="671.0" y2="219.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="691.1" y1="239.9" x2="668.8" y2="268.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="671.0" y1="219.1" x2="668.8" y2="268.5" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="671.0" y1="219.1" x2="917.8" y2="349.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="668.8" y1="268.5" x2="917.8" y2="349.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="668.8" y1="268.5" x2="962.4" y2="298.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="917.8" y1="349.0" x2="962.4" y2="298.0" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="917.8" y1="349.0" x2="613.2" y2="449.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="962.4" y1="298.0" x2="613.2" y2="449.2" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="962.4" y1="298.0" x2="826.6" y2="208.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="613.2" y1="449.2" x2="826.6" y2="208.7" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="613.2" y1="449.2" x2="960.7" y2="213.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="826.6" y1="208.7" x2="960.7" y2="213.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="826.6" y1="208.7" x2="654.7" y2="427.4" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="960.7" y1="213.1" x2="654.7" y2="427.4" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="960.7" y1="213.1" x2="905.6" y2="303.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="654.7" y1="427.4" x2="905.6" y2="303.1" stroke="#0ea5e9" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <circle cx="758.2" cy="434.8" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="758.2" cy="434.8" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="782.5" cy="185.5" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="782.5" cy="185.5" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="774.1" cy="491.7" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="774.1" cy="491.7" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="903.1" cy="197.0" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="903.1" cy="197.0" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="610.9" cy="321.8" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="610.9" cy="321.8" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="673.1" cy="149.5" r="12.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="673.1" cy="149.5" r="6.9" fill="url(#nodeCore)"><animate attributeName="r" values="6.9;8.9;6.9" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="712.0" cy="246.9" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="712.0" cy="246.9" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="662.2" cy="251.8" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="662.2" cy="251.8" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="691.1" cy="239.9" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="691.1" cy="239.9" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="671.0" cy="219.1" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="671.0" cy="219.1" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="668.8" cy="268.5" r="13.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="668.8" cy="268.5" r="7.9" fill="url(#nodeCore)"><animate attributeName="r" values="7.9;9.9;7.9" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="917.8" cy="349.0" r="12.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="917.8" cy="349.0" r="6.9" fill="url(#nodeCore)"><animate attributeName="r" values="6.9;8.9;6.9" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="962.4" cy="298.0" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="962.4" cy="298.0" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="613.2" cy="449.2" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="613.2" cy="449.2" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="826.6" cy="208.7" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="826.6" cy="208.7" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="960.7" cy="213.1" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="960.7" cy="213.1" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="654.7" cy="427.4" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="654.7" cy="427.4" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="905.6" cy="303.1" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="905.6" cy="303.1" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="939.9" cy="437.8" r="2.4" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="437.8;383.8;437.8" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1032.0" cy="102.8" r="2.5" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="102.8;31.4;102.8" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="874.2" cy="84.8" r="2.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="84.8;5.0;84.8" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="586.4" cy="331.4" r="2.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="331.4;283.2;331.4" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="717.7" cy="207.8" r="1.8" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="207.8;131.7;207.8" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1139.1" cy="140.0" r="3.1" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="140.0;72.4;140.0" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="712.2" cy="165.9" r="2.9" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="165.9;125.9;165.9" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="864.9" cy="149.3" r="1.7" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="149.3;94.8;149.3" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="989.0" cy="520.7" r="2.9" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="520.7;437.7;520.7" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1137.2" cy="310.6" r="1.7" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="310.6;266.4;310.6" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="983.7" cy="88.1" r="1.9" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="88.1;26.3;88.1" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1055.6" cy="510.4" r="2.8" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="510.4;452.8;510.4" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="983.4" cy="421.3" r="2.6" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="421.3;362.9;421.3" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="742.8" cy="542.3" r="2.0" fill="#7dd3fc" opacity="0.75"><animate attributeName="cy" values="542.3;498.4;542.3" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#14b8a6" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#7dd3fc" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#0ea5e9" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#0ea5e9" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#7dd3fc"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">ZERO<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">DAY<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">CVE</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">PATCH</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#14b8a6" fill-opacity="0.12" stroke="#14b8a6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#7dd3fc" text-anchor="middle" letter-spacing="2">RUST</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#0ea5e9" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#14b8a6" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#7dd3fc"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#bae6fd" letter-spacing="3.5" opacity="0.9">APR 13 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">ZERO</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">DAY</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#14b8a6" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#0ea5e9" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#7dd3fc" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#0ea5e9" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#14b8a6" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#14b8a6" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#bae6fd" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#7dd3fc" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.8,1.2H5.2V1.6H4.8zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM10,1.2H10.4V1.6H10zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM5.6,1.6H6V2H5.6zM7.6,1.6H8V2H7.6zM8.8,1.6H9.2V2H8.8zM10.4,1.6H10.8V2H10.4zM10.8,1.6H11.2V2H10.8zM11.2,1.6H11.6V2H11.2zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM10.4,2.4H10.8V2.8H10.4zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM14,4.8H14.4V5.2H14zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM2,5.2H2.4V5.6H2zM2.8,5.2H3.2V5.6H2.8zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM5.6,5.2H6V5.6H5.6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.2,5.2H15.6V5.6H15.2zM16.4,5.2H16.8V5.6H16.4zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM4,6H4.4V6.4H4zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM8.8,6H9.2V6.4H8.8zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.8,6H13.2V6.4H12.8zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM2.4,6.4H2.8V6.8H2.4zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.8,6.4H7.2V6.8H6.8zM8.4,6.4H8.8V6.8H8.4zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM10,6.4H10.4V6.8H10zM10.8,6.4H11.2V6.8H10.8zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM8,6.8H8.4V7.2H8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM6,7.2H6.4V7.6H6zM7.2,7.2H7.6V7.6H7.2zM8,7.2H8.4V7.6H8zM9.6,7.2H10V7.6H9.6zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM5.2,7.6H5.6V8H5.2zM6,7.6H6.4V8H6zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM10.8,7.6H11.2V8H10.8zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM3.6,8.4H4V8.8H3.6zM6,8.4H6.4V8.8H6zM6.8,8.4H7.2V8.8H6.8zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM9.2,8.4H9.6V8.8H9.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM5.6,8.8H6V9.2H5.6zM6,8.8H6.4V9.2H6zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2.4,9.2H2.8V9.6H2.4zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.6,9.6H2V10H1.6zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.4,9.6H16.8V10H16.4zM0.8,10H1.2V10.4H0.8zM2,10H2.4V10.4H2zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10,10H10.4V10.4H10zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM15.2,10H15.6V10.4H15.2zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM1.2,10.4H1.6V10.8H1.2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.4,10.4H16.8V10.8H16.4zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2.4,11.6H2.8V12H2.4zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.8,12H5.2V12.4H4.8zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM16.4,12H16.8V12.4H16.4zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.6,12.4H10V12.8H9.6zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM6,12.8H6.4V13.2H6zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.4,12.8H8.8V13.2H8.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.4,13.2H8.8V13.6H8.4zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM6.8,13.6H7.2V14H6.8zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM10,13.6H10.4V14H10zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM6.8,14H7.2V14.4H6.8zM7.6,14H8V14.4H7.6zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.8,14.4H7.2V14.8H6.8zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8.8,14.8H9.2V15.2H8.8zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM12,14.8H12.4V15.2H12zM12.8,14.8H13.2V15.2H12.8zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM6,15.2H6.4V15.6H6zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM9.2,15.2H9.6V15.6H9.2zM10.8,15.2H11.2V15.6H10.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM9.6,15.6H10V16H9.6zM11.2,15.6H11.6V16H11.2zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10.4,16H10.8V16.4H10.4zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM5.6,16.8H6V17.2H5.6zM6.4,16.8H6.8V17.2H6.4zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: tampered downloads, model RCE, CVE exploit triage">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Industrial rack -->
+  <g transform="translate(-60,-100)">
+    <rect x="0" y="0" width="120" height="150" rx="4" fill="#0B132B" stroke="#E63946" stroke-width="2.4"/>
+    <!-- 1U rows -->
+    <rect x="6" y="8" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="30" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="52" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="74" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="96" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="118" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <!-- row LEDs blinking (red = vulnerable) -->
+    <circle cx="14" cy="17" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="17" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="61" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="61" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="105" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="105" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.5s" repeatCount="indefinite"/></circle>
+    <!-- serial ports (right side of each row) -->
+    <rect x="90" y="14" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="36" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="58" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="80" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="102" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="124" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <!-- progress bars of each row -->
+    <rect x="34" y="15" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="15" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="37" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="37" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="59" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="59" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="81" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="81" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="103" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="103" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="125" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="125" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2.5s" repeatCount="indefinite"/></rect>
   </g>
+  <!-- Serial cable snaking out -->
+  <path d="M 70 -30 Q 100 -30 100 0 Q 100 30 70 30 Q 40 30 40 60" fill="none" stroke="#E63946" stroke-width="3" stroke-linecap="round">
+    <animate attributeName="stroke-dasharray" values="0 300;300 0" dur="4s" repeatCount="indefinite"/>
+  </path>
+  <circle cx="40" cy="60" r="4" fill="#E63946">
+    <animate attributeName="r" values="4;6;4" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Glowing vulnerability burst -->
+  <g transform="translate(-100,60)">
+    <circle cx="0" cy="0" r="10" fill="url(#glowRed)" opacity="0.7">
+      <animate attributeName="r" values="10;20;10" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <!-- crack star burst -->
+    <path d="M 0 -14 L 0 14 M -14 0 L 14 0 M -10 -10 L 10 10 M 10 -10 L -10 10"
+          stroke="#E63946" stroke-width="1.8" fill="none">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.5s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Exposure count beads (3 small circles, visual-only) -->
+  <circle cx="90" cy="-80" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.6s" repeatCount="indefinite"/></circle>
+  <circle cx="96" cy="-72" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="102" cy="-64" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="2.0s" repeatCount="indefinite"/></circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">CPUZ</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Tampered utility installers ship hidden RAT</text>
+<g transform="translate(576,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
+  </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">MARIMO</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Preauth notebook RCE under active exploitation</text>
+<g transform="translate(936,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">ADOBE</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Reader flaw delivers wiper payload</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM10.4,1.2H10.8V1.6H10.4zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6.4,2H6.8V2.4H6.4zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.2,2.8H5.6V3.2H5.2zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM6,3.6H6.4V4H6zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.8,4.8H5.2V5.2H4.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM8.8,5.6H9.2V6H8.8zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM1.2,6H1.6V6.4H1.2zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM6.4,6.4H6.8V6.8H6.4zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM8,6.8H8.4V7.2H8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6.4,7.2H6.8V7.6H6.4zM7.6,7.2H8V7.6H7.6zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM6,7.6H6.4V8H6zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.6,8H2V8.4H1.6zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.6,8H10V8.4H9.6zM10.8,8H11.2V8.4H10.8zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM5.2,8.4H5.6V8.8H5.2zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM8.8,8.4H9.2V8.8H8.8zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM8,8.8H8.4V9.2H8zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM4,9.2H4.4V9.6H4zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM3.6,10H4V10.4H3.6zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM1.6,10.8H2V11.2H1.6zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.2,11.2H15.6V11.6H15.2zM1.6,11.6H2V12H1.6zM2.4,11.6H2.8V12H2.4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.4,11.6H16.8V12H16.4zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2,12H2.4V12.4H2zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM0.8,12.4H1.2V12.8H0.8zM2,12.4H2.4V12.8H2zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM8,12.4H8.4V12.8H8zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM5.2,12.8H5.6V13.2H5.2zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM8,12.8H8.4V13.2H8zM8.4,12.8H8.8V13.2H8.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4.8,13.2H5.2V13.6H4.8zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM8.4,13.2H8.8V13.6H8.4zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM13.2,13.2H13.6V13.6H13.2zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM6.8,13.6H7.2V14H6.8zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM5.2,14H5.6V14.4H5.2zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM9.6,14H10V14.4H9.6zM10,14H10.4V14.4H10zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM5.2,14.4H5.6V14.8H5.2zM6,14.4H6.4V14.8H6zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM11.2,14.4H11.6V14.8H11.2zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM5.2,14.8H5.6V15.2H5.2zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM9.2,15.2H9.6V15.6H9.2zM10.8,15.2H11.2V15.6H10.8zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM5.2,15.6H5.6V16H5.2zM5.6,15.6H6V16H5.6zM6.8,15.6H7.2V16H6.8zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM9.6,15.6H10V16H9.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.8,16H5.2V16.4H4.8zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.2,16.8H5.6V17.2H5.2zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-14-Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data.svg
+++ b/assets/images/2026-04-14-Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 14 2026 THREAT AI">
-  <title>Style A v3 APR 14 2026 THREAT AI</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#120d04"/><stop offset="100%" stop-color="#1c1608"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#1c1608"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.34"/><stop offset="100%" stop-color="#120d04" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#ca8a04" stop-opacity="0.32"/><stop offset="100%" stop-color="#1c1608" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ca8a04"><animate attributeName="stop-color" values="#ca8a04;#fde047;#eab308;#ca8a04" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fde047"><animate attributeName="stop-color" values="#fde047;#facc15;#ca8a04;#fde047" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#facc15"><animate attributeName="stop-color" values="#facc15;#eab308;#fde047;#facc15" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.9"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#120d04" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0"/><stop offset="50%" stop-color="#eab308" stop-opacity="0.7"/><stop offset="100%" stop-color="#eab308" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fde047" stop-opacity="1"/><stop offset="55%" stop-color="#ca8a04" stop-opacity="0.75"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#facc15" stop-opacity="0.5"/><stop offset="100%" stop-color="#facc15" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fef08a" stop-opacity="0.85"/><stop offset="100%" stop-color="#fef08a" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fde047" stop-opacity="0.45"/><stop offset="100%" stop-color="#fde047" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#eab308" stop-opacity="0.85"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#ca8a04" stop-opacity="0.4"/><stop offset="100%" stop-color="#fde047" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#eab308" stop-opacity="0"/><stop offset="35%" stop-color="#eab308" stop-opacity="0.95"/><stop offset="65%" stop-color="#ca8a04" stop-opacity="0.95"/><stop offset="100%" stop-color="#ca8a04" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fde047" stop-opacity="0"/><stop offset="40%" stop-color="#fde047" stop-opacity="0.55"/><stop offset="100%" stop-color="#fde047" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#ca8a04"/><stop offset="100%" stop-color="#fde047"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#eab308" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#ca8a04" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#eab308" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="814.5" y1="449.2" x2="750.6" y2="488.1" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="814.5" y1="449.2" x2="912.0" y2="412.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="750.6" y1="488.1" x2="912.0" y2="412.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="750.6" y1="488.1" x2="580.7" y2="315.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="912.0" y1="412.4" x2="580.7" y2="315.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="912.0" y1="412.4" x2="913.0" y2="375.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="580.7" y1="315.4" x2="913.0" y2="375.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="580.7" y1="315.4" x2="835.7" y2="182.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="913.0" y1="375.7" x2="835.7" y2="182.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="913.0" y1="375.7" x2="881.9" y2="447.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="835.7" y1="182.9" x2="881.9" y2="447.7" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="835.7" y1="182.9" x2="855.0" y2="481.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="881.9" y1="447.7" x2="855.0" y2="481.8" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="881.9" y1="447.7" x2="1011.4" y2="288.0" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="855.0" y1="481.8" x2="1011.4" y2="288.0" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="855.0" y1="481.8" x2="591.6" y2="290.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="1011.4" y1="288.0" x2="591.6" y2="290.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="1011.4" y1="288.0" x2="509.8" y2="274.2" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="591.6" y1="290.6" x2="509.8" y2="274.2" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="591.6" y1="290.6" x2="734.4" y2="484.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="509.8" y1="274.2" x2="734.4" y2="484.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="509.8" y1="274.2" x2="506.4" y2="347.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="734.4" y1="484.6" x2="506.4" y2="347.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="734.4" y1="484.6" x2="879.8" y2="239.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="506.4" y1="347.5" x2="879.8" y2="239.9" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="506.4" y1="347.5" x2="700.7" y2="200.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="879.8" y1="239.9" x2="700.7" y2="200.5" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="879.8" y1="239.9" x2="859.6" y2="171.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="700.7" y1="200.5" x2="859.6" y2="171.4" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="700.7" y1="200.5" x2="992.2" y2="347.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="859.6" y1="171.4" x2="992.2" y2="347.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <line x1="859.6" y1="171.4" x2="727.5" y2="240.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="992.2" y1="347.6" x2="727.5" y2="240.6" stroke="#ca8a04" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <circle cx="814.5" cy="449.2" r="12.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="814.5" cy="449.2" r="6.6" fill="url(#nodeCore)"><animate attributeName="r" values="6.6;8.6;6.6" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="750.6" cy="488.1" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="750.6" cy="488.1" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="912.0" cy="412.4" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="912.0" cy="412.4" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="580.7" cy="315.4" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="580.7" cy="315.4" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="913.0" cy="375.7" r="11.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="913.0" cy="375.7" r="5.7" fill="url(#nodeCore)"><animate attributeName="r" values="5.7;7.7;5.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="835.7" cy="182.9" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="835.7" cy="182.9" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="2.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.7s" repeatCount="indefinite"/></circle>
-  <circle cx="881.9" cy="447.7" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="881.9" cy="447.7" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="855.0" cy="481.8" r="11.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="855.0" cy="481.8" r="5.9" fill="url(#nodeCore)"><animate attributeName="r" values="5.9;7.9;5.9" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1011.4" cy="288.0" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1011.4" cy="288.0" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="591.6" cy="290.6" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="591.6" cy="290.6" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="509.8" cy="274.2" r="10.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="509.8" cy="274.2" r="4.7" fill="url(#nodeCore)"><animate attributeName="r" values="4.7;6.7;4.7" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="734.4" cy="484.6" r="14.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="734.4" cy="484.6" r="8.3" fill="url(#nodeCore)"><animate attributeName="r" values="8.3;10.3;8.3" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="506.4" cy="347.5" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="506.4" cy="347.5" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="879.8" cy="239.9" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="879.8" cy="239.9" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="700.7" cy="200.5" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="700.7" cy="200.5" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="859.6" cy="171.4" r="13.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="859.6" cy="171.4" r="7.3" fill="url(#nodeCore)"><animate attributeName="r" values="7.3;9.3;7.3" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="992.2" cy="347.6" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="992.2" cy="347.6" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="727.5" cy="240.6" r="13.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="727.5" cy="240.6" r="7.1" fill="url(#nodeCore)"><animate attributeName="r" values="7.1;9.1;7.1" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="773.6" cy="560.6" r="2.0" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="560.6;525.6;560.6" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="1084.5" cy="93.2" r="1.6" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="93.2;33.2;93.2" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="423.4" cy="354.2" r="2.2" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="354.2;269.9;354.2" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1125.2" cy="284.4" r="2.4" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="284.4;234.8;284.4" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="922.1" cy="332.2" r="2.7" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="332.2;277.1;332.2" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1027.4" cy="509.8" r="3.0" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="509.8;439.3;509.8" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="603.0" cy="169.1" r="2.9" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="169.1;92.2;169.1" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="505.0" cy="248.3" r="1.6" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="248.3;168.6;248.3" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="878.0" cy="92.1" r="3.0" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="92.1;41.4;92.1" dur="4.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1053.5" cy="260.3" r="1.7" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="260.3;177.6;260.3" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="451.5" cy="566.7" r="2.3" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="566.7;515.2;566.7" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="955.2" cy="493.5" r="2.1" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="493.5;454.7;493.5" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1012.8" cy="416.1" r="1.6" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="416.1;380.1;416.1" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="848.8" cy="126.1" r="1.6" fill="#fde047" opacity="0.75"><animate attributeName="cy" values="126.1;80.6;126.1" dur="5.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.6s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#eab308" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fde047" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#ca8a04" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#ca8a04" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fde047"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">THREAT<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">AI<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">MALWARE</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">DATA</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#eab308" fill-opacity="0.12" stroke="#eab308" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fde047" text-anchor="middle" letter-spacing="2">VULN</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#ca8a04" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#eab308" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fde047"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fef08a" letter-spacing="3.5" opacity="0.9">APR 14 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">THREAT</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">AI</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#eab308" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#ca8a04" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fde047" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#ca8a04" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#eab308" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#eab308" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fef08a" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fde047" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM4.8,1.2H5.2V1.6H4.8zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM6,1.6H6.4V2H6zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8.8,2H9.2V2.4H8.8zM9.6,2H10V2.4H9.6zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM6.4,3.6H6.8V4H6.4zM8,3.6H8.4V4H8zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM4.8,4.4H5.2V4.8H4.8zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.6,5.2H2V5.6H1.6zM2.4,5.2H2.8V5.6H2.4zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM5.2,5.2H5.6V5.6H5.2zM6.4,5.2H6.8V5.6H6.4zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.6,6.4H10V6.8H9.6zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM2.4,6.8H2.8V7.2H2.4zM4.4,6.8H4.8V7.2H4.4zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM5.6,7.2H6V7.6H5.6zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM11.6,7.6H12V8H11.6zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.2,8.4H11.6V8.8H11.2zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM8.8,8.8H9.2V9.2H8.8zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM4.4,9.2H4.8V9.6H4.4zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM3.2,9.6H3.6V10H3.2zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM1.6,10H2V10.4H1.6zM2.4,10H2.8V10.4H2.4zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM7.2,10H7.6V10.4H7.2zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM16.8,10H17.2V10.4H16.8zM0.8,10.4H1.2V10.8H0.8zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM0.8,10.8H1.2V11.2H0.8zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM5.2,11.2H5.6V11.6H5.2zM6.8,11.2H7.2V11.6H6.8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM2,12.4H2.4V12.8H2zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.8,12.8H5.2V13.2H4.8zM6.8,12.8H7.2V13.2H6.8zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM4,13.2H4.4V13.6H4zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.8,13.2H13.2V13.6H12.8zM13.2,13.2H13.6V13.6H13.2zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.6,14H8V14.4H7.6zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.2,14.8H9.6V15.2H9.2zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM5.2,15.2H5.6V15.6H5.2zM7.2,15.2H7.6V15.6H7.2zM9.6,15.2H10V15.6H9.6zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM6.4,15.6H6.8V16H6.4zM7.6,15.6H8V16H7.6zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM5.2,16H5.6V16.4H5.2zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6,16.4H6.4V16.8H6zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.6,16.8H8V17.2H7.6zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: ransomware trends, banking RAT C2, global takedown announcement">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Vault door -->
+  <g transform="translate(-70,-100)">
+    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
+    <!-- vault handle spokes rotating -->
+    <g transform="translate(60,60)">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="6s" repeatCount="indefinite"/>
+      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
+    </g>
+    <!-- crack in door -->
+    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
+    </path>
   </g>
+  <!-- Coins flying out -->
+  <g>
+    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Masked figure silhouette (right) -->
+  <g transform="translate(90,-20)">
+    <!-- head -->
+    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- mask band -->
+    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
+    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
+    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
+    <!-- body -->
+    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- arm reaching down -->
+    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="d"
+               values="M -14 -2 Q -30 20 -28 34;
+                       M -14 -2 Q -34 22 -36 38;
+                       M -14 -2 Q -30 20 -28 34"
+               dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <!-- holding coin -->
+    <circle cx="-28" cy="34" r="4" fill="#FFB703">
+      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Down arrow stream (loss) -->
+  <g transform="translate(-30,60)">
+    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="15" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">RANSOM</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Monthly trend report shows active groups</text>
+<g transform="translate(576,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">JANELARAT</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Banking trojan hits Latin America</text>
+<g transform="translate(936,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">FBI</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Global operation disrupts multimillion fraud ring</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.8,0.8H7.2V1.2H6.8zM7.6,0.8H8V1.2H7.6zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.4,1.6H4.8V2H4.4zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6.8,2H7.2V2.4H6.8zM8.8,2H9.2V2.4H8.8zM9.6,2H10V2.4H9.6zM10.8,2H11.2V2.4H10.8zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM6.4,3.6H6.8V4H6.4zM7.2,3.6H7.6V4H7.2zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.8,4H5.2V4.4H4.8zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM4,4.4H4.4V4.8H4zM4.8,4.4H5.2V4.8H4.8zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM2.8,5.2H3.2V5.6H2.8zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM15.6,5.2H16V5.6H15.6zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM5.2,5.6H5.6V6H5.2zM6.8,5.6H7.2V6H6.8zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM10,6H10.4V6.4H10zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM8,6.4H8.4V6.8H8zM8.8,6.4H9.2V6.8H8.8zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM1.6,8H2V8.4H1.6zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM1.6,8.4H2V8.8H1.6zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.4,8.8H8.8V9.2H8.4zM9.6,8.8H10V9.2H9.6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM5.2,9.2H5.6V9.6H5.2zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM0.8,10H1.2V10.4H0.8zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.8,10H7.2V10.4H6.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM16.8,10H17.2V10.4H16.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM1.6,10.8H2V11.2H1.6zM3.6,10.8H4V11.2H3.6zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM6,10.8H6.4V11.2H6zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.4,11.2H4.8V11.6H4.4zM5.2,11.2H5.6V11.6H5.2zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM1.6,12H2V12.4H1.6zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM2.4,12.4H2.8V12.8H2.4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM6,12.4H6.4V12.8H6zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM10,12.4H10.4V12.8H10zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6.8,13.2H7.2V13.6H6.8zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.8,13.2H13.2V13.6H12.8zM13.2,13.2H13.6V13.6H13.2zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM5.2,13.6H5.6V14H5.2zM6,13.6H6.4V14H6zM6.8,13.6H7.2V14H6.8zM7.6,13.6H8V14H7.6zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.2,14H5.6V14.4H5.2zM6,14H6.4V14.4H6zM7.6,14H8V14.4H7.6zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6.4,14.8H6.8V15.2H6.4zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.2,14.8H9.6V15.2H9.2zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM4.8,15.2H5.2V15.6H4.8zM6,15.2H6.4V15.6H6zM6.8,15.2H7.2V15.6H6.8zM7.2,15.2H7.6V15.6H7.2zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.8,16.4H7.2V16.8H6.8zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.6,16.8H8V17.2H7.6zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-15-Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch.svg
+++ b/assets/images/2026-04-15-Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch.svg
@@ -1,145 +1,456 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 15 2026 AI AGENT">
-  <title>Style A v3 APR 15 2026 AI AGENT</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#100415"/><stop offset="100%" stop-color="#190622"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#190622"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.34"/><stop offset="100%" stop-color="#100415" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#c026d3" stop-opacity="0.32"/><stop offset="100%" stop-color="#190622" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#c026d3"><animate attributeName="stop-color" values="#c026d3;#f472b6;#dc2626;#c026d3" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#f472b6"><animate attributeName="stop-color" values="#f472b6;#e11d48;#c026d3;#f472b6" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#e11d48"><animate attributeName="stop-color" values="#e11d48;#dc2626;#f472b6;#e11d48" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.9"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#100415" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="50%" stop-color="#dc2626" stop-opacity="0.7"/><stop offset="100%" stop-color="#dc2626" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#f472b6" stop-opacity="1"/><stop offset="55%" stop-color="#c026d3" stop-opacity="0.75"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#e11d48" stop-opacity="0.5"/><stop offset="100%" stop-color="#e11d48" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.85"/><stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#f472b6" stop-opacity="0.45"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.85"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#c026d3" stop-opacity="0.4"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="35%" stop-color="#dc2626" stop-opacity="0.95"/><stop offset="65%" stop-color="#c026d3" stop-opacity="0.95"/><stop offset="100%" stop-color="#c026d3" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#f472b6" stop-opacity="0"/><stop offset="40%" stop-color="#f472b6" stop-opacity="0.55"/><stop offset="100%" stop-color="#f472b6" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#c026d3"/><stop offset="100%" stop-color="#f472b6"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#c026d3" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="818.8" y1="176.8" x2="859.6" y2="361.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="818.8" y1="176.8" x2="640.1" y2="386.3" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="859.6" y1="361.9" x2="640.1" y2="386.3" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="859.6" y1="361.9" x2="721.6" y2="433.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="640.1" y1="386.3" x2="721.6" y2="433.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="640.1" y1="386.3" x2="716.4" y2="135.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="721.6" y1="433.9" x2="716.4" y2="135.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="721.6" y1="433.9" x2="731.8" y2="214.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="716.4" y1="135.8" x2="731.8" y2="214.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="716.4" y1="135.8" x2="955.8" y2="319.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="731.8" y1="214.5" x2="955.8" y2="319.1" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="731.8" y1="214.5" x2="525.0" y2="393.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="955.8" y1="319.1" x2="525.0" y2="393.5" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.2s" repeatCount="indefinite"/></line>
-  <line x1="955.8" y1="319.1" x2="815.0" y2="194.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="525.0" y1="393.5" x2="815.0" y2="194.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="525.0" y1="393.5" x2="867.0" y2="280.6" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.2s" repeatCount="indefinite"/></line>
-  <line x1="815.0" y1="194.2" x2="867.0" y2="280.6" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="815.0" y1="194.2" x2="819.3" y2="411.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="867.0" y1="280.6" x2="819.3" y2="411.8" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="867.0" y1="280.6" x2="957.5" y2="427.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="819.3" y1="411.8" x2="957.5" y2="427.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="819.3" y1="411.8" x2="813.6" y2="176.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="957.5" y1="427.4" x2="813.6" y2="176.4" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="957.5" y1="427.4" x2="946.2" y2="188.0" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="813.6" y1="176.4" x2="946.2" y2="188.0" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="813.6" y1="176.4" x2="820.9" y2="148.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="946.2" y1="188.0" x2="820.9" y2="148.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="946.2" y1="188.0" x2="606.6" y2="336.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="820.9" y1="148.2" x2="606.6" y2="336.9" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="820.9" y1="148.2" x2="844.5" y2="419.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="606.6" y1="336.9" x2="844.5" y2="419.2" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="606.6" y1="336.9" x2="710.0" y2="219.6" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="844.5" y1="419.2" x2="710.0" y2="219.6" stroke="#c026d3" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <circle cx="818.8" cy="176.8" r="13.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="818.8" cy="176.8" r="7.3" fill="url(#nodeCore)"><animate attributeName="r" values="7.3;9.3;7.3" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="859.6" cy="361.9" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="859.6" cy="361.9" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="640.1" cy="386.3" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="640.1" cy="386.3" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="721.6" cy="433.9" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="721.6" cy="433.9" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="716.4" cy="135.8" r="12.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="716.4" cy="135.8" r="6.2" fill="url(#nodeCore)"><animate attributeName="r" values="6.2;8.2;6.2" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="731.8" cy="214.5" r="12.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="731.8" cy="214.5" r="6.9" fill="url(#nodeCore)"><animate attributeName="r" values="6.9;8.9;6.9" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="955.8" cy="319.1" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="955.8" cy="319.1" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="525.0" cy="393.5" r="13.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="525.0" cy="393.5" r="7.7" fill="url(#nodeCore)"><animate attributeName="r" values="7.7;9.7;7.7" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.6s" repeatCount="indefinite"/></circle>
-  <circle cx="815.0" cy="194.2" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="815.0" cy="194.2" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="867.0" cy="280.6" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="867.0" cy="280.6" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="819.3" cy="411.8" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="819.3" cy="411.8" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="957.5" cy="427.4" r="14.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="957.5" cy="427.4" r="8.8" fill="url(#nodeCore)"><animate attributeName="r" values="8.8;10.8;8.8" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="813.6" cy="176.4" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="813.6" cy="176.4" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="946.2" cy="188.0" r="11.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="946.2" cy="188.0" r="5.4" fill="url(#nodeCore)"><animate attributeName="r" values="5.4;7.4;5.4" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="820.9" cy="148.2" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="820.9" cy="148.2" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="606.6" cy="336.9" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="606.6" cy="336.9" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="844.5" cy="419.2" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="844.5" cy="419.2" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="710.0" cy="219.6" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="710.0" cy="219.6" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="717.4" cy="507.6" r="3.1" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="507.6;439.4;507.6" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="596.7" cy="556.0" r="2.8" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="556.0;497.1;556.0" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="567.9" cy="514.2" r="2.8" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="514.2;441.8;514.2" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="458.2" cy="499.0" r="1.9" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="499.0;432.4;499.0" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="939.1" cy="334.0" r="2.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="334.0;272.9;334.0" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="675.8" cy="396.0" r="2.3" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="396.0;322.6;396.0" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="676.5" cy="402.7" r="3.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="402.7;361.1;402.7" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="850.8" cy="302.7" r="2.8" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="302.7;221.7;302.7" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="462.0" cy="237.6" r="2.4" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="237.6;188.5;237.6" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="424.8" cy="283.9" r="2.6" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="283.9;230.6;283.9" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="421.2" cy="480.1" r="2.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="480.1;413.4;480.1" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="984.1" cy="284.2" r="2.4" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="284.2;248.6;284.2" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="527.9" cy="452.7" r="3.0" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="452.7;401.5;452.7" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="769.4" cy="62.9" r="2.5" fill="#f472b6" opacity="0.75"><animate attributeName="cy" values="62.9;22.0;62.9" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#dc2626" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#f472b6" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#c026d3" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#c026d3" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#f472b6"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">AI<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">AGENT<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">AWS</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">PATCH</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f472b6" text-anchor="middle" letter-spacing="2">SWARM</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#c026d3" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#dc2626" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#f472b6"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fbcfe8" letter-spacing="3.5" opacity="0.9">APR 15 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">AI</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">AGENT</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#dc2626" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#c026d3" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#f472b6" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#c026d3" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#dc2626" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fbcfe8" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#f472b6" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM8.4,0.8H8.8V1.2H8.4zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6.8,2H7.2V2.4H6.8zM7.6,2H8V2.4H7.6zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM6.4,2.4H6.8V2.8H6.4zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM6.4,2.8H6.8V3.2H6.4zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM5.2,4.4H5.6V4.8H5.2zM6.4,4.4H6.8V4.8H6.4zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.8,4.8H5.2V5.2H4.8zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM3.6,5.2H4V5.6H3.6zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.4,5.6H4.8V6H4.4zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM14,6H14.4V6.4H14zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.2,7.2H1.6V7.6H1.2zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM2.8,7.6H3.2V8H2.8zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM1.6,8.4H2V8.8H1.6zM2.4,8.4H2.8V8.8H2.4zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM6.8,8.4H7.2V8.8H6.8zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4.4,9.2H4.8V9.6H4.4zM5.6,9.2H6V9.6H5.6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.6,9.6H2V10H1.6zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM1.6,10H2V10.4H1.6zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM10.4,10H10.8V10.4H10.4zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM0.8,10.4H1.2V10.8H0.8zM2,10.4H2.4V10.8H2zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.8,10.8H3.2V11.2H2.8zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM6,10.8H6.4V11.2H6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM0.8,11.2H1.2V11.6H0.8zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM2,11.6H2.4V12H2zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM2,12H2.4V12.4H2zM3.2,12H3.6V12.4H3.2zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM5.2,12.8H5.6V13.2H5.2zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM6.4,13.6H6.8V14H6.4zM7.2,13.6H7.6V14H7.2zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.2,14H5.6V14.4H5.2zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.4,14.4H12.8V14.8H12.4zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.4,14.8H4.8V15.2H4.4zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.8,15.2H5.2V15.6H4.8zM6,15.2H6.4V15.6H6zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.8,16H5.2V16.4H4.8zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM5.2,16.4H5.6V16.8H5.2zM6.4,16.4H6.8V16.8H6.4zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: agent context protocol, composer supply patch, mobile modem security">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Cloud silhouette -->
+  <g transform="translate(0,-90)">
+    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
+          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- Lightning bolt inside -->
+    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
+          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
+    </path>
   </g>
+  <!-- AI chip (center) -->
+  <g transform="translate(0,10)">
+    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- inner square -->
+    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
+    <!-- AI script pattern (brain-like curves, not text) -->
+    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
+          fill="none" stroke="#FFB703" stroke-width="2">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
+      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <!-- chip legs (pins) -->
+    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
+    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
+    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
+    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
+  </g>
+  <!-- Data flow from cloud to chip -->
+  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Output nodes (neural) -->
+  <g transform="translate(0,90)">
+    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="6" fill="#FFB703">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="20" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="40" cy="0" r="6" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
+    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  </g>
+  <!-- Flowing pulse along connection -->
+  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
+    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-6" cy="52" r="2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
+    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Orbit rings around chip -->
+  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
+    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
+    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
+  </circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">MCP</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Protocol brokers agent access patterns</text>
+<g transform="translate(576,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
+  </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">COMPOSER</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Package manager flaw patched quickly</text>
+<g transform="translate(936,330)">
+  <!-- Industrial rack -->
+  <g transform="translate(-60,-100)">
+    <rect x="0" y="0" width="120" height="150" rx="4" fill="#0B132B" stroke="#E63946" stroke-width="2.4"/>
+    <!-- 1U rows -->
+    <rect x="6" y="8" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="30" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="52" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="74" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="96" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <rect x="6" y="118" width="108" height="18" rx="2" fill="#1C2541" stroke="#E63946" stroke-width="1.4"/>
+    <!-- row LEDs blinking (red = vulnerable) -->
+    <circle cx="14" cy="17" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="17" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="39" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="61" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="61" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="83" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="105" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="105" r="2.4" fill="#FFB703"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="14" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="22" cy="127" r="2.4" fill="#E63946"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.5s" repeatCount="indefinite"/></circle>
+    <!-- serial ports (right side of each row) -->
+    <rect x="90" y="14" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="36" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="58" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="80" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="102" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <rect x="90" y="124" width="18" height="6" rx="1" fill="#2A3256" stroke="#E63946" stroke-width="1"/>
+    <!-- progress bars of each row -->
+    <rect x="34" y="15" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="15" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="37" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="37" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="59" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="59" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="81" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="81" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="103" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="103" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2s" repeatCount="indefinite"/></rect>
+    <rect x="34" y="125" width="48" height="4" rx="1" fill="#2A3256"/>
+    <rect x="34" y="125" width="30" height="4" rx="1" fill="#E63946"><animate attributeName="width" values="10;48;10" dur="4s" begin="2.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <!-- Serial cable snaking out -->
+  <path d="M 70 -30 Q 100 -30 100 0 Q 100 30 70 30 Q 40 30 40 60" fill="none" stroke="#E63946" stroke-width="3" stroke-linecap="round">
+    <animate attributeName="stroke-dasharray" values="0 300;300 0" dur="4s" repeatCount="indefinite"/>
+  </path>
+  <circle cx="40" cy="60" r="4" fill="#E63946">
+    <animate attributeName="r" values="4;6;4" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Glowing vulnerability burst -->
+  <g transform="translate(-100,60)">
+    <circle cx="0" cy="0" r="10" fill="url(#glowRed)" opacity="0.7">
+      <animate attributeName="r" values="10;20;10" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <!-- crack star burst -->
+    <path d="M 0 -14 L 0 14 M -14 0 L 14 0 M -10 -10 L 10 10 M 10 -10 L -10 10"
+          stroke="#E63946" stroke-width="1.8" fill="none">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.5s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Exposure count beads (3 small circles, visual-only) -->
+  <circle cx="90" cy="-80" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.6s" repeatCount="indefinite"/></circle>
+  <circle cx="96" cy="-72" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="102" cy="-64" r="3" fill="#E63946"><animate attributeName="opacity" values="0.5;1;0.5" dur="2.0s" repeatCount="indefinite"/></circle>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">PIXEL</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Handset hardening blocks baseband exploits</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM6,2.4H6.4V2.8H6zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM6,2.8H6.4V3.2H6zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.8,4H5.2V4.4H4.8zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.6,5.2H16V5.6H15.6zM1.6,5.6H2V6H1.6zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM6.4,5.6H6.8V6H6.4zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM6.4,6H6.8V6.4H6.4zM8,6H8.4V6.4H8zM8.8,6H9.2V6.4H8.8zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.4,6.4H4.8V6.8H4.4zM5.2,6.4H5.6V6.8H5.2zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM7.6,6.4H8V6.8H7.6zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.6,7.2H2V7.6H1.6zM2,7.2H2.4V7.6H2zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM4.4,7.2H4.8V7.6H4.4zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM0.8,8.8H1.2V9.2H0.8zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM4,8.8H4.4V9.2H4zM6.4,8.8H6.8V9.2H6.4zM8.4,8.8H8.8V9.2H8.4zM9.2,8.8H9.6V9.2H9.2zM10.4,8.8H10.8V9.2H10.4zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM3.6,10H4V10.4H3.6zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM1.6,10.8H2V11.2H1.6zM2.8,10.8H3.2V11.2H2.8zM4.8,10.8H5.2V11.2H4.8zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.2,11.2H15.6V11.6H15.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM5.2,11.6H5.6V12H5.2zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM1.6,12H2V12.4H1.6zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM5.6,12H6V12.4H5.6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM9.2,12.4H9.6V12.8H9.2zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM5.2,12.8H5.6V13.2H5.2zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM6,13.2H6.4V13.6H6zM7.2,13.2H7.6V13.6H7.2zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM6,13.6H6.4V14H6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM5.2,14H5.6V14.4H5.2zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM10,14H10.4V14.4H10zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM6,15.2H6.4V15.6H6zM7.2,15.2H7.6V15.6H7.2zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6.4,15.6H6.8V16H6.4zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM11.2,15.6H11.6V16H11.2zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM15.6,16H16V16.4H15.6zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM8,16.8H8.4V17.2H8zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-16-Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch.svg
+++ b/assets/images/2026-04-16-Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch.svg
@@ -1,145 +1,471 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 16 2026 AI MALWARE">
-  <title>Style A v3 APR 16 2026 AI MALWARE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0d0613"/><stop offset="100%" stop-color="#1a0a14"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#1a0a14"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.34"/><stop offset="100%" stop-color="#0d0613" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#f59e0b" stop-opacity="0.32"/><stop offset="100%" stop-color="#1a0a14" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"><animate attributeName="stop-color" values="#f59e0b;#fbbf24;#dc2626;#f59e0b" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#fbbf24"><animate attributeName="stop-color" values="#fbbf24;#ef4444;#f59e0b;#fbbf24" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#ef4444"><animate attributeName="stop-color" values="#ef4444;#dc2626;#fbbf24;#ef4444" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.9"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0d0613" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="50%" stop-color="#dc2626" stop-opacity="0.7"/><stop offset="100%" stop-color="#dc2626" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="1"/><stop offset="55%" stop-color="#f59e0b" stop-opacity="0.75"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#ef4444" stop-opacity="0.5"/><stop offset="100%" stop-color="#ef4444" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fca5a5" stop-opacity="0.85"/><stop offset="100%" stop-color="#fca5a5" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="0.45"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0.85"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#f59e0b" stop-opacity="0.4"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#dc2626" stop-opacity="0"/><stop offset="35%" stop-color="#dc2626" stop-opacity="0.95"/><stop offset="65%" stop-color="#f59e0b" stop-opacity="0.95"/><stop offset="100%" stop-color="#f59e0b" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#fbbf24" stop-opacity="0"/><stop offset="40%" stop-color="#fbbf24" stop-opacity="0.55"/><stop offset="100%" stop-color="#fbbf24" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#f59e0b"/><stop offset="100%" stop-color="#fbbf24"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#f59e0b" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#dc2626" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="624.9" y1="379.1" x2="635.5" y2="214.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="624.9" y1="379.1" x2="559.6" y2="281.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="635.5" y1="214.2" x2="559.6" y2="281.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="635.5" y1="214.2" x2="932.0" y2="376.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="559.6" y1="281.6" x2="932.0" y2="376.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="559.6" y1="281.6" x2="755.5" y2="200.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="932.0" y1="376.6" x2="755.5" y2="200.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="932.0" y1="376.6" x2="913.8" y2="258.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="755.5" y1="200.8" x2="913.8" y2="258.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="755.5" y1="200.8" x2="892.3" y2="242.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="913.8" y1="258.9" x2="892.3" y2="242.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="913.8" y1="258.9" x2="754.3" y2="429.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="892.3" y1="242.3" x2="754.3" y2="429.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="892.3" y1="242.3" x2="544.4" y2="269.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="754.3" y1="429.3" x2="544.4" y2="269.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="754.3" y1="429.3" x2="891.5" y2="255.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="544.4" y1="269.4" x2="891.5" y2="255.6" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.4s" repeatCount="indefinite"/></line>
-  <line x1="544.4" y1="269.4" x2="697.1" y2="393.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="891.5" y1="255.6" x2="697.1" y2="393.9" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="891.5" y1="255.6" x2="798.7" y2="204.1" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.2s" repeatCount="indefinite"/></line>
-  <line x1="697.1" y1="393.9" x2="798.7" y2="204.1" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="697.1" y1="393.9" x2="874.0" y2="169.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="798.7" y1="204.1" x2="874.0" y2="169.4" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.6s" repeatCount="indefinite"/></line>
-  <line x1="798.7" y1="204.1" x2="676.7" y2="414.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="874.0" y1="169.4" x2="676.7" y2="414.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="874.0" y1="169.4" x2="873.4" y2="295.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="676.7" y1="414.2" x2="873.4" y2="295.7" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="676.7" y1="414.2" x2="720.2" y2="239.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="873.4" y1="295.7" x2="720.2" y2="239.3" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="873.4" y1="295.7" x2="556.9" y2="430.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="720.2" y1="239.3" x2="556.9" y2="430.2" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="720.2" y1="239.3" x2="944.9" y2="268.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="556.9" y1="430.2" x2="944.9" y2="268.8" stroke="#f59e0b" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <circle cx="624.9" cy="379.1" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="624.9" cy="379.1" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="635.5" cy="214.2" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="635.5" cy="214.2" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="559.6" cy="281.6" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="559.6" cy="281.6" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="932.0" cy="376.6" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="932.0" cy="376.6" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="755.5" cy="200.8" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="755.5" cy="200.8" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="913.8" cy="258.9" r="10.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="913.8" cy="258.9" r="4.9" fill="url(#nodeCore)"><animate attributeName="r" values="4.9;6.9;4.9" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="892.3" cy="242.3" r="12.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="892.3" cy="242.3" r="6.5" fill="url(#nodeCore)"><animate attributeName="r" values="6.5;8.5;6.5" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="754.3" cy="429.3" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="754.3" cy="429.3" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="544.4" cy="269.4" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="544.4" cy="269.4" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="891.5" cy="255.6" r="13.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="891.5" cy="255.6" r="7.8" fill="url(#nodeCore)"><animate attributeName="r" values="7.8;9.8;7.8" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="697.1" cy="393.9" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="697.1" cy="393.9" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="798.7" cy="204.1" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="798.7" cy="204.1" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="874.0" cy="169.4" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="874.0" cy="169.4" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="676.7" cy="414.2" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="676.7" cy="414.2" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="873.4" cy="295.7" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="873.4" cy="295.7" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="720.2" cy="239.3" r="11.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="720.2" cy="239.3" r="5.7" fill="url(#nodeCore)"><animate attributeName="r" values="5.7;7.7;5.7" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="556.9" cy="430.2" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="556.9" cy="430.2" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="944.9" cy="268.8" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="944.9" cy="268.8" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="892.3" cy="465.2" r="2.9" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="465.2;426.9;465.2" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1046.2" cy="177.1" r="1.6" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="177.1;106.7;177.1" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="712.7" cy="519.7" r="2.9" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="519.7;477.1;519.7" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1130.0" cy="521.1" r="1.6" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="521.1;467.4;521.1" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="1092.7" cy="414.7" r="1.5" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="414.7;376.4;414.7" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="622.9" cy="337.5" r="1.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="337.5;279.0;337.5" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="691.1" cy="129.9" r="3.1" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="129.9;46.1;129.9" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="1014.4" cy="204.7" r="3.1" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="204.7;146.7;204.7" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="719.5" cy="503.9" r="1.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="503.9;436.0;503.9" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="624.7" cy="512.2" r="1.7" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="512.2;430.9;512.2" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="1052.5" cy="123.9" r="1.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="123.9;79.2;123.9" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="429.2" cy="541.7" r="1.6" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="541.7;506.2;541.7" dur="6.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.1s" repeatCount="indefinite"/></circle>
-  <circle cx="762.8" cy="196.8" r="2.1" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="196.8;128.0;196.8" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="471.9" cy="387.7" r="2.8" fill="#fbbf24" opacity="0.75"><animate attributeName="cy" values="387.7;306.1;387.7" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.0s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#dc2626" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#fbbf24" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#f59e0b" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#f59e0b" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#fbbf24"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">AI<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">MALWARE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">CVE</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">PATCH</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#dc2626" fill-opacity="0.12" stroke="#dc2626" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#fbbf24" text-anchor="middle" letter-spacing="2">THREAT</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#f59e0b" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#dc2626" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#fbbf24"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fca5a5" letter-spacing="3.5" opacity="0.9">APR 16 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">AI</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">MALWARE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#dc2626" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#f59e0b" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#fbbf24" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#f59e0b" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#dc2626" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#dc2626" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fca5a5" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#fbbf24" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.8,0.8H5.2V1.2H4.8zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6.4,1.6H6.8V2H6.4zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM6,2.4H6.4V2.8H6zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.8,4H5.2V4.4H4.8zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM4,4.4H4.4V4.8H4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6,4.4H6.4V4.8H6zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM0.8,5.2H1.2V5.6H0.8zM2.4,5.2H2.8V5.6H2.4zM2.8,5.2H3.2V5.6H2.8zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM2,6H2.4V6.4H2zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.6,6.4H2V6.8H1.6zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.6,6.4H8V6.8H7.6zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM0.8,6.8H1.2V7.2H0.8zM1.2,6.8H1.6V7.2H1.2zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM5.6,7.2H6V7.6H5.6zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM1.2,7.6H1.6V8H1.2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM6,7.6H6.4V8H6zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM10,7.6H10.4V8H10zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.6,8H6V8.4H5.6zM6.4,8H6.8V8.4H6.4zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.4,8H12.8V8.4H12.4zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM7.2,8.4H7.6V8.8H7.2zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10.8,8.4H11.2V8.8H10.8zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2.4,8.8H2.8V9.2H2.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2.4,9.2H2.8V9.6H2.4zM4.4,9.2H4.8V9.6H4.4zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.2,9.2H11.6V9.6H11.2zM11.6,9.2H12V9.6H11.6zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16,9.2H16.4V9.6H16zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM2,9.6H2.4V10H2zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2.8,10H3.2V10.4H2.8zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10.4,10H10.8V10.4H10.4zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.4,10.4H4.8V10.8H4.4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6,10.4H6.4V10.8H6zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM2.4,10.8H2.8V11.2H2.4zM3.6,10.8H4V11.2H3.6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM3.6,11.6H4V12H3.6zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM1.6,12H2V12.4H1.6zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM5.2,12.4H5.6V12.8H5.2zM6,12.4H6.4V12.8H6zM6.8,12.4H7.2V12.8H6.8zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.8,12.8H5.2V13.2H4.8zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM9.6,12.8H10V13.2H9.6zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM7.6,13.2H8V13.6H7.6zM9.2,13.2H9.6V13.6H9.2zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8.4,14H8.8V14.4H8.4zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM5.2,14.4H5.6V14.8H5.2zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM7.2,16H7.6V16.4H7.2zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM15.6,16H16V16.4H15.6zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: webhook abuse, auth bypass triage, active exploitation">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Model file card (GGUF-style) -->
+  <g transform="translate(-80,-110)">
+    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- folded corner -->
+    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- neural net nodes inside -->
+    <circle cx="18" cy="38" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="58" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="18" cy="78" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="45" cy="68" r="4" fill="#3A86FF">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="72" cy="58" r="4" fill="#E63946">
+      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
+    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
+    <!-- bug sneaking in (upper right) -->
+    <g transform="translate(72,20)">
+      <circle cx="0" cy="0" r="4" fill="#E63946">
+        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
+    </g>
   </g>
+  <!-- Payload stream flowing rightward -->
+  <g>
+    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="-10" r="2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
+      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Shell/terminal window (right) -->
+  <g transform="translate(30,-60)">
+    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
+    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
+    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
+    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
+    <!-- prompt lines appearing -->
+    <g>
+      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <g>
+      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
+      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
+        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
+      </rect>
+    </g>
+    <!-- cursor -->
+    <rect x="8" y="76" width="6" height="10" fill="#E63946">
+      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- skull glyph near shell as RCE indicator (pure shape) -->
+  <g transform="translate(70,-80)">
+    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
+    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
+    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">N8N</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Automation webhooks abused to deliver loaders</text>
+<g transform="translate(576,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
+  </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">NGINXUI</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Authentication bypass flaw reaches dashboards</text>
+<g transform="translate(936,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">NGINX</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Exploits pivot to internal services</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6,1.2H6.4V1.6H6zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM10.8,1.2H11.2V1.6H10.8zM12.4,1.2H12.8V1.6H12.4zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM5.2,1.6H5.6V2H5.2zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM10.4,1.6H10.8V2H10.4zM10.8,1.6H11.2V2H10.8zM11.2,1.6H11.6V2H11.2zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM6.8,2.4H7.2V2.8H6.8zM8,2.4H8.4V2.8H8zM8.4,2.4H8.8V2.8H8.4zM10.4,2.4H10.8V2.8H10.4zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.8,2.8H5.2V3.2H4.8zM6,2.8H6.4V3.2H6zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM6.4,3.6H6.8V4H6.4zM7.2,3.6H7.6V4H7.2zM7.6,3.6H8V4H7.6zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM1.2,4.4H1.6V4.8H1.2zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM4.4,4.4H4.8V4.8H4.4zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6,4.4H6.4V4.8H6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.8,4.4H17.2V4.8H16.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM7.2,4.8H7.6V5.2H7.2zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.8,5.2H3.2V5.6H2.8zM4.4,5.2H4.8V5.6H4.4zM6.4,5.2H6.8V5.6H6.4zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.2,5.2H15.6V5.6H15.2zM16.4,5.2H16.8V5.6H16.4zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM0.8,6H1.2V6.4H0.8zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM7.6,6H8V6.4H7.6zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM13.6,6.4H14V6.8H13.6zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM3.6,6.8H4V7.2H3.6zM4,6.8H4.4V7.2H4zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM6,7.2H6.4V7.6H6zM7.2,7.2H7.6V7.6H7.2zM8,7.2H8.4V7.6H8zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12.8,7.2H13.2V7.6H12.8zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8.8,7.6H9.2V8H8.8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM11.6,7.6H12V8H11.6zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2.8,8.4H3.2V8.8H2.8zM3.6,8.4H4V8.8H3.6zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM9.6,8.4H10V8.8H9.6zM10.8,8.4H11.2V8.8H10.8zM11.2,8.4H11.6V8.8H11.2zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM1.2,8.8H1.6V9.2H1.2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.4,8.8H4.8V9.2H4.4zM5.6,8.8H6V9.2H5.6zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM9.6,8.8H10V9.2H9.6zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM2,9.2H2.4V9.6H2zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4,9.6H4.4V10H4zM5.6,9.6H6V10H5.6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM16.4,9.6H16.8V10H16.4zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6.4,10H6.8V10.4H6.4zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10,10H10.4V10.4H10zM10.4,10H10.8V10.4H10.4zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.4,10H14.8V10.4H14.4zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM6.4,10.4H6.8V10.8H6.4zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM1.2,10.8H1.6V11.2H1.2zM2.4,10.8H2.8V11.2H2.4zM4,10.8H4.4V11.2H4zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.4,10.8H6.8V11.2H6.4zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.4,10.8H14.8V11.2H14.4zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM1.2,12H1.6V12.4H1.2zM2,12H2.4V12.4H2zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM16.4,12H16.8V12.4H16.4zM2,12.4H2.4V12.8H2zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM5.6,12.4H6V12.8H5.6zM6,12.4H6.4V12.8H6zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8.4,12.4H8.8V12.8H8.4zM9.6,12.4H10V12.8H9.6zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4.4,12.8H4.8V13.2H4.4zM5.2,12.8H5.6V13.2H5.2zM6.8,12.8H7.2V13.2H6.8zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM1.6,13.2H2V13.6H1.6zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM4,13.2H4.4V13.6H4zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM7.6,13.2H8V13.6H7.6zM8.8,13.2H9.2V13.6H8.8zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.6,13.2H12V13.6H11.6zM12.4,13.2H12.8V13.6H12.4zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2.4,13.6H2.8V14H2.4zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6.8,13.6H7.2V14H6.8zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM10,13.6H10.4V14H10zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM5.2,14H5.6V14.4H5.2zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM8.4,14H8.8V14.4H8.4zM10,14H10.4V14.4H10zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM5.6,14.4H6V14.8H5.6zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.2,14.4H11.6V14.8H11.2zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM7.2,14.8H7.6V15.2H7.2zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM11.2,14.8H11.6V15.2H11.2zM12,14.8H12.4V15.2H12zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10.4,16H10.8V16.4H10.4zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM5.2,16.4H5.6V16.8H5.2zM6,16.4H6.4V16.8H6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM7.6,16.8H8V17.2H7.6zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM16.4,16.8H16.8V17.2H16.4z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-17-Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware.svg
+++ b/assets/images/2026-04-17-Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware.svg
@@ -1,145 +1,464 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 17 2026 BOTNET THREAT">
-  <title>Style A v3 APR 17 2026 BOTNET THREAT</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#040b1a"/><stop offset="100%" stop-color="#081029"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#081029"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.34"/><stop offset="100%" stop-color="#040b1a" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.32"/><stop offset="100%" stop-color="#081029" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"><animate attributeName="stop-color" values="#3b82f6;#60a5fa;#06b6d4;#3b82f6" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#60a5fa"><animate attributeName="stop-color" values="#60a5fa;#22d3ee;#3b82f6;#60a5fa" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#22d3ee"><animate attributeName="stop-color" values="#22d3ee;#06b6d4;#60a5fa;#22d3ee" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.9"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#040b1a" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="50%" stop-color="#06b6d4" stop-opacity="0.7"/><stop offset="100%" stop-color="#06b6d4" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="1"/><stop offset="55%" stop-color="#3b82f6" stop-opacity="0.75"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#22d3ee" stop-opacity="0.5"/><stop offset="100%" stop-color="#22d3ee" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a5f3fc" stop-opacity="0.85"/><stop offset="100%" stop-color="#a5f3fc" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0.45"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0.85"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#3b82f6" stop-opacity="0.4"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#06b6d4" stop-opacity="0"/><stop offset="35%" stop-color="#06b6d4" stop-opacity="0.95"/><stop offset="65%" stop-color="#3b82f6" stop-opacity="0.95"/><stop offset="100%" stop-color="#3b82f6" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#60a5fa" stop-opacity="0"/><stop offset="40%" stop-color="#60a5fa" stop-opacity="0.55"/><stop offset="100%" stop-color="#60a5fa" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#3b82f6"/><stop offset="100%" stop-color="#60a5fa"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#3b82f6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#06b6d4" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="711.8" y1="221.9" x2="852.3" y2="152.7" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="711.8" y1="221.9" x2="773.9" y2="162.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="852.3" y1="152.7" x2="773.9" y2="162.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="852.3" y1="152.7" x2="990.1" y2="402.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="773.9" y1="162.8" x2="990.1" y2="402.6" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="773.9" y1="162.8" x2="882.8" y2="176.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="990.1" y1="402.6" x2="882.8" y2="176.5" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="990.1" y1="402.6" x2="645.4" y2="218.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="882.8" y1="176.5" x2="645.4" y2="218.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.9s" repeatCount="indefinite"/></line>
-  <line x1="882.8" y1="176.5" x2="857.8" y2="229.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="645.4" y1="218.3" x2="857.8" y2="229.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="645.4" y1="218.3" x2="747.4" y2="482.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="857.8" y1="229.1" x2="747.4" y2="482.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="857.8" y1="229.1" x2="906.0" y2="373.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="747.4" y1="482.9" x2="906.0" y2="373.9" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.7s" repeatCount="indefinite"/></line>
-  <line x1="747.4" y1="482.9" x2="941.8" y2="425.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="906.0" y1="373.9" x2="941.8" y2="425.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="906.0" y1="373.9" x2="614.7" y2="252.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="941.8" y1="425.2" x2="614.7" y2="252.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="941.8" y1="425.2" x2="665.5" y2="177.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="614.7" y1="252.4" x2="665.5" y2="177.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="614.7" y1="252.4" x2="573.2" y2="342.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="665.5" y1="177.1" x2="573.2" y2="342.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.2s" repeatCount="indefinite"/></line>
-  <line x1="665.5" y1="177.1" x2="658.8" y2="243.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="573.2" y1="342.8" x2="658.8" y2="243.3" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="573.2" y1="342.8" x2="751.2" y2="392.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="658.8" y1="243.3" x2="751.2" y2="392.8" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="658.8" y1="243.3" x2="630.6" y2="230.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="751.2" y1="392.8" x2="630.6" y2="230.2" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="751.2" y1="392.8" x2="1015.0" y2="382.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="630.6" y1="230.2" x2="1015.0" y2="382.4" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="630.6" y1="230.2" x2="859.6" y2="256.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="1015.0" y1="382.4" x2="859.6" y2="256.1" stroke="#3b82f6" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <circle cx="711.8" cy="221.9" r="13.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="711.8" cy="221.9" r="7.8" fill="url(#nodeCore)"><animate attributeName="r" values="7.8;9.8;7.8" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="852.3" cy="152.7" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="852.3" cy="152.7" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="773.9" cy="162.8" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="773.9" cy="162.8" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="990.1" cy="402.6" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="990.1" cy="402.6" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="882.8" cy="176.5" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="882.8" cy="176.5" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="645.4" cy="218.3" r="12.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="645.4" cy="218.3" r="6.3" fill="url(#nodeCore)"><animate attributeName="r" values="6.3;8.3;6.3" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="857.8" cy="229.1" r="11.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="857.8" cy="229.1" r="5.2" fill="url(#nodeCore)"><animate attributeName="r" values="5.2;7.2;5.2" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="747.4" cy="482.9" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="747.4" cy="482.9" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="906.0" cy="373.9" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="906.0" cy="373.9" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="941.8" cy="425.2" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="941.8" cy="425.2" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="2.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.6s" repeatCount="indefinite"/></circle>
-  <circle cx="614.7" cy="252.4" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="614.7" cy="252.4" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="665.5" cy="177.1" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="665.5" cy="177.1" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="573.2" cy="342.8" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="573.2" cy="342.8" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="658.8" cy="243.3" r="11.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="658.8" cy="243.3" r="5.5" fill="url(#nodeCore)"><animate attributeName="r" values="5.5;7.5;5.5" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="751.2" cy="392.8" r="10.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="751.2" cy="392.8" r="4.7" fill="url(#nodeCore)"><animate attributeName="r" values="4.7;6.7;4.7" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="630.6" cy="230.2" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="630.6" cy="230.2" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="3.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.2s" repeatCount="indefinite"/></circle>
-  <circle cx="1015.0" cy="382.4" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="1015.0" cy="382.4" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="859.6" cy="256.1" r="13.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="859.6" cy="256.1" r="7.6" fill="url(#nodeCore)"><animate attributeName="r" values="7.6;9.6;7.6" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="798.1" cy="420.5" r="1.8" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="420.5;342.7;420.5" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="593.8" cy="460.7" r="2.3" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="460.7;382.1;460.7" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="415.5" cy="445.7" r="2.8" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="445.7;406.3;445.7" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="660.2" cy="481.1" r="3.2" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="481.1;438.7;481.1" dur="4.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.1s" repeatCount="indefinite"/></circle>
-  <circle cx="485.2" cy="279.3" r="2.0" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="279.3;226.5;279.3" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="832.6" cy="310.0" r="1.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="310.0;255.7;310.0" dur="5.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.8s" repeatCount="indefinite"/></circle>
-  <circle cx="728.4" cy="453.3" r="2.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="453.3;416.0;453.3" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="883.7" cy="327.5" r="1.5" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="327.5;266.7;327.5" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1085.4" cy="214.1" r="1.8" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="214.1;177.9;214.1" dur="5.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.7s" repeatCount="indefinite"/></circle>
-  <circle cx="673.8" cy="393.9" r="2.1" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="393.9;323.2;393.9" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.5s" repeatCount="indefinite"/></circle>
-  <circle cx="777.2" cy="135.4" r="2.2" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="135.4;95.2;135.4" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="441.6" cy="477.1" r="2.4" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="477.1;398.8;477.1" dur="3.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.4s" repeatCount="indefinite"/></circle>
-  <circle cx="985.3" cy="236.9" r="2.6" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="236.9;158.1;236.9" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="660.5" cy="238.5" r="1.9" fill="#60a5fa" opacity="0.75"><animate attributeName="cy" values="238.5;184.8;238.5" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#06b6d4" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#60a5fa" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#3b82f6" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#3b82f6" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#60a5fa"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">BOTNET<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="96" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">THREAT<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">MALWARE</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#06b6d4" fill-opacity="0.12" stroke="#06b6d4" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#60a5fa" text-anchor="middle" letter-spacing="2">SWARM</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#3b82f6" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#06b6d4" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#60a5fa"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#a5f3fc" letter-spacing="3.5" opacity="0.9">APR 17 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">BOTNET</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">THREAT</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#06b6d4" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#3b82f6" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#60a5fa" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#3b82f6" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#06b6d4" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#06b6d4" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#a5f3fc" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#60a5fa" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.6,1.6H10V2H9.6zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM5.6,2.4H6V2.8H5.6zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.2,2.4H11.6V2.8H11.2zM11.6,2.4H12V2.8H11.6zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM4.4,4H4.8V4.4H4.4zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM1.6,4.4H2V4.8H1.6zM2.4,4.4H2.8V4.8H2.4zM4,4.4H4.4V4.8H4zM4.4,4.4H4.8V4.8H4.4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM5.6,4.8H6V5.2H5.6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM2,5.2H2.4V5.6H2zM2.8,5.2H3.2V5.6H2.8zM4,5.2H4.4V5.6H4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6,5.6H6.4V6H6zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.6,5.6H14V6H13.6zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.4,5.6H16.8V6H16.4zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.8,6H5.2V6.4H4.8zM6,6H6.4V6.4H6zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10.4,6H10.8V6.4H10.4zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM2,6.8H2.4V7.2H2zM3.6,6.8H4V7.2H3.6zM4,6.8H4.4V7.2H4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM1.6,7.2H2V7.6H1.6zM2,7.2H2.4V7.6H2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM4,7.6H4.4V8H4zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM8,8H8.4V8.4H8zM9.2,8H9.6V8.4H9.2zM9.6,8H10V8.4H9.6zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM11.6,8H12V8.4H11.6zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM4.8,8.4H5.2V8.8H4.8zM5.6,8.4H6V8.8H5.6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM11.2,8.4H11.6V8.8H11.2zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8.4,8.8H8.8V9.2H8.4zM10.4,8.8H10.8V9.2H10.4zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.6,9.2H2V9.6H1.6zM2.8,9.2H3.2V9.6H2.8zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4.8,9.6H5.2V10H4.8zM5.2,9.6H5.6V10H5.2zM5.6,9.6H6V10H5.6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM16.8,9.6H17.2V10H16.8zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10.4,10H10.8V10.4H10.4zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM4.4,10.8H4.8V11.2H4.4zM5.2,10.8H5.6V11.2H5.2zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM4.8,11.2H5.2V11.6H4.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM4.4,11.6H4.8V12H4.4zM4.8,11.6H5.2V12H4.8zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM2,12H2.4V12.4H2zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.6,12.4H6V12.8H5.6zM6.4,12.4H6.8V12.8H6.4zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM10,12.4H10.4V12.8H10zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14,12.4H14.4V12.8H14zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM5.2,13.2H5.6V13.6H5.2zM6,13.2H6.4V13.6H6zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2,13.6H2.4V14H2zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM6,13.6H6.4V14H6zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM4.8,14H5.2V14.4H4.8zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM5.2,14.4H5.6V14.8H5.2zM6,14.4H6.4V14.8H6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM10.8,14.4H11.2V14.8H10.8zM11.6,14.4H12V14.8H11.6zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.8,15.2H5.2V15.6H4.8zM5.6,15.2H6V15.6H5.6zM6.8,15.2H7.2V15.6H6.8zM8,15.2H8.4V15.6H8zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM6,15.6H6.4V16H6zM6.8,15.6H7.2V16H6.8zM7.6,15.6H8V16H7.6zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.2,15.6H11.6V16H11.2zM11.6,15.6H12V16H11.6zM12.8,15.6H13.2V16H12.8zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.4,16H4.8V16.4H4.4zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.4,16.8H6.8V17.2H6.4zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: C2 botnet, threat bulletin announcement, law enforcement takedown">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">POWMIX</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Botnet randomises channels to evade detection</text>
+<g transform="translate(576,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">BULLETIN</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Bulletin tracks active intrusions recap</text>
+<g transform="translate(936,330)">
+  <!-- Vault door -->
+  <g transform="translate(-70,-100)">
+    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
+    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
+    <!-- vault handle spokes rotating -->
+    <g transform="translate(60,60)">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="6s" repeatCount="indefinite"/>
+      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
+      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
+      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
+    </g>
+    <!-- crack in door -->
+    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Coins flying out -->
+  <g>
+    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
+      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Masked figure silhouette (right) -->
+  <g transform="translate(90,-20)">
+    <!-- head -->
+    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- mask band -->
+    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
+    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
+    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
+    <!-- body -->
+    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
+    <!-- arm reaching down -->
+    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
+      <animate attributeName="d"
+               values="M -14 -2 Q -30 20 -28 34;
+                       M -14 -2 Q -34 22 -36 38;
+                       M -14 -2 Q -30 20 -28 34"
+               dur="2.4s" repeatCount="indefinite"/>
+    </path>
+    <!-- holding coin -->
+    <circle cx="-28" cy="34" r="4" fill="#FFB703">
+      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Down arrow stream (loss) -->
+  <g transform="translate(-30,60)">
+    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
+    </path>
+    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="15" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">POWEROFF</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Operation seizes booter infrastructure</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.6,1.2H6V1.6H5.6zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM11.6,1.2H12V1.6H11.6zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.2,2H5.6V2.4H5.2zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.8,2.8H5.2V3.2H4.8zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.2,3.6H5.6V4H5.2zM6.8,3.6H7.2V4H6.8zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM4,4.4H4.4V4.8H4zM4.8,4.4H5.2V4.8H4.8zM5.2,4.4H5.6V4.8H5.2zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4.8,4.8H5.2V5.2H4.8zM5.2,4.8H5.6V5.2H5.2zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14,4.8H14.4V5.2H14zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.8,5.2H7.2V5.6H6.8zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM15.6,5.2H16V5.6H15.6zM16.4,5.2H16.8V5.6H16.4zM0.8,5.6H1.2V6H0.8zM1.2,5.6H1.6V6H1.2zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12,5.6H12.4V6H12zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM7.2,6H7.6V6.4H7.2zM8,6H8.4V6.4H8zM8.8,6H9.2V6.4H8.8zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.4,6.4H4.8V6.8H4.4zM6,6.4H6.4V6.8H6zM7.2,6.4H7.6V6.8H7.2zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM0.8,6.8H1.2V7.2H0.8zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.2,6.8H5.6V7.2H5.2zM5.6,6.8H6V7.2H5.6zM6.4,6.8H6.8V7.2H6.4zM7.2,6.8H7.6V7.2H7.2zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.2,7.2H1.6V7.6H1.2zM2.4,7.2H2.8V7.6H2.4zM3.2,7.2H3.6V7.6H3.2zM4,7.2H4.4V7.6H4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.2,7.6H5.6V8H5.2zM6,7.6H6.4V8H6zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM6.4,8H6.8V8.4H6.4zM6.8,8H7.2V8.4H6.8zM7.6,8H8V8.4H7.6zM9.2,8H9.6V8.4H9.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM2,8.4H2.4V8.8H2zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM6.8,8.4H7.2V8.8H6.8zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM5.2,8.8H5.6V9.2H5.2zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM9.2,8.8H9.6V9.2H9.2zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2.8,9.2H3.2V9.6H2.8zM4.4,9.2H4.8V9.6H4.4zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.4,9.6H2.8V10H2.4zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM5.2,9.6H5.6V10H5.2zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM2.4,10H2.8V10.4H2.4zM4,10H4.4V10.4H4zM4.4,10H4.8V10.4H4.4zM5.2,10H5.6V10.4H5.2zM6.4,10H6.8V10.4H6.4zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10,10H10.4V10.4H10zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM5.2,10.8H5.6V11.2H5.2zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4.4,11.2H4.8V11.6H4.4zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6.4,11.2H6.8V11.6H6.4zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM5.2,11.6H5.6V12H5.2zM5.6,11.6H6V12H5.6zM6.4,11.6H6.8V12H6.4zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.8,12H17.2V12.4H16.8zM0.8,12.4H1.2V12.8H0.8zM1.2,12.4H1.6V12.8H1.2zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM3.6,12.4H4V12.8H3.6zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM6.4,12.4H6.8V12.8H6.4zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM9.2,12.4H9.6V12.8H9.2zM10,12.4H10.4V12.8H10zM10.4,12.4H10.8V12.8H10.4zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8.8,12.8H9.2V13.2H8.8zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM3.6,13.2H4V13.6H3.6zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.4,13.2H6.8V13.6H6.4zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.8,13.2H13.2V13.6H12.8zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.4,14H4.8V14.4H4.4zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM12.4,14H12.8V14.4H12.4zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.6,14.4H10V14.8H9.6zM10.8,14.4H11.2V14.8H10.8zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM6,14.8H6.4V15.2H6zM7.2,14.8H7.6V15.2H7.2zM8.4,14.8H8.8V15.2H8.4zM8.8,14.8H9.2V15.2H8.8zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.2,15.2H11.6V15.6H11.2zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM7.2,15.6H7.6V16H7.2zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM6.4,16H6.8V16.4H6.4zM7.2,16H7.6V16.4H7.2zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM7.6,16.4H8V16.8H7.6zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM5.6,16.8H6V17.2H5.6zM6.8,16.8H7.2V17.2H6.8zM7.6,16.8H8V17.2H7.6zM8,16.8H8.4V17.2H8zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-18-Tech_Security_Weekly_Digest_Zero-Day_Patch_Security_Go.svg
+++ b/assets/images/2026-04-18-Tech_Security_Weekly_Digest_Zero-Day_Patch_Security_Go.svg
@@ -1,145 +1,462 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 18 2026 ZERO DAY">
-  <title>Style A v3 APR 18 2026 ZERO DAY</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#04120b"/><stop offset="100%" stop-color="#071a14"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#071a14"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.34"/><stop offset="100%" stop-color="#04120b" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.32"/><stop offset="100%" stop-color="#071a14" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"><animate attributeName="stop-color" values="#84cc16;#bef264;#10b981;#84cc16" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#bef264"><animate attributeName="stop-color" values="#bef264;#34d399;#84cc16;#bef264" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#34d399"><animate attributeName="stop-color" values="#34d399;#10b981;#bef264;#34d399" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.9"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#04120b" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="50%" stop-color="#10b981" stop-opacity="0.7"/><stop offset="100%" stop-color="#10b981" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#bef264" stop-opacity="1"/><stop offset="55%" stop-color="#84cc16" stop-opacity="0.75"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#34d399" stop-opacity="0.5"/><stop offset="100%" stop-color="#34d399" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#d9f99d" stop-opacity="0.85"/><stop offset="100%" stop-color="#d9f99d" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#bef264" stop-opacity="0.45"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#10b981" stop-opacity="0.85"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#84cc16" stop-opacity="0.4"/><stop offset="100%" stop-color="#bef264" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#10b981" stop-opacity="0"/><stop offset="35%" stop-color="#10b981" stop-opacity="0.95"/><stop offset="65%" stop-color="#84cc16" stop-opacity="0.95"/><stop offset="100%" stop-color="#84cc16" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#bef264" stop-opacity="0"/><stop offset="40%" stop-color="#bef264" stop-opacity="0.55"/><stop offset="100%" stop-color="#bef264" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#84cc16"/><stop offset="100%" stop-color="#bef264"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#84cc16" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#10b981" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="909.6" y1="411.9" x2="795.1" y2="481.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="909.6" y1="411.9" x2="872.1" y2="367.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="795.1" y1="481.9" x2="872.1" y2="367.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="795.1" y1="481.9" x2="628.3" y2="220.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.6s" repeatCount="indefinite"/></line>
-  <line x1="872.1" y1="367.2" x2="628.3" y2="220.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="872.1" y1="367.2" x2="725.4" y2="230.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.8s" repeatCount="indefinite"/></line>
-  <line x1="628.3" y1="220.3" x2="725.4" y2="230.8" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.8s" repeatCount="indefinite"/></line>
-  <line x1="628.3" y1="220.3" x2="857.9" y2="438.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="725.4" y1="230.8" x2="857.9" y2="438.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="725.4" y1="230.8" x2="737.5" y2="409.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="857.9" y1="438.6" x2="737.5" y2="409.6" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.7s" repeatCount="indefinite"/></line>
-  <line x1="857.9" y1="438.6" x2="985.8" y2="261.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="737.5" y1="409.6" x2="985.8" y2="261.5" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="737.5" y1="409.6" x2="609.2" y2="270.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="985.8" y1="261.5" x2="609.2" y2="270.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="985.8" y1="261.5" x2="527.2" y2="382.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="609.2" y1="270.9" x2="527.2" y2="382.7" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="609.2" y1="270.9" x2="882.3" y2="315.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="527.2" y1="382.7" x2="882.3" y2="315.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="527.2" y1="382.7" x2="615.5" y2="412.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="882.3" y1="315.3" x2="615.5" y2="412.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="882.3" y1="315.3" x2="677.2" y2="183.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="615.5" y1="412.2" x2="677.2" y2="183.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="615.5" y1="412.2" x2="553.0" y2="407.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="677.2" y1="183.3" x2="553.0" y2="407.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.3s" repeatCount="indefinite"/></line>
-  <line x1="677.2" y1="183.3" x2="685.8" y2="434.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="553.0" y1="407.3" x2="685.8" y2="434.2" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.4s" repeatCount="indefinite"/></line>
-  <line x1="553.0" y1="407.3" x2="638.5" y2="402.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.9s" repeatCount="indefinite"/></line>
-  <line x1="685.8" y1="434.2" x2="638.5" y2="402.9" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.5s" repeatCount="indefinite"/></line>
-  <line x1="685.8" y1="434.2" x2="634.7" y2="171.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.1s" repeatCount="indefinite"/></line>
-  <line x1="638.5" y1="402.9" x2="634.7" y2="171.1" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="638.5" y1="402.9" x2="850.1" y2="224.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.0s" repeatCount="indefinite"/></line>
-  <line x1="634.7" y1="171.1" x2="850.1" y2="224.3" stroke="#84cc16" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <circle cx="909.6" cy="411.9" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="909.6" cy="411.9" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="795.1" cy="481.9" r="14.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="795.1" cy="481.9" r="8.1" fill="url(#nodeCore)"><animate attributeName="r" values="8.1;10.1;8.1" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="872.1" cy="367.2" r="14.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="872.1" cy="367.2" r="8.9" fill="url(#nodeCore)"><animate attributeName="r" values="8.9;10.9;8.9" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="628.3" cy="220.3" r="11.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="628.3" cy="220.3" r="5.8" fill="url(#nodeCore)"><animate attributeName="r" values="5.8;7.8;5.8" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="725.4" cy="230.8" r="11.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="725.4" cy="230.8" r="5.1" fill="url(#nodeCore)"><animate attributeName="r" values="5.1;7.1;5.1" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="857.9" cy="438.6" r="10.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="857.9" cy="438.6" r="4.6" fill="url(#nodeCore)"><animate attributeName="r" values="4.6;6.6;4.6" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="737.5" cy="409.6" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="737.5" cy="409.6" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="985.8" cy="261.5" r="10.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="985.8" cy="261.5" r="4.8" fill="url(#nodeCore)"><animate attributeName="r" values="4.8;6.8;4.8" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="609.2" cy="270.9" r="14.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="609.2" cy="270.9" r="8.4" fill="url(#nodeCore)"><animate attributeName="r" values="8.4;10.4;8.4" dur="3.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.8s" repeatCount="indefinite"/></circle>
-  <circle cx="527.2" cy="382.7" r="10.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="527.2" cy="382.7" r="4.4" fill="url(#nodeCore)"><animate attributeName="r" values="4.4;6.4;4.4" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="882.3" cy="315.3" r="10.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="882.3" cy="315.3" r="4.4" fill="url(#nodeCore)"><animate attributeName="r" values="4.4;6.4;4.4" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="615.5" cy="412.2" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="615.5" cy="412.2" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="677.2" cy="183.3" r="14.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="677.2" cy="183.3" r="8.0" fill="url(#nodeCore)"><animate attributeName="r" values="8.0;10.0;8.0" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="553.0" cy="407.3" r="13.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="553.0" cy="407.3" r="7.0" fill="url(#nodeCore)"><animate attributeName="r" values="7.0;9.0;7.0" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="685.8" cy="434.2" r="14.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="685.8" cy="434.2" r="8.2" fill="url(#nodeCore)"><animate attributeName="r" values="8.2;10.2;8.2" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="638.5" cy="402.9" r="10.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="638.5" cy="402.9" r="4.4" fill="url(#nodeCore)"><animate attributeName="r" values="4.4;6.4;4.4" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="634.7" cy="171.1" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="634.7" cy="171.1" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="850.1" cy="224.3" r="12.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="850.1" cy="224.3" r="6.0" fill="url(#nodeCore)"><animate attributeName="r" values="6.0;8.0;6.0" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="432.3" cy="113.2" r="2.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="113.2;72.8;113.2" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="518.3" cy="204.2" r="2.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="204.2;166.5;204.2" dur="5.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.4s" repeatCount="indefinite"/></circle>
-  <circle cx="485.6" cy="290.7" r="2.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="290.7;240.9;290.7" dur="6.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.2s" repeatCount="indefinite"/></circle>
-  <circle cx="604.7" cy="424.8" r="2.1" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="424.8;369.4;424.8" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="985.7" cy="139.7" r="3.2" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="139.7;70.6;139.7" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="402.6" cy="229.3" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="229.3;148.5;229.3" dur="3.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.9s" repeatCount="indefinite"/></circle>
-  <circle cx="1110.6" cy="353.0" r="1.6" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="353.0;276.7;353.0" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="826.4" cy="183.2" r="2.5" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="183.2;113.4;183.2" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="496.3" cy="258.7" r="2.9" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="258.7;174.8;258.7" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="643.3" cy="158.4" r="2.8" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="158.4;100.2;158.4" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <circle cx="470.3" cy="480.4" r="2.3" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="480.4;416.3;480.4" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="1097.2" cy="417.2" r="1.6" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="417.2;352.1;417.2" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="632.6" cy="381.3" r="2.7" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="381.3;306.9;381.3" dur="5.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.2s" repeatCount="indefinite"/></circle>
-  <circle cx="762.1" cy="201.6" r="3.0" fill="#bef264" opacity="0.75"><animate attributeName="cy" values="201.6;129.3;201.6" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.0s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#10b981" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#bef264" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#84cc16" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#84cc16" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#bef264"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">ZERO<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">DAY<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">PATCH</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">GO</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#10b981" fill-opacity="0.12" stroke="#10b981" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#bef264" text-anchor="middle" letter-spacing="2">SECURITY</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#84cc16" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#10b981" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#bef264"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#d9f99d" letter-spacing="3.5" opacity="0.9">APR 18 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">ZERO</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">DAY</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#10b981" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#84cc16" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#bef264" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#84cc16" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#10b981" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#10b981" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#d9f99d" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#bef264" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM5.6,0.8H6V1.2H5.6zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.8,0.8H9.2V1.2H8.8zM9.2,0.8H9.6V1.2H9.2zM9.6,0.8H10V1.2H9.6zM11.2,0.8H11.6V1.2H11.2zM11.6,0.8H12V1.2H11.6zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6.4,1.2H6.8V1.6H6.4zM6.8,1.2H7.2V1.6H6.8zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.4,1.2H8.8V1.6H8.4zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM10.8,1.2H11.2V1.6H10.8zM11.2,1.2H11.6V1.6H11.2zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.2,1.2H13.6V1.6H13.2zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.8,1.6H5.2V2H4.8zM5.2,1.6H5.6V2H5.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM10,1.6H10.4V2H10zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12.4,1.6H12.8V2H12.4zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM7.6,2H8V2.4H7.6zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.6,2H10V2.4H9.6zM10,2H10.4V2.4H10zM10.4,2H10.8V2.4H10.4zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.6,2.4H6V2.8H5.6zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM10.8,2.4H11.2V2.8H10.8zM11.6,2.4H12V2.8H11.6zM12.8,2.4H13.2V2.8H12.8zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM7.6,2.8H8V3.2H7.6zM8.4,2.8H8.8V3.2H8.4zM9.2,2.8H9.6V3.2H9.2zM11.2,2.8H11.6V3.2H11.2zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.8,3.6H5.2V4H4.8zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM9.6,3.6H10V4H9.6zM10.4,3.6H10.8V4H10.4zM11.6,3.6H12V4H11.6zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM2.4,4H2.8V4.4H2.4zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4,4H4.4V4.4H4zM5.6,4H6V4.4H5.6zM6.4,4H6.8V4.4H6.4zM7.6,4H8V4.4H7.6zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.2,4H13.6V4.4H13.2zM14,4H14.4V4.4H14zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM5.6,4.4H6V4.8H5.6zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.8,4.4H9.2V4.8H8.8zM10,4.4H10.4V4.8H10zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12.8,4.4H13.2V4.8H12.8zM14,4.4H14.4V4.8H14zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM15.6,4.4H16V4.8H15.6zM16.4,4.4H16.8V4.8H16.4zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM5.2,4.8H5.6V5.2H5.2zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM9.2,4.8H9.6V5.2H9.2zM10,4.8H10.4V5.2H10zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12,4.8H12.4V5.2H12zM12.4,4.8H12.8V5.2H12.4zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM16.8,4.8H17.2V5.2H16.8zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM5.6,5.2H6V5.6H5.6zM6.8,5.2H7.2V5.6H6.8zM7.2,5.2H7.6V5.6H7.2zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10,5.2H10.4V5.6H10zM10.4,5.2H10.8V5.6H10.4zM12.4,5.2H12.8V5.6H12.4zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.2,5.2H15.6V5.6H15.2zM15.6,5.2H16V5.6H15.6zM16.8,5.2H17.2V5.6H16.8zM0.8,5.6H1.2V6H0.8zM1.6,5.6H2V6H1.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM4,5.6H4.4V6H4zM4.4,5.6H4.8V6H4.4zM5.2,5.6H5.6V6H5.2zM6,5.6H6.4V6H6zM7.6,5.6H8V6H7.6zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM14,5.6H14.4V6H14zM14.8,5.6H15.2V6H14.8zM16.8,5.6H17.2V6H16.8zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2,6.4H2.4V6.8H2zM2.4,6.4H2.8V6.8H2.4zM3.2,6.4H3.6V6.8H3.2zM4,6.4H4.4V6.8H4zM4.4,6.4H4.8V6.8H4.4zM4.8,6.4H5.2V6.8H4.8zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.6,6.4H8V6.8H7.6zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM10,6.4H10.4V6.8H10zM10.4,6.4H10.8V6.8H10.4zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.4,6.4H14.8V6.8H14.4zM15.2,6.4H15.6V6.8H15.2zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM2,6.8H2.4V7.2H2zM2.8,6.8H3.2V7.2H2.8zM5.2,6.8H5.6V7.2H5.2zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM7.2,6.8H7.6V7.2H7.2zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14.8,6.8H15.2V7.2H14.8zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM0.8,7.2H1.2V7.6H0.8zM1.6,7.2H2V7.6H1.6zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4.4,7.2H4.8V7.6H4.4zM6.4,7.2H6.8V7.6H6.4zM7.2,7.2H7.6V7.6H7.2zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14.8,7.2H15.2V7.6H14.8zM16.4,7.2H16.8V7.6H16.4zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM3.6,7.6H4V8H3.6zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM6.4,7.6H6.8V8H6.4zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM9.2,7.6H9.6V8H9.2zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM11.2,7.6H11.6V8H11.2zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM15.6,7.6H16V8H15.6zM16,7.6H16.4V8H16zM16.8,7.6H17.2V8H16.8zM0.8,8H1.2V8.4H0.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.4,8H4.8V8.4H4.4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM7.2,8H7.6V8.4H7.2zM8,8H8.4V8.4H8zM10,8H10.4V8.4H10zM10.4,8H10.8V8.4H10.4zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12.4,8H12.8V8.4H12.4zM12.8,8H13.2V8.4H12.8zM13.6,8H14V8.4H13.6zM14.4,8H14.8V8.4H14.4zM14.8,8H15.2V8.4H14.8zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM16.8,8H17.2V8.4H16.8zM0.8,8.4H1.2V8.8H0.8zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.8,8.4H7.2V8.8H6.8zM8.4,8.4H8.8V8.8H8.4zM9.2,8.4H9.6V8.8H9.2zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM14.4,8.4H14.8V8.8H14.4zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16.8,8.4H17.2V8.8H16.8zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM4.4,8.8H4.8V9.2H4.4zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM7.2,8.8H7.6V9.2H7.2zM8.4,8.8H8.8V9.2H8.4zM10.4,8.8H10.8V9.2H10.4zM11.6,8.8H12V9.2H11.6zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.2,8.8H13.6V9.2H13.2zM14,8.8H14.4V9.2H14zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM1.2,9.2H1.6V9.6H1.2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.4,9.2H4.8V9.6H4.4zM4.8,9.2H5.2V9.6H4.8zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM10.8,9.2H11.2V9.6H10.8zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14,9.2H14.4V9.6H14zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM9.2,9.6H9.6V10H9.2zM9.6,9.6H10V10H9.6zM10,9.6H10.4V10H10zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.6,9.6H14V10H13.6zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM2,10H2.4V10.4H2zM2.8,10H3.2V10.4H2.8zM4,10H4.4V10.4H4zM4.8,10H5.2V10.4H4.8zM6.4,10H6.8V10.4H6.4zM7.6,10H8V10.4H7.6zM8,10H8.4V10.4H8zM9.2,10H9.6V10.4H9.2zM10,10H10.4V10.4H10zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM16.8,10H17.2V10.4H16.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4.4,10.4H4.8V10.8H4.4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6,10.4H6.4V10.8H6zM6.4,10.4H6.8V10.8H6.4zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM11.6,10.4H12V10.8H11.6zM12.4,10.4H12.8V10.8H12.4zM13.6,10.4H14V10.8H13.6zM14,10.4H14.4V10.8H14zM14.8,10.4H15.2V10.8H14.8zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM1.2,10.8H1.6V11.2H1.2zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM10,10.8H10.4V11.2H10zM11.6,10.8H12V11.2H11.6zM12.8,10.8H13.2V11.2H12.8zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM4.4,11.2H4.8V11.6H4.4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM10,11.2H10.4V11.6H10zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM14.4,11.2H14.8V11.6H14.4zM14.8,11.2H15.2V11.6H14.8zM16.8,11.2H17.2V11.6H16.8zM0.8,11.6H1.2V12H0.8zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.4,11.6H4.8V12H4.4zM4.8,11.6H5.2V12H4.8zM5.6,11.6H6V12H5.6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM10.4,11.6H10.8V12H10.4zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12,11.6H12.4V12H12zM12.4,11.6H12.8V12H12.4zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM15.6,11.6H16V12H15.6zM16.8,11.6H17.2V12H16.8zM2,12H2.4V12.4H2zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM6.8,12H7.2V12.4H6.8zM7.2,12H7.6V12.4H7.2zM7.6,12H8V12.4H7.6zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM14,12H14.4V12.4H14zM14.8,12H15.2V12.4H14.8zM0.8,12.4H1.2V12.8H0.8zM2.4,12.4H2.8V12.8H2.4zM4,12.4H4.4V12.8H4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6.8,12.4H7.2V12.8H6.8zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM8.8,12.4H9.2V12.8H8.8zM9.2,12.4H9.6V12.8H9.2zM10.8,12.4H11.2V12.8H10.8zM11.6,12.4H12V12.8H11.6zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM2.4,12.8H2.8V13.2H2.4zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM7.6,12.8H8V13.2H7.6zM8,12.8H8.4V13.2H8zM8.8,12.8H9.2V13.2H8.8zM9.6,12.8H10V13.2H9.6zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12.4,12.8H12.8V13.2H12.4zM12.8,12.8H13.2V13.2H12.8zM14,12.8H14.4V13.2H14zM15.2,12.8H15.6V13.2H15.2zM16.8,12.8H17.2V13.2H16.8zM3.6,13.2H4V13.6H3.6zM6.8,13.2H7.2V13.6H6.8zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12.4,13.2H12.8V13.6H12.4zM14,13.2H14.4V13.6H14zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM0.8,13.6H1.2V14H0.8zM1.2,13.6H1.6V14H1.2zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM6.4,13.6H6.8V14H6.4zM6.8,13.6H7.2V14H6.8zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM4,14H4.4V14.4H4zM5.6,14H6V14.4H5.6zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM9.2,14H9.6V14.4H9.2zM10,14H10.4V14.4H10zM11.2,14H11.6V14.4H11.2zM12,14H12.4V14.4H12zM13.2,14H13.6V14.4H13.2zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM15.6,14H16V14.4H15.6zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM8.8,14.4H9.2V14.8H8.8zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.6,14.4H12V14.8H11.6zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16.8,14.4H17.2V14.8H16.8zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.6,14.8H6V15.2H5.6zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM7.2,14.8H7.6V15.2H7.2zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM9.6,14.8H10V15.2H9.6zM10,14.8H10.4V15.2H10zM10.4,14.8H10.8V15.2H10.4zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12,14.8H12.4V15.2H12zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM5.2,15.2H5.6V15.6H5.2zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM8.8,15.2H9.2V15.6H8.8zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM13.2,15.2H13.6V15.6H13.2zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM6.8,15.6H7.2V16H6.8zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM11.6,15.6H12V16H11.6zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4.8,16H5.2V16.4H4.8zM5.6,16H6V16.4H5.6zM6.4,16H6.8V16.4H6.4zM8.8,16H9.2V16.4H8.8zM10,16H10.4V16.4H10zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12,16H12.4V16.4H12zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM10,16.4H10.4V16.8H10zM11.2,16.4H11.6V16.8H11.2zM12.4,16.4H12.8V16.8H12.4zM12.8,16.4H13.2V16.8H12.8zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.4,16.4H14.8V16.8H14.4zM14.8,16.4H15.2V16.8H14.8zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM16.8,16.4H17.2V16.8H16.8zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM5.6,16.8H6V17.2H5.6zM6.4,16.8H6.8V17.2H6.4zM7.2,16.8H7.6V17.2H7.2zM8,16.8H8.4V17.2H8zM8.4,16.8H8.8V17.2H8.4zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM12.4,16.8H12.8V17.2H12.4zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: zero-day triage, compliance ETL, ads policy announcement">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- CVE stack (left, 4 cards cascading) -->
+  <g transform="translate(-90,-80)">
+    <rect x="0" y="0" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="26" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="52" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="0" y="78" width="64" height="22" rx="4" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.95">
+      <animate attributeName="x" values="-20;0;0;-20" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="1.2s" repeatCount="indefinite"/>
+    </rect>
+    <!-- bug icon marks on each card -->
+    <circle cx="10" cy="11" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="37" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="63" r="3" fill="#FFB703"/>
+    <circle cx="10" cy="89" r="3" fill="#FFB703"/>
+    <line x1="22" y1="11" x2="50" y2="11" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="37" x2="50" y2="37" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="63" x2="50" y2="63" stroke="#8B94A8" stroke-width="1.6"/>
+    <line x1="22" y1="89" x2="50" y2="89" stroke="#8B94A8" stroke-width="1.6"/>
   </g>
+  <!-- Arrow flowing from stack to diamond -->
+  <path d="M -18 -20 L 18 -20" stroke="#FFB703" stroke-width="2.4" fill="none"
+        stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 18 -20 L 12 -24 M 18 -20 L 12 -16" stroke="#FFB703" stroke-width="2.4" fill="none"/>
+  <!-- Decision diamond (center) rotating -->
+  <g transform="translate(42,-20)">
+    <polygon points="0,-22 22,0 0,22 -22,0" fill="none" stroke="#FFB703" stroke-width="2.4" opacity="0.95">
+      <animateTransform attributeName="transform" type="rotate"
+                        values="0;360" dur="18s" repeatCount="indefinite"/>
+    </polygon>
+    <circle cx="0" cy="0" r="5" fill="#FFB703">
+      <animate attributeName="r" values="5;7;5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- small question mark via lines only (no text) -->
+    <path d="M -3 -4 Q 0 -8 3 -4 Q 3 0 0 2" fill="none" stroke="#0B132B" stroke-width="1.6"/>
+    <circle cx="0" cy="6" r="1" fill="#0B132B"/>
+  </g>
+  <!-- Branch up (keep) -->
+  <path d="M 64 -30 L 104 -58" stroke="#3A86FF" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,-66)">
+    <!-- checkmark in circle -->
+    <circle cx="0" cy="0" r="14" fill="none" stroke="#3A86FF" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <path d="M -6 0 L -2 5 L 7 -5" fill="none" stroke="#3A86FF" stroke-width="2.6" stroke-linecap="round"/>
+  </g>
+  <!-- Branch down (drop/trash) -->
+  <path d="M 64 -10 L 104 18" stroke="#E63946" stroke-width="2.4" fill="none" stroke-dasharray="4 3">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </path>
+  <g transform="translate(112,26)">
+    <!-- trash bin -->
+    <rect x="-10" y="-6" width="20" height="20" rx="2" fill="none" stroke="#E63946" stroke-width="2.2">
+      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <line x1="-12" y1="-6" x2="12" y2="-6" stroke="#E63946" stroke-width="2.2"/>
+    <rect x="-4" y="-10" width="8" height="4" fill="#E63946"/>
+    <line x1="-4" y1="-2" x2="-4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="0" y1="-2" x2="0" y2="10" stroke="#E63946" stroke-width="1.6"/>
+    <line x1="4" y1="-2" x2="4" y2="10" stroke="#E63946" stroke-width="1.6"/>
+  </g>
+  <!-- Falling CVE cards toward trash (animation) -->
+  <rect x="90" y="0" width="24" height="10" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;50" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.4s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="92" y="0" width="20" height="8" rx="2" fill="#E63946" opacity="0">
+    <animate attributeName="y" values="0;52" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- Rising card toward keep -->
+  <rect x="80" y="-40" width="20" height="8" rx="2" fill="#3A86FF" opacity="0">
+    <animate attributeName="y" values="-40;-62" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">DEFENDER</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Vendor patches active zero-day cases</text>
+<g transform="translate(576,330)">
+  <!-- Shield silhouette -->
+  <g transform="translate(-70,-100)">
+    <path d="M 0 0 L 60 0 L 60 60 Q 60 100 30 120 Q 0 100 0 60 Z"
+          fill="#0B132B" stroke="#3A86FF" stroke-width="2.4">
+      <animate attributeName="opacity" values="0.9;1;0.9" dur="3.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- inner pulse -->
+    <path d="M 10 10 L 50 10 L 50 58 Q 50 92 30 108 Q 10 92 10 58 Z"
+          fill="url(#glowBlue)" opacity="0.35">
+      <animate attributeName="opacity" values="0.2;0.55;0.2" dur="2.6s" repeatCount="indefinite"/>
+    </path>
+    <!-- big checkmark inside -->
+    <path d="M 14 58 L 26 74 L 48 40" fill="none" stroke="#3A86FF" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+      <animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/>
+    </path>
+  </g>
+  <!-- Clipboard (right) -->
+  <g transform="translate(10,-90)">
+    <rect x="0" y="0" width="90" height="120" rx="6" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
+    <!-- clip -->
+    <rect x="32" y="-8" width="26" height="14" rx="3" fill="#3A86FF"/>
+    <!-- checklist rows appearing -->
+    <g>
+      <circle cx="14" cy="24" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 24 L 13 26 L 17 22" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="22" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="28" width="42" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="44" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 44 L 13 46 L 17 42" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="1s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="42" width="58" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="48" width="46" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="64" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 64 L 13 66 L 17 62" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="2s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="62" width="50" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="68" width="38" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="84" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 84 L 13 86 L 17 82" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="3s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="82" width="54" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="88" width="44" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+    <g>
+      <circle cx="14" cy="104" r="4" fill="none" stroke="#3A86FF" stroke-width="1.6"/>
+      <path d="M 11 104 L 13 106 L 17 102" fill="none" stroke="#3A86FF" stroke-width="1.8" stroke-dasharray="0 10">
+        <animate attributeName="stroke-dasharray" values="0 10;10 0;10 0;0 10" dur="8s" begin="4s" repeatCount="indefinite"/>
+      </path>
+      <rect x="24" y="102" width="60" height="3" rx="1.5" fill="#E7ECF4" opacity="0.75"/>
+      <rect x="24" y="108" width="48" height="2.5" rx="1.25" fill="#8B94A8" opacity="0.6"/>
+    </g>
+  </g>
+  <!-- Growing service nodes around shield -->
+  <circle cx="-90" cy="40" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="60;40;40;20" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="60" r="3" fill="#3A86FF" opacity="0">
+    <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="80;60;60;40" dur="5s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- progress bar bottom -->
+  <rect x="-60" y="56" width="120" height="6" rx="3" fill="#2A3256"/>
+  <rect x="-60" y="56" width="20" height="6" rx="3" fill="#3A86FF">
+    <animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/>
+  </rect>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">ETL</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Pipeline normalises logs to open format</text>
+<g transform="translate(936,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">GOOGLE</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Policy violations prompt yearly enforcement</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM10.8,0.8H11.2V1.2H10.8zM12,0.8H12.4V1.2H12zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.4,1.2H4.8V1.6H4.4zM5.2,1.2H5.6V1.6H5.2zM5.6,1.2H6V1.6H5.6zM6,1.2H6.4V1.6H6zM6.4,1.2H6.8V1.6H6.4zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM7.2,1.6H7.6V2H7.2zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM10.8,2H11.2V2.4H10.8zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.8,2.4H5.2V2.8H4.8zM5.2,2.4H5.6V2.8H5.2zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM7.2,2.8H7.6V3.2H7.2zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.4,4H4.8V4.4H4.4zM5.2,4H5.6V4.4H5.2zM5.6,4H6V4.4H5.6zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.8,4.4H3.2V4.8H2.8zM4.4,4.4H4.8V4.8H4.4zM5.6,4.4H6V4.8H5.6zM6.4,4.4H6.8V4.8H6.4zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM2,4.8H2.4V5.2H2zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM4.8,4.8H5.2V5.2H4.8zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM16.4,4.8H16.8V5.2H16.4zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2.8,5.2H3.2V5.6H2.8zM3.6,5.2H4V5.6H3.6zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.6,5.2H16V5.6H15.6zM1.2,5.6H1.6V6H1.2zM2,5.6H2.4V6H2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6,5.6H6.4V6H6zM6.8,5.6H7.2V6H6.8zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.4,5.6H10.8V6H10.4zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM13.6,5.6H14V6H13.6zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.4,5.6H16.8V6H16.4zM16.8,5.6H17.2V6H16.8zM0.8,6H1.2V6.4H0.8zM2.4,6H2.8V6.4H2.4zM3.6,6H4V6.4H3.6zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM4.8,6H5.2V6.4H4.8zM5.6,6H6V6.4H5.6zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.8,6H9.2V6.4H8.8zM10,6H10.4V6.4H10zM10.8,6H11.2V6.4H10.8zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.8,6.4H5.2V6.8H4.8zM5.2,6.4H5.6V6.8H5.2zM5.6,6.4H6V6.8H5.6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM11.6,6.4H12V6.8H11.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM0.8,6.8H1.2V7.2H0.8zM1.6,6.8H2V7.2H1.6zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM5.6,6.8H6V7.2H5.6zM7.2,6.8H7.6V7.2H7.2zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10,6.8H10.4V7.2H10zM11.2,6.8H11.6V7.2H11.2zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM1.2,7.2H1.6V7.6H1.2zM2,7.2H2.4V7.6H2zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.8,7.2H5.2V7.6H4.8zM5.2,7.2H5.6V7.6H5.2zM5.6,7.2H6V7.6H5.6zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.2,7.2H13.6V7.6H13.2zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM0.8,7.6H1.2V8H0.8zM2.4,7.6H2.8V8H2.4zM4,7.6H4.4V8H4zM4.4,7.6H4.8V8H4.4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM5.2,8H5.6V8.4H5.2zM5.6,8H6V8.4H5.6zM6.4,8H6.8V8.4H6.4zM7.6,8H8V8.4H7.6zM9.6,8H10V8.4H9.6zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM0.8,8.4H1.2V8.8H0.8zM1.6,8.4H2V8.8H1.6zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.6,8.4H6V8.8H5.6zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.4,8.4H8.8V8.8H8.4zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM2,8.8H2.4V9.2H2zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4.8,8.8H5.2V9.2H4.8zM6,8.8H6.4V9.2H6zM7.2,8.8H7.6V9.2H7.2zM9.2,8.8H9.6V9.2H9.2zM10.4,8.8H10.8V9.2H10.4zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM14.8,8.8H15.2V9.2H14.8zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM0.8,9.2H1.2V9.6H0.8zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM3.6,9.2H4V9.6H3.6zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM6,9.2H6.4V9.6H6zM6.4,9.2H6.8V9.6H6.4zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM11.2,9.2H11.6V9.6H11.2zM12.8,9.2H13.2V9.6H12.8zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM15.6,9.2H16V9.6H15.6zM16,9.2H16.4V9.6H16zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM2,9.6H2.4V10H2zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.4,9.6H4.8V10H4.4zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM6.8,9.6H7.2V10H6.8zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM10.4,9.6H10.8V10H10.4zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM0.8,10H1.2V10.4H0.8zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM3.6,10H4V10.4H3.6zM4,10H4.4V10.4H4zM6.4,10H6.8V10.4H6.4zM6.8,10H7.2V10.4H6.8zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM4.8,10.4H5.2V10.8H4.8zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM0.8,10.8H1.2V11.2H0.8zM1.6,10.8H2V11.2H1.6zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.6,10.8H6V11.2H5.6zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.8,10.8H17.2V11.2H16.8zM0.8,11.2H1.2V11.6H0.8zM1.6,11.2H2V11.6H1.6zM2,11.2H2.4V11.6H2zM2.4,11.2H2.8V11.6H2.4zM3.2,11.2H3.6V11.6H3.2zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.2,11.2H15.6V11.6H15.2zM0.8,11.6H1.2V12H0.8zM1.2,11.6H1.6V12H1.2zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM3.6,11.6H4V12H3.6zM4.4,11.6H4.8V12H4.4zM5.2,11.6H5.6V12H5.2zM6.4,11.6H6.8V12H6.4zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM2.4,12H2.8V12.4H2.4zM2.8,12H3.2V12.4H2.8zM3.2,12H3.6V12.4H3.2zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM6,12H6.4V12.4H6zM6.4,12H6.8V12.4H6.4zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12,12H12.4V12.4H12zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM2.8,12.4H3.2V12.8H2.8zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6.8,12.4H7.2V12.8H6.8zM7.2,12.4H7.6V12.8H7.2zM8,12.4H8.4V12.8H8zM10,12.4H10.4V12.8H10zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM5.2,12.8H5.6V13.2H5.2zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM7.2,12.8H7.6V13.2H7.2zM8.8,12.8H9.2V13.2H8.8zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2.4,13.2H2.8V13.6H2.4zM2.8,13.2H3.2V13.6H2.8zM3.6,13.2H4V13.6H3.6zM5.6,13.2H6V13.6H5.6zM6.8,13.2H7.2V13.6H6.8zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM11.2,13.2H11.6V13.6H11.2zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4,13.6H4.4V14H4zM5.6,13.6H6V14H5.6zM6.4,13.6H6.8V14H6.4zM6.8,13.6H7.2V14H6.8zM7.6,13.6H8V14H7.6zM8.8,13.6H9.2V14H8.8zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.6,14H6V14.4H5.6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM10.8,14H11.2V14.4H10.8zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.2,14.4H5.6V14.8H5.2zM6.4,14.4H6.8V14.8H6.4zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6,14.8H6.4V15.2H6zM6.8,14.8H7.2V15.2H6.8zM8.8,14.8H9.2V15.2H8.8zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM6,15.2H6.4V15.6H6zM8,15.2H8.4V15.6H8zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM10.8,15.2H11.2V15.6H10.8zM12.4,15.2H12.8V15.6H12.4zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM5.6,15.6H6V16H5.6zM7.2,15.6H7.6V16H7.2zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM16.4,15.6H16.8V16H16.4zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.4,16.4H4.8V16.8H4.4zM5.6,16.4H6V16.8H5.6zM7.6,16.4H8V16.8H7.6zM8,16.4H8.4V16.8H8zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM5.6,16.8H6V17.2H5.6zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM7.2,16.8H7.6V17.2H7.2zM8,16.8H8.4V17.2H8zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>

--- a/assets/images/2026-04-19-Tech_Security_Weekly_Digest_AI_Data_CVE_Botnet.svg
+++ b/assets/images/2026-04-19-Tech_Security_Weekly_Digest_AI_Data_CVE_Botnet.svg
@@ -1,145 +1,473 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Style A v3 APR 19 2026 DATA CVE">
-  <title>Style A v3 APR 19 2026 DATA CVE</title>
-  <defs>
-  <linearGradient id="bgA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0b0420"/><stop offset="100%" stop-color="#160829"/></linearGradient>
-  <linearGradient id="bgB" x1="100%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#160829"/><stop offset="100%" stop-color="#020308"/></linearGradient>
-  <radialGradient id="haloA" cx="30%" cy="40%" r="65%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.34"/><stop offset="100%" stop-color="#0b0420" stop-opacity="0"/></radialGradient>
-  <radialGradient id="haloB" cx="75%" cy="72%" r="60%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.32"/><stop offset="100%" stop-color="#160829" stop-opacity="0"/></radialGradient>
-  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"><animate attributeName="stop-color" values="#d946ef;#f0abfc;#8b5cf6;#d946ef" dur="6s" repeatCount="indefinite"/></stop><stop offset="50%" stop-color="#f0abfc"><animate attributeName="stop-color" values="#f0abfc;#a78bfa;#d946ef;#f0abfc" dur="6s" repeatCount="indefinite"/></stop><stop offset="100%" stop-color="#a78bfa"><animate attributeName="stop-color" values="#a78bfa;#8b5cf6;#f0abfc;#a78bfa" dur="6s" repeatCount="indefinite"/></stop></linearGradient>
-  <linearGradient id="heroGradB" x1="0%" y1="100%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.9"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.95"/></linearGradient>
-  <linearGradient id="panelGrad" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#0b0420" stop-opacity="0.95"/><stop offset="100%" stop-color="#000000" stop-opacity="0.85"/></linearGradient>
-  <linearGradient id="stripe" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="50%" stop-color="#8b5cf6" stop-opacity="0.7"/><stop offset="100%" stop-color="#8b5cf6" stop-opacity="0"/></linearGradient>
-  <radialGradient id="nodeCore" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="1"/><stop offset="55%" stop-color="#d946ef" stop-opacity="0.75"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></radialGradient>
-  <radialGradient id="nodeGlow" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.5"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></radialGradient>
-  <radialGradient id="scanSpot" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#fbcfe8" stop-opacity="0.85"/><stop offset="100%" stop-color="#fbcfe8" stop-opacity="0"/></radialGradient>
-  <radialGradient id="qrHalo" cx="50%" cy="50%" r="65%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0.45"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></radialGradient>
-  <linearGradient id="ringA" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0.85"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0.15"/></linearGradient>
-  <linearGradient id="ringB" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#d946ef" stop-opacity="0.4"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0.05"/></linearGradient>
-  <linearGradient id="underline" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#8b5cf6" stop-opacity="0"/><stop offset="35%" stop-color="#8b5cf6" stop-opacity="0.95"/><stop offset="65%" stop-color="#d946ef" stop-opacity="0.95"/><stop offset="100%" stop-color="#d946ef" stop-opacity="0"/></linearGradient>
-  <linearGradient id="beam" x1="0%" y1="0%" x2="0%" y2="100%"><stop offset="0%" stop-color="#f0abfc" stop-opacity="0"/><stop offset="40%" stop-color="#f0abfc" stop-opacity="0.55"/><stop offset="100%" stop-color="#f0abfc" stop-opacity="0"/></linearGradient>
-  <linearGradient id="secGrad" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#d946ef"/><stop offset="100%" stop-color="#f0abfc"/></linearGradient>
-  <filter id="fxGlow" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="5" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><filter id="fxSoft" x="-40%" y="-40%" width="180%" height="180%"><feGaussianBlur stdDeviation="2.2"/></filter><filter id="fxHero" x="-10%" y="-10%" width="120%" height="120%"><feGaussianBlur stdDeviation="1.8" result="b"/><feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge></filter><pattern id="dotGrid" x="0" y="0" width="38" height="38" patternUnits="userSpaceOnUse"><circle cx="19" cy="19" r="0.9" fill="#1f2937" opacity="0.42"/></pattern>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bgA)"/>
-  <rect width="1200" height="630" fill="url(#haloA)"/>
-  <rect width="1200" height="630" fill="url(#haloB)"/>
-  <rect width="1200" height="630" fill="url(#dotGrid)"/>
-  <circle cx="760" cy="315" r="120" fill="none" stroke="url(#ringA)" stroke-width="1.60" opacity="0.42"><animate attributeName="r" values="120;130;120" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.42;0.18;0.42" dur="6.0s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="175" fill="none" stroke="url(#ringB)" stroke-width="1.48" opacity="0.38"><animate attributeName="r" values="175;185;175" dur="7.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.38;0.16;0.38" dur="7.1s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="230" fill="none" stroke="url(#ringA)" stroke-width="1.36" opacity="0.33"><animate attributeName="r" values="230;240;230" dur="8.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.33;0.14;0.33" dur="8.2s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="285" fill="none" stroke="url(#ringB)" stroke-width="1.24" opacity="0.28"><animate attributeName="r" values="285;295;285" dur="9.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.28;0.12;0.28" dur="9.3s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="url(#ringA)" stroke-width="1.12" opacity="0.24"><animate attributeName="r" values="340;350;340" dur="10.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.24;0.10;0.24" dur="10.4s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="395" fill="none" stroke="url(#ringB)" stroke-width="1.00" opacity="0.20"><animate attributeName="r" values="395;405;395" dur="11.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.20;0.08;0.20" dur="11.5s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="180" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="10,24"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="18s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="260" fill="none" stroke="#d946ef" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="14,29"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="-360 760 315" dur="24s" repeatCount="indefinite"/></circle>
-  <circle cx="760" cy="315" r="340" fill="none" stroke="#8b5cf6" stroke-width="1.4" stroke-opacity="0.55" stroke-dasharray="18,34"><animateTransform attributeName="transform" type="rotate" from="0 760 315" to="360 760 315" dur="30s" repeatCount="indefinite"/></circle>
-  <rect x="460" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="440;500;440" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="640" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="620;680;620" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.0s" repeatCount="indefinite"/></rect>
-  <rect x="820" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="800;860;800" dur="5.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="5.5s" repeatCount="indefinite"/></rect>
-  <rect x="1000" y="-60" width="4" height="750" fill="url(#beam)" opacity="0.55"><animate attributeName="x" values="980;1040;980" dur="6.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.25;0.85;0.25" dur="6.0s" repeatCount="indefinite"/></rect>
-  <line x1="565.4" y1="284.0" x2="569.3" y2="238.3" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.0s" repeatCount="indefinite"/></line>
-  <line x1="565.4" y1="284.0" x2="641.1" y2="377.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="569.3" y1="238.3" x2="641.1" y2="377.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.3s" repeatCount="indefinite"/></line>
-  <line x1="569.3" y1="238.3" x2="766.9" y2="414.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="641.1" y1="377.8" x2="766.9" y2="414.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="641.1" y1="377.8" x2="885.0" y2="375.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="766.9" y1="414.6" x2="885.0" y2="375.5" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <line x1="766.9" y1="414.6" x2="792.5" y2="443.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.6s" repeatCount="indefinite"/></line>
-  <line x1="885.0" y1="375.5" x2="792.5" y2="443.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="885.0" y1="375.5" x2="925.3" y2="331.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="792.5" y1="443.1" x2="925.3" y2="331.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.5s" repeatCount="indefinite"/></line>
-  <line x1="792.5" y1="443.1" x2="553.5" y2="434.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="925.3" y1="331.2" x2="553.5" y2="434.2" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="925.3" y1="331.2" x2="896.7" y2="307.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.8s" repeatCount="indefinite"/></line>
-  <line x1="553.5" y1="434.2" x2="896.7" y2="307.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.1s" repeatCount="indefinite"/></line>
-  <line x1="553.5" y1="434.2" x2="623.3" y2="269.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="896.7" y1="307.8" x2="623.3" y2="269.4" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.4s" repeatCount="indefinite"/></line>
-  <line x1="896.7" y1="307.8" x2="997.2" y2="250.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.3s" repeatCount="indefinite"/></line>
-  <line x1="623.3" y1="269.4" x2="997.2" y2="250.7" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="623.3" y1="269.4" x2="914.8" y2="352.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.1s" repeatCount="indefinite"/></line>
-  <line x1="997.2" y1="250.7" x2="914.8" y2="352.8" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.0s" repeatCount="indefinite"/></line>
-  <line x1="997.2" y1="250.7" x2="907.2" y2="355.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="914.8" y1="352.8" x2="907.2" y2="355.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="3.3s" repeatCount="indefinite"/></line>
-  <line x1="914.8" y1="352.8" x2="759.2" y2="182.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.4s" repeatCount="indefinite"/></line>
-  <line x1="907.2" y1="355.9" x2="759.2" y2="182.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.2s" repeatCount="indefinite"/></line>
-  <line x1="907.2" y1="355.9" x2="539.1" y2="338.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.2s" repeatCount="indefinite"/></line>
-  <line x1="759.2" y1="182.9" x2="539.1" y2="338.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.5s" repeatCount="indefinite"/></line>
-  <line x1="759.2" y1="182.9" x2="573.4" y2="348.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="6.5s" repeatCount="indefinite"/></line>
-  <line x1="539.1" y1="338.6" x2="573.4" y2="348.6" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.8s" repeatCount="indefinite"/></line>
-  <line x1="539.1" y1="338.6" x2="659.7" y2="241.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.6s" repeatCount="indefinite"/></line>
-  <line x1="573.4" y1="348.6" x2="659.7" y2="241.1" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.7s" repeatCount="indefinite"/></line>
-  <line x1="573.4" y1="348.6" x2="606.5" y2="218.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="4.7s" repeatCount="indefinite"/></line>
-  <line x1="659.7" y1="241.1" x2="606.5" y2="218.9" stroke="#d946ef" stroke-width="0.9" stroke-opacity="0.35"><animate attributeName="stroke-opacity" values="0.15;0.6;0.15" dur="5.9s" repeatCount="indefinite"/></line>
-  <circle cx="565.4" cy="284.0" r="12.8" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="565.4" cy="284.0" r="6.8" fill="url(#nodeCore)"><animate attributeName="r" values="6.8;8.8;6.8" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="569.3" cy="238.3" r="14.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="569.3" cy="238.3" r="8.7" fill="url(#nodeCore)"><animate attributeName="r" values="8.7;10.7;8.7" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="641.1" cy="377.8" r="11.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="641.1" cy="377.8" r="5.0" fill="url(#nodeCore)"><animate attributeName="r" values="5.0;7.0;5.0" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="766.9" cy="414.6" r="13.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="766.9" cy="414.6" r="7.3" fill="url(#nodeCore)"><animate attributeName="r" values="7.3;9.3;7.3" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="885.0" cy="375.5" r="10.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="885.0" cy="375.5" r="4.1" fill="url(#nodeCore)"><animate attributeName="r" values="4.1;6.1;4.1" dur="3.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.5s" repeatCount="indefinite"/></circle>
-  <circle cx="792.5" cy="443.1" r="13.9" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="792.5" cy="443.1" r="7.9" fill="url(#nodeCore)"><animate attributeName="r" values="7.9;9.9;7.9" dur="3.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.0s" repeatCount="indefinite"/></circle>
-  <circle cx="925.3" cy="331.2" r="11.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="925.3" cy="331.2" r="5.3" fill="url(#nodeCore)"><animate attributeName="r" values="5.3;7.3;5.3" dur="4.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.5s" repeatCount="indefinite"/></circle>
-  <circle cx="553.5" cy="434.2" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="553.5" cy="434.2" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="896.7" cy="307.8" r="13.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="896.7" cy="307.8" r="7.3" fill="url(#nodeCore)"><animate attributeName="r" values="7.3;9.3;7.3" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="623.3" cy="269.4" r="10.3" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="623.3" cy="269.4" r="4.3" fill="url(#nodeCore)"><animate attributeName="r" values="4.3;6.3;4.3" dur="2.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.9s" repeatCount="indefinite"/></circle>
-  <circle cx="997.2" cy="250.7" r="12.7" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="997.2" cy="250.7" r="6.7" fill="url(#nodeCore)"><animate attributeName="r" values="6.7;8.7;6.7" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="914.8" cy="352.8" r="12.4" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="914.8" cy="352.8" r="6.4" fill="url(#nodeCore)"><animate attributeName="r" values="6.4;8.4;6.4" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="907.2" cy="355.9" r="12.1" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="907.2" cy="355.9" r="6.1" fill="url(#nodeCore)"><animate attributeName="r" values="6.1;8.1;6.1" dur="2.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="2.8s" repeatCount="indefinite"/></circle>
-  <circle cx="759.2" cy="182.9" r="11.6" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="759.2" cy="182.9" r="5.6" fill="url(#nodeCore)"><animate attributeName="r" values="5.6;7.6;5.6" dur="3.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.7s" repeatCount="indefinite"/></circle>
-  <circle cx="539.1" cy="338.6" r="10.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="539.1" cy="338.6" r="4.2" fill="url(#nodeCore)"><animate attributeName="r" values="4.2;6.2;4.2" dur="5.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.3s" repeatCount="indefinite"/></circle>
-  <circle cx="573.4" cy="348.6" r="13.5" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="573.4" cy="348.6" r="7.5" fill="url(#nodeCore)"><animate attributeName="r" values="7.5;9.5;7.5" dur="3.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="3.6s" repeatCount="indefinite"/></circle>
-  <circle cx="659.7" cy="241.1" r="13.2" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="659.7" cy="241.1" r="7.2" fill="url(#nodeCore)"><animate attributeName="r" values="7.2;9.2;7.2" dur="5.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="5.1s" repeatCount="indefinite"/></circle>
-  <circle cx="606.5" cy="218.9" r="15.0" fill="url(#nodeGlow)" opacity="0.6"/><circle cx="606.5" cy="218.9" r="9.0" fill="url(#nodeCore)"><animate attributeName="r" values="9.0;11.0;9.0" dur="4.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.65;1;0.65" dur="4.0s" repeatCount="indefinite"/></circle>
-  <circle cx="669.4" cy="160.5" r="1.6" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="160.5;84.3;160.5" dur="3.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
-  <circle cx="461.3" cy="442.7" r="2.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="442.7;357.7;442.7" dur="4.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.2s" repeatCount="indefinite"/></circle>
-  <circle cx="412.1" cy="455.1" r="2.5" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="455.1;383.2;455.1" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="808.3" cy="368.3" r="3.2" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="368.3;305.5;368.3" dur="4.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.9s" repeatCount="indefinite"/></circle>
-  <circle cx="423.9" cy="160.6" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="160.6;83.0;160.6" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.4s" repeatCount="indefinite"/></circle>
-  <circle cx="776.0" cy="386.0" r="3.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="386.0;335.1;386.0" dur="5.0s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.0s" repeatCount="indefinite"/></circle>
-  <circle cx="1001.4" cy="105.1" r="3.1" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="105.1;55.5;105.1" dur="4.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.4s" repeatCount="indefinite"/></circle>
-  <circle cx="999.8" cy="373.7" r="2.7" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="373.7;296.6;373.7" dur="4.6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.6s" repeatCount="indefinite"/></circle>
-  <circle cx="592.2" cy="476.3" r="2.2" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="476.3;432.0;476.3" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="1110.0" cy="305.2" r="1.6" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="305.2;239.3;305.2" dur="5.9s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="5.9s" repeatCount="indefinite"/></circle>
-  <circle cx="970.4" cy="156.0" r="1.8" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="156.0;116.9;156.0" dur="4.7s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.7s" repeatCount="indefinite"/></circle>
-  <circle cx="624.0" cy="203.9" r="2.7" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="203.9;158.8;203.9" dur="6.3s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="6.3s" repeatCount="indefinite"/></circle>
-  <circle cx="436.5" cy="368.4" r="2.6" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="368.4;303.7;368.4" dur="4.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.8s" repeatCount="indefinite"/></circle>
-  <circle cx="417.0" cy="61.3" r="2.0" fill="#f0abfc" opacity="0.75"><animate attributeName="cy" values="61.3;3.2;61.3" dur="3.1s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
-  <g transform="translate(1020 120)" opacity="0.85"><path d="M 0 -46 L 44 -28 L 44 14 Q 44 50 0 72 Q -44 50 -44 14 L -44 -28 Z" fill="none" stroke="#8b5cf6" stroke-width="2.6" stroke-opacity="0.85"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="3.4s" repeatCount="indefinite"/></path><path d="M -15 5 L -3 18 L 20 -10" fill="none" stroke="#f0abfc" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"><animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></path></g>
-  <g transform="translate(445 155)" opacity="0.72"><rect x="-22" y="0" width="44" height="34" rx="5" fill="none" stroke="#d946ef" stroke-width="2.2"/><path d="M -14 0 Q -14 -22 0 -22 Q 14 -22 14 0" fill="none" stroke="#d946ef" stroke-width="2.2"><animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/></path><circle cx="0" cy="14" r="3.5" fill="#f0abfc"><animate attributeName="r" values="3;5;3" dur="2s" repeatCount="indefinite"/></circle></g>
-  <text x="755" y="260" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="url(#heroGrad)" text-anchor="middle" letter-spacing="-2" filter="url(#fxHero)">DATA<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" repeatCount="indefinite"/></text>
-  <text x="755" y="355" font-family="Arial Black, Impact, sans-serif" font-size="118" font-weight="900" fill="#f1f5f9" text-anchor="middle" letter-spacing="-2" opacity="0.97" filter="url(#fxHero)">CVE<animate attributeName="opacity" values="0.85;1;0.85" dur="3.2s" begin="1.1s" repeatCount="indefinite"/></text>
-  <rect x="535" y="373" width="440" height="4" rx="2" fill="url(#underline)"><animate attributeName="width" values="40;440;40" dur="5.2s" repeatCount="indefinite"/><animate attributeName="x" values="735;535;735" dur="5.2s" repeatCount="indefinite"/></rect>
-  <g transform="translate(615.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.0s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">AI</text></g>
-  <g transform="translate(755.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="3.6s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">BOTNET</text></g>
-  <g transform="translate(895.0 409)"><rect x="-58" y="-16" width="116" height="30" rx="15" fill="#8b5cf6" fill-opacity="0.12" stroke="#8b5cf6" stroke-width="1.2" stroke-opacity="0.7"><animate attributeName="stroke-opacity" values="0.4;0.95;0.4" dur="4.2s" repeatCount="indefinite"/></rect><text x="0" y="5" font-family="Arial Black,sans-serif" font-size="13" fill="#f0abfc" text-anchor="middle" letter-spacing="2">LEAK</text></g>
-  <rect x="420" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></rect>
-  <rect x="510" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" repeatCount="indefinite"/></rect>
-  <rect x="600" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.0s" repeatCount="indefinite"/></rect>
-  <rect x="690" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.3s" repeatCount="indefinite"/></rect>
-  <rect x="780" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.6s" repeatCount="indefinite"/></rect>
-  <rect x="870" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.9s" repeatCount="indefinite"/></rect>
-  <rect x="960" y="70" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.2s" repeatCount="indefinite"/></rect>
-  <rect x="1050" y="82" width="14" height="3" rx="1.5" fill="#d946ef" opacity="0.5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="4.5s" repeatCount="indefinite"/></rect>
-  <rect x="0" y="0" width="368" height="630" fill="url(#panelGrad)"/>
-  <rect x="0" y="0" width="4" height="630" fill="#8b5cf6" opacity="0.9"><animate attributeName="opacity" values="0.6;1;0.6" dur="3.1s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="40" width="240" height="2" fill="url(#stripe)"><animate attributeName="width" values="80;240;80" dur="4.2s" repeatCount="indefinite"/></rect>
-  <circle cx="42" cy="74" r="6" fill="#f0abfc"><animate attributeName="r" values="5;8;5" dur="2.6s" repeatCount="indefinite"/></circle>
-  <text x="62" y="80" font-family="Arial Black,sans-serif" font-size="14" fill="#fbcfe8" letter-spacing="3.5" opacity="0.9">APR 19 2026</text>
-  <text x="28" y="230" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="url(#heroGrad)" letter-spacing="-2" filter="url(#fxHero)">DATA</text>
-  <text x="28" y="302" font-family="Arial Black, Impact, sans-serif" font-size="68" fill="#f1f5f9" letter-spacing="-2" opacity="0.95" filter="url(#fxHero)">CVE</text>
-  <rect x="28" y="320" width="240" height="3" rx="1.5" fill="url(#underline)"><animate attributeName="width" values="60;240;60" dur="4.8s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="360" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="360" width="220" height="8" rx="4" fill="#8b5cf6" opacity="0.9"><animate attributeName="width" values="20;220;20" dur="4s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="378" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="378" width="170" height="8" rx="4" fill="#d946ef" opacity="0.9"><animate attributeName="width" values="20;170;20" dur="5s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="396" width="240" height="8" rx="4" fill="#111827" opacity="0.8"/><rect x="28" y="396" width="120" height="8" rx="4" fill="#f0abfc" opacity="0.9"><animate attributeName="width" values="20;120;20" dur="6s" repeatCount="indefinite"/></rect>
-  <rect x="28" y="440" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.4s" repeatCount="indefinite"/></rect><rect x="56" y="440" width="60" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="458" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="2.7s" repeatCount="indefinite"/></rect><rect x="56" y="458" width="74" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="476" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.0s" repeatCount="indefinite"/></rect><rect x="56" y="476" width="88" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="494" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.3s" repeatCount="indefinite"/></rect><rect x="56" y="494" width="102" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="512" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.6s" repeatCount="indefinite"/></rect><rect x="56" y="512" width="116" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <rect x="28" y="530" width="20" height="4" rx="1.5" fill="#d946ef" opacity="0.7"><animate attributeName="opacity" values="0.25;0.95;0.25" dur="3.9s" repeatCount="indefinite"/></rect><rect x="56" y="530" width="130" height="4" rx="1.5" fill="#8b5cf6" opacity="0.35"/>
-  <line x1="28" y1="585" x2="340" y2="585" stroke="#8b5cf6" stroke-width="1" stroke-opacity="0.4"/>
-  <text x="28" y="606" font-family="Arial,sans-serif" font-size="11" fill="#fbcfe8" letter-spacing="2" opacity="0.7">tech.2twodragon.com</text>
-  <g transform="translate(1048.0,478.0)">
-  <rect x="-6" y="-6" width="124.0" height="124.0" rx="6" fill="#FFFFFF" stroke="#f0abfc" stroke-width="1.6" opacity="0.98"/>
-  <rect x="-8" y="-8" width="128.0" height="128.0" rx="8" fill="url(#qrHalo)" opacity="0.85"><animate attributeName="opacity" values="0.55;0.95;0.55" dur="3.4s" repeatCount="indefinite"/></rect>
-  <g transform="scale(6.2222)"><path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.8,0.8H5.2V1.2H4.8zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.4,0.8H6.8V1.2H6.4zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM9.6,0.8H10V1.2H9.6zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM7.6,1.2H8V1.6H7.6zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM10,1.2H10.4V1.6H10zM11.2,1.2H11.6V1.6H11.2zM12.8,1.2H13.2V1.6H12.8zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM5.2,1.6H5.6V2H5.2zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.8,1.6H7.2V2H6.8zM7.2,1.6H7.6V2H7.2zM8,1.6H8.4V2H8zM8.4,1.6H8.8V2H8.4zM8.8,1.6H9.2V2H8.8zM9.2,1.6H9.6V2H9.2zM9.6,1.6H10V2H9.6zM10.4,1.6H10.8V2H10.4zM10.8,1.6H11.2V2H10.8zM11.2,1.6H11.6V2H11.2zM13.2,1.6H13.6V2H13.2zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.2,2H5.6V2.4H5.2zM6.4,2H6.8V2.4H6.4zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.8,2.4H5.2V2.8H4.8zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.2,2.4H7.6V2.8H7.2zM8,2.4H8.4V2.8H8zM10,2.4H10.4V2.8H10zM10.4,2.4H10.8V2.8H10.4zM11.6,2.4H12V2.8H11.6zM12.4,2.4H12.8V2.8H12.4zM13.2,2.4H13.6V2.8H13.2zM13.6,2.4H14V2.8H13.6zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.8,2.8H5.2V3.2H4.8zM5.2,2.8H5.6V3.2H5.2zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8,2.8H8.4V3.2H8zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM9.2,2.8H9.6V3.2H9.2zM9.6,2.8H10V3.2H9.6zM10.4,2.8H10.8V3.2H10.4zM12,2.8H12.4V3.2H12zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM5.2,3.6H5.6V4H5.2zM5.6,3.6H6V4H5.6zM6,3.6H6.4V4H6zM7.6,3.6H8V4H7.6zM8.4,3.6H8.8V4H8.4zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12.4,3.6H12.8V4H12.4zM13.2,3.6H13.6V4H13.2zM13.6,3.6H14V4H13.6zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4.4,4H4.8V4.4H4.4zM5.2,4H5.6V4.4H5.2zM6,4H6.4V4.4H6zM6.8,4H7.2V4.4H6.8zM7.6,4H8V4.4H7.6zM8,4H8.4V4.4H8zM9.2,4H9.6V4.4H9.2zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.2,4H11.6V4.4H11.2zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM13.2,4H13.6V4.4H13.2zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM15.6,4H16V4.4H15.6zM16.4,4H16.8V4.4H16.4zM16.8,4H17.2V4.4H16.8zM0.8,4.4H1.2V4.8H0.8zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2.8,4.4H3.2V4.8H2.8zM3.6,4.4H4V4.8H3.6zM5.2,4.4H5.6V4.8H5.2zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM0.8,4.8H1.2V5.2H0.8zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4,4.8H4.4V5.2H4zM4.4,4.8H4.8V5.2H4.4zM8.8,4.8H9.2V5.2H8.8zM9.6,4.8H10V5.2H9.6zM10,4.8H10.4V5.2H10zM12.4,4.8H12.8V5.2H12.4zM14,4.8H14.4V5.2H14zM14.4,4.8H14.8V5.2H14.4zM16,4.8H16.4V5.2H16zM16.4,4.8H16.8V5.2H16.4zM0.8,5.2H1.2V5.6H0.8zM1.6,5.2H2V5.6H1.6zM2,5.2H2.4V5.6H2zM2.4,5.2H2.8V5.6H2.4zM3.6,5.2H4V5.6H3.6zM4.4,5.2H4.8V5.6H4.4zM5.2,5.2H5.6V5.6H5.2zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM10.8,5.2H11.2V5.6H10.8zM11.6,5.2H12V5.6H11.6zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM15.2,5.2H15.6V5.6H15.2zM16.4,5.2H16.8V5.6H16.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM0.8,6H1.2V6.4H0.8zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM4,6H4.4V6.4H4zM6.4,6H6.8V6.4H6.4zM6.8,6H7.2V6.4H6.8zM7.2,6H7.6V6.4H7.2zM7.6,6H8V6.4H7.6zM9.2,6H9.6V6.4H9.2zM10,6H10.4V6.4H10zM10.8,6H11.2V6.4H10.8zM11.2,6H11.6V6.4H11.2zM12,6H12.4V6.4H12zM12.8,6H13.2V6.4H12.8zM13.2,6H13.6V6.4H13.2zM15.6,6H16V6.4H15.6zM16.4,6H16.8V6.4H16.4zM16.8,6H17.2V6.4H16.8zM1.2,6.4H1.6V6.8H1.2zM1.6,6.4H2V6.8H1.6zM2.4,6.4H2.8V6.8H2.4zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM3.6,6.4H4V6.8H3.6zM4,6.4H4.4V6.8H4zM4.8,6.4H5.2V6.8H4.8zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.8,6.4H7.2V6.8H6.8zM9.2,6.4H9.6V6.8H9.2zM10.4,6.4H10.8V6.8H10.4zM10.8,6.4H11.2V6.8H10.8zM11.6,6.4H12V6.8H11.6zM12,6.4H12.4V6.8H12zM12.4,6.4H12.8V6.8H12.4zM13.2,6.4H13.6V6.8H13.2zM14.4,6.4H14.8V6.8H14.4zM14.8,6.4H15.2V6.8H14.8zM15.2,6.4H15.6V6.8H15.2zM16,6.4H16.4V6.8H16zM16.4,6.4H16.8V6.8H16.4zM16.8,6.4H17.2V6.8H16.8zM1.2,6.8H1.6V7.2H1.2zM3.6,6.8H4V7.2H3.6zM4.4,6.8H4.8V7.2H4.4zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM6.8,6.8H7.2V7.2H6.8zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM0.8,7.2H1.2V7.6H0.8zM2.8,7.2H3.2V7.6H2.8zM3.2,7.2H3.6V7.6H3.2zM6,7.2H6.4V7.6H6zM6.4,7.2H6.8V7.6H6.4zM7.2,7.2H7.6V7.6H7.2zM8,7.2H8.4V7.6H8zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.6,7.2H10V7.6H9.6zM10,7.2H10.4V7.6H10zM10.4,7.2H10.8V7.6H10.4zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12.8,7.2H13.2V7.6H12.8zM13.6,7.2H14V7.6H13.6zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16.4,7.2H16.8V7.6H16.4zM1.6,7.6H2V8H1.6zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM5.6,7.6H6V8H5.6zM6.4,7.6H6.8V8H6.4zM7.2,7.6H7.6V8H7.2zM7.6,7.6H8V8H7.6zM8,7.6H8.4V8H8zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.6,7.6H10V8H9.6zM10,7.6H10.4V8H10zM10.4,7.6H10.8V8H10.4zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.8,7.6H15.2V8H14.8zM15.6,7.6H16V8H15.6zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM6,8H6.4V8.4H6zM6.8,8H7.2V8.4H6.8zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM2,8.4H2.4V8.8H2zM2.4,8.4H2.8V8.8H2.4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM5.6,8.4H6V8.8H5.6zM6,8.4H6.4V8.8H6zM6.8,8.4H7.2V8.8H6.8zM8.4,8.4H8.8V8.8H8.4zM9.6,8.4H10V8.8H9.6zM10.8,8.4H11.2V8.8H10.8zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM12.8,8.4H13.2V8.8H12.8zM14.8,8.4H15.2V8.8H14.8zM15.6,8.4H16V8.8H15.6zM16,8.4H16.4V8.8H16zM16.4,8.4H16.8V8.8H16.4zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM5.6,8.8H6V9.2H5.6zM6,8.8H6.4V9.2H6zM6.4,8.8H6.8V9.2H6.4zM6.8,8.8H7.2V9.2H6.8zM7.2,8.8H7.6V9.2H7.2zM8,8.8H8.4V9.2H8zM8.8,8.8H9.2V9.2H8.8zM9.6,8.8H10V9.2H9.6zM10.8,8.8H11.2V9.2H10.8zM11.2,8.8H11.6V9.2H11.2zM11.6,8.8H12V9.2H11.6zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM13.2,8.8H13.6V9.2H13.2zM13.6,8.8H14V9.2H13.6zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM14.8,8.8H15.2V9.2H14.8zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM0.8,9.2H1.2V9.6H0.8zM1.2,9.2H1.6V9.6H1.2zM2,9.2H2.4V9.6H2zM2.4,9.2H2.8V9.6H2.4zM2.8,9.2H3.2V9.6H2.8zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.8,9.2H9.2V9.6H8.8zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM0.8,9.6H1.2V10H0.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.4,9.6H4.8V10H4.4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM8.8,9.6H9.2V10H8.8zM10,9.6H10.4V10H10zM10.4,9.6H10.8V10H10.4zM12,9.6H12.4V10H12zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM14,9.6H14.4V10H14zM14.4,9.6H14.8V10H14.4zM15.6,9.6H16V10H15.6zM16.4,9.6H16.8V10H16.4zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM5.2,10H5.6V10.4H5.2zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.4,10H8.8V10.4H8.4zM10.8,10H11.2V10.4H10.8zM11.6,10H12V10.4H11.6zM12.8,10H13.2V10.4H12.8zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.8,10H15.2V10.4H14.8zM16.8,10H17.2V10.4H16.8zM1.2,10.4H1.6V10.8H1.2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16.8,10.4H17.2V10.8H16.8zM0.8,10.8H1.2V11.2H0.8zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM4,10.8H4.4V11.2H4zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.8,10.8H7.2V11.2H6.8zM7.2,10.8H7.6V11.2H7.2zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM10.4,10.8H10.8V11.2H10.4zM10.8,10.8H11.2V11.2H10.8zM11.6,10.8H12V11.2H11.6zM12.4,10.8H12.8V11.2H12.4zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM0.8,11.2H1.2V11.6H0.8zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM4.8,11.2H5.2V11.6H4.8zM5.2,11.2H5.6V11.6H5.2zM6,11.2H6.4V11.6H6zM6.4,11.2H6.8V11.6H6.4zM6.8,11.2H7.2V11.6H6.8zM7.2,11.2H7.6V11.6H7.2zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM10.4,11.2H10.8V11.6H10.4zM11.2,11.2H11.6V11.6H11.2zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM13.2,11.2H13.6V11.6H13.2zM13.6,11.2H14V11.6H13.6zM14.4,11.2H14.8V11.6H14.4zM15.6,11.2H16V11.6H15.6zM16.4,11.2H16.8V11.6H16.4zM16.8,11.2H17.2V11.6H16.8zM1.2,11.6H1.6V12H1.2zM1.6,11.6H2V12H1.6zM2,11.6H2.4V12H2zM2.8,11.6H3.2V12H2.8zM3.6,11.6H4V12H3.6zM5.2,11.6H5.6V12H5.2zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM1.2,12H1.6V12.4H1.2zM2,12H2.4V12.4H2zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4,12H4.4V12.4H4zM4.4,12H4.8V12.4H4.4zM4.8,12H5.2V12.4H4.8zM5.2,12H5.6V12.4H5.2zM5.6,12H6V12.4H5.6zM7.2,12H7.6V12.4H7.2zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM9.2,12H9.6V12.4H9.2zM9.6,12H10V12.4H9.6zM10.8,12H11.2V12.4H10.8zM11.2,12H11.6V12.4H11.2zM11.6,12H12V12.4H11.6zM13.2,12H13.6V12.4H13.2zM14,12H14.4V12.4H14zM15.2,12H15.6V12.4H15.2zM15.6,12H16V12.4H15.6zM1.6,12.4H2V12.8H1.6zM2.4,12.4H2.8V12.8H2.4zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6.8,12.4H7.2V12.8H6.8zM8.4,12.4H8.8V12.8H8.4zM9.6,12.4H10V12.8H9.6zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM11.2,12.4H11.6V12.8H11.2zM12,12.4H12.4V12.8H12zM12.4,12.4H12.8V12.8H12.4zM12.8,12.4H13.2V12.8H12.8zM13.6,12.4H14V12.8H13.6zM14.8,12.4H15.2V12.8H14.8zM15.6,12.4H16V12.8H15.6zM16.4,12.4H16.8V12.8H16.4zM0.8,12.8H1.2V13.2H0.8zM1.6,12.8H2V13.2H1.6zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM4,13.2H4.4V13.6H4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM7.2,13.2H7.6V13.6H7.2zM7.6,13.2H8V13.6H7.6zM8.8,13.2H9.2V13.6H8.8zM9.6,13.2H10V13.6H9.6zM10.4,13.2H10.8V13.6H10.4zM11.6,13.2H12V13.6H11.6zM12,13.2H12.4V13.6H12zM12.4,13.2H12.8V13.6H12.4zM13.2,13.2H13.6V13.6H13.2zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM15.6,13.2H16V13.6H15.6zM16,13.2H16.4V13.6H16zM16.4,13.2H16.8V13.6H16.4zM16.8,13.2H17.2V13.6H16.8zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM4.8,13.6H5.2V14H4.8zM5.6,13.6H6V14H5.6zM7.2,13.6H7.6V14H7.2zM7.6,13.6H8V14H7.6zM8,13.6H8.4V14H8zM8.4,13.6H8.8V14H8.4zM8.8,13.6H9.2V14H8.8zM10,13.6H10.4V14H10zM10.4,13.6H10.8V14H10.4zM11.2,13.6H11.6V14H11.2zM11.6,13.6H12V14H11.6zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM15.6,13.6H16V14H15.6zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM4,14H4.4V14.4H4zM4.8,14H5.2V14.4H4.8zM5.2,14H5.6V14.4H5.2zM6,14H6.4V14.4H6zM6.4,14H6.8V14.4H6.4zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.8,14H9.2V14.4H8.8zM10,14H10.4V14.4H10zM11.6,14H12V14.4H11.6zM12,14H12.4V14.4H12zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM4,14.4H4.4V14.8H4zM4.4,14.4H4.8V14.8H4.4zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM7.2,14.4H7.6V14.8H7.2zM7.6,14.4H8V14.8H7.6zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10,14.4H10.4V14.8H10zM10.4,14.4H10.8V14.8H10.4zM11.2,14.4H11.6V14.8H11.2zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.4,14.8H4.8V15.2H4.4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM5.6,14.8H6V15.2H5.6zM6,14.8H6.4V15.2H6zM7.2,14.8H7.6V15.2H7.2zM8,14.8H8.4V15.2H8zM8.4,14.8H8.8V15.2H8.4zM9.2,14.8H9.6V15.2H9.2zM9.6,14.8H10V15.2H9.6zM10.4,14.8H10.8V15.2H10.4zM10.8,14.8H11.2V15.2H10.8zM11.2,14.8H11.6V15.2H11.2zM12,14.8H12.4V15.2H12zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM16.4,14.8H16.8V15.2H16.4zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4.4,15.2H4.8V15.6H4.4zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.8,15.6H5.2V16H4.8zM5.2,15.6H5.6V16H5.2zM5.6,15.6H6V16H5.6zM6.4,15.6H6.8V16H6.4zM6.8,15.6H7.2V16H6.8zM7.2,15.6H7.6V16H7.2zM8,15.6H8.4V16H8zM8.4,15.6H8.8V16H8.4zM11.6,15.6H12V16H11.6zM12.4,15.6H12.8V16H12.4zM13.2,15.6H13.6V16H13.2zM15.2,15.6H15.6V16H15.2zM15.6,15.6H16V16H15.6zM16,15.6H16.4V16H16zM16.4,15.6H16.8V16H16.4zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM6.4,16H6.8V16.4H6.4zM8.4,16H8.8V16.4H8.4zM8.8,16H9.2V16.4H8.8zM9.2,16H9.6V16.4H9.2zM10.4,16H10.8V16.4H10.4zM11.2,16H11.6V16.4H11.2zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM14.8,16H15.2V16.4H14.8zM15.6,16H16V16.4H15.6zM16,16H16.4V16.4H16zM16.4,16H16.8V16.4H16.4zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.6,16.4H6V16.8H5.6zM6.4,16.4H6.8V16.8H6.4zM6.8,16.4H7.2V16.8H6.8zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.8,16.8H5.2V17.2H4.8zM6.4,16.8H6.8V17.2H6.4zM6.8,16.8H7.2V17.2H6.8zM7.6,16.8H8V17.2H7.6zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.8,16.8H11.2V17.2H10.8zM12.8,16.8H13.2V17.2H12.8zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4z" fill="#0b0b0b"/></g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: sanctions announcement, helpdesk phishing, Mirai-variant C2">
+<defs>
+  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0B132B"/>
+    <stop offset="100%" stop-color="#0A1020"/>
+  </linearGradient>
+  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
+</rect>
+<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
+  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
+<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
+</rect>
+<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
+<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
+<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
+  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
+</rect>
+<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
+  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
+</rect>
+<!-- Card footer accent dots (pulse) -->
+<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
+  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
+</circle>
+<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
+  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
+</circle>
+<g transform="translate(216,330)">
+  <!-- Building silhouette -->
+  <g transform="translate(-80,-120)">
+    <rect x="0" y="0" width="80" height="120" fill="#0B132B" stroke="#E63946" stroke-width="2" opacity="0.95"/>
+    <!-- windows grid (blinking) -->
+    <rect x="8" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="10" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="10" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="28" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.8;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="28" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="4.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="28" width="10" height="10" fill="#E63946" opacity="0.7">
+      <animate attributeName="opacity" values="0.3;0.9;0.3" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="8" y="46" width="10" height="10" fill="#E63946" opacity="0.55">
+      <animate attributeName="opacity" values="0.2;0.75;0.2" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="46" width="10" height="10" fill="#E63946" opacity="0.45">
+      <animate attributeName="opacity" values="0.2;0.65;0.2" dur="4.0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="40" y="46" width="10" height="10" fill="#E63946" opacity="0.6">
+      <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="56" y="46" width="10" height="10" fill="#E63946" opacity="0.5">
+      <animate attributeName="opacity" values="0.2;0.7;0.2" dur="3.8s" repeatCount="indefinite"/>
+    </rect>
+    <!-- entrance -->
+    <rect x="30" y="90" width="20" height="30" fill="#FFB703" opacity="0.5">
+      <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.6s" repeatCount="indefinite"/>
+    </rect>
   </g>
+  <!-- Megaphone swinging from roof -->
+  <g transform="translate(-20,-110)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-14 0 0; 14 0 0; -14 0 0"
+                      dur="2.4s" repeatCount="indefinite" additive="sum"/>
+    <polygon points="0,-10 0,10 24,18 24,-18" fill="#E63946" opacity="0.95"/>
+    <rect x="-8" y="-6" width="10" height="12" fill="#E63946"/>
+    <circle cx="28" cy="0" r="3" fill="#FFB703"/>
+  </g>
+  <!-- Sound waves expanding -->
+  <path d="M 20 -100 Q 40 -100 40 -120" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/>
+    <animate attributeName="d"
+             values="M 20 -100 Q 30 -100 30 -110;
+                     M 20 -100 Q 60 -100 60 -140;
+                     M 20 -100 Q 30 -100 30 -110"
+             dur="2.4s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 50 -100 50 -130" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.7;0" dur="2.4s" begin="0.6s" repeatCount="indefinite"/>
+  </path>
+  <path d="M 20 -100 Q 64 -100 64 -144" fill="none" stroke="#E63946" stroke-width="2" opacity="0">
+    <animate attributeName="opacity" values="0;0.55;0" dur="2.4s" begin="1.2s" repeatCount="indefinite"/>
+  </path>
+  <!-- Fractured org chart below (dashed broken lines) -->
+  <g transform="translate(0,40)">
+    <!-- top node -->
+    <rect x="-16" y="-10" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8"/>
+    <circle cx="0" cy="-3" r="2" fill="#E63946"/>
+    <!-- connector line (cracked) -->
+    <path d="M 0 4 L 0 20" stroke="#E63946" stroke-width="1.8" stroke-dasharray="2 3">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <path d="M -50 34 L 50 34" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 4" opacity="0.7">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+    </path>
+    <!-- 3 child nodes, middle one cracked -->
+    <rect x="-66" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="-50" cy="47" r="2" fill="#E63946"/>
+    <g opacity="0.6">
+      <rect x="-16" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2"/>
+      <!-- crack across it -->
+      <path d="M -18 42 L 2 52 L 18 40" stroke="#E63946" stroke-width="1.8" fill="none">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <rect x="34" y="40" width="32" height="14" rx="3" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.95"/>
+    <circle cx="50" cy="47" r="2" fill="#E63946"/>
+    <!-- falling node fragment -->
+    <rect x="-4" y="60" width="10" height="6" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="54;84" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="2" y="62" width="8" height="5" fill="#E63946" opacity="0">
+      <animate attributeName="y" values="56;86" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- brand noun -->
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">GRINEX</text>
+</g>
+<g transform="translate(216,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowBlue)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#3A86FF" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#3A86FF" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#3A86FF" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#3A86FF" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="216" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Sanctioned exchange shuttered after breach</text>
+<g transform="translate(576,330)">
+  <!-- Device frame (phone outline) -->
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="#0B132B" stroke="#3A86FF" stroke-width="2.4" opacity="0.95"/>
+  <rect x="-70" y="-130" width="140" height="220" rx="18" ry="18"
+        fill="url(#glowBlue)" opacity="0.28">
+    <animate attributeName="opacity" values="0.18;0.42;0.18" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="-20" y="-126" width="40" height="6" rx="3" fill="#2A3256"/>
+  <!-- Notification stack (3 mini rows appearing) -->
+  <g transform="translate(-54,-92)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;6.4;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="54" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="0s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-62)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="48" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="2s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <g transform="translate(-54,-32)">
+    <rect x="0" y="0" width="108" height="22" rx="5" ry="5" fill="#1C2541" stroke="#3A86FF" stroke-width="1.4" opacity="0">
+      <animate attributeName="opacity" values="0;0.95;0.95;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <circle cx="12" cy="11" r="5" fill="#E63946" opacity="0">
+      <animate attributeName="opacity" values="0;1;1;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="24" y="6" width="70" height="3" rx="1.5" fill="#E7ECF4" opacity="0">
+      <animate attributeName="opacity" values="0;0.85;0.85;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="24" y="14" width="58" height="3" rx="1.5" fill="#8B94A8" opacity="0">
+      <animate attributeName="opacity" values="0;0.65;0.65;0" dur="6s" begin="4s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+  <!-- Bell (top right of phone) pulsing -->
+  <g transform="translate(46,-104)">
+    <path d="M -10 6 Q -10 -8 0 -8 Q 10 -8 10 6 L 12 10 L -12 10 Z"
+          fill="#FFB703" opacity="0.95"/>
+    <circle cx="0" cy="-10" r="2.2" fill="#FFB703"/>
+    <path d="M -3 12 Q 0 16 3 12" fill="none" stroke="#FFB703" stroke-width="1.5"/>
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-12 0 -8; 12 0 -8; -12 0 -8"
+                      dur="1.6s" repeatCount="indefinite" additive="sum"/>
+  </g>
+  <!-- Fishhook swinging below phone -->
+  <g transform="translate(0,108)">
+    <animateTransform attributeName="transform" type="rotate"
+                      values="-10 0 -40; 10 0 -40; -10 0 -40"
+                      dur="3.2s" repeatCount="indefinite" additive="sum"/>
+    <line x1="0" y1="-40" x2="0" y2="6" stroke="#FFB703" stroke-width="2.4"/>
+    <path d="M 0 6 Q 0 22 -12 22 Q -22 22 -22 12" fill="none"
+          stroke="#FFB703" stroke-width="2.6" stroke-linecap="round"/>
+    <circle cx="-22" cy="12" r="2.6" fill="#FFB703"/>
+    <path d="M -22 12 L -18 18 L -26 18 Z" fill="#FFB703"/>
+  </g>
+  <!-- Phishing particles flying toward hook -->
+  <circle cx="-90" cy="40" r="3" fill="#E63946">
+    <animate attributeName="cx" values="-90;-22" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="40;100" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-100" cy="10" r="2.4" fill="#FFB703">
+    <animate attributeName="cx" values="-100;-22" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="10;100" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.4s" begin="0.5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-88" cy="70" r="2.8" fill="#E63946">
+    <animate attributeName="cx" values="-88;-22" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="70;100" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="1.2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- brand noun at bottom -->
+  <text x="0" y="164" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="16" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="3">HELPDESK</text>
+</g>
+<g transform="translate(576,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowAmber)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#FFB703" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#FFB703" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#FFB703" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#FFB703" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="576" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="11" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Helpdesk impersonation pivots to data theft</text>
+<g transform="translate(936,330)">
+  <!-- Central C2 server -->
+  <g transform="translate(0,-20)">
+    <rect x="-22" y="-30" width="44" height="60" rx="4" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
+    <!-- server slots -->
+    <rect x="-16" y="-22" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.4s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-12" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.6s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="-2" width="32" height="5" rx="1" fill="#FFB703" opacity="0.7">
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="1.5s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="8" width="32" height="5" rx="1" fill="#FFB703" opacity="0.6">
+      <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </rect>
+    <rect x="-16" y="18" width="32" height="5" rx="1" fill="#E63946" opacity="0.9">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.1s" repeatCount="indefinite"/>
+    </rect>
+    <!-- antenna -->
+    <line x1="0" y1="-30" x2="0" y2="-46" stroke="#FFB703" stroke-width="2"/>
+    <circle cx="0" cy="-48" r="3" fill="#FFB703">
+      <animate attributeName="r" values="3;5;3" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Radiating waves -->
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="1s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="1s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="0" cy="-20" r="40" fill="none" stroke="#FFB703" stroke-width="1.6" opacity="0">
+    <animate attributeName="r" values="40;120" dur="3s" begin="2s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.8;0" dur="3s" begin="2s" repeatCount="indefinite"/>
+  </circle>
+  <!-- Victim nodes around -->
+  <g>
+    <circle cx="-110" cy="-60" r="6" fill="#E63946" stroke="#E63946" stroke-width="1.6">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="110" cy="-60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="120" cy="0" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.0s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="100" cy="60" r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="-60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="60" cy="90" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Connection lines (dashed, flowing) -->
+  <line x1="0" y1="-20" x2="-110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="110" y2="-60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="120" y2="0" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.7s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.8s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="100" y2="60" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.9s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="-60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.0s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="-20" x2="60" y2="90" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="4 3" opacity="0.55">
+    <animate attributeName="stroke-dashoffset" values="0;-14" dur="2.1s" repeatCount="indefinite"/>
+  </line>
+  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
+        font-size="14" font-weight="800" fill="#E7ECF4"
+        text-anchor="middle" letter-spacing="2">NEXCORIUM</text>
+</g>
+<g transform="translate(936,330)">
+  <circle cx="0" cy="190" r="90" fill="url(#glowRed)" opacity="0.16">
+    <animate attributeName="opacity" values="0.1;0.22;0.1" dur="4.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="-60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="60" cy="196" r="1.6" fill="#E63946" opacity="0.55">
+    <animate attributeName="opacity" values="0.25;0.8;0.25" dur="3.0s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="70" cy="192" r="2" fill="#E63946" opacity="0.45">
+    <animate attributeName="opacity" values="0.2;0.75;0.2" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <line x1="-52" y1="204" x2="-28" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="28" y1="204" x2="52" y2="204" stroke="#E63946" stroke-width="1.2" opacity="0.6"/>
+  <line x1="-48" y1="210" x2="-34" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+  <line x1="34" y1="210" x2="48" y2="210" stroke="#E63946" stroke-width="0.9" opacity="0.4"/>
+</g>
+<text x="936" y="520" font-family="Inter,Segoe UI,Arial,sans-serif" font-size="12" font-weight="500" fill="#E7ECF4" text-anchor="middle" letter-spacing="0.3">Mirai variant targets exposed cameras</text>
+<g transform="translate(1080,510)">
+  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
+  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(5.555556)" fill="#0B132B">
+    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM5.2,0.8H5.6V1.2H5.2zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8,0.8H8.4V1.2H8zM8.4,0.8H8.8V1.2H8.4zM8.8,0.8H9.2V1.2H8.8zM10,0.8H10.4V1.2H10zM10.4,0.8H10.8V1.2H10.4zM12,0.8H12.4V1.2H12zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.2,0.8H13.6V1.2H13.2zM13.6,0.8H14V1.2H13.6zM14.4,0.8H14.8V1.2H14.4zM14.8,0.8H15.2V1.2H14.8zM15.2,0.8H15.6V1.2H15.2zM15.6,0.8H16V1.2H15.6zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4.8,1.2H5.2V1.6H4.8zM5.6,1.2H6V1.6H5.6zM6.8,1.2H7.2V1.6H6.8zM8,1.2H8.4V1.6H8zM9.6,1.2H10V1.6H9.6zM10.4,1.2H10.8V1.6H10.4zM11.6,1.2H12V1.6H11.6zM12.4,1.2H12.8V1.6H12.4zM13.6,1.2H14V1.6H13.6zM14.4,1.2H14.8V1.6H14.4zM16.8,1.2H17.2V1.6H16.8zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4,1.6H4.4V2H4zM4.4,1.6H4.8V2H4.4zM5.6,1.6H6V2H5.6zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM6.8,1.6H7.2V2H6.8zM8.8,1.6H9.2V2H8.8zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM12,1.6H12.4V2H12zM12.8,1.6H13.2V2H12.8zM13.6,1.6H14V2H13.6zM14.4,1.6H14.8V2H14.4zM15.2,1.6H15.6V2H15.2zM15.6,1.6H16V2H15.6zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.8,2H5.2V2.4H4.8zM5.6,2H6V2.4H5.6zM6.4,2H6.8V2.4H6.4zM6.8,2H7.2V2.4H6.8zM7.2,2H7.6V2.4H7.2zM8,2H8.4V2.4H8zM8.8,2H9.2V2.4H8.8zM9.2,2H9.6V2.4H9.2zM9.6,2H10V2.4H9.6zM11.6,2H12V2.4H11.6zM12,2H12.4V2.4H12zM12.4,2H12.8V2.4H12.4zM13.6,2H14V2.4H13.6zM14.4,2H14.8V2.4H14.4zM15.2,2H15.6V2.4H15.2zM15.6,2H16V2.4H15.6zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4,2.4H4.4V2.8H4zM4.4,2.4H4.8V2.8H4.4zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM10,2.4H10.4V2.8H10zM11.2,2.4H11.6V2.8H11.2zM12.8,2.4H13.2V2.8H12.8zM13.2,2.4H13.6V2.8H13.2zM14.4,2.4H14.8V2.8H14.4zM15.2,2.4H15.6V2.8H15.2zM15.6,2.4H16V2.8H15.6zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4,2.8H4.4V3.2H4zM4.4,2.8H4.8V3.2H4.4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6,2.8H6.4V3.2H6zM6.8,2.8H7.2V3.2H6.8zM7.6,2.8H8V3.2H7.6zM8.8,2.8H9.2V3.2H8.8zM10.8,2.8H11.2V3.2H10.8zM11.6,2.8H12V3.2H11.6zM14.4,2.8H14.8V3.2H14.4zM16.8,2.8H17.2V3.2H16.8zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM14.8,3.2H15.2V3.6H14.8zM15.2,3.2H15.6V3.6H15.2zM15.6,3.2H16V3.6H15.6zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM4,3.6H4.4V4H4zM4.4,3.6H4.8V4H4.4zM5.2,3.6H5.6V4H5.2zM6,3.6H6.4V4H6zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM8,3.6H8.4V4H8zM8.8,3.6H9.2V4H8.8zM9.2,3.6H9.6V4H9.2zM10,3.6H10.4V4H10zM11.6,3.6H12V4H11.6zM12.8,3.6H13.2V4H12.8zM13.2,3.6H13.6V4H13.2zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.4,4H2.8V4.4H2.4zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM7.2,4H7.6V4.4H7.2zM7.6,4H8V4.4H7.6zM8.4,4H8.8V4.4H8.4zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.8,4H11.2V4.4H10.8zM11.2,4H11.6V4.4H11.2zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM13.6,4H14V4.4H13.6zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM15.6,4H16V4.4H15.6zM16,4H16.4V4.4H16zM0.8,4.4H1.2V4.8H0.8zM1.6,4.4H2V4.8H1.6zM2,4.4H2.4V4.8H2zM2.4,4.4H2.8V4.8H2.4zM2.8,4.4H3.2V4.8H2.8zM5.2,4.4H5.6V4.8H5.2zM6,4.4H6.4V4.8H6zM7.2,4.4H7.6V4.8H7.2zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM9.2,4.4H9.6V4.8H9.2zM10,4.4H10.4V4.8H10zM11.2,4.4H11.6V4.8H11.2zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM13.6,4.4H14V4.8H13.6zM14,4.4H14.4V4.8H14zM14.4,4.4H14.8V4.8H14.4zM15.2,4.4H15.6V4.8H15.2zM16,4.4H16.4V4.8H16zM16.4,4.4H16.8V4.8H16.4zM16.8,4.4H17.2V4.8H16.8zM0.8,4.8H1.2V5.2H0.8zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM5.2,4.8H5.6V5.2H5.2zM5.6,4.8H6V5.2H5.6zM6,4.8H6.4V5.2H6zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.6,4.8H8V5.2H7.6zM8,4.8H8.4V5.2H8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM11.2,4.8H11.6V5.2H11.2zM11.6,4.8H12V5.2H11.6zM12.8,4.8H13.2V5.2H12.8zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.2,4.8H15.6V5.2H15.2zM3.6,5.2H4V5.6H3.6zM4,5.2H4.4V5.6H4zM4.4,5.2H4.8V5.6H4.4zM5.2,5.2H5.6V5.6H5.2zM6,5.2H6.4V5.6H6zM7.2,5.2H7.6V5.6H7.2zM8.4,5.2H8.8V5.6H8.4zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM12,5.2H12.4V5.6H12zM12.8,5.2H13.2V5.6H12.8zM13.2,5.2H13.6V5.6H13.2zM13.6,5.2H14V5.6H13.6zM15.6,5.2H16V5.6H15.6zM2,5.6H2.4V6H2zM2.4,5.6H2.8V6H2.4zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM6,5.6H6.4V6H6zM6.4,5.6H6.8V6H6.4zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8.4,5.6H8.8V6H8.4zM9.6,5.6H10V6H9.6zM10.8,5.6H11.2V6H10.8zM12.4,5.6H12.8V6H12.4zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM16,5.6H16.4V6H16zM16.8,5.6H17.2V6H16.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2,6H2.4V6.4H2zM2.4,6H2.8V6.4H2.4zM4,6H4.4V6.4H4zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6,6H6.4V6.4H6zM6.4,6H6.8V6.4H6.4zM8,6H8.4V6.4H8zM8.8,6H9.2V6.4H8.8zM10.4,6H10.8V6.4H10.4zM10.8,6H11.2V6.4H10.8zM11.6,6H12V6.4H11.6zM12,6H12.4V6.4H12zM12.4,6H12.8V6.4H12.4zM13.2,6H13.6V6.4H13.2zM13.6,6H14V6.4H13.6zM14,6H14.4V6.4H14zM14.4,6H14.8V6.4H14.4zM14.8,6H15.2V6.4H14.8zM15.2,6H15.6V6.4H15.2zM15.6,6H16V6.4H15.6zM16,6H16.4V6.4H16zM16.8,6H17.2V6.4H16.8zM0.8,6.4H1.2V6.8H0.8zM2,6.4H2.4V6.8H2zM2.8,6.4H3.2V6.8H2.8zM3.2,6.4H3.6V6.8H3.2zM4.8,6.4H5.2V6.8H4.8zM8,6.4H8.4V6.8H8zM8.4,6.4H8.8V6.8H8.4zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM12.4,6.4H12.8V6.8H12.4zM12.8,6.4H13.2V6.8H12.8zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM1.2,6.8H1.6V7.2H1.2zM1.6,6.8H2V7.2H1.6zM5.2,6.8H5.6V7.2H5.2zM8.4,6.8H8.8V7.2H8.4zM8.8,6.8H9.2V7.2H8.8zM9.2,6.8H9.6V7.2H9.2zM9.6,6.8H10V7.2H9.6zM10.4,6.8H10.8V7.2H10.4zM11.2,6.8H11.6V7.2H11.2zM12,6.8H12.4V7.2H12zM13.6,6.8H14V7.2H13.6zM14.4,6.8H14.8V7.2H14.4zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM1.6,7.2H2V7.6H1.6zM2,7.2H2.4V7.6H2zM3.2,7.2H3.6V7.6H3.2zM3.6,7.2H4V7.6H3.6zM4,7.2H4.4V7.6H4zM4.8,7.2H5.2V7.6H4.8zM5.6,7.2H6V7.6H5.6zM6.4,7.2H6.8V7.6H6.4zM6.8,7.2H7.2V7.6H6.8zM7.6,7.2H8V7.6H7.6zM8.4,7.2H8.8V7.6H8.4zM9.6,7.2H10V7.6H9.6zM10.8,7.2H11.2V7.6H10.8zM11.2,7.2H11.6V7.6H11.2zM12.4,7.2H12.8V7.6H12.4zM14,7.2H14.4V7.6H14zM14.8,7.2H15.2V7.6H14.8zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM0.8,7.6H1.2V8H0.8zM1.2,7.6H1.6V8H1.2zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.8,7.6H3.2V8H2.8zM3.6,7.6H4V8H3.6zM4,7.6H4.4V8H4zM4.8,7.6H5.2V8H4.8zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM6.8,7.6H7.2V8H6.8zM7.6,7.6H8V8H7.6zM8.4,7.6H8.8V8H8.4zM8.8,7.6H9.2V8H8.8zM9.2,7.6H9.6V8H9.2zM10,7.6H10.4V8H10zM10.8,7.6H11.2V8H10.8zM12,7.6H12.4V8H12zM12.8,7.6H13.2V8H12.8zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM15.2,7.6H15.6V8H15.2zM16.4,7.6H16.8V8H16.4zM16.8,7.6H17.2V8H16.8zM1.2,8H1.6V8.4H1.2zM2,8H2.4V8.4H2zM2.4,8H2.8V8.4H2.4zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM5.2,8H5.6V8.4H5.2zM6,8H6.4V8.4H6zM7.2,8H7.6V8.4H7.2zM7.6,8H8V8.4H7.6zM8.8,8H9.2V8.4H8.8zM9.2,8H9.6V8.4H9.2zM10.8,8H11.2V8.4H10.8zM11.2,8H11.6V8.4H11.2zM11.6,8H12V8.4H11.6zM12,8H12.4V8.4H12zM13.6,8H14V8.4H13.6zM15.2,8H15.6V8.4H15.2zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM1.2,8.4H1.6V8.8H1.2zM1.6,8.4H2V8.8H1.6zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM4.8,8.4H5.2V8.8H4.8zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM7.2,8.4H7.6V8.8H7.2zM7.6,8.4H8V8.8H7.6zM8,8.4H8.4V8.8H8zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM9.6,8.4H10V8.8H9.6zM10,8.4H10.4V8.8H10zM10.4,8.4H10.8V8.8H10.4zM10.8,8.4H11.2V8.8H10.8zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM13.6,8.4H14V8.8H13.6zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM15.6,8.4H16V8.8H15.6zM0.8,8.8H1.2V9.2H0.8zM1.2,8.8H1.6V9.2H1.2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM4.8,8.8H5.2V9.2H4.8zM8.4,8.8H8.8V9.2H8.4zM9.2,8.8H9.6V9.2H9.2zM10.4,8.8H10.8V9.2H10.4zM11.2,8.8H11.6V9.2H11.2zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM13.6,8.8H14V9.2H13.6zM16,8.8H16.4V9.2H16zM16.8,8.8H17.2V9.2H16.8zM1.2,9.2H1.6V9.6H1.2zM1.6,9.2H2V9.6H1.6zM2.8,9.2H3.2V9.6H2.8zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM5.2,9.2H5.6V9.6H5.2zM5.6,9.2H6V9.6H5.6zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.2,9.2H7.6V9.6H7.2zM8,9.2H8.4V9.6H8zM8.4,9.2H8.8V9.6H8.4zM9.2,9.2H9.6V9.6H9.2zM9.6,9.2H10V9.6H9.6zM10,9.2H10.4V9.6H10zM10.4,9.2H10.8V9.6H10.4zM13.2,9.2H13.6V9.6H13.2zM14.4,9.2H14.8V9.6H14.4zM15.2,9.2H15.6V9.6H15.2zM16.4,9.2H16.8V9.6H16.4zM16.8,9.2H17.2V9.6H16.8zM1.2,9.6H1.6V10H1.2zM1.6,9.6H2V10H1.6zM2,9.6H2.4V10H2zM2.8,9.6H3.2V10H2.8zM3.2,9.6H3.6V10H3.2zM3.6,9.6H4V10H3.6zM4.8,9.6H5.2V10H4.8zM5.6,9.6H6V10H5.6zM6,9.6H6.4V10H6zM6.4,9.6H6.8V10H6.4zM7.2,9.6H7.6V10H7.2zM7.6,9.6H8V10H7.6zM8,9.6H8.4V10H8zM9.2,9.6H9.6V10H9.2zM11.2,9.6H11.6V10H11.2zM11.6,9.6H12V10H11.6zM12,9.6H12.4V10H12zM13.6,9.6H14V10H13.6zM14.4,9.6H14.8V10H14.4zM14.8,9.6H15.2V10H14.8zM15.2,9.6H15.6V10H15.2zM15.6,9.6H16V10H15.6zM16,9.6H16.4V10H16zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM3.6,10H4V10.4H3.6zM4.4,10H4.8V10.4H4.4zM4.8,10H5.2V10.4H4.8zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM9.2,10H9.6V10.4H9.2zM9.6,10H10V10.4H9.6zM10.4,10H10.8V10.4H10.4zM12,10H12.4V10.4H12zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14.8,10H15.2V10.4H14.8zM15.2,10H15.6V10.4H15.2zM15.6,10H16V10.4H15.6zM16.4,10H16.8V10.4H16.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM4,10.4H4.4V10.8H4zM5.2,10.4H5.6V10.8H5.2zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.6,10.4H8V10.8H7.6zM8.4,10.4H8.8V10.8H8.4zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.4,10.4H12.8V10.8H12.4zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM16.8,10.4H17.2V10.8H16.8zM1.6,10.8H2V11.2H1.6zM4,10.8H4.4V11.2H4zM4.8,10.8H5.2V11.2H4.8zM6,10.8H6.4V11.2H6zM6.4,10.8H6.8V11.2H6.4zM7.2,10.8H7.6V11.2H7.2zM8,10.8H8.4V11.2H8zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.2,10.8H9.6V11.2H9.2zM10,10.8H10.4V11.2H10zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM12.8,10.8H13.2V11.2H12.8zM13.2,10.8H13.6V11.2H13.2zM14.4,10.8H14.8V11.2H14.4zM14.8,10.8H15.2V11.2H14.8zM15.2,10.8H15.6V11.2H15.2zM15.6,10.8H16V11.2H15.6zM16.4,10.8H16.8V11.2H16.4zM16.8,10.8H17.2V11.2H16.8zM1.2,11.2H1.6V11.6H1.2zM1.6,11.2H2V11.6H1.6zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM8.8,11.2H9.2V11.6H8.8zM9.2,11.2H9.6V11.6H9.2zM9.6,11.2H10V11.6H9.6zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM13.6,11.2H14V11.6H13.6zM14,11.2H14.4V11.6H14zM15.2,11.2H15.6V11.6H15.2zM16.4,11.2H16.8V11.6H16.4zM0.8,11.6H1.2V12H0.8zM5.2,11.6H5.6V12H5.2zM6,11.6H6.4V12H6zM6.8,11.6H7.2V12H6.8zM8.4,11.6H8.8V12H8.4zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10,11.6H10.4V12H10zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.8,11.6H13.2V12H12.8zM13.2,11.6H13.6V12H13.2zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.4,11.6H14.8V12H14.4zM14.8,11.6H15.2V12H14.8zM15.2,11.6H15.6V12H15.2zM15.6,11.6H16V12H15.6zM0.8,12H1.2V12.4H0.8zM2.4,12H2.8V12.4H2.4zM3.2,12H3.6V12.4H3.2zM4.4,12H4.8V12.4H4.4zM6,12H6.4V12.4H6zM6.8,12H7.2V12.4H6.8zM7.6,12H8V12.4H7.6zM8.4,12H8.8V12.4H8.4zM8.8,12H9.2V12.4H8.8zM9.6,12H10V12.4H9.6zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM12.4,12H12.8V12.4H12.4zM12.8,12H13.2V12.4H12.8zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14.8,12H15.2V12.4H14.8zM15.6,12H16V12.4H15.6zM16,12H16.4V12.4H16zM16.4,12H16.8V12.4H16.4zM0.8,12.4H1.2V12.8H0.8zM1.6,12.4H2V12.8H1.6zM2.8,12.4H3.2V12.8H2.8zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM8,12.4H8.4V12.8H8zM9.2,12.4H9.6V12.8H9.2zM11.2,12.4H11.6V12.8H11.2zM11.6,12.4H12V12.8H11.6zM12.4,12.4H12.8V12.8H12.4zM13.2,12.4H13.6V12.8H13.2zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM14.8,12.4H15.2V12.8H14.8zM15.2,12.4H15.6V12.8H15.2zM16.8,12.4H17.2V12.8H16.8zM0.8,12.8H1.2V13.2H0.8zM2,12.8H2.4V13.2H2zM3.2,12.8H3.6V13.2H3.2zM3.6,12.8H4V13.2H3.6zM5.6,12.8H6V13.2H5.6zM6.4,12.8H6.8V13.2H6.4zM6.8,12.8H7.2V13.2H6.8zM7.2,12.8H7.6V13.2H7.2zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM11.6,12.8H12V13.2H11.6zM12,12.8H12.4V13.2H12zM13.6,12.8H14V13.2H13.6zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM0.8,13.2H1.2V13.6H0.8zM2,13.2H2.4V13.6H2zM2.8,13.2H3.2V13.6H2.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6.4,13.2H6.8V13.6H6.4zM6.8,13.2H7.2V13.6H6.8zM8,13.2H8.4V13.6H8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM11.2,13.2H11.6V13.6H11.2zM12,13.2H12.4V13.6H12zM12.8,13.2H13.2V13.6H12.8zM13.2,13.2H13.6V13.6H13.2zM13.6,13.2H14V13.6H13.6zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM14.8,13.2H15.2V13.6H14.8zM15.6,13.2H16V13.6H15.6zM16.8,13.2H17.2V13.6H16.8zM0.8,13.6H1.2V14H0.8zM1.6,13.6H2V14H1.6zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM4.4,13.6H4.8V14H4.4zM5.6,13.6H6V14H5.6zM6.8,13.6H7.2V14H6.8zM7.6,13.6H8V14H7.6zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM10.8,13.6H11.2V14H10.8zM11.2,13.6H11.6V14H11.2zM12.4,13.6H12.8V14H12.4zM13.2,13.6H13.6V14H13.2zM13.6,13.6H14V14H13.6zM14,13.6H14.4V14H14zM14.4,13.6H14.8V14H14.4zM14.8,13.6H15.2V14H14.8zM15.2,13.6H15.6V14H15.2zM16,13.6H16.4V14H16zM16.4,13.6H16.8V14H16.4zM4,14H4.4V14.4H4zM5.2,14H5.6V14.4H5.2zM6.8,14H7.2V14.4H6.8zM7.2,14H7.6V14.4H7.2zM8,14H8.4V14.4H8zM8.4,14H8.8V14.4H8.4zM10,14H10.4V14.4H10zM13.6,14H14V14.4H13.6zM15.2,14H15.6V14.4H15.2zM16,14H16.4V14.4H16zM16.4,14H16.8V14.4H16.4zM16.8,14H17.2V14.4H16.8zM0.8,14.4H1.2V14.8H0.8zM1.2,14.4H1.6V14.8H1.2zM1.6,14.4H2V14.8H1.6zM2,14.4H2.4V14.8H2zM2.4,14.4H2.8V14.8H2.4zM2.8,14.4H3.2V14.8H2.8zM3.2,14.4H3.6V14.8H3.2zM5.2,14.4H5.6V14.8H5.2zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM6.8,14.4H7.2V14.8H6.8zM7.2,14.4H7.6V14.8H7.2zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.6,14.4H10V14.8H9.6zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM13.2,14.4H13.6V14.8H13.2zM13.6,14.4H14V14.8H13.6zM14.4,14.4H14.8V14.8H14.4zM15.2,14.4H15.6V14.8H15.2zM15.6,14.4H16V14.8H15.6zM0.8,14.8H1.2V15.2H0.8zM3.2,14.8H3.6V15.2H3.2zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM6.4,14.8H6.8V15.2H6.4zM6.8,14.8H7.2V15.2H6.8zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM15.2,14.8H15.6V15.2H15.2zM15.6,14.8H16V15.2H15.6zM16.8,14.8H17.2V15.2H16.8zM0.8,15.2H1.2V15.6H0.8zM1.6,15.2H2V15.6H1.6zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM4,15.2H4.4V15.6H4zM4.4,15.2H4.8V15.6H4.4zM6,15.2H6.4V15.6H6zM6.4,15.2H6.8V15.6H6.4zM8,15.2H8.4V15.6H8zM8.4,15.2H8.8V15.6H8.4zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM12.4,15.2H12.8V15.6H12.4zM12.8,15.2H13.2V15.6H12.8zM13.6,15.2H14V15.6H13.6zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM14.8,15.2H15.2V15.6H14.8zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.8,15.2H17.2V15.6H16.8zM0.8,15.6H1.2V16H0.8zM1.6,15.6H2V16H1.6zM2,15.6H2.4V16H2zM2.4,15.6H2.8V16H2.4zM3.2,15.6H3.6V16H3.2zM4,15.6H4.4V16H4zM4.4,15.6H4.8V16H4.4zM7.6,15.6H8V16H7.6zM8.4,15.6H8.8V16H8.4zM8.8,15.6H9.2V16H8.8zM9.2,15.6H9.6V16H9.2zM10,15.6H10.4V16H10zM10.4,15.6H10.8V16H10.4zM11.2,15.6H11.6V16H11.2zM12.8,15.6H13.2V16H12.8zM13.2,15.6H13.6V16H13.2zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM14.8,15.6H15.2V16H14.8zM15.6,15.6H16V16H15.6zM0.8,16H1.2V16.4H0.8zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM5.6,16H6V16.4H5.6zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM6.8,16H7.2V16.4H6.8zM8,16H8.4V16.4H8zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.8,16H11.2V16.4H10.8zM11.2,16H11.6V16.4H11.2zM11.6,16H12V16.4H11.6zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM13.2,16H13.6V16.4H13.2zM14,16H14.4V16.4H14zM14.4,16H14.8V16.4H14.4zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4.8,16.4H5.2V16.8H4.8zM5.2,16.4H5.6V16.8H5.2zM6.4,16.4H6.8V16.8H6.4zM7.2,16.4H7.6V16.8H7.2zM8.4,16.4H8.8V16.8H8.4zM9.2,16.4H9.6V16.8H9.2zM9.6,16.4H10V16.8H9.6zM10.4,16.4H10.8V16.8H10.4zM11.2,16.4H11.6V16.8H11.2zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM15.2,16.4H15.6V16.8H15.2zM15.6,16.4H16V16.8H15.6zM16.4,16.4H16.8V16.8H16.4zM0.8,16.8H1.2V17.2H0.8zM1.2,16.8H1.6V17.2H1.2zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM2.8,16.8H3.2V17.2H2.8zM3.2,16.8H3.6V17.2H3.2zM4,16.8H4.4V17.2H4zM4.4,16.8H4.8V17.2H4.4zM4.8,16.8H5.2V17.2H4.8zM5.2,16.8H5.6V17.2H5.2zM5.6,16.8H6V17.2H5.6zM8,16.8H8.4V17.2H8zM9.6,16.8H10V17.2H9.6zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.2,16.8H11.6V17.2H11.2zM11.6,16.8H12V17.2H11.6zM12.4,16.8H12.8V17.2H12.4zM14.4,16.8H14.8V17.2H14.4zM14.8,16.8H15.2V17.2H14.8zM15.2,16.8H15.6V17.2H15.2zM16,16.8H16.4V17.2H16z"/>
+  </g>
+</g>
 </svg>


### PR DESCRIPTION
## Summary

Extends the Style A **v4c** pure-visual cover SVG treatment (introduced in PR #288 for 04-20/21/22) to the 19 remaining weekly-digest posts **2026-04-01 through 2026-04-19**. Each cover follows the v4c constraints and adds the coordinator-mandated updates applied to this batch.

## v4c Principles (unchanged)

- **1200x630** viewBox, 3-card infographic at x=48/408/768, w=336, h=430
- Card-specific palette: blue / amber / red
- **NO** date, "INCIDENT BRIEF", severity (HIGH/LOW/CRITICAL), percentages, or genre words in `<text>`
- **80+ SMIL animations** per SVG
- QR bottom-right 100x100 points at the post URL
- No Korean characters, no forbidden proper nouns in text

## New in this batch (per coordinator update 2026-04-21)

1. **QR URL = Jekyll slug** — lowercase with `_` -> `-` (previous pattern produced 404s).
   Example: `…/posts/2026/04/01/tech-security-weekly-digest-zero-day-go-ai-aws/`
2. **1-line factual English summary per card** — 5-8 words, derived from the post's `highlights_html`. Total SVG words 15-20 (≤ 30 budget).
3. **More icon detail** — gradient halo + fine-line hatching accent layer under each card's brand noun for depth.

## Metrics (per file)

| Date | Lines | Size (B) | Anim | Words |
|------|------:|---------:|-----:|------:|
| 04-01 | 425 | 46787 |  95 | 15 |
| 04-02 | 474 | 43140 | 111 | 18 |
| 04-03 | 469 | 45732 |  98 | 15 |
| 04-04 | 451 | 45106 | 102 | 18 |
| 04-05 | 465 | 46575 |  98 | 17 |
| 04-06 | 448 | 45012 | 103 | 16 |
| 04-07 | 465 | 46288 | 107 | 19 |
| 04-08 | 465 | 47379 | 107 | 20 |
| 04-09 | 443 | 47337 | 111 | 18 |
| 04-10 | 481 | 46490 | 110 | 19 |
| 04-11 | 465 | 47185 | 107 | 19 |
| 04-12 | 472 | 47088 | 103 | 20 |
| 04-13 | 448 | 47532 | 104 | 20 |
| 04-14 | 465 | 46231 | 107 | 20 |
| 04-15 | 457 | 47378 | 107 | 18 |
| 04-16 | 472 | 46659 | 107 | 19 |
| 04-17 | 465 | 46563 | 107 | 18 |
| 04-18 | 463 | 46117 |  95 | 19 |
| 04-19 | 474 | 46133 | 112 | 19 |

## Evidence of Compliance

- All 19 SVGs parse as valid XML (ElementTree validated).
- Automated scan: 0 underscores in `https://tech.*` URLs, 0 Korean characters, 0 forbidden words (INCIDENT/BRIEF/HIGH/LOW/CRITICAL/SEVERITY/WEEKLY/DIGEST/TECH/SECURITY/month-abbrev/year), 0 multi-digit numbers in `<text>`, 0 percent signs.
- Animation count 80+ on every file (min 95, max 112).
- Text elements: 6 per SVG (3 brand nouns + 3 summaries).
- QR block at `transform="translate(1080,510)"` on every file.

## Test plan

- [ ] Visual review of a random sample (suggest 04-04, 04-12, 04-18) against the v4c reference (04-20/21/22).
- [ ] Scan one QR code with a phone to confirm it lands on the correct `/posts/YYYY/MM/DD/<slug>/` permalink (no 404).
- [ ] Confirm `jekyll build` emits cover images unchanged at `/assets/images/…` paths.
- [ ] Optional: render in Safari + Chrome to confirm SMIL animations loop smoothly.