### PR TITLE
feat(images): research-based unique cover (04-21) - metro line map

### DIFF
--- a/assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg
+++ b/assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg
@@ -1,405 +1,440 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly digest three-card infographic: model RCE, DeFi heist, cloud AI">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly metro map: SGLang GGUF RCE, Vercel ShinyHunters breach, KelpDAO Lazarus heist">
+<title>SGLang GGUF RCE, Vercel ShinyHunters breach, KelpDAO Lazarus 292M heist</title>
 <defs>
-  <linearGradient id="bg" x1="0%" y1="0%" x2="0%" y2="100%">
-    <stop offset="0%" stop-color="#0B132B"/>
-    <stop offset="100%" stop-color="#0A1020"/>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1020"/>
+    <stop offset="50%" stop-color="#0C1630"/>
+    <stop offset="100%" stop-color="#0F1A3A"/>
   </linearGradient>
-  <linearGradient id="stripeBlue" x1="0%" y1="0%" x2="100%" y2="0%">
-    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0"/>
-    <stop offset="50%" stop-color="#3A86FF" stop-opacity="0.9"/>
-    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
-  </linearGradient>
-  <linearGradient id="stripeAmber" x1="0%" y1="0%" x2="100%" y2="0%">
-    <stop offset="0%" stop-color="#FFB703" stop-opacity="0"/>
-    <stop offset="50%" stop-color="#FFB703" stop-opacity="0.9"/>
-    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
-  </linearGradient>
-  <linearGradient id="stripeRed" x1="0%" y1="0%" x2="100%" y2="0%">
-    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
-    <stop offset="50%" stop-color="#E63946" stop-opacity="0.9"/>
+  <radialGradient id="pulseRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF4D5E" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#E63946" stop-opacity="0.45"/>
     <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
-  </linearGradient>
-  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
-    <circle cx="16" cy="16" r="0.9" fill="#2A3256" opacity="0.5"/>
+  </radialGradient>
+  <radialGradient id="pulseAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFC43D" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#FFA107" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FFA107" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseCyan" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#5FD3F3" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#2AA8CE" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#2AA8CE" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="15" cy="15" r="0.7" fill="#2E3A66" opacity="0.55"/>
   </pattern>
-  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.55"/>
-    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
-  </radialGradient>
-  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/>
-    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
-  </radialGradient>
-  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
-    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
-    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
-  </radialGradient>
+  <filter id="stationShadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.2"/>
+    <feOffset dx="0" dy="2"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="glowRed" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowAmber" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowCyan" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <clipPath id="canvasClip">
+    <rect x="0" y="0" width="1200" height="630"/>
+  </clipPath>
 </defs>
-<rect width="1200" height="630" fill="url(#bg)"/>
+
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
 <rect width="1200" height="630" fill="url(#dotGrid)"/>
-<rect x="0" y="56" width="1200" height="2" fill="url(#stripeBlue)" opacity="0.85">
-  <animate attributeName="opacity" values="0.4;1;0.4" dur="5.2s" repeatCount="indefinite"/>
-</rect>
-<rect x="0" y="598" width="1200" height="2" fill="url(#stripeAmber)" opacity="0.7">
-  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="6.1s" repeatCount="indefinite"/>
-</rect>
-<circle cx="170" cy="80" r="60" fill="url(#glowBlue)" opacity="0.55">
-  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="4.4s" repeatCount="indefinite"/>
-</circle>
-<circle cx="1030" cy="550" r="70" fill="url(#glowRed)" opacity="0.4">
-  <animate attributeName="opacity" values="0.2;0.55;0.2" dur="5.8s" repeatCount="indefinite"/>
-</circle>
-<rect x="48" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#3A86FF" stroke-width="1.6" opacity="0.96"/>
-<rect x="66" y="114" width="56" height="3" fill="#3A86FF" rx="1.5">
-  <animate attributeName="width" values="56;92;56" dur="3.8s" repeatCount="indefinite"/>
-</rect>
-<rect x="48" y="94" width="336" height="2" fill="url(#stripeBlue)" opacity="0.7">
-  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.2s" repeatCount="indefinite"/>
-</rect>
-<rect x="408" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#FFB703" stroke-width="1.6" opacity="0.96"/>
-<rect x="426" y="114" width="56" height="3" fill="#FFB703" rx="1.5">
-  <animate attributeName="width" values="56;92;56" dur="3.6s" repeatCount="indefinite"/>
-</rect>
-<rect x="408" y="94" width="336" height="2" fill="url(#stripeAmber)" opacity="0.7">
-  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="4.6s" repeatCount="indefinite"/>
-</rect>
-<rect x="768" y="96" width="336" height="482" rx="18" ry="18" fill="#1C2541" stroke="#E63946" stroke-width="1.6" opacity="0.96"/>
-<rect x="786" y="114" width="56" height="3" fill="#E63946" rx="1.5">
-  <animate attributeName="width" values="56;92;56" dur="3.4s" repeatCount="indefinite"/>
-</rect>
-<rect x="768" y="94" width="336" height="2" fill="url(#stripeRed)" opacity="0.7">
-  <animate attributeName="opacity" values="0.35;0.85;0.35" dur="5.0s" repeatCount="indefinite"/>
-</rect>
-<!-- Card footer accent dots (pulse) -->
-<circle cx="102" cy="562" r="3" fill="#3A86FF" opacity="0.7">
-  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
-</circle>
-<circle cx="118" cy="562" r="3" fill="#3A86FF" opacity="0.55">
-  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
-</circle>
-<circle cx="134" cy="562" r="3" fill="#3A86FF" opacity="0.4">
-  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.2s" repeatCount="indefinite"/>
-</circle>
-<circle cx="462" cy="562" r="3" fill="#FFB703" opacity="0.7">
-  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
-</circle>
-<circle cx="478" cy="562" r="3" fill="#FFB703" opacity="0.55">
-  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.6s" repeatCount="indefinite"/>
-</circle>
-<circle cx="494" cy="562" r="3" fill="#FFB703" opacity="0.4">
-  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.0s" repeatCount="indefinite"/>
-</circle>
-<circle cx="822" cy="562" r="3" fill="#E63946" opacity="0.7">
-  <animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" repeatCount="indefinite"/>
-</circle>
-<circle cx="838" cy="562" r="3" fill="#E63946" opacity="0.55">
-  <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.7s" repeatCount="indefinite"/>
-</circle>
-<circle cx="854" cy="562" r="3" fill="#E63946" opacity="0.4">
-  <animate attributeName="opacity" values="0.25;0.65;0.25" dur="3.1s" repeatCount="indefinite"/>
-</circle>
-<g transform="translate(216,330)">
-  <!-- Model file card (GGUF-style) -->
-  <g transform="translate(-80,-110)">
-    <rect x="0" y="0" width="90" height="110" rx="8" fill="#0B132B" stroke="#3A86FF" stroke-width="2.2"/>
-    <!-- folded corner -->
-    <path d="M 70 0 L 90 20 L 70 20 Z" fill="#1C2541" stroke="#3A86FF" stroke-width="2.2"/>
-    <!-- neural net nodes inside -->
-    <circle cx="18" cy="38" r="4" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.2s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="18" cy="58" r="4" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.6s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="18" cy="78" r="4" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="45" cy="48" r="4" fill="#3A86FF">
+
+<!-- Subtle map guides -->
+<g opacity="0.12" stroke="#4A6AA0" stroke-width="0.6" fill="none">
+  <line x1="0" y1="150" x2="1200" y2="150">
+    <animate attributeName="opacity" values="0.08;0.18;0.08" dur="6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="300" x2="1200" y2="300">
+    <animate attributeName="opacity" values="0.08;0.18;0.08" dur="6s" repeatCount="indefinite" begin="1s"/>
+  </line>
+  <line x1="0" y1="450" x2="1200" y2="450">
+    <animate attributeName="opacity" values="0.08;0.18;0.08" dur="6s" repeatCount="indefinite" begin="2s"/>
+  </line>
+  <line x1="200" y1="0" x2="200" y2="630"/>
+  <line x1="500" y1="0" x2="500" y2="630"/>
+  <line x1="800" y1="0" x2="800" y2="630"/>
+  <line x1="1050" y1="0" x2="1050" y2="630"/>
+</g>
+
+<!-- Title -->
+<g filter="url(#textShadow)">
+  <text x="60" y="62" font-family="Helvetica, Arial, sans-serif" font-size="30" font-weight="800" fill="#E9EEF8" letter-spacing="1.2">
+    WEEKLY
+    <animate attributeName="fill" values="#E9EEF8;#8FB8FF;#E9EEF8" dur="6s" repeatCount="indefinite"/>
+  </text>
+  </g>
+
+<!-- Legend -->
+<g transform="translate(1020,60)" filter="url(#textShadow)">
+  <rect x="-6" y="-26" width="160" height="52" rx="10" fill="#14213E" stroke="#3A4E82" stroke-width="1.2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <circle cx="8" cy="0" r="5" fill="#E63946">
+    <animate attributeName="r" values="5;6.5;5" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="8" cy="0" r="5" fill="url(#pulseRed)" opacity="0.9">
+    <animate attributeName="opacity" values="0.4;1;0.4" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <text x="22" y="5" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#E9EEF8">CRITICAL</text>
+  <circle cx="85" cy="0" r="5" fill="#FFA107">
+    <animate attributeName="r" values="5;6.5;5" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <text x="96" y="5" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#E9EEF8">HIGH</text>
+</g>
+
+<!-- ==================== LINE 1: SGLang RCE (RED) ==================== -->
+<g>
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowRed)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite"/>
+  </line>
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="9" stroke-linecap="round"/>
+  <g transform="translate(60,170)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#E63946">
+      <animate attributeName="fill" values="#E63946;#FF6B7A;#E63946" dur="4s" repeatCount="indefinite"/>
+    </rect>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#FFFFFF" text-anchor="middle">L1</text>
+  </g>
+  <circle r="10" fill="#FFE1E4" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="9s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="170;170;170" dur="9s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="9s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station A: SGLang -->
+  <g transform="translate(200,170)">
+    <circle r="18" fill="url(#pulseRed)">
+      <animate attributeName="r" values="18;28;18" dur="2.8s" repeatCount="indefinite"/>
       <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
     </circle>
-    <circle cx="45" cy="68" r="4" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.0s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="72" cy="58" r="4" fill="#E63946">
-      <animate attributeName="r" values="4;6;4" dur="2.2s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.7;1;0.7" dur="2.2s" repeatCount="indefinite"/>
-    </circle>
-    <line x1="18" y1="38" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
-    <line x1="18" y1="58" x2="45" y2="48" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
-    <line x1="18" y1="58" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
-    <line x1="18" y1="78" x2="45" y2="68" stroke="#3A86FF" stroke-width="1.4" opacity="0.6"/>
-    <line x1="45" y1="48" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
-    <line x1="45" y1="68" x2="72" y2="58" stroke="#E63946" stroke-width="1.6" opacity="0.75"/>
-    <!-- bug sneaking in (upper right) -->
-    <g transform="translate(72,20)">
-      <circle cx="0" cy="0" r="4" fill="#E63946">
-        <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
-      </circle>
-      <line x1="-4" y1="-4" x2="-6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
-      <line x1="4" y1="-4" x2="6" y2="-6" stroke="#E63946" stroke-width="1.4"/>
-      <line x1="-4" y1="4" x2="-6" y2="6" stroke="#E63946" stroke-width="1.4"/>
-      <line x1="4" y1="4" x2="6" y2="6" stroke="#E63946" stroke-width="1.4"/>
-    </g>
-  </g>
-  <!-- Payload stream flowing rightward -->
-  <g>
-    <circle cx="-8" cy="-30" r="2.4" fill="#E63946">
-      <animate attributeName="cx" values="-8;64" dur="2.2s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.2s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="-8" cy="-10" r="2" fill="#E63946">
-      <animate attributeName="cx" values="-8;64" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="-8" cy="10" r="2.6" fill="#E63946">
-      <animate attributeName="cx" values="-8;64" dur="2.4s" begin="1s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="-8" cy="30" r="2.2" fill="#E63946">
-      <animate attributeName="cx" values="-8;64" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.5s" repeatCount="indefinite"/>
+    <circle r="12" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="4" fill="#FF4D5E">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.4s" repeatCount="indefinite"/>
     </circle>
   </g>
-  <!-- Shell/terminal window (right) -->
-  <g transform="translate(30,-60)">
-    <rect x="0" y="0" width="80" height="100" rx="6" fill="#0B132B" stroke="#E63946" stroke-width="2.2"/>
-    <rect x="0" y="0" width="80" height="14" rx="6" fill="#1C2541"/>
-    <circle cx="8" cy="7" r="2.4" fill="#E63946"/>
-    <circle cx="16" cy="7" r="2.4" fill="#FFB703"/>
-    <circle cx="24" cy="7" r="2.4" fill="#3A86FF"/>
-    <!-- prompt lines appearing -->
-    <g>
-      <path d="M 8 28 L 14 24 L 8 20" fill="none" stroke="#E63946" stroke-width="2"/>
-      <rect x="18" y="22" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
-        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" repeatCount="indefinite"/>
-        <animate attributeName="width" values="0;48;48;0" dur="5s" repeatCount="indefinite"/>
-      </rect>
-    </g>
-    <g>
-      <path d="M 8 44 L 14 40 L 8 36" fill="none" stroke="#E63946" stroke-width="2"/>
-      <rect x="18" y="38" width="36" height="3" rx="1.5" fill="#FFB703" opacity="0">
-        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
-        <animate attributeName="width" values="0;44;44;0" dur="5s" begin="1.2s" repeatCount="indefinite"/>
-      </rect>
-    </g>
-    <g>
-      <path d="M 8 60 L 14 56 L 8 52" fill="none" stroke="#E63946" stroke-width="2"/>
-      <rect x="18" y="54" width="40" height="3" rx="1.5" fill="#E63946" opacity="0">
-        <animate attributeName="opacity" values="0;0.9;0.9;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
-        <animate attributeName="width" values="0;54;54;0" dur="5s" begin="2.4s" repeatCount="indefinite"/>
-      </rect>
-    </g>
-    <!-- cursor -->
-    <rect x="8" y="76" width="6" height="10" fill="#E63946">
-      <animate attributeName="opacity" values="1;0;1" dur="0.9s" repeatCount="indefinite"/>
+  <g filter="url(#textShadow)">
+    <text x="200" y="138" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">SGLang</text>
+    <text x="200" y="212" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFB8BE" text-anchor="middle">LLM</text>
+  </g>
+
+  <!-- Station B: CVE -->
+  <g transform="translate(420,170)">
+    <circle r="16" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="6" fill="#E63946">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="6;8;6" dur="2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="420" y="138" font-family="Helvetica, Arial, sans-serif" font-size="20" font-weight="900" fill="#FFE1E4" text-anchor="middle">CVE-2026-5760</text>
+    <text x="420" y="212" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#E63946" text-anchor="middle">CVSS 9.8</text>
+  </g>
+
+  <!-- Station C: GGUF -->
+  <g transform="translate(640,170)">
+    <rect x="-18" y="-14" width="36" height="28" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+      <animate attributeName="stroke-width" values="4;5;4" dur="2.5s" repeatCount="indefinite"/>
     </rect>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#FF4D5E">.gguf</text>
   </g>
-  <!-- skull glyph near shell as RCE indicator (pure shape) -->
-  <g transform="translate(70,-80)">
-    <circle cx="0" cy="0" r="9" fill="#E63946" opacity="0.9">
-      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+  <g filter="url(#textShadow)">
+    <text x="640" y="138" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">GGUF model</text>
+    <text x="640" y="212" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFB8BE" text-anchor="middle">SSTI payload</text>
+  </g>
+
+  <!-- Station D: Jinja2 -->
+  <g transform="translate(860,170)">
+    <polygon points="-14,-14 14,-14 0,14" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="14s" repeatCount="indefinite"/>
+    </polygon>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="860" y="138" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">Jinja2</text>
+    <text x="860" y="212" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFB8BE" text-anchor="middle">escape</text>
+  </g>
+
+  <!-- Terminus -->
+  <g transform="translate(1050,170)">
+    <circle r="22" fill="none" stroke="#E63946" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="8s" repeatCount="indefinite"/>
     </circle>
-    <circle cx="-3" cy="-1" r="1.4" fill="#0B132B"/>
-    <circle cx="3" cy="-1" r="1.4" fill="#0B132B"/>
-    <rect x="-3" y="3" width="6" height="3" fill="#0B132B"/>
+    <circle r="14" fill="#E63946" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#E63946;#FF4D5E;#E63946" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#FFFFFF">RCE</text>
   </g>
-  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
-        font-size="16" font-weight="800" fill="#E7ECF4"
-        text-anchor="middle" letter-spacing="3">SGLANG</text>
 </g>
-<g transform="translate(576,330)">
-  <!-- Vault door -->
-  <g transform="translate(-70,-100)">
-    <rect x="0" y="0" width="120" height="120" rx="8" fill="#0B132B" stroke="#FFB703" stroke-width="2.4"/>
-    <circle cx="60" cy="60" r="40" fill="none" stroke="#FFB703" stroke-width="2.4"/>
-    <circle cx="60" cy="60" r="28" fill="none" stroke="#FFB703" stroke-width="2" opacity="0.7"/>
-    <!-- vault handle spokes rotating -->
-    <g transform="translate(60,60)">
-      <animateTransform attributeName="transform" type="rotate"
-                        values="0;360" dur="6s" repeatCount="indefinite"/>
-      <line x1="-32" y1="0" x2="32" y2="0" stroke="#FFB703" stroke-width="2.4"/>
-      <line x1="0" y1="-32" x2="0" y2="32" stroke="#FFB703" stroke-width="2.4"/>
-      <line x1="-22" y1="-22" x2="22" y2="22" stroke="#FFB703" stroke-width="2"/>
-      <line x1="22" y1="-22" x2="-22" y2="22" stroke="#FFB703" stroke-width="2"/>
-      <circle cx="0" cy="0" r="6" fill="#FFB703"/>
-    </g>
-    <!-- crack in door -->
-    <path d="M 20 10 L 40 50 L 30 90 L 50 110" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
-      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
-    </path>
-    <path d="M 90 20 L 100 70 L 80 100" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3 2">
-      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.8s" repeatCount="indefinite"/>
-    </path>
-  </g>
-  <!-- Coins flying out -->
-  <g>
-    <circle cx="10" cy="-40" r="6" fill="#FFB703" opacity="0">
-      <animate attributeName="cx" values="-10;90" dur="2.6s" repeatCount="indefinite"/>
-      <animate attributeName="cy" values="-30;-90" dur="2.6s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.6s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="10" cy="-20" r="5" fill="#FFB703" opacity="0">
-      <animate attributeName="cx" values="-10;100" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
-      <animate attributeName="cy" values="-20;-70" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="3.0s" begin="0.6s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="10" cy="0" r="5" fill="#FFB703" opacity="0">
-      <animate attributeName="cx" values="-10;110" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
-      <animate attributeName="cy" values="0;-50" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.8s" begin="1.2s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="10" cy="-60" r="4" fill="#FFB703" opacity="0">
-      <animate attributeName="cx" values="-10;80" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
-      <animate attributeName="cy" values="-60;-110" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
-      <animate attributeName="opacity" values="0.9;0" dur="2.4s" begin="1.8s" repeatCount="indefinite"/>
-    </circle>
-  </g>
-  <!-- Masked figure silhouette (right) -->
-  <g transform="translate(90,-20)">
-    <!-- head -->
-    <circle cx="0" cy="-20" r="12" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
-    <!-- mask band -->
-    <rect x="-14" y="-24" width="28" height="6" fill="#E63946" opacity="0.85"/>
-    <circle cx="-5" cy="-21" r="2" fill="#E7ECF4"/>
-    <circle cx="5" cy="-21" r="2" fill="#E7ECF4"/>
-    <!-- body -->
-    <path d="M -14 -6 Q 0 -10 14 -6 L 18 40 L -18 40 Z" fill="#1C2541" stroke="#E63946" stroke-width="1.8"/>
-    <!-- arm reaching down -->
-    <path d="M -14 -2 Q -30 20 -28 34" fill="none" stroke="#E63946" stroke-width="2.4">
-      <animate attributeName="d"
-               values="M -14 -2 Q -30 20 -28 34;
-                       M -14 -2 Q -34 22 -36 38;
-                       M -14 -2 Q -30 20 -28 34"
-               dur="2.4s" repeatCount="indefinite"/>
-    </path>
-    <!-- holding coin -->
-    <circle cx="-28" cy="34" r="4" fill="#FFB703">
-      <animate attributeName="cy" values="34;38;34" dur="2.4s" repeatCount="indefinite"/>
-    </circle>
-  </g>
-  <!-- Down arrow stream (loss) -->
-  <g transform="translate(-30,60)">
-    <path d="M 0 0 L 0 30 M -6 24 L 0 30 L 6 24" stroke="#E63946" stroke-width="2.4" fill="none">
-      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/>
-    </path>
-    <path d="M 16 -6 L 16 24 M 10 18 L 16 24 L 22 18" stroke="#E63946" stroke-width="2.4" fill="none">
-      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" begin="0.5s" repeatCount="indefinite"/>
-    </path>
-    <path d="M 32 0 L 32 30 M 26 24 L 32 30 L 38 24" stroke="#E63946" stroke-width="2.4" fill="none">
-      <animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" begin="1.0s" repeatCount="indefinite"/>
-    </path>
-  </g>
-  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
-        font-size="15" font-weight="800" fill="#E7ECF4"
-        text-anchor="middle" letter-spacing="2">KELPDAO</text>
-</g>
-<g transform="translate(936,330)">
-  <!-- Cloud silhouette -->
-  <g transform="translate(0,-90)">
-    <path d="M -50 0 Q -60 -14 -46 -22 Q -44 -38 -24 -38 Q -12 -48 6 -42 Q 24 -48 34 -34 Q 52 -34 54 -18 Q 64 -10 54 2 Z"
-          fill="#0B132B" stroke="#E63946" stroke-width="2.4">
-      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.6s" repeatCount="indefinite"/>
-    </path>
-    <!-- Lightning bolt inside -->
-    <path d="M -8 -28 L 0 -18 L -4 -18 L 6 -6 L -2 -14 L 2 -14 Z"
-          fill="#FFB703" stroke="#FFB703" stroke-width="1.2">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="1.6s" repeatCount="indefinite"/>
-    </path>
-  </g>
-  <!-- AI chip (center) -->
-  <g transform="translate(0,10)">
-    <rect x="-34" y="-34" width="68" height="68" rx="8" fill="#0B132B" stroke="#E63946" stroke-width="2.2">
-      <animate attributeName="opacity" values="0.92;1;0.92" dur="3.2s" repeatCount="indefinite"/>
+
+<!-- ==================== LINE 2: Vercel / ShinyHunters (AMBER) ==================== -->
+<g>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowAmber)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite" begin="0.7s"/>
+  </line>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="9" stroke-linecap="round"/>
+  <g transform="translate(60,330)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#FFA107">
+      <animate attributeName="fill" values="#FFA107;#FFC43D;#FFA107" dur="4s" repeatCount="indefinite"/>
     </rect>
-    <!-- inner square -->
-    <rect x="-20" y="-20" width="40" height="40" rx="4" fill="none" stroke="#E63946" stroke-width="1.8" opacity="0.8"/>
-    <!-- AI script pattern (brain-like curves, not text) -->
-    <path d="M -12 -8 Q -4 -16 4 -8 Q 12 0 4 8 Q -4 16 -12 8 Z"
-          fill="none" stroke="#FFB703" stroke-width="2">
-      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.4s" repeatCount="indefinite"/>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#1A1202" text-anchor="middle">L2</text>
+  </g>
+  <circle r="10" fill="#FFF0C9" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="10s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="330;330;330" dur="10s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="10s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- A: Lumma -->
+  <g transform="translate(200,330)">
+    <circle r="18" fill="url(#pulseAmber)">
+      <animate attributeName="r" values="18;26;18" dur="3.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="12" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="900" fill="#FFC43D">LUMMA</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="298" font-family="Helvetica, Arial, sans-serif" font-size="17" font-weight="800" fill="#FFFFFF" text-anchor="middle">Lumma stealer</text>
+    <text x="200" y="372" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFD27A" text-anchor="middle">Feb 2026</text>
+  </g>
+
+  <!-- B: Context.ai -->
+  <g transform="translate(420,330)">
+    <circle r="16" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="6" fill="#FFA107">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="6;8;6" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="420" y="298" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">Context.ai</text>
+    <text x="420" y="372" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFD27A" text-anchor="middle">SaaS</text>
+  </g>
+
+  <!-- C: Workspace -->
+  <g transform="translate(640,330)">
+    <rect x="-14" y="-14" width="28" height="28" rx="3" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+      <animate attributeName="stroke-width" values="4;5;4" dur="2.5s" repeatCount="indefinite" begin="0.4s"/>
+    </rect>
+    <text y="4" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#FFC43D">GWS</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="640" y="298" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">Google Workspace</text>
+    <text x="640" y="372" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFD27A" text-anchor="middle">OAuth</text>
+  </g>
+
+  <!-- D: Vercel -->
+  <g transform="translate(860,330)">
+    <polygon points="0,-16 14,8 -14,8" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="16s" repeatCount="indefinite"/>
+    </polygon>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="860" y="298" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">Vercel env</text>
+    <text x="860" y="372" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#FFD27A" text-anchor="middle">secrets</text>
+  </g>
+
+  <!-- Terminus -->
+  <g transform="translate(1050,330)">
+    <circle r="22" fill="none" stroke="#FFA107" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;-360" dur="9s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="14" fill="#FFA107" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#FFA107;#FFC43D;#FFA107" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#1A1202">$2M</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="1050" y="298" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFE7B5" text-anchor="middle">ShinyHunters</text>
+  </g>
+</g>
+
+<!-- ==================== LINE 3: KelpDAO / Lazarus (CYAN) ==================== -->
+<g>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowCyan)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite" begin="1.4s"/>
+  </line>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="9" stroke-linecap="round"/>
+  <g transform="translate(60,490)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#2AA8CE">
+      <animate attributeName="fill" values="#2AA8CE;#5FD3F3;#2AA8CE" dur="4s" repeatCount="indefinite"/>
+    </rect>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#061622" text-anchor="middle">L3</text>
+  </g>
+  <circle r="10" fill="#CFF0FA" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="11s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="490;490;490" dur="11s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- A: RPC 2 -->
+  <g transform="translate(200,490)">
+    <circle r="18" fill="url(#pulseCyan)">
+      <animate attributeName="r" values="18;26;18" dur="3s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="12" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#5FD3F3">2x</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="458" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">RPC nodes</text>
+    <text x="200" y="532" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#A6E6F7" text-anchor="middle">op-geth swap</text>
+  </g>
+
+  <!-- B: DDoS -->
+  <g transform="translate(420,490)">
+    <circle r="16" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <g stroke="#5FD3F3" stroke-width="2" fill="none">
+      <path d="M-9 0 L9 0"/>
+      <path d="M0 -9 L0 9"/>
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="3s" repeatCount="indefinite"/>
+    </g>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="420" y="458" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">DDoS failover</text>
+    <text x="420" y="532" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#A6E6F7" text-anchor="middle">DVN 1/1</text>
+  </g>
+
+  <!-- C: rsETH drain -->
+  <g transform="translate(640,490)">
+    <rect x="-20" y="-14" width="40" height="28" rx="4" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)">
+      <animate attributeName="stroke-width" values="4;5;4" dur="2.5s" repeatCount="indefinite" begin="0.8s"/>
+    </rect>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="900" fill="#5FD3F3">rsETH</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="640" y="458" font-family="Helvetica, Arial, sans-serif" font-size="20" font-weight="900" fill="#CFF0FA" text-anchor="middle">116,500 rsETH</text>
+    <text x="640" y="532" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#A6E6F7" text-anchor="middle">17:35 UTC</text>
+  </g>
+
+  <!-- D: Tornado -->
+  <g transform="translate(860,490)">
+    <circle r="15" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <path d="M-7 -5 Q0 -10 7 -5 Q10 0 7 5 Q0 10 -7 5 Q-10 0 -7 -5 Z" fill="none" stroke="#5FD3F3" stroke-width="1.6">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="4s" repeatCount="indefinite"/>
     </path>
-    <circle cx="-2" cy="0" r="2.4" fill="#FFB703">
-      <animate attributeName="r" values="2.4;4;2.4" dur="1.8s" repeatCount="indefinite"/>
-    </circle>
-    <!-- chip legs (pins) -->
-    <line x1="-34" y1="-20" x2="-44" y2="-20" stroke="#E63946" stroke-width="2"/>
-    <line x1="-34" y1="0" x2="-44" y2="0" stroke="#E63946" stroke-width="2"/>
-    <line x1="-34" y1="20" x2="-44" y2="20" stroke="#E63946" stroke-width="2"/>
-    <line x1="34" y1="-20" x2="44" y2="-20" stroke="#E63946" stroke-width="2"/>
-    <line x1="34" y1="0" x2="44" y2="0" stroke="#E63946" stroke-width="2"/>
-    <line x1="34" y1="20" x2="44" y2="20" stroke="#E63946" stroke-width="2"/>
-    <line x1="-20" y1="-34" x2="-20" y2="-44" stroke="#E63946" stroke-width="2"/>
-    <line x1="0" y1="-34" x2="0" y2="-44" stroke="#E63946" stroke-width="2"/>
-    <line x1="20" y1="-34" x2="20" y2="-44" stroke="#E63946" stroke-width="2"/>
-    <line x1="-20" y1="34" x2="-20" y2="44" stroke="#E63946" stroke-width="2"/>
-    <line x1="0" y1="34" x2="0" y2="44" stroke="#E63946" stroke-width="2"/>
-    <line x1="20" y1="34" x2="20" y2="44" stroke="#E63946" stroke-width="2"/>
   </g>
-  <!-- Data flow from cloud to chip -->
-  <circle cx="0" cy="-60" r="2.4" fill="#FFB703">
-    <animate attributeName="cy" values="-60;-24" dur="1.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="1.8s" repeatCount="indefinite"/>
-  </circle>
-  <circle cx="-10" cy="-54" r="2" fill="#FFB703">
-    <animate attributeName="cy" values="-54;-24" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/>
-  </circle>
-  <circle cx="10" cy="-58" r="2.2" fill="#FFB703">
-    <animate attributeName="cy" values="-58;-24" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="2.2s" begin="0.8s" repeatCount="indefinite"/>
-  </circle>
-  <!-- Output nodes (neural) -->
-  <g transform="translate(0,90)">
-    <circle cx="-40" cy="0" r="6" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.0s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="-20" cy="0" r="6" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.2s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="0" cy="0" r="6" fill="#FFB703">
-      <animate attributeName="opacity" values="0.55;1;0.55" dur="1.8s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="20" cy="0" r="6" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.4s" repeatCount="indefinite"/>
-    </circle>
-    <circle cx="40" cy="0" r="6" fill="#3A86FF">
-      <animate attributeName="opacity" values="0.55;1;0.55" dur="2.6s" repeatCount="indefinite"/>
-    </circle>
-    <line x1="0" y1="-30" x2="-40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
-    <line x1="0" y1="-30" x2="-20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
-    <line x1="0" y1="-30" x2="0" y2="0" stroke="#FFB703" stroke-width="1.6" opacity="0.7"/>
-    <line x1="0" y1="-30" x2="20" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
-    <line x1="0" y1="-30" x2="40" y2="0" stroke="#3A86FF" stroke-width="1.4" opacity="0.55"/>
+  <g filter="url(#textShadow)">
+    <text x="860" y="458" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="800" fill="#FFFFFF" text-anchor="middle">Tornado Cash</text>
+    <text x="860" y="532" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="600" fill="#A6E6F7" text-anchor="middle">laundry</text>
   </g>
-  <!-- Flowing pulse along connection -->
-  <circle cx="0" cy="50" r="2.4" fill="#FFB703">
-    <animate attributeName="cy" values="50;86" dur="1.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="1.2s" repeatCount="indefinite"/>
-  </circle>
-  <circle cx="-6" cy="52" r="2" fill="#FFB703">
-    <animate attributeName="cy" values="52;86" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="1.4s" begin="0.2s" repeatCount="indefinite"/>
-  </circle>
-  <circle cx="6" cy="52" r="2.2" fill="#FFB703">
-    <animate attributeName="cy" values="52;86" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
-    <animate attributeName="opacity" values="0.9;0" dur="1.6s" begin="0.4s" repeatCount="indefinite"/>
-  </circle>
-  <!-- Orbit rings around chip -->
-  <circle cx="0" cy="10" r="56" fill="none" stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 4" opacity="0.4">
-    <animateTransform attributeName="transform" type="rotate" values="0 0 10;360 0 10" dur="12s" repeatCount="indefinite"/>
-  </circle>
-  <circle cx="0" cy="10" r="64" fill="none" stroke="#FFB703" stroke-width="1" stroke-dasharray="2 5" opacity="0.35">
-    <animateTransform attributeName="transform" type="rotate" values="360 0 10;0 0 10" dur="18s" repeatCount="indefinite"/>
-  </circle>
-  <text x="0" y="170" font-family="Inter,Segoe UI,Arial,sans-serif"
-        font-size="16" font-weight="800" fill="#E7ECF4"
-        text-anchor="middle" letter-spacing="3">AWS</text>
-</g>
-<g transform="translate(1080,510)">
-  <rect x="-6" y="-6" width="112" height="112" rx="8" fill="#E7ECF4" opacity="0.96"/>
-  <rect x="-2" y="-2" width="104" height="104" rx="6" fill="#FFFFFF"/>
-  <g transform="scale(5.102041)" fill="#0B132B">
-    <path d="M0.8,0.8H1.2V1.2H0.8zM1.2,0.8H1.6V1.2H1.2zM1.6,0.8H2V1.2H1.6zM2,0.8H2.4V1.2H2zM2.4,0.8H2.8V1.2H2.4zM2.8,0.8H3.2V1.2H2.8zM3.2,0.8H3.6V1.2H3.2zM4,0.8H4.4V1.2H4zM4.4,0.8H4.8V1.2H4.4zM4.8,0.8H5.2V1.2H4.8zM5.6,0.8H6V1.2H5.6zM6,0.8H6.4V1.2H6zM6.8,0.8H7.2V1.2H6.8zM7.2,0.8H7.6V1.2H7.2zM8.4,0.8H8.8V1.2H8.4zM9.6,0.8H10V1.2H9.6zM10.8,0.8H11.2V1.2H10.8zM12.4,0.8H12.8V1.2H12.4zM12.8,0.8H13.2V1.2H12.8zM13.6,0.8H14V1.2H13.6zM15.2,0.8H15.6V1.2H15.2zM16,0.8H16.4V1.2H16zM16.4,0.8H16.8V1.2H16.4zM16.8,0.8H17.2V1.2H16.8zM17.2,0.8H17.6V1.2H17.2zM17.6,0.8H18V1.2H17.6zM18,0.8H18.4V1.2H18zM18.4,0.8H18.8V1.2H18.4zM0.8,1.2H1.2V1.6H0.8zM3.2,1.2H3.6V1.6H3.2zM4,1.2H4.4V1.6H4zM4.8,1.2H5.2V1.6H4.8zM5.2,1.2H5.6V1.6H5.2zM6.4,1.2H6.8V1.6H6.4zM7.2,1.2H7.6V1.6H7.2zM8,1.2H8.4V1.6H8zM8.8,1.2H9.2V1.6H8.8zM9.2,1.2H9.6V1.6H9.2zM9.6,1.2H10V1.6H9.6zM12,1.2H12.4V1.6H12zM12.8,1.2H13.2V1.6H12.8zM13.6,1.2H14V1.6H13.6zM14,1.2H14.4V1.6H14zM14.8,1.2H15.2V1.6H14.8zM16,1.2H16.4V1.6H16zM18.4,1.2H18.8V1.6H18.4zM0.8,1.6H1.2V2H0.8zM1.6,1.6H2V2H1.6zM2,1.6H2.4V2H2zM2.4,1.6H2.8V2H2.4zM3.2,1.6H3.6V2H3.2zM4.4,1.6H4.8V2H4.4zM5.2,1.6H5.6V2H5.2zM6,1.6H6.4V2H6zM6.4,1.6H6.8V2H6.4zM7.2,1.6H7.6V2H7.2zM7.6,1.6H8V2H7.6zM8,1.6H8.4V2H8zM9.6,1.6H10V2H9.6zM10.4,1.6H10.8V2H10.4zM11.2,1.6H11.6V2H11.2zM11.6,1.6H12V2H11.6zM13.6,1.6H14V2H13.6zM14.8,1.6H15.2V2H14.8zM16,1.6H16.4V2H16zM16.8,1.6H17.2V2H16.8zM17.2,1.6H17.6V2H17.2zM17.6,1.6H18V2H17.6zM18.4,1.6H18.8V2H18.4zM0.8,2H1.2V2.4H0.8zM1.6,2H2V2.4H1.6zM2,2H2.4V2.4H2zM2.4,2H2.8V2.4H2.4zM3.2,2H3.6V2.4H3.2zM4,2H4.4V2.4H4zM4.4,2H4.8V2.4H4.4zM5.6,2H6V2.4H5.6zM6,2H6.4V2.4H6zM6.4,2H6.8V2.4H6.4zM7.6,2H8V2.4H7.6zM8,2H8.4V2.4H8zM8.4,2H8.8V2.4H8.4zM8.8,2H9.2V2.4H8.8zM9.6,2H10V2.4H9.6zM10,2H10.4V2.4H10zM11.2,2H11.6V2.4H11.2zM11.6,2H12V2.4H11.6zM12.8,2H13.2V2.4H12.8zM13.2,2H13.6V2.4H13.2zM14.8,2H15.2V2.4H14.8zM15.2,2H15.6V2.4H15.2zM16,2H16.4V2.4H16zM16.8,2H17.2V2.4H16.8zM17.2,2H17.6V2.4H17.2zM17.6,2H18V2.4H17.6zM18.4,2H18.8V2.4H18.4zM0.8,2.4H1.2V2.8H0.8zM1.6,2.4H2V2.8H1.6zM2,2.4H2.4V2.8H2zM2.4,2.4H2.8V2.8H2.4zM3.2,2.4H3.6V2.8H3.2zM4.4,2.4H4.8V2.8H4.4zM4.8,2.4H5.2V2.8H4.8zM5.6,2.4H6V2.8H5.6zM6,2.4H6.4V2.8H6zM6.4,2.4H6.8V2.8H6.4zM6.8,2.4H7.2V2.8H6.8zM7.2,2.4H7.6V2.8H7.2zM7.6,2.4H8V2.8H7.6zM8.4,2.4H8.8V2.8H8.4zM8.8,2.4H9.2V2.8H8.8zM9.2,2.4H9.6V2.8H9.2zM9.6,2.4H10V2.8H9.6zM10,2.4H10.4V2.8H10zM10.4,2.4H10.8V2.8H10.4zM10.8,2.4H11.2V2.8H10.8zM12,2.4H12.4V2.8H12zM13.6,2.4H14V2.8H13.6zM14,2.4H14.4V2.8H14zM14.4,2.4H14.8V2.8H14.4zM14.8,2.4H15.2V2.8H14.8zM15.2,2.4H15.6V2.8H15.2zM16,2.4H16.4V2.8H16zM16.8,2.4H17.2V2.8H16.8zM17.2,2.4H17.6V2.8H17.2zM17.6,2.4H18V2.8H17.6zM18.4,2.4H18.8V2.8H18.4zM0.8,2.8H1.2V3.2H0.8zM3.2,2.8H3.6V3.2H3.2zM4.4,2.8H4.8V3.2H4.4zM5.2,2.8H5.6V3.2H5.2zM5.6,2.8H6V3.2H5.6zM6.4,2.8H6.8V3.2H6.4zM6.8,2.8H7.2V3.2H6.8zM7.2,2.8H7.6V3.2H7.2zM8.4,2.8H8.8V3.2H8.4zM8.8,2.8H9.2V3.2H8.8zM10.4,2.8H10.8V3.2H10.4zM10.8,2.8H11.2V3.2H10.8zM12,2.8H12.4V3.2H12zM12.4,2.8H12.8V3.2H12.4zM12.8,2.8H13.2V3.2H12.8zM13.2,2.8H13.6V3.2H13.2zM13.6,2.8H14V3.2H13.6zM16,2.8H16.4V3.2H16zM18.4,2.8H18.8V3.2H18.4zM0.8,3.2H1.2V3.6H0.8zM1.2,3.2H1.6V3.6H1.2zM1.6,3.2H2V3.6H1.6zM2,3.2H2.4V3.6H2zM2.4,3.2H2.8V3.6H2.4zM2.8,3.2H3.2V3.6H2.8zM3.2,3.2H3.6V3.6H3.2zM4,3.2H4.4V3.6H4zM4.8,3.2H5.2V3.6H4.8zM5.6,3.2H6V3.6H5.6zM6.4,3.2H6.8V3.6H6.4zM7.2,3.2H7.6V3.6H7.2zM8,3.2H8.4V3.6H8zM8.8,3.2H9.2V3.6H8.8zM9.6,3.2H10V3.6H9.6zM10.4,3.2H10.8V3.6H10.4zM11.2,3.2H11.6V3.6H11.2zM12,3.2H12.4V3.6H12zM12.8,3.2H13.2V3.6H12.8zM13.6,3.2H14V3.6H13.6zM14.4,3.2H14.8V3.6H14.4zM15.2,3.2H15.6V3.6H15.2zM16,3.2H16.4V3.6H16zM16.4,3.2H16.8V3.6H16.4zM16.8,3.2H17.2V3.6H16.8zM17.2,3.2H17.6V3.6H17.2zM17.6,3.2H18V3.6H17.6zM18,3.2H18.4V3.6H18zM18.4,3.2H18.8V3.6H18.4zM4,3.6H4.4V4H4zM6.4,3.6H6.8V4H6.4zM6.8,3.6H7.2V4H6.8zM7.2,3.6H7.6V4H7.2zM8.4,3.6H8.8V4H8.4zM8.8,3.6H9.2V4H8.8zM10.4,3.6H10.8V4H10.4zM11.2,3.6H11.6V4H11.2zM12,3.6H12.4V4H12zM12.4,3.6H12.8V4H12.4zM12.8,3.6H13.2V4H12.8zM14,3.6H14.4V4H14zM0.8,4H1.2V4.4H0.8zM1.6,4H2V4.4H1.6zM2,4H2.4V4.4H2zM2.8,4H3.2V4.4H2.8zM3.2,4H3.6V4.4H3.2zM3.6,4H4V4.4H3.6zM4.8,4H5.2V4.4H4.8zM5.6,4H6V4.4H5.6zM6.8,4H7.2V4.4H6.8zM7.2,4H7.6V4.4H7.2zM8.8,4H9.2V4.4H8.8zM9.2,4H9.6V4.4H9.2zM9.6,4H10V4.4H9.6zM10,4H10.4V4.4H10zM10.4,4H10.8V4.4H10.4zM11.6,4H12V4.4H11.6zM12,4H12.4V4.4H12zM12.4,4H12.8V4.4H12.4zM12.8,4H13.2V4.4H12.8zM14.4,4H14.8V4.4H14.4zM14.8,4H15.2V4.4H14.8zM15.2,4H15.6V4.4H15.2zM16,4H16.4V4.4H16zM17.2,4H17.6V4.4H17.2zM18,4H18.4V4.4H18zM18.4,4H18.8V4.4H18.4zM1.2,4.4H1.6V4.8H1.2zM1.6,4.4H2V4.8H1.6zM2.4,4.4H2.8V4.8H2.4zM5.6,4.4H6V4.8H5.6zM6.8,4.4H7.2V4.8H6.8zM7.2,4.4H7.6V4.8H7.2zM7.6,4.4H8V4.8H7.6zM8,4.4H8.4V4.8H8zM8.4,4.4H8.8V4.8H8.4zM8.8,4.4H9.2V4.8H8.8zM9.6,4.4H10V4.8H9.6zM10.4,4.4H10.8V4.8H10.4zM10.8,4.4H11.2V4.8H10.8zM11.6,4.4H12V4.8H11.6zM12,4.4H12.4V4.8H12zM12.4,4.4H12.8V4.8H12.4zM12.8,4.4H13.2V4.8H12.8zM13.2,4.4H13.6V4.8H13.2zM14.8,4.4H15.2V4.8H14.8zM15.2,4.4H15.6V4.8H15.2zM16.8,4.4H17.2V4.8H16.8zM17.2,4.4H17.6V4.8H17.2zM17.6,4.4H18V4.8H17.6zM18,4.4H18.4V4.8H18zM18.4,4.4H18.8V4.8H18.4zM1.2,4.8H1.6V5.2H1.2zM1.6,4.8H2V5.2H1.6zM2,4.8H2.4V5.2H2zM2.4,4.8H2.8V5.2H2.4zM2.8,4.8H3.2V5.2H2.8zM3.2,4.8H3.6V5.2H3.2zM3.6,4.8H4V5.2H3.6zM4.4,4.8H4.8V5.2H4.4zM6.4,4.8H6.8V5.2H6.4zM6.8,4.8H7.2V5.2H6.8zM7.2,4.8H7.6V5.2H7.2zM7.6,4.8H8V5.2H7.6zM8.8,4.8H9.2V5.2H8.8zM9.2,4.8H9.6V5.2H9.2zM9.6,4.8H10V5.2H9.6zM10.4,4.8H10.8V5.2H10.4zM12.4,4.8H12.8V5.2H12.4zM12.8,4.8H13.2V5.2H12.8zM13.2,4.8H13.6V5.2H13.2zM13.6,4.8H14V5.2H13.6zM14.4,4.8H14.8V5.2H14.4zM14.8,4.8H15.2V5.2H14.8zM15.6,4.8H16V5.2H15.6zM18,4.8H18.4V5.2H18zM18.4,4.8H18.8V5.2H18.4zM1.2,5.2H1.6V5.6H1.2zM1.6,5.2H2V5.6H1.6zM2.4,5.2H2.8V5.6H2.4zM4.4,5.2H4.8V5.6H4.4zM4.8,5.2H5.2V5.6H4.8zM5.6,5.2H6V5.6H5.6zM6,5.2H6.4V5.6H6zM6.4,5.2H6.8V5.6H6.4zM6.8,5.2H7.2V5.6H6.8zM7.6,5.2H8V5.6H7.6zM8,5.2H8.4V5.6H8zM8.8,5.2H9.2V5.6H8.8zM9.2,5.2H9.6V5.6H9.2zM9.6,5.2H10V5.6H9.6zM10.4,5.2H10.8V5.6H10.4zM11.6,5.2H12V5.6H11.6zM12,5.2H12.4V5.6H12zM12.4,5.2H12.8V5.6H12.4zM13.6,5.2H14V5.6H13.6zM14,5.2H14.4V5.6H14zM14.4,5.2H14.8V5.6H14.4zM14.8,5.2H15.2V5.6H14.8zM15.6,5.2H16V5.6H15.6zM16,5.2H16.4V5.6H16zM16.8,5.2H17.2V5.6H16.8zM17.2,5.2H17.6V5.6H17.2zM18,5.2H18.4V5.6H18zM1.2,5.6H1.6V6H1.2zM2.8,5.6H3.2V6H2.8zM3.2,5.6H3.6V6H3.2zM3.6,5.6H4V6H3.6zM4,5.6H4.4V6H4zM4.8,5.6H5.2V6H4.8zM5.2,5.6H5.6V6H5.2zM5.6,5.6H6V6H5.6zM6.4,5.6H6.8V6H6.4zM7.2,5.6H7.6V6H7.2zM7.6,5.6H8V6H7.6zM8,5.6H8.4V6H8zM8.8,5.6H9.2V6H8.8zM9.2,5.6H9.6V6H9.2zM10,5.6H10.4V6H10zM11.2,5.6H11.6V6H11.2zM11.6,5.6H12V6H11.6zM12.8,5.6H13.2V6H12.8zM13.2,5.6H13.6V6H13.2zM14,5.6H14.4V6H14zM14.4,5.6H14.8V6H14.4zM14.8,5.6H15.2V6H14.8zM15.6,5.6H16V6H15.6zM17.2,5.6H17.6V6H17.2zM18.4,5.6H18.8V6H18.4zM0.8,6H1.2V6.4H0.8zM1.2,6H1.6V6.4H1.2zM1.6,6H2V6.4H1.6zM2.4,6H2.8V6.4H2.4zM2.8,6H3.2V6.4H2.8zM3.6,6H4V6.4H3.6zM4.4,6H4.8V6.4H4.4zM5.2,6H5.6V6.4H5.2zM5.6,6H6V6.4H5.6zM6.8,6H7.2V6.4H6.8zM7.6,6H8V6.4H7.6zM8,6H8.4V6.4H8zM8.4,6H8.8V6.4H8.4zM11.2,6H11.6V6.4H11.2zM11.6,6H12V6.4H11.6zM13.2,6H13.6V6.4H13.2zM14,6H14.4V6.4H14zM16,6H16.4V6.4H16zM16.4,6H16.8V6.4H16.4zM17.6,6H18V6.4H17.6zM2,6.4H2.4V6.8H2zM3.2,6.4H3.6V6.8H3.2zM4.4,6.4H4.8V6.8H4.4zM5.6,6.4H6V6.8H5.6zM6,6.4H6.4V6.8H6zM6.4,6.4H6.8V6.8H6.4zM6.8,6.4H7.2V6.8H6.8zM7.2,6.4H7.6V6.8H7.2zM7.6,6.4H8V6.8H7.6zM9.2,6.4H9.6V6.8H9.2zM9.6,6.4H10V6.8H9.6zM10,6.4H10.4V6.8H10zM10.8,6.4H11.2V6.8H10.8zM11.2,6.4H11.6V6.8H11.2zM12,6.4H12.4V6.8H12zM12.8,6.4H13.2V6.8H12.8zM13.6,6.4H14V6.8H13.6zM14,6.4H14.4V6.8H14zM14.8,6.4H15.2V6.8H14.8zM15.6,6.4H16V6.8H15.6zM16,6.4H16.4V6.8H16zM16.8,6.4H17.2V6.8H16.8zM17.2,6.4H17.6V6.8H17.2zM17.6,6.4H18V6.8H17.6zM0.8,6.8H1.2V7.2H0.8zM2,6.8H2.4V7.2H2zM2.4,6.8H2.8V7.2H2.4zM2.8,6.8H3.2V7.2H2.8zM4,6.8H4.4V7.2H4zM4.4,6.8H4.8V7.2H4.4zM4.8,6.8H5.2V7.2H4.8zM5.6,6.8H6V7.2H5.6zM6,6.8H6.4V7.2H6zM6.4,6.8H6.8V7.2H6.4zM7.6,6.8H8V7.2H7.6zM8,6.8H8.4V7.2H8zM8.4,6.8H8.8V7.2H8.4zM9.2,6.8H9.6V7.2H9.2zM10.4,6.8H10.8V7.2H10.4zM10.8,6.8H11.2V7.2H10.8zM11.6,6.8H12V7.2H11.6zM12,6.8H12.4V7.2H12zM12.4,6.8H12.8V7.2H12.4zM12.8,6.8H13.2V7.2H12.8zM13.2,6.8H13.6V7.2H13.2zM13.6,6.8H14V7.2H13.6zM14,6.8H14.4V7.2H14zM14.4,6.8H14.8V7.2H14.4zM14.8,6.8H15.2V7.2H14.8zM15.2,6.8H15.6V7.2H15.2zM15.6,6.8H16V7.2H15.6zM16.8,6.8H17.2V7.2H16.8zM17.2,6.8H17.6V7.2H17.2zM17.6,6.8H18V7.2H17.6zM2,7.2H2.4V7.6H2zM3.2,7.2H3.6V7.6H3.2zM4.4,7.2H4.8V7.6H4.4zM4.8,7.2H5.2V7.6H4.8zM6.8,7.2H7.2V7.6H6.8zM7.2,7.2H7.6V7.6H7.2zM8.4,7.2H8.8V7.6H8.4zM8.8,7.2H9.2V7.6H8.8zM9.2,7.2H9.6V7.6H9.2zM10.8,7.2H11.2V7.6H10.8zM11.6,7.2H12V7.6H11.6zM12.4,7.2H12.8V7.6H12.4zM13.6,7.2H14V7.6H13.6zM14,7.2H14.4V7.6H14zM15.2,7.2H15.6V7.6H15.2zM15.6,7.2H16V7.6H15.6zM16,7.2H16.4V7.6H16zM16.4,7.2H16.8V7.6H16.4zM18.4,7.2H18.8V7.6H18.4zM1.6,7.6H2V8H1.6zM2,7.6H2.4V8H2zM2.4,7.6H2.8V8H2.4zM2.8,7.6H3.2V8H2.8zM4.4,7.6H4.8V8H4.4zM5.2,7.6H5.6V8H5.2zM5.6,7.6H6V8H5.6zM6,7.6H6.4V8H6zM6.4,7.6H6.8V8H6.4zM8,7.6H8.4V8H8zM9.6,7.6H10V8H9.6zM10.4,7.6H10.8V8H10.4zM12,7.6H12.4V8H12zM12.4,7.6H12.8V8H12.4zM13.2,7.6H13.6V8H13.2zM13.6,7.6H14V8H13.6zM14,7.6H14.4V8H14zM14.4,7.6H14.8V8H14.4zM14.8,7.6H15.2V8H14.8zM16.4,7.6H16.8V8H16.4zM17.2,7.6H17.6V8H17.2zM17.6,7.6H18V8H17.6zM1.6,8H2V8.4H1.6zM2,8H2.4V8.4H2zM2.8,8H3.2V8.4H2.8zM3.2,8H3.6V8.4H3.2zM3.6,8H4V8.4H3.6zM4,8H4.4V8.4H4zM4.8,8H5.2V8.4H4.8zM5.6,8H6V8.4H5.6zM6,8H6.4V8.4H6zM8,8H8.4V8.4H8zM8.4,8H8.8V8.4H8.4zM9.6,8H10V8.4H9.6zM10.4,8H10.8V8.4H10.4zM11.2,8H11.6V8.4H11.2zM12.4,8H12.8V8.4H12.4zM13.2,8H13.6V8.4H13.2zM13.6,8H14V8.4H13.6zM14.8,8H15.2V8.4H14.8zM15.6,8H16V8.4H15.6zM16,8H16.4V8.4H16zM16.4,8H16.8V8.4H16.4zM17.6,8H18V8.4H17.6zM18,8H18.4V8.4H18zM1.6,8.4H2V8.8H1.6zM2.4,8.4H2.8V8.8H2.4zM2.8,8.4H3.2V8.8H2.8zM4,8.4H4.4V8.8H4zM4.4,8.4H4.8V8.8H4.4zM5.2,8.4H5.6V8.8H5.2zM6,8.4H6.4V8.8H6zM6.4,8.4H6.8V8.8H6.4zM8.4,8.4H8.8V8.8H8.4zM8.8,8.4H9.2V8.8H8.8zM9.2,8.4H9.6V8.8H9.2zM10,8.4H10.4V8.8H10zM11.2,8.4H11.6V8.8H11.2zM11.6,8.4H12V8.8H11.6zM12,8.4H12.4V8.8H12zM12.4,8.4H12.8V8.8H12.4zM14,8.4H14.4V8.8H14zM15.2,8.4H15.6V8.8H15.2zM16.4,8.4H16.8V8.8H16.4zM16.8,8.4H17.2V8.8H16.8zM18.4,8.4H18.8V8.8H18.4zM1.2,8.8H1.6V9.2H1.2zM1.6,8.8H2V9.2H1.6zM2,8.8H2.4V9.2H2zM2.4,8.8H2.8V9.2H2.4zM2.8,8.8H3.2V9.2H2.8zM3.2,8.8H3.6V9.2H3.2zM3.6,8.8H4V9.2H3.6zM4,8.8H4.4V9.2H4zM4.4,8.8H4.8V9.2H4.4zM4.8,8.8H5.2V9.2H4.8zM5.6,8.8H6V9.2H5.6zM7.6,8.8H8V9.2H7.6zM8.8,8.8H9.2V9.2H8.8zM9.2,8.8H9.6V9.2H9.2zM9.6,8.8H10V9.2H9.6zM10,8.8H10.4V9.2H10zM10.4,8.8H10.8V9.2H10.4zM12,8.8H12.4V9.2H12zM12.4,8.8H12.8V9.2H12.4zM12.8,8.8H13.2V9.2H12.8zM14,8.8H14.4V9.2H14zM14.4,8.8H14.8V9.2H14.4zM15.2,8.8H15.6V9.2H15.2zM15.6,8.8H16V9.2H15.6zM16,8.8H16.4V9.2H16zM16.4,8.8H16.8V9.2H16.4zM16.8,8.8H17.2V9.2H16.8zM17.6,8.8H18V9.2H17.6zM18,8.8H18.4V9.2H18zM18.4,8.8H18.8V9.2H18.4zM0.8,9.2H1.2V9.6H0.8zM2.4,9.2H2.8V9.6H2.4zM4,9.2H4.4V9.6H4zM4.8,9.2H5.2V9.6H4.8zM6,9.2H6.4V9.6H6zM6.8,9.2H7.2V9.6H6.8zM7.6,9.2H8V9.6H7.6zM8.4,9.2H8.8V9.6H8.4zM8.8,9.2H9.2V9.6H8.8zM10.4,9.2H10.8V9.6H10.4zM11.6,9.2H12V9.6H11.6zM12.8,9.2H13.2V9.6H12.8zM13.6,9.2H14V9.6H13.6zM14.8,9.2H15.2V9.6H14.8zM15.2,9.2H15.6V9.6H15.2zM16.8,9.2H17.2V9.6H16.8zM17.2,9.2H17.6V9.6H17.2zM17.6,9.2H18V9.6H17.6zM18,9.2H18.4V9.6H18zM18.4,9.2H18.8V9.6H18.4zM0.8,9.6H1.2V10H0.8zM2.4,9.6H2.8V10H2.4zM3.2,9.6H3.6V10H3.2zM4,9.6H4.4V10H4zM4.8,9.6H5.2V10H4.8zM6,9.6H6.4V10H6zM6.8,9.6H7.2V10H6.8zM8,9.6H8.4V10H8zM8.4,9.6H8.8V10H8.4zM8.8,9.6H9.2V10H8.8zM9.6,9.6H10V10H9.6zM10.4,9.6H10.8V10H10.4zM10.8,9.6H11.2V10H10.8zM11.2,9.6H11.6V10H11.2zM12.4,9.6H12.8V10H12.4zM12.8,9.6H13.2V10H12.8zM13.2,9.6H13.6V10H13.2zM14.4,9.6H14.8V10H14.4zM15.2,9.6H15.6V10H15.2zM16,9.6H16.4V10H16zM16.8,9.6H17.2V10H16.8zM17.2,9.6H17.6V10H17.2zM18,9.6H18.4V10H18zM18.4,9.6H18.8V10H18.4zM1.2,10H1.6V10.4H1.2zM1.6,10H2V10.4H1.6zM2,10H2.4V10.4H2zM2.4,10H2.8V10.4H2.4zM4,10H4.4V10.4H4zM4.8,10H5.2V10.4H4.8zM5.2,10H5.6V10.4H5.2zM5.6,10H6V10.4H5.6zM6,10H6.4V10.4H6zM6.4,10H6.8V10.4H6.4zM7.2,10H7.6V10.4H7.2zM8,10H8.4V10.4H8zM8.8,10H9.2V10.4H8.8zM10.4,10H10.8V10.4H10.4zM11.6,10H12V10.4H11.6zM12.4,10H12.8V10.4H12.4zM12.8,10H13.2V10.4H12.8zM13.2,10H13.6V10.4H13.2zM13.6,10H14V10.4H13.6zM14,10H14.4V10.4H14zM14.4,10H14.8V10.4H14.4zM15.2,10H15.6V10.4H15.2zM16.8,10H17.2V10.4H16.8zM17.2,10H17.6V10.4H17.2zM18.4,10H18.8V10.4H18.4zM0.8,10.4H1.2V10.8H0.8zM1.2,10.4H1.6V10.8H1.2zM1.6,10.4H2V10.8H1.6zM2,10.4H2.4V10.8H2zM2.4,10.4H2.8V10.8H2.4zM2.8,10.4H3.2V10.8H2.8zM3.2,10.4H3.6V10.8H3.2zM3.6,10.4H4V10.8H3.6zM4,10.4H4.4V10.8H4zM4.4,10.4H4.8V10.8H4.4zM5.6,10.4H6V10.8H5.6zM6.4,10.4H6.8V10.8H6.4zM6.8,10.4H7.2V10.8H6.8zM7.2,10.4H7.6V10.8H7.2zM7.6,10.4H8V10.8H7.6zM8.8,10.4H9.2V10.8H8.8zM9.2,10.4H9.6V10.8H9.2zM9.6,10.4H10V10.8H9.6zM10,10.4H10.4V10.8H10zM10.4,10.4H10.8V10.8H10.4zM10.8,10.4H11.2V10.8H10.8zM11.2,10.4H11.6V10.8H11.2zM12.8,10.4H13.2V10.8H12.8zM13.2,10.4H13.6V10.8H13.2zM14.8,10.4H15.2V10.8H14.8zM15.2,10.4H15.6V10.8H15.2zM15.6,10.4H16V10.8H15.6zM16,10.4H16.4V10.8H16zM16.4,10.4H16.8V10.8H16.4zM16.8,10.4H17.2V10.8H16.8zM17.2,10.4H17.6V10.8H17.2zM1.6,10.8H2V11.2H1.6zM2,10.8H2.4V11.2H2zM2.4,10.8H2.8V11.2H2.4zM2.8,10.8H3.2V11.2H2.8zM3.6,10.8H4V11.2H3.6zM4.4,10.8H4.8V11.2H4.4zM4.8,10.8H5.2V11.2H4.8zM5.2,10.8H5.6V11.2H5.2zM5.6,10.8H6V11.2H5.6zM6.8,10.8H7.2V11.2H6.8zM7.6,10.8H8V11.2H7.6zM8.4,10.8H8.8V11.2H8.4zM8.8,10.8H9.2V11.2H8.8zM9.6,10.8H10V11.2H9.6zM10.8,10.8H11.2V11.2H10.8zM11.2,10.8H11.6V11.2H11.2zM13.2,10.8H13.6V11.2H13.2zM13.6,10.8H14V11.2H13.6zM14,10.8H14.4V11.2H14zM14.8,10.8H15.2V11.2H14.8zM15.6,10.8H16V11.2H15.6zM16,10.8H16.4V11.2H16zM16.4,10.8H16.8V11.2H16.4zM17.2,10.8H17.6V11.2H17.2zM1.2,11.2H1.6V11.6H1.2zM2,11.2H2.4V11.6H2zM2.8,11.2H3.2V11.6H2.8zM3.2,11.2H3.6V11.6H3.2zM3.6,11.2H4V11.6H3.6zM4,11.2H4.4V11.6H4zM5.2,11.2H5.6V11.6H5.2zM5.6,11.2H6V11.6H5.6zM6,11.2H6.4V11.6H6zM7.2,11.2H7.6V11.6H7.2zM7.6,11.2H8V11.6H7.6zM8,11.2H8.4V11.6H8zM8.4,11.2H8.8V11.6H8.4zM8.8,11.2H9.2V11.6H8.8zM9.6,11.2H10V11.6H9.6zM10.4,11.2H10.8V11.6H10.4zM10.8,11.2H11.2V11.6H10.8zM11.2,11.2H11.6V11.6H11.2zM11.6,11.2H12V11.6H11.6zM12,11.2H12.4V11.6H12zM12.4,11.2H12.8V11.6H12.4zM12.8,11.2H13.2V11.6H12.8zM15.2,11.2H15.6V11.6H15.2zM16.8,11.2H17.2V11.6H16.8zM17.6,11.2H18V11.6H17.6zM0.8,11.6H1.2V12H0.8zM2,11.6H2.4V12H2zM2.4,11.6H2.8V12H2.4zM2.8,11.6H3.2V12H2.8zM4,11.6H4.4V12H4zM4.8,11.6H5.2V12H4.8zM5.2,11.6H5.6V12H5.2zM6,11.6H6.4V12H6zM6.4,11.6H6.8V12H6.4zM7.2,11.6H7.6V12H7.2zM7.6,11.6H8V12H7.6zM8,11.6H8.4V12H8zM8.8,11.6H9.2V12H8.8zM9.2,11.6H9.6V12H9.2zM9.6,11.6H10V12H9.6zM10.4,11.6H10.8V12H10.4zM10.8,11.6H11.2V12H10.8zM11.2,11.6H11.6V12H11.2zM11.6,11.6H12V12H11.6zM12.4,11.6H12.8V12H12.4zM13.6,11.6H14V12H13.6zM14,11.6H14.4V12H14zM14.8,11.6H15.2V12H14.8zM15.6,11.6H16V12H15.6zM17.2,11.6H17.6V12H17.2zM17.6,11.6H18V12H17.6zM18,11.6H18.4V12H18zM2,12H2.4V12.4H2zM3.2,12H3.6V12.4H3.2zM3.6,12H4V12.4H3.6zM4.8,12H5.2V12.4H4.8zM5.6,12H6V12.4H5.6zM8,12H8.4V12.4H8zM8.4,12H8.8V12.4H8.4zM10,12H10.4V12.4H10zM10.4,12H10.8V12.4H10.4zM10.8,12H11.2V12.4H10.8zM11.6,12H12V12.4H11.6zM12,12H12.4V12.4H12zM13.2,12H13.6V12.4H13.2zM13.6,12H14V12.4H13.6zM14,12H14.4V12.4H14zM14.4,12H14.8V12.4H14.4zM14.8,12H15.2V12.4H14.8zM15.2,12H15.6V12.4H15.2zM16.4,12H16.8V12.4H16.4zM16.8,12H17.2V12.4H16.8zM17.2,12H17.6V12.4H17.2zM17.6,12H18V12.4H17.6zM18,12H18.4V12.4H18zM1.2,12.4H1.6V12.8H1.2zM1.6,12.4H2V12.8H1.6zM2,12.4H2.4V12.8H2zM4.4,12.4H4.8V12.8H4.4zM4.8,12.4H5.2V12.8H4.8zM5.2,12.4H5.6V12.8H5.2zM6,12.4H6.4V12.8H6zM6.4,12.4H6.8V12.8H6.4zM7.2,12.4H7.6V12.8H7.2zM7.6,12.4H8V12.8H7.6zM8,12.4H8.4V12.8H8zM8.4,12.4H8.8V12.8H8.4zM9.2,12.4H9.6V12.8H9.2zM10,12.4H10.4V12.8H10zM10.4,12.4H10.8V12.8H10.4zM10.8,12.4H11.2V12.8H10.8zM12.4,12.4H12.8V12.8H12.4zM13.6,12.4H14V12.8H13.6zM14,12.4H14.4V12.8H14zM14.4,12.4H14.8V12.8H14.4zM15.6,12.4H16V12.8H15.6zM16,12.4H16.4V12.8H16zM16.4,12.4H16.8V12.8H16.4zM16.8,12.4H17.2V12.8H16.8zM18.4,12.4H18.8V12.8H18.4zM0.8,12.8H1.2V13.2H0.8zM1.2,12.8H1.6V13.2H1.2zM2.4,12.8H2.8V13.2H2.4zM2.8,12.8H3.2V13.2H2.8zM3.2,12.8H3.6V13.2H3.2zM4,12.8H4.4V13.2H4zM4.4,12.8H4.8V13.2H4.4zM4.8,12.8H5.2V13.2H4.8zM5.6,12.8H6V13.2H5.6zM6,12.8H6.4V13.2H6zM7.2,12.8H7.6V13.2H7.2zM7.6,12.8H8V13.2H7.6zM8.8,12.8H9.2V13.2H8.8zM9.2,12.8H9.6V13.2H9.2zM10,12.8H10.4V13.2H10zM10.4,12.8H10.8V13.2H10.4zM10.8,12.8H11.2V13.2H10.8zM11.2,12.8H11.6V13.2H11.2zM12,12.8H12.4V13.2H12zM14,12.8H14.4V13.2H14zM14.4,12.8H14.8V13.2H14.4zM14.8,12.8H15.2V13.2H14.8zM15.2,12.8H15.6V13.2H15.2zM16.4,12.8H16.8V13.2H16.4zM17.2,12.8H17.6V13.2H17.2zM18,12.8H18.4V13.2H18zM0.8,13.2H1.2V13.6H0.8zM1.6,13.2H2V13.6H1.6zM2,13.2H2.4V13.6H2zM2.4,13.2H2.8V13.6H2.4zM3.6,13.2H4V13.6H3.6zM4,13.2H4.4V13.6H4zM4.4,13.2H4.8V13.6H4.4zM4.8,13.2H5.2V13.6H4.8zM5.2,13.2H5.6V13.6H5.2zM5.6,13.2H6V13.6H5.6zM6,13.2H6.4V13.6H6zM6.8,13.2H7.2V13.6H6.8zM7.6,13.2H8V13.6H7.6zM8,13.2H8.4V13.6H8zM8.8,13.2H9.2V13.6H8.8zM9.2,13.2H9.6V13.6H9.2zM9.6,13.2H10V13.6H9.6zM10,13.2H10.4V13.6H10zM10.8,13.2H11.2V13.6H10.8zM11.2,13.2H11.6V13.6H11.2zM14,13.2H14.4V13.6H14zM14.4,13.2H14.8V13.6H14.4zM15.2,13.2H15.6V13.6H15.2zM18.4,13.2H18.8V13.6H18.4zM1.2,13.6H1.6V14H1.2zM1.6,13.6H2V14H1.6zM2,13.6H2.4V14H2zM2.4,13.6H2.8V14H2.4zM2.8,13.6H3.2V14H2.8zM3.2,13.6H3.6V14H3.2zM3.6,13.6H4V14H3.6zM4,13.6H4.4V14H4zM4.8,13.6H5.2V14H4.8zM5.2,13.6H5.6V14H5.2zM5.6,13.6H6V14H5.6zM7.2,13.6H7.6V14H7.2zM8.4,13.6H8.8V14H8.4zM9.2,13.6H9.6V14H9.2zM9.6,13.6H10V14H9.6zM10,13.6H10.4V14H10zM11.6,13.6H12V14H11.6zM12,13.6H12.4V14H12zM12.4,13.6H12.8V14H12.4zM12.8,13.6H13.2V14H12.8zM13.2,13.6H13.6V14H13.2zM14,13.6H14.4V14H14zM16,13.6H16.4V14H16zM16.8,13.6H17.2V14H16.8zM17.6,13.6H18V14H17.6zM18,13.6H18.4V14H18zM0.8,14H1.2V14.4H0.8zM1.6,14H2V14.4H1.6zM2,14H2.4V14.4H2zM3.6,14H4V14.4H3.6zM4.8,14H5.2V14.4H4.8zM5.6,14H6V14.4H5.6zM7.2,14H7.6V14.4H7.2zM7.6,14H8V14.4H7.6zM8.8,14H9.2V14.4H8.8zM10.4,14H10.8V14.4H10.4zM10.8,14H11.2V14.4H10.8zM12,14H12.4V14.4H12zM12.4,14H12.8V14.4H12.4zM12.8,14H13.2V14.4H12.8zM15.6,14H16V14.4H15.6zM16,14H16.4V14.4H16zM17.2,14H17.6V14.4H17.2zM17.6,14H18V14.4H17.6zM18.4,14H18.8V14.4H18.4zM2.4,14.4H2.8V14.8H2.4zM3.2,14.4H3.6V14.8H3.2zM3.6,14.4H4V14.8H3.6zM4.4,14.4H4.8V14.8H4.4zM4.8,14.4H5.2V14.8H4.8zM5.6,14.4H6V14.8H5.6zM6.4,14.4H6.8V14.8H6.4zM7.6,14.4H8V14.8H7.6zM8,14.4H8.4V14.8H8zM8.8,14.4H9.2V14.8H8.8zM9.2,14.4H9.6V14.8H9.2zM9.6,14.4H10V14.8H9.6zM10.4,14.4H10.8V14.8H10.4zM10.8,14.4H11.2V14.8H10.8zM11.6,14.4H12V14.8H11.6zM12,14.4H12.4V14.8H12zM12.4,14.4H12.8V14.8H12.4zM12.8,14.4H13.2V14.8H12.8zM14,14.4H14.4V14.8H14zM14.8,14.4H15.2V14.8H14.8zM15.6,14.4H16V14.8H15.6zM16,14.4H16.4V14.8H16zM16.4,14.4H16.8V14.8H16.4zM16.8,14.4H17.2V14.8H16.8zM18,14.4H18.4V14.8H18zM18.4,14.4H18.8V14.8H18.4zM1.2,14.8H1.6V15.2H1.2zM1.6,14.8H2V15.2H1.6zM2,14.8H2.4V15.2H2zM2.4,14.8H2.8V15.2H2.4zM4,14.8H4.4V15.2H4zM4.8,14.8H5.2V15.2H4.8zM5.2,14.8H5.6V15.2H5.2zM6.4,14.8H6.8V15.2H6.4zM7.6,14.8H8V15.2H7.6zM8,14.8H8.4V15.2H8zM8.8,14.8H9.2V15.2H8.8zM10,14.8H10.4V15.2H10zM11.2,14.8H11.6V15.2H11.2zM11.6,14.8H12V15.2H11.6zM12.4,14.8H12.8V15.2H12.4zM12.8,14.8H13.2V15.2H12.8zM13.2,14.8H13.6V15.2H13.2zM13.6,14.8H14V15.2H13.6zM14,14.8H14.4V15.2H14zM14.8,14.8H15.2V15.2H14.8zM15.6,14.8H16V15.2H15.6zM16,14.8H16.4V15.2H16zM16.4,14.8H16.8V15.2H16.4zM17.2,14.8H17.6V15.2H17.2zM18.4,14.8H18.8V15.2H18.4zM0.8,15.2H1.2V15.6H0.8zM2,15.2H2.4V15.6H2zM2.4,15.2H2.8V15.6H2.4zM3.2,15.2H3.6V15.6H3.2zM5.2,15.2H5.6V15.6H5.2zM5.6,15.2H6V15.6H5.6zM6.4,15.2H6.8V15.6H6.4zM6.8,15.2H7.2V15.6H6.8zM8.8,15.2H9.2V15.6H8.8zM9.2,15.2H9.6V15.6H9.2zM9.6,15.2H10V15.6H9.6zM10,15.2H10.4V15.6H10zM10.4,15.2H10.8V15.6H10.4zM11.2,15.2H11.6V15.6H11.2zM11.6,15.2H12V15.6H11.6zM12.4,15.2H12.8V15.6H12.4zM14,15.2H14.4V15.6H14zM14.4,15.2H14.8V15.6H14.4zM15.2,15.2H15.6V15.6H15.2zM15.6,15.2H16V15.6H15.6zM16,15.2H16.4V15.6H16zM16.4,15.2H16.8V15.6H16.4zM16.8,15.2H17.2V15.6H16.8zM17.2,15.2H17.6V15.6H17.2zM17.6,15.2H18V15.6H17.6zM4,15.6H4.4V16H4zM5.6,15.6H6V16H5.6zM6,15.6H6.4V16H6zM7.6,15.6H8V16H7.6zM8.8,15.6H9.2V16H8.8zM10.4,15.6H10.8V16H10.4zM10.8,15.6H11.2V16H10.8zM12,15.6H12.4V16H12zM12.4,15.6H12.8V16H12.4zM13.6,15.6H14V16H13.6zM14,15.6H14.4V16H14zM15.2,15.6H15.6V16H15.2zM16.8,15.6H17.2V16H16.8zM0.8,16H1.2V16.4H0.8zM1.2,16H1.6V16.4H1.2zM1.6,16H2V16.4H1.6zM2,16H2.4V16.4H2zM2.4,16H2.8V16.4H2.4zM2.8,16H3.2V16.4H2.8zM3.2,16H3.6V16.4H3.2zM4,16H4.4V16.4H4zM4.4,16H4.8V16.4H4.4zM4.8,16H5.2V16.4H4.8zM5.2,16H5.6V16.4H5.2zM6,16H6.4V16.4H6zM6.4,16H6.8V16.4H6.4zM7.6,16H8V16.4H7.6zM8.8,16H9.2V16.4H8.8zM9.6,16H10V16.4H9.6zM10.4,16H10.8V16.4H10.4zM10.8,16H11.2V16.4H10.8zM12,16H12.4V16.4H12zM12.4,16H12.8V16.4H12.4zM12.8,16H13.2V16.4H12.8zM14,16H14.4V16.4H14zM14.8,16H15.2V16.4H14.8zM15.2,16H15.6V16.4H15.2zM16,16H16.4V16.4H16zM16.8,16H17.2V16.4H16.8zM0.8,16.4H1.2V16.8H0.8zM3.2,16.4H3.6V16.8H3.2zM4,16.4H4.4V16.8H4zM5.2,16.4H5.6V16.8H5.2zM5.6,16.4H6V16.8H5.6zM6,16.4H6.4V16.8H6zM6.8,16.4H7.2V16.8H6.8zM8,16.4H8.4V16.8H8zM8.8,16.4H9.2V16.8H8.8zM10.4,16.4H10.8V16.8H10.4zM10.8,16.4H11.2V16.8H10.8zM11.2,16.4H11.6V16.8H11.2zM11.6,16.4H12V16.8H11.6zM12,16.4H12.4V16.8H12zM13.6,16.4H14V16.8H13.6zM14,16.4H14.4V16.8H14zM14.8,16.4H15.2V16.8H14.8zM15.2,16.4H15.6V16.8H15.2zM16.8,16.4H17.2V16.8H16.8zM17.2,16.4H17.6V16.8H17.2zM17.6,16.4H18V16.8H17.6zM18,16.4H18.4V16.8H18zM0.8,16.8H1.2V17.2H0.8zM1.6,16.8H2V17.2H1.6zM2,16.8H2.4V17.2H2zM2.4,16.8H2.8V17.2H2.4zM3.2,16.8H3.6V17.2H3.2zM4.4,16.8H4.8V17.2H4.4zM5.2,16.8H5.6V17.2H5.2zM6,16.8H6.4V17.2H6zM6.8,16.8H7.2V17.2H6.8zM8.8,16.8H9.2V17.2H8.8zM9.2,16.8H9.6V17.2H9.2zM9.6,16.8H10V17.2H9.6zM10,16.8H10.4V17.2H10zM10.4,16.8H10.8V17.2H10.4zM10.8,16.8H11.2V17.2H10.8zM11.6,16.8H12V17.2H11.6zM13.2,16.8H13.6V17.2H13.2zM13.6,16.8H14V17.2H13.6zM14,16.8H14.4V17.2H14zM14.4,16.8H14.8V17.2H14.4zM15.2,16.8H15.6V17.2H15.2zM15.6,16.8H16V17.2H15.6zM16,16.8H16.4V17.2H16zM16.4,16.8H16.8V17.2H16.4zM16.8,16.8H17.2V17.2H16.8zM17.6,16.8H18V17.2H17.6zM18,16.8H18.4V17.2H18zM18.4,16.8H18.8V17.2H18.4zM0.8,17.2H1.2V17.6H0.8zM1.6,17.2H2V17.6H1.6zM2,17.2H2.4V17.6H2zM2.4,17.2H2.8V17.6H2.4zM3.2,17.2H3.6V17.6H3.2zM4,17.2H4.4V17.6H4zM5.2,17.2H5.6V17.6H5.2zM6,17.2H6.4V17.6H6zM6.8,17.2H7.2V17.6H6.8zM7.2,17.2H7.6V17.6H7.2zM9.2,17.2H9.6V17.6H9.2zM10,17.2H10.4V17.6H10zM10.4,17.2H10.8V17.6H10.4zM11.6,17.2H12V17.6H11.6zM12.4,17.2H12.8V17.6H12.4zM13.6,17.2H14V17.6H13.6zM14,17.2H14.4V17.6H14zM14.4,17.2H14.8V17.6H14.4zM15.6,17.2H16V17.6H15.6zM17.6,17.2H18V17.6H17.6zM18,17.2H18.4V17.6H18zM18.4,17.2H18.8V17.6H18.4zM0.8,17.6H1.2V18H0.8zM1.6,17.6H2V18H1.6zM2,17.6H2.4V18H2zM2.4,17.6H2.8V18H2.4zM3.2,17.6H3.6V18H3.2zM4,17.6H4.4V18H4zM4.8,17.6H5.2V18H4.8zM5.2,17.6H5.6V18H5.2zM5.6,17.6H6V18H5.6zM9.2,17.6H9.6V18H9.2zM10.4,17.6H10.8V18H10.4zM11.2,17.6H11.6V18H11.2zM12,17.6H12.4V18H12zM12.4,17.6H12.8V18H12.4zM12.8,17.6H13.2V18H12.8zM13.2,17.6H13.6V18H13.2zM14,17.6H14.4V18H14zM14.4,17.6H14.8V18H14.4zM14.8,17.6H15.2V18H14.8zM15.2,17.6H15.6V18H15.2zM16,17.6H16.4V18H16zM17.2,17.6H17.6V18H17.2zM17.6,17.6H18V18H17.6zM18,17.6H18.4V18H18zM0.8,18H1.2V18.4H0.8zM3.2,18H3.6V18.4H3.2zM4.4,18H4.8V18.4H4.4zM5.2,18H5.6V18.4H5.2zM6.4,18H6.8V18.4H6.4zM7.2,18H7.6V18.4H7.2zM7.6,18H8V18.4H7.6zM9.2,18H9.6V18.4H9.2zM9.6,18H10V18.4H9.6zM10.4,18H10.8V18.4H10.4zM11.2,18H11.6V18.4H11.2zM12.8,18H13.2V18.4H12.8zM14,18H14.4V18.4H14zM15.2,18H15.6V18.4H15.2zM15.6,18H16V18.4H15.6zM16,18H16.4V18.4H16zM16.4,18H16.8V18.4H16.4zM18.4,18H18.8V18.4H18.4zM0.8,18.4H1.2V18.8H0.8zM1.2,18.4H1.6V18.8H1.2zM1.6,18.4H2V18.8H1.6zM2,18.4H2.4V18.8H2zM2.4,18.4H2.8V18.8H2.4zM2.8,18.4H3.2V18.8H2.8zM3.2,18.4H3.6V18.8H3.2zM4,18.4H4.4V18.8H4zM5.6,18.4H6V18.8H5.6zM9.2,18.4H9.6V18.8H9.2zM10.8,18.4H11.2V18.8H10.8zM12,18.4H12.4V18.8H12zM14,18.4H14.4V18.8H14zM14.4,18.4H14.8V18.8H14.4zM14.8,18.4H15.2V18.8H14.8zM15.2,18.4H15.6V18.8H15.2zM15.6,18.4H16V18.8H15.6zM16,18.4H16.4V18.8H16zM16.4,18.4H16.8V18.8H16.4zM16.8,18.4H17.2V18.8H16.8zM17.2,18.4H17.6V18.8H17.2zM17.6,18.4H18V18.8H17.6z"/>
+
+  <!-- Terminus -->
+  <g transform="translate(1050,490)">
+    <circle r="22" fill="none" stroke="#2AA8CE" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="7s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="14" fill="#2AA8CE" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#2AA8CE;#5FD3F3;#2AA8CE" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="900" fill="#061622">$292M</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="1050" y="458" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#CFF0FA" text-anchor="middle">Lazarus DPRK</text>
   </g>
 </g>
+
+<!-- Vertical interchange bridges (motion between lines) -->
+<g opacity="0.8">
+  <circle cx="420" cy="250" r="3" fill="#FFFFFF">
+    <animate attributeName="cy" values="188;312;188" dur="3s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="420" cy="250" r="3" fill="#FFFFFF">
+    <animate attributeName="cy" values="188;312;188" dur="3s" repeatCount="indefinite" begin="1.5s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3s" repeatCount="indefinite" begin="1.5s"/>
+  </circle>
+  <circle cx="640" cy="410" r="3" fill="#FFFFFF">
+    <animate attributeName="cy" values="348;472;348" dur="3.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="640" cy="410" r="3" fill="#FFFFFF">
+    <animate attributeName="cy" values="348;472;348" dur="3.4s" repeatCount="indefinite" begin="1.7s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="3.4s" repeatCount="indefinite" begin="1.7s"/>
+  </circle>
+</g>
+
+<!-- Moving data pulses along each line -->
+<g>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="170;170" dur="4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4s" repeatCount="indefinite" begin="1.3s"/>
+    <animate attributeName="cy" values="170;170" dur="4s" repeatCount="indefinite" begin="1.3s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4s" repeatCount="indefinite" begin="1.3s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4s" repeatCount="indefinite" begin="2.6s"/>
+    <animate attributeName="cy" values="170;170" dur="4s" repeatCount="indefinite" begin="2.6s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4s" repeatCount="indefinite" begin="2.6s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4.5s" repeatCount="indefinite" begin="0.4s"/>
+    <animate attributeName="cy" values="330;330" dur="4.5s" repeatCount="indefinite" begin="0.4s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4.5s" repeatCount="indefinite" begin="0.4s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4.5s" repeatCount="indefinite" begin="1.9s"/>
+    <animate attributeName="cy" values="330;330" dur="4.5s" repeatCount="indefinite" begin="1.9s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4.5s" repeatCount="indefinite" begin="1.9s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="4.5s" repeatCount="indefinite" begin="3.4s"/>
+    <animate attributeName="cy" values="330;330" dur="4.5s" repeatCount="indefinite" begin="3.4s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="4.5s" repeatCount="indefinite" begin="3.4s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="5s" repeatCount="indefinite" begin="0.7s"/>
+    <animate attributeName="cy" values="490;490" dur="5s" repeatCount="indefinite" begin="0.7s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="5s" repeatCount="indefinite" begin="0.7s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="5s" repeatCount="indefinite" begin="2.4s"/>
+    <animate attributeName="cy" values="490;490" dur="5s" repeatCount="indefinite" begin="2.4s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="5s" repeatCount="indefinite" begin="2.4s"/>
+  </circle>
+  <circle r="3" fill="#FFFFFF" opacity="0.9">
+    <animate attributeName="cx" values="120;1080" dur="5s" repeatCount="indefinite" begin="4.1s"/>
+    <animate attributeName="cy" values="490;490" dur="5s" repeatCount="indefinite" begin="4.1s"/>
+    <animate attributeName="opacity" values="0;1;0" dur="5s" repeatCount="indefinite" begin="4.1s"/>
+  </circle>
+</g>
+
+<!-- Ambient corner glows (extra subtle motion) -->
+<g opacity="0.35">
+  <circle cx="100" cy="60" r="50" fill="url(#pulseRed)">
+    <animate attributeName="r" values="50;70;50" dur="5s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.25;0.5;0.25" dur="5s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="1150" cy="580" r="50" fill="url(#pulseCyan)">
+    <animate attributeName="r" values="50;75;50" dur="6s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.25;0.55;0.25" dur="6s" repeatCount="indefinite"/>
+  </circle>
+</g>
+
+<!-- QR code bottom-right -->
+<g transform="translate(1080,500)">
+  <rect x="-6" y="-6" width="112" height="112" rx="6" fill="#FFFFFF">
+    <animate attributeName="opacity" values="0.92;1;0.92" dur="5s" repeatCount="indefinite"/>
+  </rect>
+  <path d="M0.00 0.00h2.44v2.44h-2.44ZM2.44 0.00h2.44v2.44h-2.44ZM4.88 0.00h2.44v2.44h-2.44ZM7.32 0.00h2.44v2.44h-2.44ZM9.76 0.00h2.44v2.44h-2.44ZM12.20 0.00h2.44v2.44h-2.44ZM14.63 0.00h2.44v2.44h-2.44ZM21.95 0.00h2.44v2.44h-2.44ZM24.39 0.00h2.44v2.44h-2.44ZM34.15 0.00h2.44v2.44h-2.44ZM36.59 0.00h2.44v2.44h-2.44ZM39.02 0.00h2.44v2.44h-2.44ZM43.90 0.00h2.44v2.44h-2.44ZM51.22 0.00h2.44v2.44h-2.44ZM63.41 0.00h2.44v2.44h-2.44ZM65.85 0.00h2.44v2.44h-2.44ZM73.17 0.00h2.44v2.44h-2.44ZM75.61 0.00h2.44v2.44h-2.44ZM82.93 0.00h2.44v2.44h-2.44ZM85.37 0.00h2.44v2.44h-2.44ZM87.80 0.00h2.44v2.44h-2.44ZM90.24 0.00h2.44v2.44h-2.44ZM92.68 0.00h2.44v2.44h-2.44ZM95.12 0.00h2.44v2.44h-2.44ZM97.56 0.00h2.44v2.44h-2.44ZM0.00 2.44h2.44v2.44h-2.44ZM14.63 2.44h2.44v2.44h-2.44ZM21.95 2.44h2.44v2.44h-2.44ZM24.39 2.44h2.44v2.44h-2.44ZM26.83 2.44h2.44v2.44h-2.44ZM31.71 2.44h2.44v2.44h-2.44ZM39.02 2.44h2.44v2.44h-2.44ZM41.46 2.44h2.44v2.44h-2.44ZM48.78 2.44h2.44v2.44h-2.44ZM56.10 2.44h2.44v2.44h-2.44ZM65.85 2.44h2.44v2.44h-2.44ZM68.29 2.44h2.44v2.44h-2.44ZM70.73 2.44h2.44v2.44h-2.44ZM73.17 2.44h2.44v2.44h-2.44ZM78.05 2.44h2.44v2.44h-2.44ZM82.93 2.44h2.44v2.44h-2.44ZM97.56 2.44h2.44v2.44h-2.44ZM0.00 4.88h2.44v2.44h-2.44ZM4.88 4.88h2.44v2.44h-2.44ZM7.32 4.88h2.44v2.44h-2.44ZM9.76 4.88h2.44v2.44h-2.44ZM14.63 4.88h2.44v2.44h-2.44ZM21.95 4.88h2.44v2.44h-2.44ZM24.39 4.88h2.44v2.44h-2.44ZM31.71 4.88h2.44v2.44h-2.44ZM34.15 4.88h2.44v2.44h-2.44ZM39.02 4.88h2.44v2.44h-2.44ZM41.46 4.88h2.44v2.44h-2.44ZM46.34 4.88h2.44v2.44h-2.44ZM48.78 4.88h2.44v2.44h-2.44ZM51.22 4.88h2.44v2.44h-2.44ZM53.66 4.88h2.44v2.44h-2.44ZM56.10 4.88h2.44v2.44h-2.44ZM63.41 4.88h2.44v2.44h-2.44ZM70.73 4.88h2.44v2.44h-2.44ZM78.05 4.88h2.44v2.44h-2.44ZM82.93 4.88h2.44v2.44h-2.44ZM87.80 4.88h2.44v2.44h-2.44ZM90.24 4.88h2.44v2.44h-2.44ZM92.68 4.88h2.44v2.44h-2.44ZM97.56 4.88h2.44v2.44h-2.44ZM0.00 7.32h2.44v2.44h-2.44ZM4.88 7.32h2.44v2.44h-2.44ZM7.32 7.32h2.44v2.44h-2.44ZM9.76 7.32h2.44v2.44h-2.44ZM14.63 7.32h2.44v2.44h-2.44ZM24.39 7.32h2.44v2.44h-2.44ZM26.83 7.32h2.44v2.44h-2.44ZM41.46 7.32h2.44v2.44h-2.44ZM48.78 7.32h2.44v2.44h-2.44ZM51.22 7.32h2.44v2.44h-2.44ZM53.66 7.32h2.44v2.44h-2.44ZM56.10 7.32h2.44v2.44h-2.44ZM58.54 7.32h2.44v2.44h-2.44ZM60.98 7.32h2.44v2.44h-2.44ZM65.85 7.32h2.44v2.44h-2.44ZM68.29 7.32h2.44v2.44h-2.44ZM73.17 7.32h2.44v2.44h-2.44ZM75.61 7.32h2.44v2.44h-2.44ZM78.05 7.32h2.44v2.44h-2.44ZM82.93 7.32h2.44v2.44h-2.44ZM87.80 7.32h2.44v2.44h-2.44ZM90.24 7.32h2.44v2.44h-2.44ZM92.68 7.32h2.44v2.44h-2.44ZM97.56 7.32h2.44v2.44h-2.44ZM0.00 9.76h2.44v2.44h-2.44ZM4.88 9.76h2.44v2.44h-2.44ZM7.32 9.76h2.44v2.44h-2.44ZM9.76 9.76h2.44v2.44h-2.44ZM14.63 9.76h2.44v2.44h-2.44ZM29.27 9.76h2.44v2.44h-2.44ZM41.46 9.76h2.44v2.44h-2.44ZM46.34 9.76h2.44v2.44h-2.44ZM60.98 9.76h2.44v2.44h-2.44ZM65.85 9.76h2.44v2.44h-2.44ZM73.17 9.76h2.44v2.44h-2.44ZM78.05 9.76h2.44v2.44h-2.44ZM82.93 9.76h2.44v2.44h-2.44ZM87.80 9.76h2.44v2.44h-2.44ZM90.24 9.76h2.44v2.44h-2.44ZM92.68 9.76h2.44v2.44h-2.44ZM97.56 9.76h2.44v2.44h-2.44ZM0.00 12.20h2.44v2.44h-2.44ZM14.63 12.20h2.44v2.44h-2.44ZM19.51 12.20h2.44v2.44h-2.44ZM21.95 12.20h2.44v2.44h-2.44ZM26.83 12.20h2.44v2.44h-2.44ZM29.27 12.20h2.44v2.44h-2.44ZM34.15 12.20h2.44v2.44h-2.44ZM36.59 12.20h2.44v2.44h-2.44ZM41.46 12.20h2.44v2.44h-2.44ZM43.90 12.20h2.44v2.44h-2.44ZM46.34 12.20h2.44v2.44h-2.44ZM58.54 12.20h2.44v2.44h-2.44ZM63.41 12.20h2.44v2.44h-2.44ZM65.85 12.20h2.44v2.44h-2.44ZM73.17 12.20h2.44v2.44h-2.44ZM75.61 12.20h2.44v2.44h-2.44ZM78.05 12.20h2.44v2.44h-2.44ZM82.93 12.20h2.44v2.44h-2.44ZM97.56 12.20h2.44v2.44h-2.44ZM0.00 14.63h2.44v2.44h-2.44ZM2.44 14.63h2.44v2.44h-2.44ZM4.88 14.63h2.44v2.44h-2.44ZM7.32 14.63h2.44v2.44h-2.44ZM9.76 14.63h2.44v2.44h-2.44ZM12.20 14.63h2.44v2.44h-2.44ZM14.63 14.63h2.44v2.44h-2.44ZM19.51 14.63h2.44v2.44h-2.44ZM24.39 14.63h2.44v2.44h-2.44ZM29.27 14.63h2.44v2.44h-2.44ZM34.15 14.63h2.44v2.44h-2.44ZM39.02 14.63h2.44v2.44h-2.44ZM43.90 14.63h2.44v2.44h-2.44ZM48.78 14.63h2.44v2.44h-2.44ZM53.66 14.63h2.44v2.44h-2.44ZM58.54 14.63h2.44v2.44h-2.44ZM63.41 14.63h2.44v2.44h-2.44ZM68.29 14.63h2.44v2.44h-2.44ZM73.17 14.63h2.44v2.44h-2.44ZM78.05 14.63h2.44v2.44h-2.44ZM82.93 14.63h2.44v2.44h-2.44ZM85.37 14.63h2.44v2.44h-2.44ZM87.80 14.63h2.44v2.44h-2.44ZM90.24 14.63h2.44v2.44h-2.44ZM92.68 14.63h2.44v2.44h-2.44ZM95.12 14.63h2.44v2.44h-2.44ZM97.56 14.63h2.44v2.44h-2.44ZM21.95 17.07h2.44v2.44h-2.44ZM24.39 17.07h2.44v2.44h-2.44ZM29.27 17.07h2.44v2.44h-2.44ZM31.71 17.07h2.44v2.44h-2.44ZM34.15 17.07h2.44v2.44h-2.44ZM36.59 17.07h2.44v2.44h-2.44ZM39.02 17.07h2.44v2.44h-2.44ZM41.46 17.07h2.44v2.44h-2.44ZM46.34 17.07h2.44v2.44h-2.44ZM48.78 17.07h2.44v2.44h-2.44ZM51.22 17.07h2.44v2.44h-2.44ZM53.66 17.07h2.44v2.44h-2.44ZM58.54 17.07h2.44v2.44h-2.44ZM65.85 17.07h2.44v2.44h-2.44ZM68.29 17.07h2.44v2.44h-2.44ZM70.73 17.07h2.44v2.44h-2.44ZM75.61 17.07h2.44v2.44h-2.44ZM0.00 19.51h2.44v2.44h-2.44ZM7.32 19.51h2.44v2.44h-2.44ZM12.20 19.51h2.44v2.44h-2.44ZM14.63 19.51h2.44v2.44h-2.44ZM19.51 19.51h2.44v2.44h-2.44ZM21.95 19.51h2.44v2.44h-2.44ZM29.27 19.51h2.44v2.44h-2.44ZM36.59 19.51h2.44v2.44h-2.44ZM46.34 19.51h2.44v2.44h-2.44ZM51.22 19.51h2.44v2.44h-2.44ZM60.98 19.51h2.44v2.44h-2.44ZM63.41 19.51h2.44v2.44h-2.44ZM78.05 19.51h2.44v2.44h-2.44ZM80.49 19.51h2.44v2.44h-2.44ZM85.37 19.51h2.44v2.44h-2.44ZM0.00 21.95h2.44v2.44h-2.44ZM2.44 21.95h2.44v2.44h-2.44ZM9.76 21.95h2.44v2.44h-2.44ZM17.07 21.95h2.44v2.44h-2.44ZM19.51 21.95h2.44v2.44h-2.44ZM21.95 21.95h2.44v2.44h-2.44ZM29.27 21.95h2.44v2.44h-2.44ZM31.71 21.95h2.44v2.44h-2.44ZM39.02 21.95h2.44v2.44h-2.44ZM41.46 21.95h2.44v2.44h-2.44ZM51.22 21.95h2.44v2.44h-2.44ZM58.54 21.95h2.44v2.44h-2.44ZM60.98 21.95h2.44v2.44h-2.44ZM63.41 21.95h2.44v2.44h-2.44ZM70.73 21.95h2.44v2.44h-2.44ZM78.05 21.95h2.44v2.44h-2.44ZM90.24 21.95h2.44v2.44h-2.44ZM92.68 21.95h2.44v2.44h-2.44ZM95.12 21.95h2.44v2.44h-2.44ZM97.56 21.95h2.44v2.44h-2.44ZM0.00 24.39h2.44v2.44h-2.44ZM2.44 24.39h2.44v2.44h-2.44ZM7.32 24.39h2.44v2.44h-2.44ZM9.76 24.39h2.44v2.44h-2.44ZM12.20 24.39h2.44v2.44h-2.44ZM14.63 24.39h2.44v2.44h-2.44ZM17.07 24.39h2.44v2.44h-2.44ZM24.39 24.39h2.44v2.44h-2.44ZM26.83 24.39h2.44v2.44h-2.44ZM29.27 24.39h2.44v2.44h-2.44ZM31.71 24.39h2.44v2.44h-2.44ZM41.46 24.39h2.44v2.44h-2.44ZM43.90 24.39h2.44v2.44h-2.44ZM46.34 24.39h2.44v2.44h-2.44ZM48.78 24.39h2.44v2.44h-2.44ZM53.66 24.39h2.44v2.44h-2.44ZM58.54 24.39h2.44v2.44h-2.44ZM60.98 24.39h2.44v2.44h-2.44ZM73.17 24.39h2.44v2.44h-2.44ZM75.61 24.39h2.44v2.44h-2.44ZM82.93 24.39h2.44v2.44h-2.44ZM85.37 24.39h2.44v2.44h-2.44ZM87.80 24.39h2.44v2.44h-2.44ZM90.24 24.39h2.44v2.44h-2.44ZM92.68 24.39h2.44v2.44h-2.44ZM95.12 24.39h2.44v2.44h-2.44ZM0.00 26.83h2.44v2.44h-2.44ZM4.88 26.83h2.44v2.44h-2.44ZM17.07 26.83h2.44v2.44h-2.44ZM19.51 26.83h2.44v2.44h-2.44ZM24.39 26.83h2.44v2.44h-2.44ZM26.83 26.83h2.44v2.44h-2.44ZM29.27 26.83h2.44v2.44h-2.44ZM34.15 26.83h2.44v2.44h-2.44ZM39.02 26.83h2.44v2.44h-2.44ZM43.90 26.83h2.44v2.44h-2.44ZM51.22 26.83h2.44v2.44h-2.44ZM58.54 26.83h2.44v2.44h-2.44ZM60.98 26.83h2.44v2.44h-2.44ZM63.41 26.83h2.44v2.44h-2.44ZM68.29 26.83h2.44v2.44h-2.44ZM87.80 26.83h2.44v2.44h-2.44ZM92.68 26.83h2.44v2.44h-2.44ZM95.12 26.83h2.44v2.44h-2.44ZM0.00 29.27h2.44v2.44h-2.44ZM2.44 29.27h2.44v2.44h-2.44ZM9.76 29.27h2.44v2.44h-2.44ZM12.20 29.27h2.44v2.44h-2.44ZM14.63 29.27h2.44v2.44h-2.44ZM19.51 29.27h2.44v2.44h-2.44ZM21.95 29.27h2.44v2.44h-2.44ZM24.39 29.27h2.44v2.44h-2.44ZM31.71 29.27h2.44v2.44h-2.44ZM34.15 29.27h2.44v2.44h-2.44ZM36.59 29.27h2.44v2.44h-2.44ZM41.46 29.27h2.44v2.44h-2.44ZM46.34 29.27h2.44v2.44h-2.44ZM48.78 29.27h2.44v2.44h-2.44ZM51.22 29.27h2.44v2.44h-2.44ZM60.98 29.27h2.44v2.44h-2.44ZM63.41 29.27h2.44v2.44h-2.44ZM65.85 29.27h2.44v2.44h-2.44ZM68.29 29.27h2.44v2.44h-2.44ZM70.73 29.27h2.44v2.44h-2.44ZM73.17 29.27h2.44v2.44h-2.44ZM75.61 29.27h2.44v2.44h-2.44ZM78.05 29.27h2.44v2.44h-2.44ZM80.49 29.27h2.44v2.44h-2.44ZM82.93 29.27h2.44v2.44h-2.44ZM85.37 29.27h2.44v2.44h-2.44ZM90.24 29.27h2.44v2.44h-2.44ZM95.12 29.27h2.44v2.44h-2.44ZM0.00 31.71h2.44v2.44h-2.44ZM4.88 31.71h2.44v2.44h-2.44ZM7.32 31.71h2.44v2.44h-2.44ZM12.20 31.71h2.44v2.44h-2.44ZM24.39 31.71h2.44v2.44h-2.44ZM26.83 31.71h2.44v2.44h-2.44ZM34.15 31.71h2.44v2.44h-2.44ZM41.46 31.71h2.44v2.44h-2.44ZM48.78 31.71h2.44v2.44h-2.44ZM53.66 31.71h2.44v2.44h-2.44ZM56.10 31.71h2.44v2.44h-2.44ZM60.98 31.71h2.44v2.44h-2.44ZM65.85 31.71h2.44v2.44h-2.44ZM73.17 31.71h2.44v2.44h-2.44ZM75.61 31.71h2.44v2.44h-2.44ZM78.05 31.71h2.44v2.44h-2.44ZM82.93 31.71h2.44v2.44h-2.44ZM90.24 31.71h2.44v2.44h-2.44ZM92.68 31.71h2.44v2.44h-2.44ZM0.00 34.15h2.44v2.44h-2.44ZM4.88 34.15h2.44v2.44h-2.44ZM7.32 34.15h2.44v2.44h-2.44ZM9.76 34.15h2.44v2.44h-2.44ZM14.63 34.15h2.44v2.44h-2.44ZM17.07 34.15h2.44v2.44h-2.44ZM24.39 34.15h2.44v2.44h-2.44ZM26.83 34.15h2.44v2.44h-2.44ZM31.71 34.15h2.44v2.44h-2.44ZM39.02 34.15h2.44v2.44h-2.44ZM41.46 34.15h2.44v2.44h-2.44ZM43.90 34.15h2.44v2.44h-2.44ZM46.34 34.15h2.44v2.44h-2.44ZM51.22 34.15h2.44v2.44h-2.44ZM56.10 34.15h2.44v2.44h-2.44ZM65.85 34.15h2.44v2.44h-2.44ZM68.29 34.15h2.44v2.44h-2.44ZM73.17 34.15h2.44v2.44h-2.44ZM78.05 34.15h2.44v2.44h-2.44ZM82.93 34.15h2.44v2.44h-2.44ZM90.24 34.15h2.44v2.44h-2.44ZM92.68 34.15h2.44v2.44h-2.44ZM95.12 34.15h2.44v2.44h-2.44ZM97.56 34.15h2.44v2.44h-2.44ZM0.00 36.59h2.44v2.44h-2.44ZM4.88 36.59h2.44v2.44h-2.44ZM12.20 36.59h2.44v2.44h-2.44ZM17.07 36.59h2.44v2.44h-2.44ZM21.95 36.59h2.44v2.44h-2.44ZM24.39 36.59h2.44v2.44h-2.44ZM34.15 36.59h2.44v2.44h-2.44ZM36.59 36.59h2.44v2.44h-2.44ZM39.02 36.59h2.44v2.44h-2.44ZM41.46 36.59h2.44v2.44h-2.44ZM43.90 36.59h2.44v2.44h-2.44ZM48.78 36.59h2.44v2.44h-2.44ZM51.22 36.59h2.44v2.44h-2.44ZM53.66 36.59h2.44v2.44h-2.44ZM56.10 36.59h2.44v2.44h-2.44ZM60.98 36.59h2.44v2.44h-2.44ZM63.41 36.59h2.44v2.44h-2.44ZM68.29 36.59h2.44v2.44h-2.44ZM70.73 36.59h2.44v2.44h-2.44ZM73.17 36.59h2.44v2.44h-2.44ZM78.05 36.59h2.44v2.44h-2.44ZM82.93 36.59h2.44v2.44h-2.44ZM85.37 36.59h2.44v2.44h-2.44ZM2.44 39.02h2.44v2.44h-2.44ZM4.88 39.02h2.44v2.44h-2.44ZM14.63 39.02h2.44v2.44h-2.44ZM17.07 39.02h2.44v2.44h-2.44ZM21.95 39.02h2.44v2.44h-2.44ZM26.83 39.02h2.44v2.44h-2.44ZM29.27 39.02h2.44v2.44h-2.44ZM31.71 39.02h2.44v2.44h-2.44ZM34.15 39.02h2.44v2.44h-2.44ZM39.02 39.02h2.44v2.44h-2.44ZM41.46 39.02h2.44v2.44h-2.44ZM53.66 39.02h2.44v2.44h-2.44ZM65.85 39.02h2.44v2.44h-2.44ZM70.73 39.02h2.44v2.44h-2.44ZM75.61 39.02h2.44v2.44h-2.44ZM78.05 39.02h2.44v2.44h-2.44ZM85.37 39.02h2.44v2.44h-2.44ZM95.12 39.02h2.44v2.44h-2.44ZM7.32 41.46h2.44v2.44h-2.44ZM12.20 41.46h2.44v2.44h-2.44ZM21.95 41.46h2.44v2.44h-2.44ZM24.39 41.46h2.44v2.44h-2.44ZM29.27 41.46h2.44v2.44h-2.44ZM31.71 41.46h2.44v2.44h-2.44ZM34.15 41.46h2.44v2.44h-2.44ZM39.02 41.46h2.44v2.44h-2.44ZM41.46 41.46h2.44v2.44h-2.44ZM43.90 41.46h2.44v2.44h-2.44ZM46.34 41.46h2.44v2.44h-2.44ZM51.22 41.46h2.44v2.44h-2.44ZM56.10 41.46h2.44v2.44h-2.44ZM58.54 41.46h2.44v2.44h-2.44ZM63.41 41.46h2.44v2.44h-2.44ZM65.85 41.46h2.44v2.44h-2.44ZM68.29 41.46h2.44v2.44h-2.44ZM70.73 41.46h2.44v2.44h-2.44ZM82.93 41.46h2.44v2.44h-2.44ZM85.37 41.46h2.44v2.44h-2.44ZM90.24 41.46h2.44v2.44h-2.44ZM92.68 41.46h2.44v2.44h-2.44ZM95.12 41.46h2.44v2.44h-2.44ZM97.56 41.46h2.44v2.44h-2.44ZM0.00 43.90h2.44v2.44h-2.44ZM4.88 43.90h2.44v2.44h-2.44ZM12.20 43.90h2.44v2.44h-2.44ZM14.63 43.90h2.44v2.44h-2.44ZM17.07 43.90h2.44v2.44h-2.44ZM21.95 43.90h2.44v2.44h-2.44ZM24.39 43.90h2.44v2.44h-2.44ZM26.83 43.90h2.44v2.44h-2.44ZM29.27 43.90h2.44v2.44h-2.44ZM31.71 43.90h2.44v2.44h-2.44ZM36.59 43.90h2.44v2.44h-2.44ZM39.02 43.90h2.44v2.44h-2.44ZM41.46 43.90h2.44v2.44h-2.44ZM53.66 43.90h2.44v2.44h-2.44ZM60.98 43.90h2.44v2.44h-2.44ZM70.73 43.90h2.44v2.44h-2.44ZM80.49 43.90h2.44v2.44h-2.44ZM82.93 43.90h2.44v2.44h-2.44ZM87.80 43.90h2.44v2.44h-2.44ZM97.56 43.90h2.44v2.44h-2.44ZM4.88 46.34h2.44v2.44h-2.44ZM19.51 46.34h2.44v2.44h-2.44ZM21.95 46.34h2.44v2.44h-2.44ZM26.83 46.34h2.44v2.44h-2.44ZM31.71 46.34h2.44v2.44h-2.44ZM34.15 46.34h2.44v2.44h-2.44ZM48.78 46.34h2.44v2.44h-2.44ZM51.22 46.34h2.44v2.44h-2.44ZM60.98 46.34h2.44v2.44h-2.44ZM70.73 46.34h2.44v2.44h-2.44ZM78.05 46.34h2.44v2.44h-2.44ZM80.49 46.34h2.44v2.44h-2.44ZM82.93 46.34h2.44v2.44h-2.44ZM85.37 46.34h2.44v2.44h-2.44ZM90.24 46.34h2.44v2.44h-2.44ZM97.56 46.34h2.44v2.44h-2.44ZM0.00 48.78h2.44v2.44h-2.44ZM2.44 48.78h2.44v2.44h-2.44ZM7.32 48.78h2.44v2.44h-2.44ZM9.76 48.78h2.44v2.44h-2.44ZM14.63 48.78h2.44v2.44h-2.44ZM19.51 48.78h2.44v2.44h-2.44ZM21.95 48.78h2.44v2.44h-2.44ZM24.39 48.78h2.44v2.44h-2.44ZM26.83 48.78h2.44v2.44h-2.44ZM31.71 48.78h2.44v2.44h-2.44ZM34.15 48.78h2.44v2.44h-2.44ZM39.02 48.78h2.44v2.44h-2.44ZM41.46 48.78h2.44v2.44h-2.44ZM48.78 48.78h2.44v2.44h-2.44ZM53.66 48.78h2.44v2.44h-2.44ZM56.10 48.78h2.44v2.44h-2.44ZM58.54 48.78h2.44v2.44h-2.44ZM63.41 48.78h2.44v2.44h-2.44ZM65.85 48.78h2.44v2.44h-2.44ZM78.05 48.78h2.44v2.44h-2.44ZM80.49 48.78h2.44v2.44h-2.44ZM82.93 48.78h2.44v2.44h-2.44ZM85.37 48.78h2.44v2.44h-2.44ZM87.80 48.78h2.44v2.44h-2.44ZM92.68 48.78h2.44v2.44h-2.44ZM95.12 48.78h2.44v2.44h-2.44ZM7.32 51.22h2.44v2.44h-2.44ZM9.76 51.22h2.44v2.44h-2.44ZM19.51 51.22h2.44v2.44h-2.44ZM39.02 51.22h2.44v2.44h-2.44ZM41.46 51.22h2.44v2.44h-2.44ZM46.34 51.22h2.44v2.44h-2.44ZM48.78 51.22h2.44v2.44h-2.44ZM51.22 51.22h2.44v2.44h-2.44ZM53.66 51.22h2.44v2.44h-2.44ZM60.98 51.22h2.44v2.44h-2.44ZM70.73 51.22h2.44v2.44h-2.44ZM73.17 51.22h2.44v2.44h-2.44ZM82.93 51.22h2.44v2.44h-2.44ZM95.12 51.22h2.44v2.44h-2.44ZM97.56 51.22h2.44v2.44h-2.44ZM0.00 53.66h2.44v2.44h-2.44ZM7.32 53.66h2.44v2.44h-2.44ZM9.76 53.66h2.44v2.44h-2.44ZM14.63 53.66h2.44v2.44h-2.44ZM17.07 53.66h2.44v2.44h-2.44ZM19.51 53.66h2.44v2.44h-2.44ZM21.95 53.66h2.44v2.44h-2.44ZM24.39 53.66h2.44v2.44h-2.44ZM29.27 53.66h2.44v2.44h-2.44ZM36.59 53.66h2.44v2.44h-2.44ZM39.02 53.66h2.44v2.44h-2.44ZM41.46 53.66h2.44v2.44h-2.44ZM43.90 53.66h2.44v2.44h-2.44ZM46.34 53.66h2.44v2.44h-2.44ZM48.78 53.66h2.44v2.44h-2.44ZM60.98 53.66h2.44v2.44h-2.44ZM68.29 53.66h2.44v2.44h-2.44ZM75.61 53.66h2.44v2.44h-2.44ZM80.49 53.66h2.44v2.44h-2.44ZM82.93 53.66h2.44v2.44h-2.44ZM85.37 53.66h2.44v2.44h-2.44ZM87.80 53.66h2.44v2.44h-2.44ZM92.68 53.66h2.44v2.44h-2.44ZM95.12 53.66h2.44v2.44h-2.44ZM7.32 56.10h2.44v2.44h-2.44ZM12.20 56.10h2.44v2.44h-2.44ZM19.51 56.10h2.44v2.44h-2.44ZM21.95 56.10h2.44v2.44h-2.44ZM24.39 56.10h2.44v2.44h-2.44ZM39.02 56.10h2.44v2.44h-2.44ZM43.90 56.10h2.44v2.44h-2.44ZM46.34 56.10h2.44v2.44h-2.44ZM48.78 56.10h2.44v2.44h-2.44ZM51.22 56.10h2.44v2.44h-2.44ZM53.66 56.10h2.44v2.44h-2.44ZM60.98 56.10h2.44v2.44h-2.44ZM63.41 56.10h2.44v2.44h-2.44ZM68.29 56.10h2.44v2.44h-2.44ZM73.17 56.10h2.44v2.44h-2.44ZM82.93 56.10h2.44v2.44h-2.44ZM92.68 56.10h2.44v2.44h-2.44ZM95.12 56.10h2.44v2.44h-2.44ZM2.44 58.54h2.44v2.44h-2.44ZM4.88 58.54h2.44v2.44h-2.44ZM7.32 58.54h2.44v2.44h-2.44ZM9.76 58.54h2.44v2.44h-2.44ZM12.20 58.54h2.44v2.44h-2.44ZM14.63 58.54h2.44v2.44h-2.44ZM17.07 58.54h2.44v2.44h-2.44ZM19.51 58.54h2.44v2.44h-2.44ZM21.95 58.54h2.44v2.44h-2.44ZM24.39 58.54h2.44v2.44h-2.44ZM26.83 58.54h2.44v2.44h-2.44ZM29.27 58.54h2.44v2.44h-2.44ZM36.59 58.54h2.44v2.44h-2.44ZM39.02 58.54h2.44v2.44h-2.44ZM41.46 58.54h2.44v2.44h-2.44ZM46.34 58.54h2.44v2.44h-2.44ZM48.78 58.54h2.44v2.44h-2.44ZM51.22 58.54h2.44v2.44h-2.44ZM58.54 58.54h2.44v2.44h-2.44ZM60.98 58.54h2.44v2.44h-2.44ZM65.85 58.54h2.44v2.44h-2.44ZM68.29 58.54h2.44v2.44h-2.44ZM70.73 58.54h2.44v2.44h-2.44ZM75.61 58.54h2.44v2.44h-2.44ZM78.05 58.54h2.44v2.44h-2.44ZM80.49 58.54h2.44v2.44h-2.44ZM82.93 58.54h2.44v2.44h-2.44ZM85.37 58.54h2.44v2.44h-2.44ZM90.24 58.54h2.44v2.44h-2.44ZM92.68 58.54h2.44v2.44h-2.44ZM95.12 58.54h2.44v2.44h-2.44ZM0.00 60.98h2.44v2.44h-2.44ZM2.44 60.98h2.44v2.44h-2.44ZM7.32 60.98h2.44v2.44h-2.44ZM9.76 60.98h2.44v2.44h-2.44ZM12.20 60.98h2.44v2.44h-2.44ZM17.07 60.98h2.44v2.44h-2.44ZM19.51 60.98h2.44v2.44h-2.44ZM21.95 60.98h2.44v2.44h-2.44ZM26.83 60.98h2.44v2.44h-2.44ZM29.27 60.98h2.44v2.44h-2.44ZM34.15 60.98h2.44v2.44h-2.44ZM41.46 60.98h2.44v2.44h-2.44ZM46.34 60.98h2.44v2.44h-2.44ZM48.78 60.98h2.44v2.44h-2.44ZM51.22 60.98h2.44v2.44h-2.44ZM53.66 60.98h2.44v2.44h-2.44ZM58.54 60.98h2.44v2.44h-2.44ZM60.98 60.98h2.44v2.44h-2.44ZM63.41 60.98h2.44v2.44h-2.44ZM68.29 60.98h2.44v2.44h-2.44ZM70.73 60.98h2.44v2.44h-2.44ZM75.61 60.98h2.44v2.44h-2.44ZM82.93 60.98h2.44v2.44h-2.44ZM90.24 60.98h2.44v2.44h-2.44ZM95.12 60.98h2.44v2.44h-2.44ZM0.00 63.41h2.44v2.44h-2.44ZM2.44 63.41h2.44v2.44h-2.44ZM4.88 63.41h2.44v2.44h-2.44ZM7.32 63.41h2.44v2.44h-2.44ZM14.63 63.41h2.44v2.44h-2.44ZM17.07 63.41h2.44v2.44h-2.44ZM19.51 63.41h2.44v2.44h-2.44ZM21.95 63.41h2.44v2.44h-2.44ZM24.39 63.41h2.44v2.44h-2.44ZM29.27 63.41h2.44v2.44h-2.44ZM36.59 63.41h2.44v2.44h-2.44ZM39.02 63.41h2.44v2.44h-2.44ZM41.46 63.41h2.44v2.44h-2.44ZM48.78 63.41h2.44v2.44h-2.44ZM56.10 63.41h2.44v2.44h-2.44ZM60.98 63.41h2.44v2.44h-2.44ZM63.41 63.41h2.44v2.44h-2.44ZM68.29 63.41h2.44v2.44h-2.44ZM73.17 63.41h2.44v2.44h-2.44ZM78.05 63.41h2.44v2.44h-2.44ZM80.49 63.41h2.44v2.44h-2.44ZM85.37 63.41h2.44v2.44h-2.44ZM87.80 63.41h2.44v2.44h-2.44ZM95.12 63.41h2.44v2.44h-2.44ZM97.56 63.41h2.44v2.44h-2.44ZM4.88 65.85h2.44v2.44h-2.44ZM7.32 65.85h2.44v2.44h-2.44ZM21.95 65.85h2.44v2.44h-2.44ZM24.39 65.85h2.44v2.44h-2.44ZM29.27 65.85h2.44v2.44h-2.44ZM36.59 65.85h2.44v2.44h-2.44ZM41.46 65.85h2.44v2.44h-2.44ZM43.90 65.85h2.44v2.44h-2.44ZM48.78 65.85h2.44v2.44h-2.44ZM51.22 65.85h2.44v2.44h-2.44ZM53.66 65.85h2.44v2.44h-2.44ZM58.54 65.85h2.44v2.44h-2.44ZM60.98 65.85h2.44v2.44h-2.44ZM63.41 65.85h2.44v2.44h-2.44ZM65.85 65.85h2.44v2.44h-2.44ZM70.73 65.85h2.44v2.44h-2.44ZM78.05 65.85h2.44v2.44h-2.44ZM82.93 65.85h2.44v2.44h-2.44ZM95.12 65.85h2.44v2.44h-2.44ZM0.00 68.29h2.44v2.44h-2.44ZM4.88 68.29h2.44v2.44h-2.44ZM14.63 68.29h2.44v2.44h-2.44ZM21.95 68.29h2.44v2.44h-2.44ZM24.39 68.29h2.44v2.44h-2.44ZM29.27 68.29h2.44v2.44h-2.44ZM31.71 68.29h2.44v2.44h-2.44ZM39.02 68.29h2.44v2.44h-2.44ZM41.46 68.29h2.44v2.44h-2.44ZM51.22 68.29h2.44v2.44h-2.44ZM53.66 68.29h2.44v2.44h-2.44ZM56.10 68.29h2.44v2.44h-2.44ZM58.54 68.29h2.44v2.44h-2.44ZM63.41 68.29h2.44v2.44h-2.44ZM65.85 68.29h2.44v2.44h-2.44ZM70.73 68.29h2.44v2.44h-2.44ZM73.17 68.29h2.44v2.44h-2.44ZM78.05 68.29h2.44v2.44h-2.44ZM80.49 68.29h2.44v2.44h-2.44ZM85.37 68.29h2.44v2.44h-2.44ZM2.44 70.73h2.44v2.44h-2.44ZM4.88 70.73h2.44v2.44h-2.44ZM7.32 70.73h2.44v2.44h-2.44ZM21.95 70.73h2.44v2.44h-2.44ZM24.39 70.73h2.44v2.44h-2.44ZM34.15 70.73h2.44v2.44h-2.44ZM36.59 70.73h2.44v2.44h-2.44ZM46.34 70.73h2.44v2.44h-2.44ZM48.78 70.73h2.44v2.44h-2.44ZM51.22 70.73h2.44v2.44h-2.44ZM58.54 70.73h2.44v2.44h-2.44ZM60.98 70.73h2.44v2.44h-2.44ZM65.85 70.73h2.44v2.44h-2.44ZM70.73 70.73h2.44v2.44h-2.44ZM73.17 70.73h2.44v2.44h-2.44ZM80.49 70.73h2.44v2.44h-2.44ZM85.37 70.73h2.44v2.44h-2.44ZM90.24 70.73h2.44v2.44h-2.44ZM92.68 70.73h2.44v2.44h-2.44ZM97.56 70.73h2.44v2.44h-2.44ZM0.00 73.17h2.44v2.44h-2.44ZM7.32 73.17h2.44v2.44h-2.44ZM9.76 73.17h2.44v2.44h-2.44ZM14.63 73.17h2.44v2.44h-2.44ZM19.51 73.17h2.44v2.44h-2.44ZM21.95 73.17h2.44v2.44h-2.44ZM26.83 73.17h2.44v2.44h-2.44ZM31.71 73.17h2.44v2.44h-2.44ZM34.15 73.17h2.44v2.44h-2.44ZM36.59 73.17h2.44v2.44h-2.44ZM39.02 73.17h2.44v2.44h-2.44ZM43.90 73.17h2.44v2.44h-2.44ZM51.22 73.17h2.44v2.44h-2.44ZM53.66 73.17h2.44v2.44h-2.44ZM56.10 73.17h2.44v2.44h-2.44ZM58.54 73.17h2.44v2.44h-2.44ZM60.98 73.17h2.44v2.44h-2.44ZM85.37 73.17h2.44v2.44h-2.44ZM92.68 73.17h2.44v2.44h-2.44ZM95.12 73.17h2.44v2.44h-2.44ZM97.56 73.17h2.44v2.44h-2.44ZM4.88 75.61h2.44v2.44h-2.44ZM9.76 75.61h2.44v2.44h-2.44ZM19.51 75.61h2.44v2.44h-2.44ZM24.39 75.61h2.44v2.44h-2.44ZM29.27 75.61h2.44v2.44h-2.44ZM39.02 75.61h2.44v2.44h-2.44ZM41.46 75.61h2.44v2.44h-2.44ZM51.22 75.61h2.44v2.44h-2.44ZM58.54 75.61h2.44v2.44h-2.44ZM63.41 75.61h2.44v2.44h-2.44ZM70.73 75.61h2.44v2.44h-2.44ZM80.49 75.61h2.44v2.44h-2.44ZM87.80 75.61h2.44v2.44h-2.44ZM90.24 75.61h2.44v2.44h-2.44ZM0.00 78.05h2.44v2.44h-2.44ZM7.32 78.05h2.44v2.44h-2.44ZM9.76 78.05h2.44v2.44h-2.44ZM14.63 78.05h2.44v2.44h-2.44ZM26.83 78.05h2.44v2.44h-2.44ZM36.59 78.05h2.44v2.44h-2.44ZM60.98 78.05h2.44v2.44h-2.44ZM63.41 78.05h2.44v2.44h-2.44ZM65.85 78.05h2.44v2.44h-2.44ZM78.05 78.05h2.44v2.44h-2.44ZM80.49 78.05h2.44v2.44h-2.44ZM82.93 78.05h2.44v2.44h-2.44ZM85.37 78.05h2.44v2.44h-2.44ZM87.80 78.05h2.44v2.44h-2.44ZM92.68 78.05h2.44v2.44h-2.44ZM97.56 78.05h2.44v2.44h-2.44ZM19.51 80.49h2.44v2.44h-2.44ZM29.27 80.49h2.44v2.44h-2.44ZM39.02 80.49h2.44v2.44h-2.44ZM41.46 80.49h2.44v2.44h-2.44ZM43.90 80.49h2.44v2.44h-2.44ZM46.34 80.49h2.44v2.44h-2.44ZM48.78 80.49h2.44v2.44h-2.44ZM53.66 80.49h2.44v2.44h-2.44ZM58.54 80.49h2.44v2.44h-2.44ZM60.98 80.49h2.44v2.44h-2.44ZM65.85 80.49h2.44v2.44h-2.44ZM68.29 80.49h2.44v2.44h-2.44ZM70.73 80.49h2.44v2.44h-2.44ZM73.17 80.49h2.44v2.44h-2.44ZM75.61 80.49h2.44v2.44h-2.44ZM78.05 80.49h2.44v2.44h-2.44ZM87.80 80.49h2.44v2.44h-2.44ZM90.24 80.49h2.44v2.44h-2.44ZM92.68 80.49h2.44v2.44h-2.44ZM95.12 80.49h2.44v2.44h-2.44ZM97.56 80.49h2.44v2.44h-2.44ZM0.00 82.93h2.44v2.44h-2.44ZM2.44 82.93h2.44v2.44h-2.44ZM4.88 82.93h2.44v2.44h-2.44ZM7.32 82.93h2.44v2.44h-2.44ZM9.76 82.93h2.44v2.44h-2.44ZM12.20 82.93h2.44v2.44h-2.44ZM14.63 82.93h2.44v2.44h-2.44ZM21.95 82.93h2.44v2.44h-2.44ZM29.27 82.93h2.44v2.44h-2.44ZM34.15 82.93h2.44v2.44h-2.44ZM43.90 82.93h2.44v2.44h-2.44ZM46.34 82.93h2.44v2.44h-2.44ZM48.78 82.93h2.44v2.44h-2.44ZM51.22 82.93h2.44v2.44h-2.44ZM53.66 82.93h2.44v2.44h-2.44ZM60.98 82.93h2.44v2.44h-2.44ZM63.41 82.93h2.44v2.44h-2.44ZM68.29 82.93h2.44v2.44h-2.44ZM78.05 82.93h2.44v2.44h-2.44ZM82.93 82.93h2.44v2.44h-2.44ZM87.80 82.93h2.44v2.44h-2.44ZM92.68 82.93h2.44v2.44h-2.44ZM95.12 82.93h2.44v2.44h-2.44ZM0.00 85.37h2.44v2.44h-2.44ZM14.63 85.37h2.44v2.44h-2.44ZM19.51 85.37h2.44v2.44h-2.44ZM26.83 85.37h2.44v2.44h-2.44ZM39.02 85.37h2.44v2.44h-2.44ZM43.90 85.37h2.44v2.44h-2.44ZM58.54 85.37h2.44v2.44h-2.44ZM60.98 85.37h2.44v2.44h-2.44ZM65.85 85.37h2.44v2.44h-2.44ZM78.05 85.37h2.44v2.44h-2.44ZM87.80 85.37h2.44v2.44h-2.44ZM92.68 85.37h2.44v2.44h-2.44ZM97.56 85.37h2.44v2.44h-2.44ZM0.00 87.80h2.44v2.44h-2.44ZM4.88 87.80h2.44v2.44h-2.44ZM7.32 87.80h2.44v2.44h-2.44ZM9.76 87.80h2.44v2.44h-2.44ZM14.63 87.80h2.44v2.44h-2.44ZM24.39 87.80h2.44v2.44h-2.44ZM26.83 87.80h2.44v2.44h-2.44ZM31.71 87.80h2.44v2.44h-2.44ZM36.59 87.80h2.44v2.44h-2.44ZM39.02 87.80h2.44v2.44h-2.44ZM43.90 87.80h2.44v2.44h-2.44ZM48.78 87.80h2.44v2.44h-2.44ZM63.41 87.80h2.44v2.44h-2.44ZM65.85 87.80h2.44v2.44h-2.44ZM68.29 87.80h2.44v2.44h-2.44ZM70.73 87.80h2.44v2.44h-2.44ZM73.17 87.80h2.44v2.44h-2.44ZM78.05 87.80h2.44v2.44h-2.44ZM80.49 87.80h2.44v2.44h-2.44ZM82.93 87.80h2.44v2.44h-2.44ZM85.37 87.80h2.44v2.44h-2.44ZM87.80 87.80h2.44v2.44h-2.44ZM90.24 87.80h2.44v2.44h-2.44ZM95.12 87.80h2.44v2.44h-2.44ZM0.00 90.24h2.44v2.44h-2.44ZM4.88 90.24h2.44v2.44h-2.44ZM7.32 90.24h2.44v2.44h-2.44ZM9.76 90.24h2.44v2.44h-2.44ZM14.63 90.24h2.44v2.44h-2.44ZM19.51 90.24h2.44v2.44h-2.44ZM21.95 90.24h2.44v2.44h-2.44ZM34.15 90.24h2.44v2.44h-2.44ZM36.59 90.24h2.44v2.44h-2.44ZM39.02 90.24h2.44v2.44h-2.44ZM43.90 90.24h2.44v2.44h-2.44ZM46.34 90.24h2.44v2.44h-2.44ZM48.78 90.24h2.44v2.44h-2.44ZM51.22 90.24h2.44v2.44h-2.44ZM53.66 90.24h2.44v2.44h-2.44ZM63.41 90.24h2.44v2.44h-2.44ZM68.29 90.24h2.44v2.44h-2.44ZM70.73 90.24h2.44v2.44h-2.44ZM75.61 90.24h2.44v2.44h-2.44ZM78.05 90.24h2.44v2.44h-2.44ZM80.49 90.24h2.44v2.44h-2.44ZM82.93 90.24h2.44v2.44h-2.44ZM87.80 90.24h2.44v2.44h-2.44ZM90.24 90.24h2.44v2.44h-2.44ZM92.68 90.24h2.44v2.44h-2.44ZM97.56 90.24h2.44v2.44h-2.44ZM0.00 92.68h2.44v2.44h-2.44ZM4.88 92.68h2.44v2.44h-2.44ZM7.32 92.68h2.44v2.44h-2.44ZM9.76 92.68h2.44v2.44h-2.44ZM14.63 92.68h2.44v2.44h-2.44ZM21.95 92.68h2.44v2.44h-2.44ZM24.39 92.68h2.44v2.44h-2.44ZM31.71 92.68h2.44v2.44h-2.44ZM34.15 92.68h2.44v2.44h-2.44ZM39.02 92.68h2.44v2.44h-2.44ZM41.46 92.68h2.44v2.44h-2.44ZM43.90 92.68h2.44v2.44h-2.44ZM48.78 92.68h2.44v2.44h-2.44ZM51.22 92.68h2.44v2.44h-2.44ZM56.10 92.68h2.44v2.44h-2.44ZM58.54 92.68h2.44v2.44h-2.44ZM60.98 92.68h2.44v2.44h-2.44ZM63.41 92.68h2.44v2.44h-2.44ZM68.29 92.68h2.44v2.44h-2.44ZM73.17 92.68h2.44v2.44h-2.44ZM75.61 92.68h2.44v2.44h-2.44ZM87.80 92.68h2.44v2.44h-2.44ZM90.24 92.68h2.44v2.44h-2.44ZM92.68 92.68h2.44v2.44h-2.44ZM95.12 92.68h2.44v2.44h-2.44ZM97.56 92.68h2.44v2.44h-2.44ZM0.00 95.12h2.44v2.44h-2.44ZM14.63 95.12h2.44v2.44h-2.44ZM24.39 95.12h2.44v2.44h-2.44ZM26.83 95.12h2.44v2.44h-2.44ZM31.71 95.12h2.44v2.44h-2.44ZM34.15 95.12h2.44v2.44h-2.44ZM36.59 95.12h2.44v2.44h-2.44ZM39.02 95.12h2.44v2.44h-2.44ZM41.46 95.12h2.44v2.44h-2.44ZM43.90 95.12h2.44v2.44h-2.44ZM51.22 95.12h2.44v2.44h-2.44ZM53.66 95.12h2.44v2.44h-2.44ZM60.98 95.12h2.44v2.44h-2.44ZM63.41 95.12h2.44v2.44h-2.44ZM68.29 95.12h2.44v2.44h-2.44ZM70.73 95.12h2.44v2.44h-2.44ZM73.17 95.12h2.44v2.44h-2.44ZM75.61 95.12h2.44v2.44h-2.44ZM78.05 95.12h2.44v2.44h-2.44ZM80.49 95.12h2.44v2.44h-2.44ZM85.37 95.12h2.44v2.44h-2.44ZM95.12 95.12h2.44v2.44h-2.44ZM0.00 97.56h2.44v2.44h-2.44ZM2.44 97.56h2.44v2.44h-2.44ZM4.88 97.56h2.44v2.44h-2.44ZM7.32 97.56h2.44v2.44h-2.44ZM9.76 97.56h2.44v2.44h-2.44ZM12.20 97.56h2.44v2.44h-2.44ZM14.63 97.56h2.44v2.44h-2.44ZM19.51 97.56h2.44v2.44h-2.44ZM24.39 97.56h2.44v2.44h-2.44ZM29.27 97.56h2.44v2.44h-2.44ZM31.71 97.56h2.44v2.44h-2.44ZM34.15 97.56h2.44v2.44h-2.44ZM43.90 97.56h2.44v2.44h-2.44ZM46.34 97.56h2.44v2.44h-2.44ZM48.78 97.56h2.44v2.44h-2.44ZM51.22 97.56h2.44v2.44h-2.44ZM53.66 97.56h2.44v2.44h-2.44ZM58.54 97.56h2.44v2.44h-2.44ZM70.73 97.56h2.44v2.44h-2.44ZM75.61 97.56h2.44v2.44h-2.44ZM78.05 97.56h2.44v2.44h-2.44ZM80.49 97.56h2.44v2.44h-2.44ZM82.93 97.56h2.44v2.44h-2.44ZM85.37 97.56h2.44v2.44h-2.44ZM87.80 97.56h2.44v2.44h-2.44ZM90.24 97.56h2.44v2.44h-2.44ZM92.68 97.56h2.44v2.44h-2.44ZM95.12 97.56h2.44v2.44h-2.44Z" fill="#000000"/>
+  <text x="50" y="122" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#E9EEF8" text-anchor="middle">scan post URL</text>
+</g>
+
 </svg>


### PR DESCRIPTION
## Summary

Replaces the 2026-04-21 weekly digest cover (`assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg`) with a research-grounded, layout-distinct unique design following the 04-20 pilot quality bar.

## Layout chosen: Option I — Three-line Metro/Subway Map

Three parallel horizontal transit lines (y=170, 330, 490), each representing one of the post's real highlights. Five stations per line carry concrete facts pulled from live WebSearch; interchange bridges and running data pulses connect the lines.

**Why this layout:** the pilot branch (`feat/research-based-unique-04-20`, PR #290) used an asymmetric left-hero + two-right-panels composition. Per the "layout 재사용 금지" rule, this cover picks a fundamentally different composition (horizontal transit lines, left-to-right causal reading, no hero panel, no envelope/paper metaphors). Shared markers between the two SVGs: none of 04-20's visual primitives (`envMask`, `appleMail`, `phishMail`, `funnelGrad`, `paperGrad`, `hotRed/hotBlue/hotAmber`); 04-21 introduces new primitives (`metro`, `L1/L2/L3`, `pulseRed/Amber/Cyan`, `dotGrid`, `stationShadow`, `glowRed/Amber/Cyan`).

## WebSearch research (3 queries)

| # | Query | Key findings baked into the SVG |
|---|-------|--------------------------------|
| 1 | `SGLang CVE-2026-5760 CVSS 9.8 GGUF model remote code execution` | CVSS 9.8, Jinja2 SSTI in `tokenizer.chat_template`, `/v1/rerank` endpoint, sandbox escape via Python bypass. Source: thehackernews.com, kb.cert.org VU#915947. |
| 2 | `Vercel hack push fraud QEMU abuse Android RAT April 2026 weekly recap Hacker News` | Chain: Lumma stealer (Feb 2026) -> Context.ai employee creds -> Google Workspace OAuth takeover -> non-sensitive env leak from Vercel. ShinyHunters posed $2M BreachForums sale. Source: thehackernews.com, vercel.com KB, securityweek.com. |
| 3 | `KelpDAO 290 million heist Lazarus hackers DeFi April 2026` | 2 RPC nodes compromised + op-geth binary swap, DDoS failover on DVN 1/1 setup, 116,500 rsETH drained at 17:35 UTC (~\$292M), laundered via Tornado Cash, attributed to Lazarus DPRK / TraderTraitor by LayerZero. Source: bleepingcomputer.com, coindesk.com, securityweek.com. |

## Metrics

| Metric | Value | Target | Status |
|--------|-------|--------|--------|
| Dimensions | 1200x630 | 1200x630 | PASS |
| XML valid | yes | yes | PASS |
| `<title>` element | present (2nd line) | required for check-svg CI | PASS |
| SMIL animations | 87 (80 `<animate>` + 7 `<animateTransform>`) | 80+ | PASS |
| Words in `<text>` | 57 | <=60 | PASS |
| Total text characters | 311 | <=900 (HQ) | PASS |
| Text nodes | 41 | <=45 (HQ via `clipPath` marker) | PASS |
| Font sizes | 11, 12, 13, 14, 16, 17, 18, 20, 30 | primary >=16, sub-label >=14, QR caption >=10 | PASS |
| Korean chars | 0 | 0 | PASS |
| Forbidden chars (bullet, mdash, curly quotes) | 0 | 0 | PASS |
| QR target | `https://tech.2twodragon.com/posts/2026/04/21/Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent/` | actual post URL | PASS |
| File size | 50 KB | n/a | - |
| Lines | 439 | n/a | - |

## Local CI verification

```
$ python3 scripts/check_svg_quality.py --ci assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg
[PASS] assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg
Summary: 1 PASS, 0 WARNING, 0 FAIL / 1 files checked

$ python3 scripts/check_posts.py 2>&1 | grep -E "2026-04-21.*truncated|2026-04-21.*text too dense"
(empty -> CI check-svg gate passes)
```

## Differentiation from 04-20 pilot

04-20 composition: asymmetric left hero (Apple phishing envelope 600x510) + two stacked right panels (NIST CVE funnel 516x248, Palantir manifesto wall 516x248). Visual metaphor: envelope + paper + funnel.

04-21 composition: three full-width horizontal transit lines with five stations each, vertical interchange bridges, moving trains + data pulses. Visual metaphor: subway/metro map, left-to-right causal attack chain reading.

No shared layout primitives or gradients between the two SVGs.

## Test plan

- [ ] check-svg.yml CI workflow passes (`<title>` + 0 SVG warnings)
- [ ] QR scan on mobile resolves to the actual post URL and loads the rendered article
- [ ] Visual: three distinct color-coded lines (red/amber/cyan), station markers readable at 1200x630 preview size
- [ ] Post page OG image renders correctly when shared on Twitter/LinkedIn/Slack

## Scope

- Only `assets/images/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.svg` changed (1 file, +397/-362)
- 04-20 and 04-22 covers untouched (per instruction)
- No post body or include/layout edits