### PR TITLE
fix(svg): add <title> element to 2026-04-05 cover

### DIFF
--- a/assets/images/2026-04-05-Tech_Security_Weekly_Digest_AWS_AI_Security_Malware.svg
+++ b/assets/images/2026-04-05-Tech_Security_Weekly_Digest_AWS_AI_Security_Malware.svg
@@ -1,4 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+<title>Tech Security Weekly Digest - AWS LZA Compliance, Device Code Phishing, Axios npm Hack - April 5, 2026</title>
 <defs>
   <linearGradient id="a05_bg" x1="0" y1="0" x2="0" y2="1">
     <stop offset="0%" stop-color="#0d1117"/><stop offset="50%" stop-color="#0a1025"/><stop offset="100%" stop-color="#070d1a"/>


### PR DESCRIPTION
## Summary
Follow-up to PR #293. The 2026-04-05 dashboard cover SVG was missing a `<title>` element, causing the `check-svg` CI gate to fail. Adding a descriptive title resolves the lint error and improves accessibility.

## Test plan
- [x] `check-svg` lint passes locally (title element present)
- [x] No other SVG changes
- [x] No code changes