### PR TITLE
feat(images): upgrade Jan 22 batch (5 covers) to ultra-tier L22

### DIFF
--- a/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
+++ b/assets/images/2026-01-22-AWS_GCP_Cloud_Updates_January_2026.svg
@@ -1,100 +1,462 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
-  <title>AWS/GCP 2026 1 EC2 G7E/X8I</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="52%" stop-color="#121a2f"/>
-      <stop offset="100%" stop-color="#170f25"/>
-    </linearGradient>
-    <linearGradient id="panel" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.96"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.86"/>
-    </linearGradient>
-    <pattern id="microGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#334155" stroke-width="1" opacity="0.25"/>
-      <circle cx="18" cy="18" r="1.2" fill="#34d399" opacity="0.15"/>
-    </pattern>
-    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="sg" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="36"/>
-    </filter>
-    <filter id="shadow" x="-30%" y="-30%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#microGrid)"/>
-  <circle cx="202" cy="150" r="190" fill="#34d399" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="1020" cy="486" r="220" fill="#059669" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="920" cy="160" r="140" fill="#38bdf8" opacity="0.04" filter="url(#sg)"/>
-  <path d="M0 96 C224 46 426 44 654 118 L654 630 L0 630 Z" fill="#020617" opacity="0.24"/>
-  <path d="M0 526 C248 490 426 486 654 548" fill="none" stroke="#475569" stroke-width="1.2" opacity="0.22"/>
-  <rect x="736" y="104" width="362" height="326" rx="28" fill="url(#panel)" stroke="#34d399" stroke-opacity="0.28" stroke-width="1.4" filter="url(#shadow)"/>
-  <rect x="754" y="122" width="326" height="290" rx="22" fill="none" stroke="#334155" stroke-opacity="0.7" stroke-width="1"/>
-  <rect x="758" y="124" width="108" height="12" rx="6" fill="#34d399" opacity="0.28"/>
-  <rect x="880" y="124" width="72" height="12" rx="6" fill="#334155" opacity="0.55"/>
-  <rect x="964" y="124" width="48" height="12" rx="6" fill="#334155" opacity="0.35"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="AWS GCP Cloud Updates January 2026 EC2 G7e X8i Bangkok Region Sovereign Cloud">
+<title>AWS GCP Jan 2026: EC2 G7e/X8i, Bangkok Region, Sovereign Cloud</title>
+<defs>
+<linearGradient id="bgSpreadag22" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0A1226"/><stop offset="50%" stop-color="#0C1430"/><stop offset="100%" stop-color="#131038"/></linearGradient>
+<linearGradient id="bandAag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2A1A0C"/><stop offset="100%" stop-color="#1E1F0A"/></linearGradient>
+<linearGradient id="bandBag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0A1B35"/><stop offset="100%" stop-color="#0D2040"/></linearGradient>
+<linearGradient id="bandCag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0E2038"/><stop offset="100%" stop-color="#12283F"/></linearGradient>
+<linearGradient id="streakAag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0"/><stop offset="50%" stop-color="#FFB703" stop-opacity="0.85"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakBag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0"/><stop offset="50%" stop-color="#60A5FA" stop-opacity="0.85"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakCag22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0"/><stop offset="50%" stop-color="#4ADE80" stop-opacity="0.85"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></linearGradient>
+<radialGradient id="glowAag22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowBag22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0.55"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowCag22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0.55"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></radialGradient>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%"><feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/><feOffset dx="0" dy="1.5"/><feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<pattern id="ledgerGrid" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse"><path d="M0 20 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/><path d="M40 0 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/></pattern>
+<pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/></pattern>
+<pattern id="hexGridag22" x="0" y="0" width="28" height="32" patternUnits="userSpaceOnUse"><path d="M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+<pattern id="radarRippleag22" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse"><circle cx="30" cy="30" r="14" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+</defs>
+<rect width="1200" height="630" fill="url(#bgSpreadag22)"/>
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandAag22)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="0" width="8" height="210" fill="#FFB703"/>
   
-  <path d="M724 152 C822 126 922 136 1020 202" fill="none" stroke="#f59e0b" stroke-width="1.3" opacity="0.24"/>
-  <path d="M706 420 C782 454 878 462 968 410" fill="none" stroke="#60a5fa" stroke-width="1.2" opacity="0.22"/>
-
-  <g transform="translate(917,270)" filter="url(#shadow)">
-    <circle r="96" fill="#0f172a" stroke="#34d399" stroke-width="2.6" opacity="0.94"/>
-    <circle r="124" fill="none" stroke="#34d399" stroke-opacity="0.15" stroke-width="1.2" stroke-dasharray="8 8"/>
-    <circle r="54" fill="none" stroke="#e2e8f0" stroke-opacity="0.15" stroke-width="1"/>
-
-    <path d="M-30,15 C-50,15 -55,0 -55,-12 C-55,-28 -42,-38 -28,-38 C-22,-52 -8,-60 8,-60 C28,-60 42,-48 44,-38 C56,-38 64,-28 64,-16 C64,0 56,15 38,15 Z" fill="none" stroke="#34d399" stroke-width="3"/>
-    <line x1="-20" y1="30" x2="-20" y2="45" stroke="#34d399" stroke-width="2" opacity="0.5"/>
-    <line x1="10" y1="30" x2="10" y2="50" stroke="#34d399" stroke-width="2" opacity="0.5"/>
-    <line x1="35" y1="30" x2="35" y2="42" stroke="#34d399" stroke-width="2" opacity="0.5"/>
-    <rect x="-30" y="48" width="20" height="14" rx="3" fill="none" stroke="#34d399" stroke-width="1.5" opacity="0.5"/>
-    <rect x="0" y="52" width="20" height="14" rx="3" fill="none" stroke="#34d399" stroke-width="1.5" opacity="0.5"/>
-    <rect x="25" y="45" width="20" height="14" rx="3" fill="none" stroke="#34d399" stroke-width="1.5" opacity="0.5"/>
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FFB703">AWS EC2 LAUNCH</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">G7e Blackwell GPU</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FFD58A">NVIDIA Blackwell B200 · 8x performance vs H100</text>
+    <text x="30" y="144" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E0D5B6">X8i SAP-certified · 16TB memory · in-memory DB tier</text>
+    <text x="30" y="162" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FFD58A">HBM3e 192GB · NVLink 5.0 · Grace Hopper interconnect</text><text x="30" y="178" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#E0D5B6" fill-opacity="0.85">Multi-instance GPU · MIG partitioning supported</text>
+    
   </g>
-  <g transform="translate(84 66)">
-    <rect width="164" height="36" rx="18" fill="#34d399" opacity="0.2" stroke="#34d399" stroke-width="1.2"/>
-    <text x="82" y="23" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#34d399" text-anchor="middle">CLOUD</text>
+  <g transform="translate(690,105)">
+    <g stroke="#FFB703" stroke-width="0.4" stroke-opacity="0.3">
+      <line x1="-90" y1="-50" x2="100" y2="-50"/><line x1="-90" y1="-25" x2="100" y2="-25"/>
+      <line x1="-90" y1="0" x2="100" y2="0"/><line x1="-90" y1="20" x2="100" y2="20"/>
+    </g>
+    <line x1="-85" y1="40" x2="100" y2="40" stroke="#FFB703" stroke-width="1" opacity="0.6"/>
+    <rect x="-75" y="10" width="20" height="30" rx="2" fill="#FFB703" opacity="0.5"><animate attributeName="height" values="20;30;20" dur="1.6s" repeatCount="indefinite"/><animate attributeName="y" values="20;10;20" dur="1.6s" repeatCount="indefinite"/></rect><rect x="-47" y="-15" width="20" height="55" rx="2" fill="#FFB703" opacity="0.58"><animate attributeName="height" values="45;55;45" dur="1.8s" repeatCount="indefinite"/><animate attributeName="y" values="-5;-15;-5" dur="1.8s" repeatCount="indefinite"/></rect><rect x="-19" y="0" width="20" height="40" rx="2" fill="#FFB703" opacity="0.66"><animate attributeName="height" values="30;40;30" dur="2.0s" repeatCount="indefinite"/><animate attributeName="y" values="10;0;10" dur="2.0s" repeatCount="indefinite"/></rect><rect x="9" y="-30" width="20" height="70" rx="2" fill="#FFB703" opacity="0.74"><animate attributeName="height" values="60;70;60" dur="2.2s" repeatCount="indefinite"/><animate attributeName="y" values="-20;-30;-20" dur="2.2s" repeatCount="indefinite"/></rect><rect x="37" y="-45" width="20" height="85" rx="2" fill="#FFB703" opacity="0.8200000000000001"><animate attributeName="height" values="75;85;75" dur="2.4000000000000004s" repeatCount="indefinite"/><animate attributeName="y" values="-35;-45;-35" dur="2.4000000000000004s" repeatCount="indefinite"/></rect><rect x="65" y="-22" width="20" height="62" rx="2" fill="#FFB703" opacity="0.9"><animate attributeName="height" values="52;62;52" dur="2.6s" repeatCount="indefinite"/><animate attributeName="y" values="-12;-22;-12" dur="2.6s" repeatCount="indefinite"/></rect>
+    <path d="M-78 -8 L-50 -22 L-22 -18 L6 -38 L34 -52 L62 -64" stroke="#FCD34D" stroke-width="1.6" fill="none" stroke-opacity="0.7" stroke-dasharray="3 3">
+      <animate attributeName="stroke-dashoffset" values="0;-12" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="62,-64 70,-58 64,-50" fill="#FCD34D"/>
+    <g fill="#FCD34D" opacity="0.75">
+      <circle cx="-90" cy="-50" r="1.5"/><circle cx="-90" cy="-25" r="1.5"/><circle cx="-90" cy="0" r="1.5"/>
+    </g>
+    <g fill="#FFB703" opacity="0.7">
+      <rect x="-95" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></rect>
+      <rect x="-85" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></rect>
+      <rect x="-75" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></rect>
+    </g>
+    <g fill="#FCD34D" opacity="0.65">
+      <circle cx="100" cy="-50" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="-25" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="0" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FFB703" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-90" y1="48" x2="100" y2="48"><animate attributeName="stroke-opacity" values="0.2;0.6;0.2" dur="2s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-90" y="-56" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FFB703" opacity="0.7">peak</text>
+    <text x="100" y="-56" text-anchor="end" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FFB703" opacity="0.7">+24%</text>
+    <text y="58" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FCD34D">GPU</text>
+    <text y="72" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCD34D" opacity="0.7">6 buckets : qoq trend</text>
   </g>
-  <text x="84" y="170" font-family="Arial,sans-serif" font-size="54" font-weight="700" fill="#f8fafc" letter-spacing="0.5">AWS/GCP 2026 1 EC2</text>
-  <text x="84" y="232" font-family="Arial,sans-serif" font-size="52" font-weight="700" fill="#dbeafe" letter-spacing="0.5">G7E/X8I</text>
-  <text x="84" y="288" font-family="Arial,sans-serif" font-size="18" fill="#cbd5e1">CLOUD / FINOPS / AWS</text>
-  <rect x="84" y="314" width="520" height="1.5" fill="#334155" opacity="0.9"/>
-  <text x="84" y="344" font-family="Arial,sans-serif" font-size="14" font-weight="700" fill="#94a3b8">VISUAL SYSTEM 09E3F693A1F8</text>
-  <text x="84" y="372" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">AWS and GCP cloud platform updates for January 2026: EC2 G7e/X8i instances, GPU architecture, and cloud security changes.</text>
-  <g transform="translate(84 474)">
-    <rect width="110" height="38" rx="19" fill="#34d399" opacity="0.16" stroke="#34d399" stroke-width="1.2"/>
-    <text x="55.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">CLOUD</text>
+  <g transform="translate(870,105)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#FFB703">SAP CERT</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">X8i</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFD58A">HANA ready</text>
   </g>
-  <g transform="translate(208 474)">
-    <rect width="110" height="38" rx="19" fill="#34d399" opacity="0.16" stroke="#34d399" stroke-width="1.2"/>
-    <text x="55.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">FINOPS</text>
+  <g transform="translate(1110,105)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#FFB703">VS H100</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">8x</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FFD58A">throughput</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#FFB703" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCD34D"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
   </g>
-  <g transform="translate(332 474)">
-    <rect width="110" height="38" rx="19" fill="#34d399" opacity="0.16" stroke="#34d399" stroke-width="1.2"/>
-    <text x="55.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">AWS</text>
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E1805" stroke="#FFB703" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FFB703">EC2 INSTANCE</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">G7e</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD58A">Blackwell</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#FFB703" stroke-width="0.8" stroke-opacity="0.5"/>
+    
   </g>
-  <g transform="translate(84 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#34d399" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">CATEGORY</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">CLOUD</text>
+  <g transform="translate(990,105)">
+    <circle cx="10" cy="-50" r="3" fill="#FFB703"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
   </g>
-  <g transform="translate(246 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#34d399" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">SIGNALS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">05</text>
+  <g opacity="0.85">
+    <line x1="20" y1="210" x2="1180" y2="210" stroke="#FFB703" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="210" r="2.2" fill="#FFB703">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <g transform="translate(408 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#34d399" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">TAGS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">12</text>
+</g>
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandBag22)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="210" width="8" height="210" fill="#60A5FA"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#93C5FD">GCP REGION</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Bangkok · asia-southeast2</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#BFDBFE">3 AZ · low latency for SE Asia financial sector</text>
+    <text x="30" y="354" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D0DCF0">Gemini 3 Flash model · BigQuery edge analytics</text>
+    <text x="30" y="372" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#BFDBFE">BigQuery · Cloud Run · Vertex AI all available</text><text x="30" y="388" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D0DCF0" fill-opacity="0.85">VPC global · cross-region replication included</text>
+    
   </g>
-  <g transform="translate(1030 74)">
-    <rect width="130" height="34" rx="17" fill="#1d4ed8" opacity="0.18" stroke="#3b82f6" stroke-width="1.2"/>
-    <text x="65" y="22" font-family="Arial,sans-serif" font-size="12" font-weight="700" fill="#bfdbfe" text-anchor="middle">April 14, 2026</text>
+  <g transform="translate(690,315)">
+    <circle r="80" fill="#60A5FA" fill-opacity="0.06"><animate attributeName="r" values="64;86;64" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-60 0 Q-70 -25 -45 -30 Q-40 -50 -10 -45 Q10 -60 30 -45 Q55 -50 60 -20 Q80 -15 70 10 Q65 25 40 25 L-40 25 Q-70 25 -60 0 Z" fill="#60A5FA" fill-opacity="0.12" stroke="#60A5FA" stroke-width="1.8"/>
+    <g fill="#60A5FA" stroke="#93C5FD" stroke-width="1.2">
+      <polygon points="-30,-10 -18,-17 -6,-10 -6,4 -18,11 -30,4"/>
+      <polygon points="0,-10 12,-17 24,-10 24,4 12,11 0,4"/>
+      <polygon points="-15,10 -3,3 9,10 9,24 -3,31 -15,24"/>
+    </g>
+    <g fill="#93C5FD">
+      <circle cx="-18" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="12" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-3" cy="17" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#FFF">
+      <circle r="1.6"><animateMotion path="M-18 -3 L12 -3" dur="2.4s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M12 -3 L-3 17" dur="2.2s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M-3 17 L-18 -3" dur="2.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#93C5FD" opacity="0.6">
+      <circle cx="-50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="1.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#60A5FA" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-90" y1="-58" x2="-78" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" repeatCount="indefinite"/></line>
+      <line x1="78" y1="-58" x2="90" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.4s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-86" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD" opacity="0.7">3 pods</text>
+    <text x="86" y="-58" text-anchor="end" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD" opacity="0.7">healthy</text>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#60A5FA">K8s CLOUD</text>
+    <text y="74" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#93C5FD" opacity="0.7">3 nodes : workload identity</text>
   </g>
-  <line x1="50" y1="588" x2="1150" y2="588" stroke="#334155" stroke-width="1" opacity="0.5"/>
-  <text x="1150" y="612" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <g transform="translate(870,315)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#93C5FD">AVAIL ZONES</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">3</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#BFDBFE">HA setup</text>
+  </g>
+  <g transform="translate(1110,315)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#93C5FD">GEMINI</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">G3</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#BFDBFE">Flash model</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#60A5FA" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#93C5FD"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1628" stroke="#60A5FA" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#93C5FD">NEW REGION</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">BKK</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#BFDBFE">GCP</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#60A5FA" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,315)">
+    <circle cx="10" cy="-50" r="3" fill="#60A5FA"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g opacity="0.85">
+    <line x1="20" y1="420" x2="1180" y2="420" stroke="#60A5FA" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="420" r="2.2" fill="#60A5FA">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandCag22)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#4ADE80"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#4ADE80">DATA SOVEREIGNTY</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">EU Sovereign Cloud</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#9FD3B0">GDPR-aligned · EU-only key management · isolated control</text>
+    <text x="30" y="564" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">French · German · Italian datacenter regions covered</text>
+    <text x="30" y="582" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0">FedRAMP · IL5 · BSI C5 compliance roadmap aligned</text><text x="30" y="598" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#BFC9D9" fill-opacity="0.85">Migration tooling · S3/Cloud Storage cross-account</text>
+    
+  </g>
+  <g transform="translate(690,525)">
+    <circle r="78" fill="#4ADE80" fill-opacity="0.05"><animate attributeName="r" values="68;84;68" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M0 -60 L55 -40 L50 25 Q40 55 0 65 Q-40 55 -50 25 L-55 -40 Z" fill="#4ADE80" fill-opacity="0.15" stroke="#4ADE80" stroke-width="2.4" filter="url(#softShadow)"/>
+    <path d="M0 -50 L45 -33 L40 22 Q32 46 0 55 Q-32 46 -40 22 L-45 -33 Z" fill="none" stroke="#86EFAC" stroke-width="1" opacity="0.7"/>
+    <path d="M0 -40 L35 -26 L31 18 Q24 38 0 45 Q-24 38 -31 18 L-35 -26 Z" fill="none" stroke="#86EFAC" stroke-width="0.6" opacity="0.5"/>
+    <g transform="translate(0,-5)" stroke="#86EFAC" stroke-width="3" fill="none">
+      <path d="M-18 5 L-4 20 L22 -12"><animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#86EFAC" opacity="0.7">
+      <circle cx="-40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.2s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#86EFAC" opacity="0.55">
+      <circle cx="-65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#4ADE80" stroke-width="0.4" stroke-opacity="0.35" fill="none">
+      <path d="M-78 -68 L-66 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2s" repeatCount="indefinite"/></path>
+      <path d="M66 -68 L78 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2.3s" begin="0.4s" repeatCount="indefinite"/></path>
+    </g>
+    <text x="-78" y="-72" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#86EFAC" opacity="0.7">verified</text>
+    <text y="84" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#4ADE80">GDPR</text>
+    <text y="98" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#86EFAC" opacity="0.7">3 rings : signed by CA</text>
+  </g>
+  <g transform="translate(870,525)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#4ADE80">EU CITIZEN</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">100%</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#9FD3B0">operators</text>
+  </g>
+  <g transform="translate(1110,525)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#4ADE80">LOCAL KEY</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">KMS</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#9FD3B0">EU only</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#4ADE80" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#86EFAC"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1B2E" stroke="#4ADE80" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#4ADE80">SOVEREIGN</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">EU</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#9FD3B0">control</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#4ADE80" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,525)">
+    <circle cx="10" cy="-50" r="3" fill="#4ADE80"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  
+</g>
+<g opacity="0.9">
+  <g fill="#FFB703">
+    <circle cx="240" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="35" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="175" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="27" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="81" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="129" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.6">
+    <rect x="780" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCD34D" opacity="0.85">
+    <rect x="730" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#FFB703" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 95 L28 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 125 L28 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 155 L28 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 185 L28 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 95 L1172 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 125 L1172 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 155 L1172 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 185 L1172 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCD34D" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="105" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="105" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.55">
+    <rect x="120" y="15" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="195" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#60A5FA">
+    <circle cx="240" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="245" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="385" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="237" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="291" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="339" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.6">
+    <rect x="780" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#93C5FD" opacity="0.85">
+    <rect x="730" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#60A5FA" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 305 L28 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 335 L28 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 365 L28 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 395 L28 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 305 L1172 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 335 L1172 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 365 L1172 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 395 L1172 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#93C5FD" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="315" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="315" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.55">
+    <rect x="120" y="225" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="405" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#4ADE80">
+    <circle cx="240" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="455" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="595" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="447" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="501" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="549" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.6">
+    <rect x="780" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#86EFAC" opacity="0.85">
+    <rect x="730" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#4ADE80" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 515 L28 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 545 L28 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 575 L28 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 605 L28 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 515 L1172 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 545 L1172 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 575 L1172 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 605 L1172 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#86EFAC" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="525" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="525" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.55">
+    <rect x="120" y="435" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="615" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+<g opacity="0.85">
+  <g fill="#FFB703" opacity="0.7">
+    <circle cx="500" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="1.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.7">
+    <circle cx="500" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.7">
+    <circle cx="500" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.4s" begin="1.1s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke-width="0.5" stroke-opacity="0.4" fill="none">
+    <rect x="700" y="40" width="36" height="2" fill="#FFB703" stroke="none"><animate attributeName="x" values="700;1000;700" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.4s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="250" width="36" height="2" fill="#60A5FA" stroke="none"><animate attributeName="x" values="1000;700;1000" dur="6.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.8s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="460" width="36" height="2" fill="#4ADE80" stroke="none"><animate attributeName="x" values="700;1000;700" dur="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="7.2s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCD34D" opacity="0.6">
+    <circle cx="60" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="270" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke="#93C5FD" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+    <line x1="640" y1="200" x2="640" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="200" x2="660" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.4s" repeatCount="indefinite"/></line>
+    <line x1="640" y1="410" x2="640" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.0s" begin="0.7s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="410" x2="660" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="1.1s" repeatCount="indefinite"/></line>
+  </g>
+</g>
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <path fill="#0A1020" d="M0.0 0.0h12.0v1.714h-12.0z M13.714 0.0h1.714v1.714h-1.714z M24.0 0.0h1.714v1.714h-1.714z M27.429 0.0h3.429v1.714h-3.429z M32.571 0.0h3.429v1.714h-3.429z M37.714 0.0h1.714v1.714h-1.714z M41.143 0.0h1.714v1.714h-1.714z M44.571 0.0h1.714v1.714h-1.714z M48.0 0.0h1.714v1.714h-1.714z M51.429 0.0h1.714v1.714h-1.714z M58.286 0.0h1.714v1.714h-1.714z M61.714 0.0h3.429v1.714h-3.429z M68.571 0.0h1.714v1.714h-1.714z M72.0 0.0h12.0v1.714h-12.0z M0.0 1.714h1.714v1.714h-1.714z M10.286 1.714h1.714v1.714h-1.714z M13.714 1.714h3.429v1.714h-3.429z M20.571 1.714h1.714v1.714h-1.714z M24.0 1.714h6.857v1.714h-6.857z M32.571 1.714h1.714v1.714h-1.714z M37.714 1.714h6.857v1.714h-6.857z M46.286 1.714h5.143v1.714h-5.143z M58.286 1.714h1.714v1.714h-1.714z M65.143 1.714h5.143v1.714h-5.143z M72.0 1.714h1.714v1.714h-1.714z M82.286 1.714h1.714v1.714h-1.714z M0.0 3.429h1.714v1.714h-1.714z M3.429 3.429h5.143v1.714h-5.143z M10.286 3.429h1.714v1.714h-1.714z M13.714 3.429h1.714v1.714h-1.714z M20.571 3.429h1.714v1.714h-1.714z M24.0 3.429h1.714v1.714h-1.714z M29.143 3.429h1.714v1.714h-1.714z M32.571 3.429h6.857v1.714h-6.857z M41.143 3.429h1.714v1.714h-1.714z M44.571 3.429h3.429v1.714h-3.429z M49.714 3.429h1.714v1.714h-1.714z M53.143 3.429h3.429v1.714h-3.429z M58.286 3.429h1.714v1.714h-1.714z M61.714 3.429h3.429v1.714h-3.429z M66.857 3.429h3.429v1.714h-3.429z M72.0 3.429h1.714v1.714h-1.714z M75.429 3.429h5.143v1.714h-5.143z M82.286 3.429h1.714v1.714h-1.714z M0.0 5.143h1.714v1.714h-1.714z M3.429 5.143h5.143v1.714h-5.143z M10.286 5.143h1.714v1.714h-1.714z M15.429 5.143h1.714v1.714h-1.714z M18.857 5.143h3.429v1.714h-3.429z M24.0 5.143h3.429v1.714h-3.429z M30.857 5.143h1.714v1.714h-1.714z M34.286 5.143h6.857v1.714h-6.857z M42.857 5.143h1.714v1.714h-1.714z M46.286 5.143h5.143v1.714h-5.143z M53.143 5.143h5.143v1.714h-5.143z M60.0 5.143h5.143v1.714h-5.143z M66.857 5.143h1.714v1.714h-1.714z M72.0 5.143h1.714v1.714h-1.714z M75.429 5.143h5.143v1.714h-5.143z M82.286 5.143h1.714v1.714h-1.714z M0.0 6.857h1.714v1.714h-1.714z M3.429 6.857h5.143v1.714h-5.143z M10.286 6.857h1.714v1.714h-1.714z M13.714 6.857h1.714v1.714h-1.714z M17.143 6.857h1.714v1.714h-1.714z M20.571 6.857h1.714v1.714h-1.714z M24.0 6.857h3.429v1.714h-3.429z M30.857 6.857h3.429v1.714h-3.429z M36.0 6.857h10.286v1.714h-10.286z M48.0 6.857h1.714v1.714h-1.714z M51.429 6.857h1.714v1.714h-1.714z M54.857 6.857h1.714v1.714h-1.714z M63.429 6.857h1.714v1.714h-1.714z M72.0 6.857h1.714v1.714h-1.714z M75.429 6.857h5.143v1.714h-5.143z M82.286 6.857h1.714v1.714h-1.714z M0.0 8.571h1.714v1.714h-1.714z M10.286 8.571h1.714v1.714h-1.714z M15.429 8.571h3.429v1.714h-3.429z M25.714 8.571h3.429v1.714h-3.429z M30.857 8.571h1.714v1.714h-1.714z M34.286 8.571h5.143v1.714h-5.143z M44.571 8.571h6.857v1.714h-6.857z M54.857 8.571h1.714v1.714h-1.714z M65.143 8.571h1.714v1.714h-1.714z M72.0 8.571h1.714v1.714h-1.714z M82.286 8.571h1.714v1.714h-1.714z M0.0 10.286h12.0v1.714h-12.0z M13.714 10.286h1.714v1.714h-1.714z M17.143 10.286h1.714v1.714h-1.714z M20.571 10.286h1.714v1.714h-1.714z M24.0 10.286h1.714v1.714h-1.714z M27.429 10.286h1.714v1.714h-1.714z M30.857 10.286h1.714v1.714h-1.714z M34.286 10.286h1.714v1.714h-1.714z M37.714 10.286h1.714v1.714h-1.714z M41.143 10.286h1.714v1.714h-1.714z M44.571 10.286h1.714v1.714h-1.714z M48.0 10.286h1.714v1.714h-1.714z M51.429 10.286h1.714v1.714h-1.714z M54.857 10.286h1.714v1.714h-1.714z M58.286 10.286h1.714v1.714h-1.714z M61.714 10.286h1.714v1.714h-1.714z M65.143 10.286h1.714v1.714h-1.714z M68.571 10.286h1.714v1.714h-1.714z M72.0 10.286h12.0v1.714h-12.0z M20.571 12.0h1.714v1.714h-1.714z M25.714 12.0h1.714v1.714h-1.714z M29.143 12.0h1.714v1.714h-1.714z M36.0 12.0h3.429v1.714h-3.429z M44.571 12.0h3.429v1.714h-3.429z M49.714 12.0h1.714v1.714h-1.714z M54.857 12.0h3.429v1.714h-3.429z M60.0 12.0h8.571v1.714h-8.571z M0.0 13.714h1.714v1.714h-1.714z M5.143 13.714h10.286v1.714h-10.286z M18.857 13.714h1.714v1.714h-1.714z M24.0 13.714h3.429v1.714h-3.429z M37.714 13.714h8.571v1.714h-8.571z M48.0 13.714h3.429v1.714h-3.429z M60.0 13.714h3.429v1.714h-3.429z M66.857 13.714h1.714v1.714h-1.714z M70.286 13.714h1.714v1.714h-1.714z M75.429 13.714h1.714v1.714h-1.714z M78.857 13.714h5.143v1.714h-5.143z M1.714 15.429h1.714v1.714h-1.714z M5.143 15.429h1.714v1.714h-1.714z M8.571 15.429h1.714v1.714h-1.714z M13.714 15.429h3.429v1.714h-3.429z M18.857 15.429h1.714v1.714h-1.714z M22.286 15.429h1.714v1.714h-1.714z M25.714 15.429h3.429v1.714h-3.429z M30.857 15.429h5.143v1.714h-5.143z M37.714 15.429h1.714v1.714h-1.714z M42.857 15.429h3.429v1.714h-3.429z M48.0 15.429h5.143v1.714h-5.143z M54.857 15.429h8.571v1.714h-8.571z M65.143 15.429h13.714v1.714h-13.714z M80.571 15.429h1.714v1.714h-1.714z M0.0 17.143h5.143v1.714h-5.143z M6.857 17.143h1.714v1.714h-1.714z M10.286 17.143h1.714v1.714h-1.714z M18.857 17.143h3.429v1.714h-3.429z M24.0 17.143h6.857v1.714h-6.857z M36.0 17.143h3.429v1.714h-3.429z M49.714 17.143h3.429v1.714h-3.429z M54.857 17.143h1.714v1.714h-1.714z M60.0 17.143h3.429v1.714h-3.429z M68.571 17.143h3.429v1.714h-3.429z M73.714 17.143h6.857v1.714h-6.857z M82.286 17.143h1.714v1.714h-1.714z M1.714 18.857h1.714v1.714h-1.714z M6.857 18.857h3.429v1.714h-3.429z M13.714 18.857h1.714v1.714h-1.714z M17.143 18.857h3.429v1.714h-3.429z M24.0 18.857h3.429v1.714h-3.429z M29.143 18.857h1.714v1.714h-1.714z M32.571 18.857h6.857v1.714h-6.857z M41.143 18.857h5.143v1.714h-5.143z M49.714 18.857h1.714v1.714h-1.714z M54.857 18.857h5.143v1.714h-5.143z M63.429 18.857h1.714v1.714h-1.714z M68.571 18.857h3.429v1.714h-3.429z M73.714 18.857h1.714v1.714h-1.714z M77.143 18.857h6.857v1.714h-6.857z M6.857 20.571h1.714v1.714h-1.714z M10.286 20.571h3.429v1.714h-3.429z M25.714 20.571h1.714v1.714h-1.714z M29.143 20.571h3.429v1.714h-3.429z M34.286 20.571h3.429v1.714h-3.429z M41.143 20.571h1.714v1.714h-1.714z M46.286 20.571h3.429v1.714h-3.429z M51.429 20.571h1.714v1.714h-1.714z M54.857 20.571h1.714v1.714h-1.714z M61.714 20.571h3.429v1.714h-3.429z M70.286 20.571h1.714v1.714h-1.714z M75.429 20.571h1.714v1.714h-1.714z M80.571 20.571h3.429v1.714h-3.429z M1.714 22.286h1.714v1.714h-1.714z M8.571 22.286h1.714v1.714h-1.714z M13.714 22.286h5.143v1.714h-5.143z M20.571 22.286h1.714v1.714h-1.714z M24.0 22.286h1.714v1.714h-1.714z M29.143 22.286h6.857v1.714h-6.857z M39.429 22.286h1.714v1.714h-1.714z M44.571 22.286h3.429v1.714h-3.429z M49.714 22.286h3.429v1.714h-3.429z M61.714 22.286h1.714v1.714h-1.714z M65.143 22.286h1.714v1.714h-1.714z M72.0 22.286h1.714v1.714h-1.714z M75.429 22.286h3.429v1.714h-3.429z M80.571 22.286h1.714v1.714h-1.714z M0.0 24.0h1.714v1.714h-1.714z M3.429 24.0h1.714v1.714h-1.714z M6.857 24.0h1.714v1.714h-1.714z M10.286 24.0h6.857v1.714h-6.857z M20.571 24.0h3.429v1.714h-3.429z M30.857 24.0h1.714v1.714h-1.714z M37.714 24.0h3.429v1.714h-3.429z M49.714 24.0h3.429v1.714h-3.429z M60.0 24.0h3.429v1.714h-3.429z M66.857 24.0h1.714v1.714h-1.714z M73.714 24.0h3.429v1.714h-3.429z M78.857 24.0h5.143v1.714h-5.143z M0.0 25.714h5.143v1.714h-5.143z M6.857 25.714h1.714v1.714h-1.714z M15.429 25.714h1.714v1.714h-1.714z M18.857 25.714h3.429v1.714h-3.429z M29.143 25.714h1.714v1.714h-1.714z M34.286 25.714h1.714v1.714h-1.714z M37.714 25.714h1.714v1.714h-1.714z M49.714 25.714h3.429v1.714h-3.429z M56.571 25.714h3.429v1.714h-3.429z M63.429 25.714h1.714v1.714h-1.714z M68.571 25.714h1.714v1.714h-1.714z M72.0 25.714h3.429v1.714h-3.429z M77.143 25.714h3.429v1.714h-3.429z M82.286 25.714h1.714v1.714h-1.714z M0.0 27.429h6.857v1.714h-6.857z M10.286 27.429h1.714v1.714h-1.714z M13.714 27.429h1.714v1.714h-1.714z M20.571 27.429h1.714v1.714h-1.714z M24.0 27.429h3.429v1.714h-3.429z M29.143 27.429h1.714v1.714h-1.714z M41.143 27.429h3.429v1.714h-3.429z M51.429 27.429h5.143v1.714h-5.143z M58.286 27.429h1.714v1.714h-1.714z M61.714 27.429h3.429v1.714h-3.429z M68.571 27.429h3.429v1.714h-3.429z M75.429 27.429h1.714v1.714h-1.714z M78.857 27.429h3.429v1.714h-3.429z M0.0 29.143h1.714v1.714h-1.714z M3.429 29.143h3.429v1.714h-3.429z M13.714 29.143h1.714v1.714h-1.714z M17.143 29.143h1.714v1.714h-1.714z M20.571 29.143h5.143v1.714h-5.143z M29.143 29.143h5.143v1.714h-5.143z M36.0 29.143h8.571v1.714h-8.571z M48.0 29.143h1.714v1.714h-1.714z M51.429 29.143h1.714v1.714h-1.714z M56.571 29.143h3.429v1.714h-3.429z M61.714 29.143h3.429v1.714h-3.429z M68.571 29.143h5.143v1.714h-5.143z M77.143 29.143h3.429v1.714h-3.429z M1.714 30.857h3.429v1.714h-3.429z M6.857 30.857h1.714v1.714h-1.714z M10.286 30.857h3.429v1.714h-3.429z M15.429 30.857h1.714v1.714h-1.714z M18.857 30.857h1.714v1.714h-1.714z M22.286 30.857h5.143v1.714h-5.143z M29.143 30.857h3.429v1.714h-3.429z M36.0 30.857h3.429v1.714h-3.429z M41.143 30.857h3.429v1.714h-3.429z M48.0 30.857h3.429v1.714h-3.429z M56.571 30.857h1.714v1.714h-1.714z M61.714 30.857h1.714v1.714h-1.714z M66.857 30.857h3.429v1.714h-3.429z M73.714 30.857h6.857v1.714h-6.857z M82.286 30.857h1.714v1.714h-1.714z M0.0 32.571h5.143v1.714h-5.143z M6.857 32.571h1.714v1.714h-1.714z M12.0 32.571h1.714v1.714h-1.714z M15.429 32.571h3.429v1.714h-3.429z M20.571 32.571h8.571v1.714h-8.571z M30.857 32.571h1.714v1.714h-1.714z M39.429 32.571h1.714v1.714h-1.714z M48.0 32.571h3.429v1.714h-3.429z M56.571 32.571h10.286v1.714h-10.286z M70.286 32.571h1.714v1.714h-1.714z M77.143 32.571h1.714v1.714h-1.714z M80.571 32.571h3.429v1.714h-3.429z M0.0 34.286h12.0v1.714h-12.0z M13.714 34.286h1.714v1.714h-1.714z M17.143 34.286h3.429v1.714h-3.429z M22.286 34.286h1.714v1.714h-1.714z M25.714 34.286h3.429v1.714h-3.429z M32.571 34.286h1.714v1.714h-1.714z M36.0 34.286h1.714v1.714h-1.714z M39.429 34.286h5.143v1.714h-5.143z M48.0 34.286h1.714v1.714h-1.714z M53.143 34.286h1.714v1.714h-1.714z M60.0 34.286h3.429v1.714h-3.429z M65.143 34.286h3.429v1.714h-3.429z M70.286 34.286h1.714v1.714h-1.714z M73.714 34.286h1.714v1.714h-1.714z M80.571 34.286h3.429v1.714h-3.429z M0.0 36.0h6.857v1.714h-6.857z M15.429 36.0h1.714v1.714h-1.714z M20.571 36.0h1.714v1.714h-1.714z M25.714 36.0h1.714v1.714h-1.714z M29.143 36.0h1.714v1.714h-1.714z M32.571 36.0h8.571v1.714h-8.571z M44.571 36.0h1.714v1.714h-1.714z M51.429 36.0h1.714v1.714h-1.714z M54.857 36.0h5.143v1.714h-5.143z M63.429 36.0h6.857v1.714h-6.857z M72.0 36.0h3.429v1.714h-3.429z M78.857 36.0h1.714v1.714h-1.714z M3.429 37.714h1.714v1.714h-1.714z M6.857 37.714h10.286v1.714h-10.286z M25.714 37.714h3.429v1.714h-3.429z M30.857 37.714h3.429v1.714h-3.429z M36.0 37.714h10.286v1.714h-10.286z M48.0 37.714h3.429v1.714h-3.429z M56.571 37.714h6.857v1.714h-6.857z M66.857 37.714h10.286v1.714h-10.286z M78.857 37.714h1.714v1.714h-1.714z M82.286 37.714h1.714v1.714h-1.714z M3.429 39.429h1.714v1.714h-1.714z M6.857 39.429h1.714v1.714h-1.714z M13.714 39.429h1.714v1.714h-1.714z M17.143 39.429h3.429v1.714h-3.429z M24.0 39.429h5.143v1.714h-5.143z M30.857 39.429h5.143v1.714h-5.143z M37.714 39.429h1.714v1.714h-1.714z M44.571 39.429h1.714v1.714h-1.714z M49.714 39.429h5.143v1.714h-5.143z M58.286 39.429h8.571v1.714h-8.571z M68.571 39.429h1.714v1.714h-1.714z M75.429 39.429h1.714v1.714h-1.714z M78.857 39.429h1.714v1.714h-1.714z M82.286 39.429h1.714v1.714h-1.714z M5.143 41.143h3.429v1.714h-3.429z M10.286 41.143h1.714v1.714h-1.714z M13.714 41.143h1.714v1.714h-1.714z M17.143 41.143h1.714v1.714h-1.714z M24.0 41.143h1.714v1.714h-1.714z M29.143 41.143h1.714v1.714h-1.714z M36.0 41.143h3.429v1.714h-3.429z M41.143 41.143h1.714v1.714h-1.714z M44.571 41.143h1.714v1.714h-1.714z M48.0 41.143h1.714v1.714h-1.714z M54.857 41.143h1.714v1.714h-1.714z M61.714 41.143h1.714v1.714h-1.714z M68.571 41.143h1.714v1.714h-1.714z M72.0 41.143h1.714v1.714h-1.714z M75.429 41.143h3.429v1.714h-3.429z M80.571 41.143h3.429v1.714h-3.429z M0.0 42.857h1.714v1.714h-1.714z M3.429 42.857h5.143v1.714h-5.143z M13.714 42.857h1.714v1.714h-1.714z M17.143 42.857h3.429v1.714h-3.429z M24.0 42.857h6.857v1.714h-6.857z M34.286 42.857h5.143v1.714h-5.143z M44.571 42.857h3.429v1.714h-3.429z M49.714 42.857h3.429v1.714h-3.429z M56.571 42.857h1.714v1.714h-1.714z M60.0 42.857h1.714v1.714h-1.714z M63.429 42.857h3.429v1.714h-3.429z M68.571 42.857h1.714v1.714h-1.714z M75.429 42.857h3.429v1.714h-3.429z M80.571 42.857h1.714v1.714h-1.714z M0.0 44.571h15.429v1.714h-15.429z M17.143 44.571h6.857v1.714h-6.857z M25.714 44.571h1.714v1.714h-1.714z M29.143 44.571h3.429v1.714h-3.429z M37.714 44.571h8.571v1.714h-8.571z M48.0 44.571h1.714v1.714h-1.714z M53.143 44.571h1.714v1.714h-1.714z M58.286 44.571h3.429v1.714h-3.429z M65.143 44.571h1.714v1.714h-1.714z M68.571 44.571h8.571v1.714h-8.571z M78.857 44.571h5.143v1.714h-5.143z M0.0 46.286h3.429v1.714h-3.429z M5.143 46.286h1.714v1.714h-1.714z M12.0 46.286h6.857v1.714h-6.857z M29.143 46.286h6.857v1.714h-6.857z M37.714 46.286h3.429v1.714h-3.429z M44.571 46.286h1.714v1.714h-1.714z M49.714 46.286h1.714v1.714h-1.714z M56.571 46.286h5.143v1.714h-5.143z M63.429 46.286h1.714v1.714h-1.714z M70.286 46.286h1.714v1.714h-1.714z M75.429 46.286h6.857v1.714h-6.857z M1.714 48.0h3.429v1.714h-3.429z M6.857 48.0h6.857v1.714h-6.857z M15.429 48.0h10.286v1.714h-10.286z M29.143 48.0h1.714v1.714h-1.714z M34.286 48.0h5.143v1.714h-5.143z M41.143 48.0h1.714v1.714h-1.714z M44.571 48.0h1.714v1.714h-1.714z M53.143 48.0h3.429v1.714h-3.429z M58.286 48.0h1.714v1.714h-1.714z M61.714 48.0h3.429v1.714h-3.429z M66.857 48.0h6.857v1.714h-6.857z M77.143 48.0h3.429v1.714h-3.429z M0.0 49.714h3.429v1.714h-3.429z M6.857 49.714h3.429v1.714h-3.429z M15.429 49.714h3.429v1.714h-3.429z M20.571 49.714h5.143v1.714h-5.143z M29.143 49.714h1.714v1.714h-1.714z M32.571 49.714h3.429v1.714h-3.429z M39.429 49.714h8.571v1.714h-8.571z M51.429 49.714h3.429v1.714h-3.429z M56.571 49.714h5.143v1.714h-5.143z M63.429 49.714h1.714v1.714h-1.714z M66.857 49.714h1.714v1.714h-1.714z M72.0 49.714h3.429v1.714h-3.429z M78.857 49.714h3.429v1.714h-3.429z M0.0 51.429h1.714v1.714h-1.714z M3.429 51.429h1.714v1.714h-1.714z M6.857 51.429h1.714v1.714h-1.714z M10.286 51.429h1.714v1.714h-1.714z M13.714 51.429h1.714v1.714h-1.714z M20.571 51.429h1.714v1.714h-1.714z M24.0 51.429h5.143v1.714h-5.143z M32.571 51.429h1.714v1.714h-1.714z M41.143 51.429h1.714v1.714h-1.714z M44.571 51.429h1.714v1.714h-1.714z M49.714 51.429h8.571v1.714h-8.571z M60.0 51.429h6.857v1.714h-6.857z M72.0 51.429h6.857v1.714h-6.857z M82.286 51.429h1.714v1.714h-1.714z M0.0 53.143h8.571v1.714h-8.571z M13.714 53.143h1.714v1.714h-1.714z M20.571 53.143h5.143v1.714h-5.143z M27.429 53.143h1.714v1.714h-1.714z M30.857 53.143h1.714v1.714h-1.714z M36.0 53.143h1.714v1.714h-1.714z M41.143 53.143h3.429v1.714h-3.429z M46.286 53.143h8.571v1.714h-8.571z M56.571 53.143h3.429v1.714h-3.429z M65.143 53.143h3.429v1.714h-3.429z M73.714 53.143h5.143v1.714h-5.143z M80.571 53.143h1.714v1.714h-1.714z M0.0 54.857h5.143v1.714h-5.143z M10.286 54.857h1.714v1.714h-1.714z M18.857 54.857h3.429v1.714h-3.429z M24.0 54.857h1.714v1.714h-1.714z M27.429 54.857h1.714v1.714h-1.714z M30.857 54.857h5.143v1.714h-5.143z M39.429 54.857h3.429v1.714h-3.429z M48.0 54.857h1.714v1.714h-1.714z M51.429 54.857h1.714v1.714h-1.714z M56.571 54.857h1.714v1.714h-1.714z M60.0 54.857h12.0v1.714h-12.0z M75.429 54.857h3.429v1.714h-3.429z M80.571 54.857h1.714v1.714h-1.714z M5.143 56.571h5.143v1.714h-5.143z M13.714 56.571h3.429v1.714h-3.429z M18.857 56.571h6.857v1.714h-6.857z M32.571 56.571h13.714v1.714h-13.714z M48.0 56.571h1.714v1.714h-1.714z M51.429 56.571h3.429v1.714h-3.429z M56.571 56.571h3.429v1.714h-3.429z M63.429 56.571h3.429v1.714h-3.429z M68.571 56.571h3.429v1.714h-3.429z M73.714 56.571h6.857v1.714h-6.857z M82.286 56.571h1.714v1.714h-1.714z M0.0 58.286h1.714v1.714h-1.714z M10.286 58.286h1.714v1.714h-1.714z M15.429 58.286h1.714v1.714h-1.714z M18.857 58.286h3.429v1.714h-3.429z M24.0 58.286h5.143v1.714h-5.143z M30.857 58.286h8.571v1.714h-8.571z M42.857 58.286h8.571v1.714h-8.571z M54.857 58.286h1.714v1.714h-1.714z M60.0 58.286h3.429v1.714h-3.429z M66.857 58.286h6.857v1.714h-6.857z M77.143 58.286h1.714v1.714h-1.714z M82.286 58.286h1.714v1.714h-1.714z M6.857 60.0h3.429v1.714h-3.429z M18.857 60.0h5.143v1.714h-5.143z M25.714 60.0h5.143v1.714h-5.143z M34.286 60.0h6.857v1.714h-6.857z M42.857 60.0h3.429v1.714h-3.429z M53.143 60.0h1.714v1.714h-1.714z M56.571 60.0h3.429v1.714h-3.429z M65.143 60.0h6.857v1.714h-6.857z M77.143 60.0h3.429v1.714h-3.429z M0.0 61.714h13.714v1.714h-13.714z M15.429 61.714h8.571v1.714h-8.571z M25.714 61.714h3.429v1.714h-3.429z M34.286 61.714h1.714v1.714h-1.714z M39.429 61.714h1.714v1.714h-1.714z M48.0 61.714h3.429v1.714h-3.429z M54.857 61.714h13.714v1.714h-13.714z M72.0 61.714h1.714v1.714h-1.714z M0.0 63.429h1.714v1.714h-1.714z M3.429 63.429h6.857v1.714h-6.857z M18.857 63.429h1.714v1.714h-1.714z M24.0 63.429h1.714v1.714h-1.714z M29.143 63.429h3.429v1.714h-3.429z M34.286 63.429h1.714v1.714h-1.714z M37.714 63.429h5.143v1.714h-5.143z M46.286 63.429h1.714v1.714h-1.714z M49.714 63.429h3.429v1.714h-3.429z M56.571 63.429h1.714v1.714h-1.714z M60.0 63.429h1.714v1.714h-1.714z M63.429 63.429h6.857v1.714h-6.857z M73.714 63.429h6.857v1.714h-6.857z M1.714 65.143h1.714v1.714h-1.714z M8.571 65.143h5.143v1.714h-5.143z M17.143 65.143h1.714v1.714h-1.714z M20.571 65.143h5.143v1.714h-5.143z M29.143 65.143h1.714v1.714h-1.714z M34.286 65.143h1.714v1.714h-1.714z M41.143 65.143h1.714v1.714h-1.714z M46.286 65.143h3.429v1.714h-3.429z M54.857 65.143h1.714v1.714h-1.714z M61.714 65.143h5.143v1.714h-5.143z M72.0 65.143h5.143v1.714h-5.143z M80.571 65.143h3.429v1.714h-3.429z M1.714 66.857h5.143v1.714h-5.143z M13.714 66.857h1.714v1.714h-1.714z M17.143 66.857h1.714v1.714h-1.714z M24.0 66.857h1.714v1.714h-1.714z M30.857 66.857h1.714v1.714h-1.714z M34.286 66.857h1.714v1.714h-1.714z M37.714 66.857h1.714v1.714h-1.714z M41.143 66.857h1.714v1.714h-1.714z M46.286 66.857h1.714v1.714h-1.714z M49.714 66.857h1.714v1.714h-1.714z M54.857 66.857h3.429v1.714h-3.429z M65.143 66.857h3.429v1.714h-3.429z M75.429 66.857h1.714v1.714h-1.714z M78.857 66.857h1.714v1.714h-1.714z M0.0 68.571h5.143v1.714h-5.143z M10.286 68.571h1.714v1.714h-1.714z M15.429 68.571h1.714v1.714h-1.714z M18.857 68.571h5.143v1.714h-5.143z M25.714 68.571h3.429v1.714h-3.429z M30.857 68.571h1.714v1.714h-1.714z M37.714 68.571h8.571v1.714h-8.571z M49.714 68.571h6.857v1.714h-6.857z M58.286 68.571h5.143v1.714h-5.143z M66.857 68.571h10.286v1.714h-10.286z M78.857 68.571h3.429v1.714h-3.429z M13.714 70.286h1.714v1.714h-1.714z M17.143 70.286h5.143v1.714h-5.143z M24.0 70.286h10.286v1.714h-10.286z M37.714 70.286h1.714v1.714h-1.714z M44.571 70.286h3.429v1.714h-3.429z M51.429 70.286h10.286v1.714h-10.286z M66.857 70.286h3.429v1.714h-3.429z M75.429 70.286h1.714v1.714h-1.714z M78.857 70.286h3.429v1.714h-3.429z M0.0 72.0h12.0v1.714h-12.0z M13.714 72.0h1.714v1.714h-1.714z M18.857 72.0h3.429v1.714h-3.429z M24.0 72.0h1.714v1.714h-1.714z M27.429 72.0h1.714v1.714h-1.714z M30.857 72.0h5.143v1.714h-5.143z M37.714 72.0h1.714v1.714h-1.714z M41.143 72.0h1.714v1.714h-1.714z M44.571 72.0h1.714v1.714h-1.714z M49.714 72.0h1.714v1.714h-1.714z M54.857 72.0h8.571v1.714h-8.571z M68.571 72.0h1.714v1.714h-1.714z M72.0 72.0h1.714v1.714h-1.714z M75.429 72.0h1.714v1.714h-1.714z M78.857 72.0h1.714v1.714h-1.714z M82.286 72.0h1.714v1.714h-1.714z M0.0 73.714h1.714v1.714h-1.714z M10.286 73.714h1.714v1.714h-1.714z M13.714 73.714h3.429v1.714h-3.429z M18.857 73.714h1.714v1.714h-1.714z M24.0 73.714h1.714v1.714h-1.714z M29.143 73.714h1.714v1.714h-1.714z M34.286 73.714h1.714v1.714h-1.714z M37.714 73.714h1.714v1.714h-1.714z M44.571 73.714h1.714v1.714h-1.714z M48.0 73.714h1.714v1.714h-1.714z M51.429 73.714h3.429v1.714h-3.429z M56.571 73.714h1.714v1.714h-1.714z M60.0 73.714h1.714v1.714h-1.714z M65.143 73.714h5.143v1.714h-5.143z M75.429 73.714h3.429v1.714h-3.429z M0.0 75.429h1.714v1.714h-1.714z M3.429 75.429h5.143v1.714h-5.143z M10.286 75.429h1.714v1.714h-1.714z M13.714 75.429h12.0v1.714h-12.0z M29.143 75.429h3.429v1.714h-3.429z M37.714 75.429h8.571v1.714h-8.571z M48.0 75.429h1.714v1.714h-1.714z M58.286 75.429h1.714v1.714h-1.714z M61.714 75.429h1.714v1.714h-1.714z M68.571 75.429h8.571v1.714h-8.571z M80.571 75.429h3.429v1.714h-3.429z M0.0 77.143h1.714v1.714h-1.714z M3.429 77.143h5.143v1.714h-5.143z M10.286 77.143h1.714v1.714h-1.714z M13.714 77.143h1.714v1.714h-1.714z M17.143 77.143h5.143v1.714h-5.143z M25.714 77.143h1.714v1.714h-1.714z M30.857 77.143h1.714v1.714h-1.714z M34.286 77.143h3.429v1.714h-3.429z M42.857 77.143h1.714v1.714h-1.714z M46.286 77.143h1.714v1.714h-1.714z M49.714 77.143h3.429v1.714h-3.429z M56.571 77.143h3.429v1.714h-3.429z M63.429 77.143h6.857v1.714h-6.857z M72.0 77.143h3.429v1.714h-3.429z M77.143 77.143h1.714v1.714h-1.714z M82.286 77.143h1.714v1.714h-1.714z M0.0 78.857h1.714v1.714h-1.714z M3.429 78.857h5.143v1.714h-5.143z M10.286 78.857h1.714v1.714h-1.714z M17.143 78.857h1.714v1.714h-1.714z M27.429 78.857h8.571v1.714h-8.571z M41.143 78.857h1.714v1.714h-1.714z M46.286 78.857h1.714v1.714h-1.714z M49.714 78.857h1.714v1.714h-1.714z M54.857 78.857h1.714v1.714h-1.714z M65.143 78.857h1.714v1.714h-1.714z M70.286 78.857h1.714v1.714h-1.714z M73.714 78.857h3.429v1.714h-3.429z M78.857 78.857h3.429v1.714h-3.429z M0.0 80.571h1.714v1.714h-1.714z M10.286 80.571h1.714v1.714h-1.714z M15.429 80.571h5.143v1.714h-5.143z M25.714 80.571h5.143v1.714h-5.143z M36.0 80.571h1.714v1.714h-1.714z M39.429 80.571h6.857v1.714h-6.857z M56.571 80.571h1.714v1.714h-1.714z M63.429 80.571h1.714v1.714h-1.714z M70.286 80.571h3.429v1.714h-3.429z M77.143 80.571h6.857v1.714h-6.857z M0.0 82.286h12.0v1.714h-12.0z M13.714 82.286h1.714v1.714h-1.714z M17.143 82.286h1.714v1.714h-1.714z M20.571 82.286h1.714v1.714h-1.714z M24.0 82.286h1.714v1.714h-1.714z M27.429 82.286h1.714v1.714h-1.714z M32.571 82.286h1.714v1.714h-1.714z M37.714 82.286h1.714v1.714h-1.714z M42.857 82.286h3.429v1.714h-3.429z M48.0 82.286h3.429v1.714h-3.429z M54.857 82.286h1.714v1.714h-1.714z M61.714 82.286h1.714v1.714h-1.714z M65.143 82.286h1.714v1.714h-1.714z M73.714 82.286h3.429v1.714h-3.429z M82.286 82.286h1.714v1.714h-1.714z"/>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes_Security_Practical_Guide.svg
@@ -1,99 +1,465 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
-  <title>8 8 CI/CD KUBERNETES PIPELINE</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="52%" stop-color="#121a2f"/>
-      <stop offset="100%" stop-color="#170f25"/>
-    </linearGradient>
-    <linearGradient id="panel" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.96"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.86"/>
-    </linearGradient>
-    <pattern id="microGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#334155" stroke-width="1" opacity="0.25"/>
-      <circle cx="18" cy="18" r="1.2" fill="#60a5fa" opacity="0.15"/>
-    </pattern>
-    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="sg" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="36"/>
-    </filter>
-    <filter id="shadow" x="-30%" y="-30%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#microGrid)"/>
-  <circle cx="202" cy="150" r="190" fill="#60a5fa" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="1020" cy="486" r="220" fill="#1d4ed8" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="920" cy="160" r="140" fill="#38bdf8" opacity="0.04" filter="url(#sg)"/>
-  <path d="M0 96 C224 46 426 44 654 118 L654 630 L0 630 Z" fill="#020617" opacity="0.24"/>
-  <path d="M0 526 C248 490 426 486 654 548" fill="none" stroke="#475569" stroke-width="1.2" opacity="0.22"/>
-  <rect x="736" y="104" width="362" height="326" rx="28" fill="url(#panel)" stroke="#60a5fa" stroke-opacity="0.28" stroke-width="1.4" filter="url(#shadow)"/>
-  <rect x="754" y="122" width="326" height="290" rx="22" fill="none" stroke="#334155" stroke-opacity="0.7" stroke-width="1"/>
-  <rect x="758" y="124" width="108" height="12" rx="6" fill="#60a5fa" opacity="0.28"/>
-  <rect x="880" y="124" width="72" height="12" rx="6" fill="#334155" opacity="0.55"/>
-  <rect x="964" y="124" width="48" height="12" rx="6" fill="#334155" opacity="0.35"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Cloud Security Course 8Batch 8Week CI/CD Kubernetes Security Practical">
+<title>Cloud Security 8W: CI/CD + K8s Security with AI-Assisted DevSecOps</title>
+<defs>
+<linearGradient id="bgSpreadcc22" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0A1226"/><stop offset="50%" stop-color="#0C1430"/><stop offset="100%" stop-color="#131038"/></linearGradient>
+<linearGradient id="bandAcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0E2038"/><stop offset="100%" stop-color="#12283F"/></linearGradient>
+<linearGradient id="bandBcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0A1B35"/><stop offset="100%" stop-color="#0D2040"/></linearGradient>
+<linearGradient id="bandCcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#1E0A3A"/><stop offset="100%" stop-color="#2A0E4A"/></linearGradient>
+<linearGradient id="streakAcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0"/><stop offset="50%" stop-color="#4ADE80" stop-opacity="0.85"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakBcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0"/><stop offset="50%" stop-color="#60A5FA" stop-opacity="0.85"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakCcc22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#A78BFA" stop-opacity="0"/><stop offset="50%" stop-color="#A78BFA" stop-opacity="0.85"/><stop offset="100%" stop-color="#A78BFA" stop-opacity="0"/></linearGradient>
+<radialGradient id="glowAcc22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0.55"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowBcc22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0.55"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowCcc22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#A78BFA" stop-opacity="0.55"/><stop offset="100%" stop-color="#A78BFA" stop-opacity="0"/></radialGradient>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%"><feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/><feOffset dx="0" dy="1.5"/><feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<pattern id="ledgerGrid" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse"><path d="M0 20 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/><path d="M40 0 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/></pattern>
+<pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/></pattern>
+<pattern id="hexGridcc22" x="0" y="0" width="28" height="32" patternUnits="userSpaceOnUse"><path d="M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+<pattern id="radarRipplecc22" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse"><circle cx="30" cy="30" r="14" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+</defs>
+<rect width="1200" height="630" fill="url(#bgSpreadcc22)"/>
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandAcc22)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="0" width="8" height="210" fill="#4ADE80"/>
   
-  <path d="M724 152 C822 126 922 136 1020 202" fill="none" stroke="#f59e0b" stroke-width="1.3" opacity="0.24"/>
-  <path d="M706 420 C782 454 878 462 968 410" fill="none" stroke="#60a5fa" stroke-width="1.2" opacity="0.22"/>
-
-  <g transform="translate(917,270)" filter="url(#shadow)">
-    <circle r="96" fill="#0f172a" stroke="#60a5fa" stroke-width="2.6" opacity="0.94"/>
-    <circle r="124" fill="none" stroke="#60a5fa" stroke-opacity="0.15" stroke-width="1.2" stroke-dasharray="8 8"/>
-    <circle r="54" fill="none" stroke="#e2e8f0" stroke-opacity="0.15" stroke-width="1"/>
-
-    <path d="M0,-50 L40,-35 L40,10 C40,35 0,55 0,55 C0,55 -40,35 -40,10 L-40,-35 Z" fill="none" stroke="#60a5fa" stroke-width="3"/>
-    <path d="M-12,2 L-4,12 L16,-10" stroke="#60a5fa" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <circle cx="-50" cy="-30" r="8" fill="#60a5fa" opacity="0.3"/>
-    <circle cx="50" cy="-30" r="8" fill="#60a5fa" opacity="0.3"/>
-    <line x1="-42" y1="-26" x2="-20" y2="-15" stroke="#60a5fa" stroke-width="1.5" opacity="0.4"/>
-    <line x1="42" y1="-26" x2="20" y2="-15" stroke="#60a5fa" stroke-width="1.5" opacity="0.4"/>
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#4ADE80">CI/CD PIPELINE SECURITY</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Trivy · Snyk · Vault</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#9FD3B0">Image scan in CI · secret rotation · SBOM generation</text>
+    <text x="30" y="144" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">Pre-merge gates · failed-scan blocks deploy · SLA enforced</text>
+    <text x="30" y="162" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0">ArgoCD GitOps · Jenkins shared-library security</text><text x="30" y="178" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#BFC9D9" fill-opacity="0.85">Vault dynamic secrets · short-TTL DB credentials</text>
+    
   </g>
-  <g transform="translate(84 66)">
-    <rect width="164" height="36" rx="18" fill="#60a5fa" opacity="0.2" stroke="#60a5fa" stroke-width="1.2"/>
-    <text x="82" y="23" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#60a5fa" text-anchor="middle">SECURITY</text>
+  <g transform="translate(690,105)">
+    <rect x="-92" y="-56" width="184" height="116" rx="8" fill="#4ADE80" fill-opacity="0.05" stroke="#4ADE80" stroke-width="1.2" stroke-opacity="0.5"/>
+    <g stroke="#4ADE80" stroke-width="2" opacity="0.85">
+      <line x1="-80" y1="-40" x2="-30" y2="-40"/><line x1="-25" y1="-40" x2="40" y2="-40"/>
+      <line x1="-80" y1="-20" x2="-10" y2="-20"/><line x1="-5" y1="-20" x2="55" y2="-20"/>
+      <line x1="-80" y1="0" x2="-40" y2="0"/><line x1="-35" y1="0" x2="60" y2="0"/>
+      <line x1="-80" y1="20" x2="-20" y2="20"/><line x1="-15" y1="20" x2="30" y2="20"/>
+      <line x1="-80" y1="40" x2="-50" y2="40"/><line x1="-45" y1="40" x2="50" y2="40"/>
+    </g>
+    <rect x="-86" y="-50" width="4" height="104" fill="#4ADE80" opacity="0.6"/>
+    <g fill="#86EFAC">
+      <circle cx="74" cy="-40" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="-20" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="0" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="20" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="40" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <rect x="-86" y="-50" width="178" height="3" fill="#4ADE80" opacity="0.4">
+      <animate attributeName="y" values="-50;46;-50" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <g fill="#86EFAC" opacity="0.65">
+      <circle cx="-86" cy="-40" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="-20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="0" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="40" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#4ADE80" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+      <path d="M-94 -54 L-78 -54"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="1.8s" repeatCount="indefinite"/></path>
+      <path d="M82 -54 L94 -54"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2s" begin="0.3s" repeatCount="indefinite"/></path>
+    </g>
+    <text x="-86" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#86EFAC" opacity="0.7">5 lines</text>
+    <text x="80" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#86EFAC" opacity="0.7">live</text>
+    <text y="68" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#4ADE80">CI/CD</text>
+    <text y="82" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#86EFAC" opacity="0.7">cursor : line 5 col 14</text>
   </g>
-  <text x="84" y="170" font-family="Arial,sans-serif" font-size="54" font-weight="700" fill="#f8fafc" letter-spacing="0.5">8 8 CI/CD KUBERNETES</text>
-  <text x="84" y="232" font-family="Arial,sans-serif" font-size="52" font-weight="700" fill="#dbeafe" letter-spacing="0.5">PIPELINE</text>
-  <text x="84" y="288" font-family="Arial,sans-serif" font-size="18" fill="#cbd5e1">PIPELINE / DEVSECOPS / KUBERNETES</text>
-  <rect x="84" y="314" width="520" height="1.5" fill="#334155" opacity="0.9"/>
-  <text x="84" y="344" font-family="Arial,sans-serif" font-size="14" font-weight="700" fill="#94a3b8">VISUAL SYSTEM F056648C5BEA</text>
-  <text x="84" y="372" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">Batch 8 Week 8: CI/CD pipeline and Kubernetes security practical implementation guide.</text>
-  <g transform="translate(84 474)">
-    <rect width="114" height="38" rx="19" fill="#60a5fa" opacity="0.16" stroke="#60a5fa" stroke-width="1.2"/>
-    <text x="57.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">PIPELINE</text>
+  <g transform="translate(870,105)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#4ADE80">IMAGE SCAN</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">100%</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#9FD3B0">pre-merge</text>
   </g>
-  <g transform="translate(212 474)">
-    <rect width="124" height="38" rx="19" fill="#60a5fa" opacity="0.16" stroke="#60a5fa" stroke-width="1.2"/>
-    <text x="62.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">DEVSECOPS</text>
+  <g transform="translate(1110,105)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#4ADE80">GENERATED</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">SBOM</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#9FD3B0">per build</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#4ADE80" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#86EFAC"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
   </g>
-  <g transform="translate(350 474)">
-    <rect width="134" height="38" rx="19" fill="#60a5fa" opacity="0.16" stroke="#60a5fa" stroke-width="1.2"/>
-    <text x="67.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">KUBERNETES</text>
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1B2E" stroke="#4ADE80" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#4ADE80">PIPELINE</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">CI</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#9FD3B0">hardened</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#4ADE80" stroke-width="0.8" stroke-opacity="0.5"/>
+    
   </g>
-  <g transform="translate(84 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#60a5fa" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">CATEGORY</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">SECURITY</text>
+  <g transform="translate(990,105)">
+    <circle cx="10" cy="-50" r="3" fill="#4ADE80"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
   </g>
-  <g transform="translate(246 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#60a5fa" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">SIGNALS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">05</text>
+  <g opacity="0.85">
+    <line x1="20" y1="210" x2="1180" y2="210" stroke="#4ADE80" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="210" r="2.2" fill="#4ADE80">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <g transform="translate(408 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#60a5fa" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">TAGS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">10</text>
+</g>
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandBcc22)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="210" width="8" height="210" fill="#60A5FA"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#93C5FD">KUBERNETES NETWORK</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">NetworkPolicy · RBAC</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#BFDBFE">Default-deny ingress · namespace isolation enforced</text>
+    <text x="30" y="354" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D0DCF0">Calico CNI · eBPF dataplane · L7 policy authoring</text>
+    <text x="30" y="372" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#BFDBFE">Pod Security Standards · Restricted profile enforced</text><text x="30" y="388" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D0DCF0" fill-opacity="0.85">Service mesh mTLS · Istio/Linkerd integration ready</text>
+    
   </g>
-  <g transform="translate(1030 74)">
-    <rect width="130" height="34" rx="17" fill="#1d4ed8" opacity="0.18" stroke="#3b82f6" stroke-width="1.2"/>
-    <text x="65" y="22" font-family="Arial,sans-serif" font-size="12" font-weight="700" fill="#bfdbfe" text-anchor="middle">April 14, 2026</text>
+  <g transform="translate(690,315)">
+    <circle r="80" fill="#60A5FA" fill-opacity="0.06"><animate attributeName="r" values="64;86;64" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-60 0 Q-70 -25 -45 -30 Q-40 -50 -10 -45 Q10 -60 30 -45 Q55 -50 60 -20 Q80 -15 70 10 Q65 25 40 25 L-40 25 Q-70 25 -60 0 Z" fill="#60A5FA" fill-opacity="0.12" stroke="#60A5FA" stroke-width="1.8"/>
+    <g fill="#60A5FA" stroke="#93C5FD" stroke-width="1.2">
+      <polygon points="-30,-10 -18,-17 -6,-10 -6,4 -18,11 -30,4"/>
+      <polygon points="0,-10 12,-17 24,-10 24,4 12,11 0,4"/>
+      <polygon points="-15,10 -3,3 9,10 9,24 -3,31 -15,24"/>
+    </g>
+    <g fill="#93C5FD">
+      <circle cx="-18" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="12" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-3" cy="17" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#FFF">
+      <circle r="1.6"><animateMotion path="M-18 -3 L12 -3" dur="2.4s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M12 -3 L-3 17" dur="2.2s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M-3 17 L-18 -3" dur="2.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#93C5FD" opacity="0.6">
+      <circle cx="-50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="1.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#60A5FA" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-90" y1="-58" x2="-78" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" repeatCount="indefinite"/></line>
+      <line x1="78" y1="-58" x2="90" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.4s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-86" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD" opacity="0.7">3 pods</text>
+    <text x="86" y="-58" text-anchor="end" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#93C5FD" opacity="0.7">healthy</text>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#60A5FA">K8s CLOUD</text>
+    <text y="74" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#93C5FD" opacity="0.7">3 nodes : workload identity</text>
   </g>
-  <line x1="50" y1="588" x2="1150" y2="588" stroke="#334155" stroke-width="1" opacity="0.5"/>
-  <text x="1150" y="612" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <g transform="translate(870,315)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#93C5FD">MIN PRIV</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">RBAC</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#BFDBFE">role-bound</text>
+  </g>
+  <g transform="translate(1110,315)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#93C5FD">DEFAULT</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">DENY</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#BFDBFE">policy stance</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#60A5FA" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#93C5FD"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1628" stroke="#60A5FA" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#93C5FD">NETWORK</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">K8S</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#BFDBFE">zero trust</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#60A5FA" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,315)">
+    <circle cx="10" cy="-50" r="3" fill="#60A5FA"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g opacity="0.85">
+    <line x1="20" y1="420" x2="1180" y2="420" stroke="#60A5FA" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="420" r="2.2" fill="#60A5FA">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandCcc22)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#circuitDot)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#A78BFA"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#C4B5FD">AI-ASSISTED DEVSECOPS</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Cursor · Claude</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#DDD6FE">AI code-review · auto-patch suggestions · threat triage</text>
+    <text x="30" y="564" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D0CCE5">LLM-powered SAST · false-positive reduction in pipeline</text>
+    <text x="30" y="582" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#DDD6FE">Auto remediation · contextual fix generation in PRs</text><text x="30" y="598" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D0CCE5" fill-opacity="0.85">Threat model derivation · attack path visualization</text>
+    
+  </g>
+  <g transform="translate(690,525)">
+    <circle r="78" fill="#A78BFA" fill-opacity="0.05"><animate attributeName="r" values="68;84;68" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M0 -60 L55 -40 L50 25 Q40 55 0 65 Q-40 55 -50 25 L-55 -40 Z" fill="#A78BFA" fill-opacity="0.15" stroke="#A78BFA" stroke-width="2.4" filter="url(#softShadow)"/>
+    <path d="M0 -50 L45 -33 L40 22 Q32 46 0 55 Q-32 46 -40 22 L-45 -33 Z" fill="none" stroke="#C4B5FD" stroke-width="1" opacity="0.7"/>
+    <path d="M0 -40 L35 -26 L31 18 Q24 38 0 45 Q-24 38 -31 18 L-35 -26 Z" fill="none" stroke="#C4B5FD" stroke-width="0.6" opacity="0.5"/>
+    <g transform="translate(0,-5)" stroke="#C4B5FD" stroke-width="3" fill="none">
+      <path d="M-18 5 L-4 20 L22 -12"><animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#C4B5FD" opacity="0.7">
+      <circle cx="-40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.2s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#C4B5FD" opacity="0.55">
+      <circle cx="-65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#A78BFA" stroke-width="0.4" stroke-opacity="0.35" fill="none">
+      <path d="M-78 -68 L-66 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2s" repeatCount="indefinite"/></path>
+      <path d="M66 -68 L78 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2.3s" begin="0.4s" repeatCount="indefinite"/></path>
+    </g>
+    <text x="-78" y="-72" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#C4B5FD" opacity="0.7">verified</text>
+    <text y="84" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#A78BFA">AI</text>
+    <text y="98" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#C4B5FD" opacity="0.7">3 rings : signed by CA</text>
+  </g>
+  <g transform="translate(870,525)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#160629" stroke="#A78BFA" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#C4B5FD">CURSOR IDE</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">Cur</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#DDD6FE">security</text>
+  </g>
+  <g transform="translate(1110,525)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#160629" stroke="#A78BFA" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#C4B5FD">CLAUDE CODE</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">CC</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#DDD6FE">reviewer</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#A78BFA" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#C4B5FD"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#160629" stroke="#A78BFA" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#C4B5FD">DEVSECOPS</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">AI</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#DDD6FE">next-gen</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#A78BFA" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,525)">
+    <circle cx="10" cy="-50" r="3" fill="#A78BFA"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#C4B5FD"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#C4B5FD"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#A78BFA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#C4B5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#A78BFA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#C4B5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  
+</g>
+<g opacity="0.9">
+  <g fill="#4ADE80">
+    <circle cx="240" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="35" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="175" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="27" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="81" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="129" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.6">
+    <rect x="780" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#86EFAC" opacity="0.85">
+    <rect x="730" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#4ADE80" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 95 L28 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 125 L28 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 155 L28 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 185 L28 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 95 L1172 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 125 L1172 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 155 L1172 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 185 L1172 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#86EFAC" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="105" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="105" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.55">
+    <rect x="120" y="15" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="195" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#60A5FA">
+    <circle cx="240" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="245" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="385" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="237" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="291" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="339" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.6">
+    <rect x="780" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#93C5FD" opacity="0.85">
+    <rect x="730" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#60A5FA" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 305 L28 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 335 L28 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 365 L28 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 395 L28 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 305 L1172 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 335 L1172 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 365 L1172 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 395 L1172 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#93C5FD" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="315" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="315" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.55">
+    <rect x="120" y="225" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="405" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#A78BFA">
+    <circle cx="240" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="455" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="595" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="447" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="501" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="549" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.6">
+    <rect x="780" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#C4B5FD" opacity="0.85">
+    <rect x="730" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#A78BFA" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 515 L28 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 545 L28 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 575 L28 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 605 L28 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 515 L1172 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 545 L1172 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 575 L1172 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 605 L1172 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#C4B5FD" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="525" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="525" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.55">
+    <rect x="120" y="435" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="615" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+<g opacity="0.85">
+  <g fill="#4ADE80" opacity="0.7">
+    <circle cx="500" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="1.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.7">
+    <circle cx="500" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.7">
+    <circle cx="500" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.4s" begin="1.1s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke-width="0.5" stroke-opacity="0.4" fill="none">
+    <rect x="700" y="40" width="36" height="2" fill="#4ADE80" stroke="none"><animate attributeName="x" values="700;1000;700" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.4s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="250" width="36" height="2" fill="#60A5FA" stroke="none"><animate attributeName="x" values="1000;700;1000" dur="6.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.8s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="460" width="36" height="2" fill="#A78BFA" stroke="none"><animate attributeName="x" values="700;1000;700" dur="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="7.2s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#86EFAC" opacity="0.6">
+    <circle cx="60" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="270" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke="#93C5FD" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+    <line x1="640" y1="200" x2="640" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="200" x2="660" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.4s" repeatCount="indefinite"/></line>
+    <line x1="640" y1="410" x2="640" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.0s" begin="0.7s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="410" x2="660" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="1.1s" repeatCount="indefinite"/></line>
+  </g>
+</g>
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <path fill="#0A1020" d="M0.0 0.0h12.0v1.714h-12.0z M13.714 0.0h3.429v1.714h-3.429z M18.857 0.0h1.714v1.714h-1.714z M29.143 0.0h3.429v1.714h-3.429z M34.286 0.0h3.429v1.714h-3.429z M39.429 0.0h3.429v1.714h-3.429z M44.571 0.0h3.429v1.714h-3.429z M49.714 0.0h3.429v1.714h-3.429z M54.857 0.0h3.429v1.714h-3.429z M60.0 0.0h1.714v1.714h-1.714z M63.429 0.0h1.714v1.714h-1.714z M68.571 0.0h1.714v1.714h-1.714z M72.0 0.0h12.0v1.714h-12.0z M0.0 1.714h1.714v1.714h-1.714z M10.286 1.714h1.714v1.714h-1.714z M18.857 1.714h1.714v1.714h-1.714z M22.286 1.714h3.429v1.714h-3.429z M36.0 1.714h8.571v1.714h-8.571z M46.286 1.714h1.714v1.714h-1.714z M53.143 1.714h1.714v1.714h-1.714z M56.571 1.714h1.714v1.714h-1.714z M60.0 1.714h1.714v1.714h-1.714z M65.143 1.714h5.143v1.714h-5.143z M72.0 1.714h1.714v1.714h-1.714z M82.286 1.714h1.714v1.714h-1.714z M0.0 3.429h1.714v1.714h-1.714z M3.429 3.429h5.143v1.714h-5.143z M10.286 3.429h1.714v1.714h-1.714z M15.429 3.429h5.143v1.714h-5.143z M22.286 3.429h6.857v1.714h-6.857z M32.571 3.429h1.714v1.714h-1.714z M36.0 3.429h10.286v1.714h-10.286z M48.0 3.429h1.714v1.714h-1.714z M51.429 3.429h3.429v1.714h-3.429z M58.286 3.429h1.714v1.714h-1.714z M61.714 3.429h1.714v1.714h-1.714z M66.857 3.429h3.429v1.714h-3.429z M72.0 3.429h1.714v1.714h-1.714z M75.429 3.429h5.143v1.714h-5.143z M82.286 3.429h1.714v1.714h-1.714z M0.0 5.143h1.714v1.714h-1.714z M3.429 5.143h5.143v1.714h-5.143z M10.286 5.143h1.714v1.714h-1.714z M13.714 5.143h3.429v1.714h-3.429z M32.571 5.143h1.714v1.714h-1.714z M42.857 5.143h3.429v1.714h-3.429z M48.0 5.143h1.714v1.714h-1.714z M51.429 5.143h3.429v1.714h-3.429z M60.0 5.143h1.714v1.714h-1.714z M63.429 5.143h1.714v1.714h-1.714z M66.857 5.143h1.714v1.714h-1.714z M72.0 5.143h1.714v1.714h-1.714z M75.429 5.143h5.143v1.714h-5.143z M82.286 5.143h1.714v1.714h-1.714z M0.0 6.857h1.714v1.714h-1.714z M3.429 6.857h5.143v1.714h-5.143z M10.286 6.857h1.714v1.714h-1.714z M13.714 6.857h1.714v1.714h-1.714z M17.143 6.857h1.714v1.714h-1.714z M24.0 6.857h1.714v1.714h-1.714z M29.143 6.857h6.857v1.714h-6.857z M37.714 6.857h20.571v1.714h-20.571z M60.0 6.857h1.714v1.714h-1.714z M72.0 6.857h1.714v1.714h-1.714z M75.429 6.857h5.143v1.714h-5.143z M82.286 6.857h1.714v1.714h-1.714z M0.0 8.571h1.714v1.714h-1.714z M10.286 8.571h1.714v1.714h-1.714z M13.714 8.571h3.429v1.714h-3.429z M18.857 8.571h3.429v1.714h-3.429z M25.714 8.571h1.714v1.714h-1.714z M34.286 8.571h5.143v1.714h-5.143z M44.571 8.571h1.714v1.714h-1.714z M48.0 8.571h1.714v1.714h-1.714z M53.143 8.571h1.714v1.714h-1.714z M58.286 8.571h3.429v1.714h-3.429z M63.429 8.571h3.429v1.714h-3.429z M72.0 8.571h1.714v1.714h-1.714z M82.286 8.571h1.714v1.714h-1.714z M0.0 10.286h12.0v1.714h-12.0z M13.714 10.286h1.714v1.714h-1.714z M17.143 10.286h1.714v1.714h-1.714z M20.571 10.286h1.714v1.714h-1.714z M24.0 10.286h1.714v1.714h-1.714z M27.429 10.286h1.714v1.714h-1.714z M30.857 10.286h1.714v1.714h-1.714z M34.286 10.286h1.714v1.714h-1.714z M37.714 10.286h1.714v1.714h-1.714z M41.143 10.286h1.714v1.714h-1.714z M44.571 10.286h1.714v1.714h-1.714z M48.0 10.286h1.714v1.714h-1.714z M51.429 10.286h1.714v1.714h-1.714z M54.857 10.286h1.714v1.714h-1.714z M58.286 10.286h1.714v1.714h-1.714z M61.714 10.286h1.714v1.714h-1.714z M65.143 10.286h1.714v1.714h-1.714z M68.571 10.286h1.714v1.714h-1.714z M72.0 10.286h12.0v1.714h-12.0z M13.714 12.0h6.857v1.714h-6.857z M22.286 12.0h1.714v1.714h-1.714z M25.714 12.0h1.714v1.714h-1.714z M29.143 12.0h3.429v1.714h-3.429z M37.714 12.0h1.714v1.714h-1.714z M44.571 12.0h3.429v1.714h-3.429z M49.714 12.0h1.714v1.714h-1.714z M53.143 12.0h3.429v1.714h-3.429z M58.286 12.0h5.143v1.714h-5.143z M65.143 12.0h1.714v1.714h-1.714z M68.571 12.0h1.714v1.714h-1.714z M0.0 13.714h1.714v1.714h-1.714z M6.857 13.714h1.714v1.714h-1.714z M10.286 13.714h5.143v1.714h-5.143z M17.143 13.714h6.857v1.714h-6.857z M32.571 13.714h1.714v1.714h-1.714z M37.714 13.714h8.571v1.714h-8.571z M51.429 13.714h6.857v1.714h-6.857z M60.0 13.714h3.429v1.714h-3.429z M66.857 13.714h12.0v1.714h-12.0z M82.286 13.714h1.714v1.714h-1.714z M0.0 15.429h5.143v1.714h-5.143z M15.429 15.429h1.714v1.714h-1.714z M20.571 15.429h1.714v1.714h-1.714z M24.0 15.429h3.429v1.714h-3.429z M30.857 15.429h1.714v1.714h-1.714z M34.286 15.429h1.714v1.714h-1.714z M44.571 15.429h3.429v1.714h-3.429z M51.429 15.429h3.429v1.714h-3.429z M56.571 15.429h1.714v1.714h-1.714z M65.143 15.429h3.429v1.714h-3.429z M70.286 15.429h3.429v1.714h-3.429z M77.143 15.429h1.714v1.714h-1.714z M80.571 15.429h1.714v1.714h-1.714z M3.429 17.143h8.571v1.714h-8.571z M13.714 17.143h8.571v1.714h-8.571z M24.0 17.143h5.143v1.714h-5.143z M34.286 17.143h1.714v1.714h-1.714z M41.143 17.143h8.571v1.714h-8.571z M51.429 17.143h1.714v1.714h-1.714z M61.714 17.143h5.143v1.714h-5.143z M78.857 17.143h1.714v1.714h-1.714z M3.429 18.857h3.429v1.714h-3.429z M12.0 18.857h3.429v1.714h-3.429z M17.143 18.857h1.714v1.714h-1.714z M22.286 18.857h3.429v1.714h-3.429z M27.429 18.857h5.143v1.714h-5.143z M37.714 18.857h3.429v1.714h-3.429z M42.857 18.857h5.143v1.714h-5.143z M51.429 18.857h1.714v1.714h-1.714z M54.857 18.857h3.429v1.714h-3.429z M61.714 18.857h15.429v1.714h-15.429z M78.857 18.857h1.714v1.714h-1.714z M1.714 20.571h6.857v1.714h-6.857z M10.286 20.571h3.429v1.714h-3.429z M15.429 20.571h1.714v1.714h-1.714z M18.857 20.571h1.714v1.714h-1.714z M24.0 20.571h1.714v1.714h-1.714z M32.571 20.571h3.429v1.714h-3.429z M39.429 20.571h3.429v1.714h-3.429z M49.714 20.571h1.714v1.714h-1.714z M54.857 20.571h1.714v1.714h-1.714z M60.0 20.571h3.429v1.714h-3.429z M68.571 20.571h1.714v1.714h-1.714z M75.429 20.571h1.714v1.714h-1.714z M78.857 20.571h5.143v1.714h-5.143z M5.143 22.286h5.143v1.714h-5.143z M17.143 22.286h1.714v1.714h-1.714z M20.571 22.286h8.571v1.714h-8.571z M30.857 22.286h1.714v1.714h-1.714z M37.714 22.286h3.429v1.714h-3.429z M42.857 22.286h5.143v1.714h-5.143z M51.429 22.286h1.714v1.714h-1.714z M56.571 22.286h1.714v1.714h-1.714z M61.714 22.286h1.714v1.714h-1.714z M65.143 22.286h3.429v1.714h-3.429z M72.0 22.286h1.714v1.714h-1.714z M75.429 22.286h6.857v1.714h-6.857z M1.714 24.0h1.714v1.714h-1.714z M5.143 24.0h1.714v1.714h-1.714z M10.286 24.0h1.714v1.714h-1.714z M13.714 24.0h1.714v1.714h-1.714z M20.571 24.0h1.714v1.714h-1.714z M24.0 24.0h8.571v1.714h-8.571z M34.286 24.0h5.143v1.714h-5.143z M41.143 24.0h5.143v1.714h-5.143z M51.429 24.0h3.429v1.714h-3.429z M56.571 24.0h3.429v1.714h-3.429z M63.429 24.0h3.429v1.714h-3.429z M70.286 24.0h3.429v1.714h-3.429z M75.429 24.0h3.429v1.714h-3.429z M0.0 25.714h1.714v1.714h-1.714z M3.429 25.714h1.714v1.714h-1.714z M8.571 25.714h1.714v1.714h-1.714z M12.0 25.714h1.714v1.714h-1.714z M15.429 25.714h1.714v1.714h-1.714z M18.857 25.714h1.714v1.714h-1.714z M32.571 25.714h3.429v1.714h-3.429z M37.714 25.714h3.429v1.714h-3.429z M42.857 25.714h3.429v1.714h-3.429z M49.714 25.714h1.714v1.714h-1.714z M54.857 25.714h5.143v1.714h-5.143z M63.429 25.714h1.714v1.714h-1.714z M66.857 25.714h3.429v1.714h-3.429z M72.0 25.714h1.714v1.714h-1.714z M75.429 25.714h1.714v1.714h-1.714z M78.857 25.714h3.429v1.714h-3.429z M0.0 27.429h1.714v1.714h-1.714z M3.429 27.429h1.714v1.714h-1.714z M6.857 27.429h1.714v1.714h-1.714z M10.286 27.429h1.714v1.714h-1.714z M17.143 27.429h3.429v1.714h-3.429z M24.0 27.429h1.714v1.714h-1.714z M27.429 27.429h6.857v1.714h-6.857z M36.0 27.429h6.857v1.714h-6.857z M46.286 27.429h1.714v1.714h-1.714z M49.714 27.429h1.714v1.714h-1.714z M54.857 27.429h1.714v1.714h-1.714z M60.0 27.429h3.429v1.714h-3.429z M65.143 27.429h1.714v1.714h-1.714z M68.571 27.429h3.429v1.714h-3.429z M75.429 27.429h1.714v1.714h-1.714z M78.857 27.429h1.714v1.714h-1.714z M0.0 29.143h3.429v1.714h-3.429z M5.143 29.143h3.429v1.714h-3.429z M12.0 29.143h1.714v1.714h-1.714z M18.857 29.143h12.0v1.714h-12.0z M34.286 29.143h1.714v1.714h-1.714z M39.429 29.143h1.714v1.714h-1.714z M44.571 29.143h13.714v1.714h-13.714z M60.0 29.143h3.429v1.714h-3.429z M65.143 29.143h3.429v1.714h-3.429z M70.286 29.143h3.429v1.714h-3.429z M77.143 29.143h1.714v1.714h-1.714z M0.0 30.857h3.429v1.714h-3.429z M10.286 30.857h1.714v1.714h-1.714z M15.429 30.857h5.143v1.714h-5.143z M24.0 30.857h1.714v1.714h-1.714z M27.429 30.857h6.857v1.714h-6.857z M36.0 30.857h1.714v1.714h-1.714z M41.143 30.857h1.714v1.714h-1.714z M48.0 30.857h6.857v1.714h-6.857z M60.0 30.857h6.857v1.714h-6.857z M72.0 30.857h1.714v1.714h-1.714z M77.143 30.857h3.429v1.714h-3.429z M0.0 32.571h1.714v1.714h-1.714z M3.429 32.571h1.714v1.714h-1.714z M8.571 32.571h1.714v1.714h-1.714z M12.0 32.571h3.429v1.714h-3.429z M22.286 32.571h3.429v1.714h-3.429z M27.429 32.571h1.714v1.714h-1.714z M30.857 32.571h3.429v1.714h-3.429z M37.714 32.571h1.714v1.714h-1.714z M41.143 32.571h1.714v1.714h-1.714z M44.571 32.571h3.429v1.714h-3.429z M51.429 32.571h1.714v1.714h-1.714z M54.857 32.571h1.714v1.714h-1.714z M73.714 32.571h3.429v1.714h-3.429z M78.857 32.571h5.143v1.714h-5.143z M1.714 34.286h3.429v1.714h-3.429z M10.286 34.286h6.857v1.714h-6.857z M18.857 34.286h10.286v1.714h-10.286z M30.857 34.286h1.714v1.714h-1.714z M34.286 34.286h1.714v1.714h-1.714z M37.714 34.286h5.143v1.714h-5.143z M44.571 34.286h3.429v1.714h-3.429z M54.857 34.286h8.571v1.714h-8.571z M68.571 34.286h1.714v1.714h-1.714z M72.0 34.286h8.571v1.714h-8.571z M82.286 34.286h1.714v1.714h-1.714z M1.714 36.0h1.714v1.714h-1.714z M5.143 36.0h5.143v1.714h-5.143z M18.857 36.0h3.429v1.714h-3.429z M27.429 36.0h5.143v1.714h-5.143z M34.286 36.0h6.857v1.714h-6.857z M44.571 36.0h3.429v1.714h-3.429z M51.429 36.0h1.714v1.714h-1.714z M56.571 36.0h1.714v1.714h-1.714z M60.0 36.0h3.429v1.714h-3.429z M65.143 36.0h3.429v1.714h-3.429z M70.286 36.0h3.429v1.714h-3.429z M77.143 36.0h1.714v1.714h-1.714z M3.429 37.714h12.0v1.714h-12.0z M17.143 37.714h1.714v1.714h-1.714z M22.286 37.714h3.429v1.714h-3.429z M27.429 37.714h5.143v1.714h-5.143z M36.0 37.714h10.286v1.714h-10.286z M48.0 37.714h5.143v1.714h-5.143z M56.571 37.714h1.714v1.714h-1.714z M65.143 37.714h13.714v1.714h-13.714z M0.0 39.429h1.714v1.714h-1.714z M3.429 39.429h5.143v1.714h-5.143z M13.714 39.429h3.429v1.714h-3.429z M18.857 39.429h1.714v1.714h-1.714z M22.286 39.429h1.714v1.714h-1.714z M30.857 39.429h3.429v1.714h-3.429z M36.0 39.429h3.429v1.714h-3.429z M44.571 39.429h1.714v1.714h-1.714z M49.714 39.429h1.714v1.714h-1.714z M53.143 39.429h3.429v1.714h-3.429z M58.286 39.429h6.857v1.714h-6.857z M66.857 39.429h3.429v1.714h-3.429z M75.429 39.429h1.714v1.714h-1.714z M78.857 39.429h1.714v1.714h-1.714z M82.286 39.429h1.714v1.714h-1.714z M1.714 41.143h1.714v1.714h-1.714z M6.857 41.143h1.714v1.714h-1.714z M10.286 41.143h1.714v1.714h-1.714z M13.714 41.143h5.143v1.714h-5.143z M24.0 41.143h3.429v1.714h-3.429z M29.143 41.143h5.143v1.714h-5.143z M37.714 41.143h1.714v1.714h-1.714z M41.143 41.143h1.714v1.714h-1.714z M44.571 41.143h1.714v1.714h-1.714z M53.143 41.143h3.429v1.714h-3.429z M60.0 41.143h3.429v1.714h-3.429z M65.143 41.143h5.143v1.714h-5.143z M72.0 41.143h1.714v1.714h-1.714z M75.429 41.143h5.143v1.714h-5.143z M82.286 41.143h1.714v1.714h-1.714z M0.0 42.857h1.714v1.714h-1.714z M6.857 42.857h1.714v1.714h-1.714z M13.714 42.857h1.714v1.714h-1.714z M17.143 42.857h1.714v1.714h-1.714z M20.571 42.857h1.714v1.714h-1.714z M24.0 42.857h1.714v1.714h-1.714z M29.143 42.857h10.286v1.714h-10.286z M44.571 42.857h1.714v1.714h-1.714z M51.429 42.857h1.714v1.714h-1.714z M56.571 42.857h1.714v1.714h-1.714z M65.143 42.857h1.714v1.714h-1.714z M68.571 42.857h1.714v1.714h-1.714z M75.429 42.857h1.714v1.714h-1.714z M0.0 44.571h5.143v1.714h-5.143z M6.857 44.571h10.286v1.714h-10.286z M20.571 44.571h1.714v1.714h-1.714z M24.0 44.571h10.286v1.714h-10.286z M37.714 44.571h12.0v1.714h-12.0z M51.429 44.571h6.857v1.714h-6.857z M60.0 44.571h1.714v1.714h-1.714z M65.143 44.571h12.0v1.714h-12.0z M1.714 46.286h3.429v1.714h-3.429z M6.857 46.286h1.714v1.714h-1.714z M12.0 46.286h3.429v1.714h-3.429z M25.714 46.286h3.429v1.714h-3.429z M34.286 46.286h6.857v1.714h-6.857z M44.571 46.286h3.429v1.714h-3.429z M49.714 46.286h3.429v1.714h-3.429z M54.857 46.286h5.143v1.714h-5.143z M61.714 46.286h3.429v1.714h-3.429z M72.0 46.286h1.714v1.714h-1.714z M78.857 46.286h3.429v1.714h-3.429z M0.0 48.0h1.714v1.714h-1.714z M3.429 48.0h8.571v1.714h-8.571z M25.714 48.0h1.714v1.714h-1.714z M30.857 48.0h5.143v1.714h-5.143z M37.714 48.0h1.714v1.714h-1.714z M42.857 48.0h5.143v1.714h-5.143z M51.429 48.0h1.714v1.714h-1.714z M54.857 48.0h1.714v1.714h-1.714z M58.286 48.0h5.143v1.714h-5.143z M65.143 48.0h1.714v1.714h-1.714z M68.571 48.0h3.429v1.714h-3.429z M77.143 48.0h6.857v1.714h-6.857z M3.429 49.714h1.714v1.714h-1.714z M8.571 49.714h1.714v1.714h-1.714z M12.0 49.714h6.857v1.714h-6.857z M22.286 49.714h1.714v1.714h-1.714z M27.429 49.714h8.571v1.714h-8.571z M41.143 49.714h1.714v1.714h-1.714z M46.286 49.714h6.857v1.714h-6.857z M54.857 49.714h3.429v1.714h-3.429z M65.143 49.714h1.714v1.714h-1.714z M68.571 49.714h3.429v1.714h-3.429z M75.429 49.714h3.429v1.714h-3.429z M3.429 51.429h1.714v1.714h-1.714z M10.286 51.429h1.714v1.714h-1.714z M13.714 51.429h1.714v1.714h-1.714z M17.143 51.429h5.143v1.714h-5.143z M24.0 51.429h1.714v1.714h-1.714z M29.143 51.429h3.429v1.714h-3.429z M36.0 51.429h1.714v1.714h-1.714z M42.857 51.429h1.714v1.714h-1.714z M56.571 51.429h1.714v1.714h-1.714z M60.0 51.429h1.714v1.714h-1.714z M63.429 51.429h6.857v1.714h-6.857z M73.714 51.429h1.714v1.714h-1.714z M78.857 51.429h1.714v1.714h-1.714z M0.0 53.143h3.429v1.714h-3.429z M6.857 53.143h3.429v1.714h-3.429z M12.0 53.143h1.714v1.714h-1.714z M15.429 53.143h1.714v1.714h-1.714z M20.571 53.143h1.714v1.714h-1.714z M25.714 53.143h1.714v1.714h-1.714z M29.143 53.143h1.714v1.714h-1.714z M32.571 53.143h5.143v1.714h-5.143z M44.571 53.143h6.857v1.714h-6.857z M53.143 53.143h6.857v1.714h-6.857z M61.714 53.143h1.714v1.714h-1.714z M66.857 53.143h1.714v1.714h-1.714z M73.714 53.143h1.714v1.714h-1.714z M78.857 53.143h5.143v1.714h-5.143z M0.0 54.857h1.714v1.714h-1.714z M6.857 54.857h1.714v1.714h-1.714z M10.286 54.857h3.429v1.714h-3.429z M18.857 54.857h5.143v1.714h-5.143z M30.857 54.857h1.714v1.714h-1.714z M37.714 54.857h10.286v1.714h-10.286z M49.714 54.857h3.429v1.714h-3.429z M54.857 54.857h1.714v1.714h-1.714z M58.286 54.857h6.857v1.714h-6.857z M68.571 54.857h3.429v1.714h-3.429z M73.714 54.857h1.714v1.714h-1.714z M77.143 54.857h6.857v1.714h-6.857z M0.0 56.571h1.714v1.714h-1.714z M3.429 56.571h3.429v1.714h-3.429z M12.0 56.571h3.429v1.714h-3.429z M17.143 56.571h10.286v1.714h-10.286z M29.143 56.571h1.714v1.714h-1.714z M34.286 56.571h1.714v1.714h-1.714z M39.429 56.571h5.143v1.714h-5.143z M46.286 56.571h6.857v1.714h-6.857z M56.571 56.571h1.714v1.714h-1.714z M61.714 56.571h1.714v1.714h-1.714z M65.143 56.571h6.857v1.714h-6.857z M75.429 56.571h3.429v1.714h-3.429z M80.571 56.571h1.714v1.714h-1.714z M0.0 58.286h1.714v1.714h-1.714z M5.143 58.286h3.429v1.714h-3.429z M10.286 58.286h1.714v1.714h-1.714z M13.714 58.286h5.143v1.714h-5.143z M20.571 58.286h3.429v1.714h-3.429z M25.714 58.286h1.714v1.714h-1.714z M29.143 58.286h6.857v1.714h-6.857z M49.714 58.286h3.429v1.714h-3.429z M56.571 58.286h1.714v1.714h-1.714z M65.143 58.286h1.714v1.714h-1.714z M68.571 58.286h3.429v1.714h-3.429z M75.429 58.286h5.143v1.714h-5.143z M3.429 60.0h6.857v1.714h-6.857z M15.429 60.0h3.429v1.714h-3.429z M20.571 60.0h1.714v1.714h-1.714z M25.714 60.0h6.857v1.714h-6.857z M34.286 60.0h1.714v1.714h-1.714z M37.714 60.0h10.286v1.714h-10.286z M51.429 60.0h1.714v1.714h-1.714z M54.857 60.0h1.714v1.714h-1.714z M58.286 60.0h5.143v1.714h-5.143z M65.143 60.0h1.714v1.714h-1.714z M68.571 60.0h5.143v1.714h-5.143z M78.857 60.0h1.714v1.714h-1.714z M0.0 61.714h3.429v1.714h-3.429z M6.857 61.714h1.714v1.714h-1.714z M10.286 61.714h5.143v1.714h-5.143z M17.143 61.714h1.714v1.714h-1.714z M20.571 61.714h1.714v1.714h-1.714z M25.714 61.714h3.429v1.714h-3.429z M30.857 61.714h3.429v1.714h-3.429z M42.857 61.714h5.143v1.714h-5.143z M54.857 61.714h1.714v1.714h-1.714z M60.0 61.714h6.857v1.714h-6.857z M68.571 61.714h1.714v1.714h-1.714z M72.0 61.714h3.429v1.714h-3.429z M77.143 61.714h6.857v1.714h-6.857z M0.0 63.429h3.429v1.714h-3.429z M15.429 63.429h3.429v1.714h-3.429z M22.286 63.429h1.714v1.714h-1.714z M25.714 63.429h3.429v1.714h-3.429z M30.857 63.429h1.714v1.714h-1.714z M34.286 63.429h1.714v1.714h-1.714z M37.714 63.429h1.714v1.714h-1.714z M41.143 63.429h1.714v1.714h-1.714z M46.286 63.429h1.714v1.714h-1.714z M49.714 63.429h8.571v1.714h-8.571z M60.0 63.429h1.714v1.714h-1.714z M63.429 63.429h5.143v1.714h-5.143z M72.0 63.429h1.714v1.714h-1.714z M75.429 63.429h1.714v1.714h-1.714z M80.571 63.429h3.429v1.714h-3.429z M1.714 65.143h1.714v1.714h-1.714z M8.571 65.143h6.857v1.714h-6.857z M17.143 65.143h1.714v1.714h-1.714z M20.571 65.143h1.714v1.714h-1.714z M27.429 65.143h1.714v1.714h-1.714z M30.857 65.143h3.429v1.714h-3.429z M39.429 65.143h5.143v1.714h-5.143z M48.0 65.143h6.857v1.714h-6.857z M60.0 65.143h1.714v1.714h-1.714z M65.143 65.143h3.429v1.714h-3.429z M73.714 65.143h1.714v1.714h-1.714z M1.714 66.857h5.143v1.714h-5.143z M12.0 66.857h1.714v1.714h-1.714z M15.429 66.857h3.429v1.714h-3.429z M20.571 66.857h3.429v1.714h-3.429z M27.429 66.857h3.429v1.714h-3.429z M32.571 66.857h1.714v1.714h-1.714z M39.429 66.857h1.714v1.714h-1.714z M54.857 66.857h1.714v1.714h-1.714z M58.286 66.857h1.714v1.714h-1.714z M61.714 66.857h1.714v1.714h-1.714z M72.0 66.857h3.429v1.714h-3.429z M78.857 66.857h1.714v1.714h-1.714z M82.286 66.857h1.714v1.714h-1.714z M0.0 68.571h5.143v1.714h-5.143z M10.286 68.571h10.286v1.714h-10.286z M30.857 68.571h1.714v1.714h-1.714z M36.0 68.571h10.286v1.714h-10.286z M53.143 68.571h5.143v1.714h-5.143z M60.0 68.571h5.143v1.714h-5.143z M68.571 68.571h8.571v1.714h-8.571z M78.857 68.571h3.429v1.714h-3.429z M13.714 70.286h1.714v1.714h-1.714z M24.0 70.286h6.857v1.714h-6.857z M34.286 70.286h5.143v1.714h-5.143z M44.571 70.286h5.143v1.714h-5.143z M51.429 70.286h1.714v1.714h-1.714z M56.571 70.286h1.714v1.714h-1.714z M60.0 70.286h3.429v1.714h-3.429z M65.143 70.286h5.143v1.714h-5.143z M75.429 70.286h3.429v1.714h-3.429z M0.0 72.0h12.0v1.714h-12.0z M13.714 72.0h1.714v1.714h-1.714z M20.571 72.0h1.714v1.714h-1.714z M25.714 72.0h6.857v1.714h-6.857z M37.714 72.0h1.714v1.714h-1.714z M41.143 72.0h1.714v1.714h-1.714z M44.571 72.0h1.714v1.714h-1.714z M49.714 72.0h3.429v1.714h-3.429z M65.143 72.0h1.714v1.714h-1.714z M68.571 72.0h1.714v1.714h-1.714z M72.0 72.0h1.714v1.714h-1.714z M75.429 72.0h1.714v1.714h-1.714z M78.857 72.0h1.714v1.714h-1.714z M0.0 73.714h1.714v1.714h-1.714z M10.286 73.714h1.714v1.714h-1.714z M17.143 73.714h1.714v1.714h-1.714z M24.0 73.714h6.857v1.714h-6.857z M32.571 73.714h1.714v1.714h-1.714z M36.0 73.714h3.429v1.714h-3.429z M44.571 73.714h3.429v1.714h-3.429z M54.857 73.714h5.143v1.714h-5.143z M61.714 73.714h1.714v1.714h-1.714z M68.571 73.714h1.714v1.714h-1.714z M75.429 73.714h1.714v1.714h-1.714z M78.857 73.714h1.714v1.714h-1.714z M82.286 73.714h1.714v1.714h-1.714z M0.0 75.429h1.714v1.714h-1.714z M3.429 75.429h5.143v1.714h-5.143z M10.286 75.429h1.714v1.714h-1.714z M13.714 75.429h1.714v1.714h-1.714z M18.857 75.429h3.429v1.714h-3.429z M25.714 75.429h8.571v1.714h-8.571z M36.0 75.429h12.0v1.714h-12.0z M49.714 75.429h1.714v1.714h-1.714z M54.857 75.429h3.429v1.714h-3.429z M61.714 75.429h3.429v1.714h-3.429z M66.857 75.429h15.429v1.714h-15.429z M0.0 77.143h1.714v1.714h-1.714z M3.429 77.143h5.143v1.714h-5.143z M10.286 77.143h1.714v1.714h-1.714z M15.429 77.143h5.143v1.714h-5.143z M24.0 77.143h1.714v1.714h-1.714z M27.429 77.143h1.714v1.714h-1.714z M30.857 77.143h1.714v1.714h-1.714z M34.286 77.143h5.143v1.714h-5.143z M44.571 77.143h10.286v1.714h-10.286z M56.571 77.143h1.714v1.714h-1.714z M65.143 77.143h1.714v1.714h-1.714z M68.571 77.143h1.714v1.714h-1.714z M77.143 77.143h1.714v1.714h-1.714z M80.571 77.143h3.429v1.714h-3.429z M0.0 78.857h1.714v1.714h-1.714z M3.429 78.857h5.143v1.714h-5.143z M10.286 78.857h1.714v1.714h-1.714z M18.857 78.857h1.714v1.714h-1.714z M22.286 78.857h8.571v1.714h-8.571z M32.571 78.857h1.714v1.714h-1.714z M46.286 78.857h6.857v1.714h-6.857z M61.714 78.857h5.143v1.714h-5.143z M68.571 78.857h1.714v1.714h-1.714z M73.714 78.857h1.714v1.714h-1.714z M77.143 78.857h6.857v1.714h-6.857z M0.0 80.571h1.714v1.714h-1.714z M10.286 80.571h1.714v1.714h-1.714z M15.429 80.571h3.429v1.714h-3.429z M20.571 80.571h1.714v1.714h-1.714z M24.0 80.571h1.714v1.714h-1.714z M27.429 80.571h3.429v1.714h-3.429z M32.571 80.571h3.429v1.714h-3.429z M42.857 80.571h1.714v1.714h-1.714z M48.0 80.571h1.714v1.714h-1.714z M51.429 80.571h1.714v1.714h-1.714z M54.857 80.571h5.143v1.714h-5.143z M61.714 80.571h1.714v1.714h-1.714z M65.143 80.571h1.714v1.714h-1.714z M78.857 80.571h3.429v1.714h-3.429z M0.0 82.286h12.0v1.714h-12.0z M13.714 82.286h1.714v1.714h-1.714z M20.571 82.286h1.714v1.714h-1.714z M24.0 82.286h1.714v1.714h-1.714z M29.143 82.286h1.714v1.714h-1.714z M32.571 82.286h5.143v1.714h-5.143z M39.429 82.286h5.143v1.714h-5.143z M46.286 82.286h1.714v1.714h-1.714z M51.429 82.286h1.714v1.714h-1.714z M54.857 82.286h3.429v1.714h-3.429z M60.0 82.286h3.429v1.714h-3.429z M65.143 82.286h1.714v1.714h-1.714z M70.286 82.286h6.857v1.714h-6.857z M78.857 82.286h5.143v1.714h-5.143z"/>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
+++ b/assets/images/2026-01-22-Cloud_Security_Trends_January_2026.svg
@@ -1,99 +1,463 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
-  <title>2026 1 KUBERNETES 82 VS</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="52%" stop-color="#121a2f"/>
-      <stop offset="100%" stop-color="#170f25"/>
-    </linearGradient>
-    <linearGradient id="panel" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.96"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.86"/>
-    </linearGradient>
-    <pattern id="microGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#334155" stroke-width="1" opacity="0.25"/>
-      <circle cx="18" cy="18" r="1.2" fill="#ef4444" opacity="0.15"/>
-    </pattern>
-    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="sg" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="36"/>
-    </filter>
-    <filter id="shadow" x="-30%" y="-30%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#microGrid)"/>
-  <circle cx="202" cy="150" r="190" fill="#ef4444" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="1020" cy="486" r="220" fill="#991b1b" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="920" cy="160" r="140" fill="#38bdf8" opacity="0.04" filter="url(#sg)"/>
-  <path d="M0 96 C224 46 426 44 654 118 L654 630 L0 630 Z" fill="#020617" opacity="0.24"/>
-  <path d="M0 526 C248 490 426 486 654 548" fill="none" stroke="#475569" stroke-width="1.2" opacity="0.22"/>
-  <rect x="736" y="104" width="362" height="326" rx="28" fill="url(#panel)" stroke="#ef4444" stroke-opacity="0.28" stroke-width="1.4" filter="url(#shadow)"/>
-  <rect x="754" y="122" width="326" height="290" rx="22" fill="none" stroke="#334155" stroke-opacity="0.7" stroke-width="1"/>
-  <rect x="758" y="124" width="108" height="12" rx="6" fill="#ef4444" opacity="0.28"/>
-  <rect x="880" y="124" width="72" height="12" rx="6" fill="#334155" opacity="0.55"/>
-  <rect x="964" y="124" width="48" height="12" rx="6" fill="#334155" opacity="0.35"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="Cloud Security Trends January 2026 Kubernetes 82 Production VS Code CNCF">
+<title>Cloud Security Jan 2026: K8s 82% Production, VS Code Threats, CNCF</title>
+<defs>
+<linearGradient id="bgSpreadct22" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0A1226"/><stop offset="50%" stop-color="#0C1430"/><stop offset="100%" stop-color="#131038"/></linearGradient>
+<linearGradient id="bandAct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0A1B35"/><stop offset="100%" stop-color="#0D2040"/></linearGradient>
+<linearGradient id="bandBct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#1A0E2E"/><stop offset="100%" stop-color="#24122F"/></linearGradient>
+<linearGradient id="bandCct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2A1A0C"/><stop offset="100%" stop-color="#1E1F0A"/></linearGradient>
+<linearGradient id="streakAct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0"/><stop offset="50%" stop-color="#60A5FA" stop-opacity="0.85"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakBct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#E63946" stop-opacity="0"/><stop offset="50%" stop-color="#E63946" stop-opacity="0.85"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakCct22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0"/><stop offset="50%" stop-color="#FFB703" stop-opacity="0.85"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></linearGradient>
+<radialGradient id="glowAct22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#60A5FA" stop-opacity="0.55"/><stop offset="100%" stop-color="#60A5FA" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowBct22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowCct22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></radialGradient>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%"><feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/><feOffset dx="0" dy="1.5"/><feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<pattern id="ledgerGrid" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse"><path d="M0 20 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/><path d="M40 0 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/></pattern>
+<pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/></pattern>
+<pattern id="hexGridct22" x="0" y="0" width="28" height="32" patternUnits="userSpaceOnUse"><path d="M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+<pattern id="radarRipplect22" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse"><circle cx="30" cy="30" r="14" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+</defs>
+<rect width="1200" height="630" fill="url(#bgSpreadct22)"/>
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandAct22)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="0" width="8" height="210" fill="#60A5FA"/>
   
-  <path d="M724 152 C822 126 922 136 1020 202" fill="none" stroke="#f59e0b" stroke-width="1.3" opacity="0.24"/>
-  <path d="M706 420 C782 454 878 462 968 410" fill="none" stroke="#60a5fa" stroke-width="1.2" opacity="0.22"/>
-
-  <g transform="translate(917,270)" filter="url(#shadow)">
-    <circle r="96" fill="#0f172a" stroke="#ef4444" stroke-width="2.6" opacity="0.94"/>
-    <circle r="124" fill="none" stroke="#ef4444" stroke-opacity="0.15" stroke-width="1.2" stroke-dasharray="8 8"/>
-    <circle r="54" fill="none" stroke="#e2e8f0" stroke-opacity="0.15" stroke-width="1"/>
-
-    <path d="M0,-50 L40,-35 L40,10 C40,35 0,55 0,55 C0,55 -40,35 -40,10 L-40,-35 Z" fill="none" stroke="#ef4444" stroke-width="3"/>
-    <path d="M-12,2 L-4,12 L16,-10" stroke="#ef4444" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <circle cx="-50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <circle cx="50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <line x1="-42" y1="-26" x2="-20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-    <line x1="42" y1="-26" x2="20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#93C5FD">CNCF SURVEY 2026</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">K8s 82% Production</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#BFDBFE">Year-over-year growth · enterprise adoption surge</text>
+    <text x="30" y="144" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D0DCF0">Platform engineering up 67% · GitOps becomes default</text>
+    <text x="30" y="162" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#BFDBFE">Multi-cluster federation · 5+ clusters average</text><text x="30" y="178" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D0DCF0" fill-opacity="0.85">Service mesh adoption · Istio/Linkerd 50% combined</text>
+    
   </g>
-  <g transform="translate(84 66)">
-    <rect width="164" height="36" rx="18" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="82" y="23" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SECURITY</text>
+  <g transform="translate(690,105)">
+    <g stroke="#60A5FA" stroke-width="0.4" stroke-opacity="0.3">
+      <line x1="-90" y1="-50" x2="100" y2="-50"/><line x1="-90" y1="-25" x2="100" y2="-25"/>
+      <line x1="-90" y1="0" x2="100" y2="0"/><line x1="-90" y1="20" x2="100" y2="20"/>
+    </g>
+    <line x1="-85" y1="40" x2="100" y2="40" stroke="#60A5FA" stroke-width="1" opacity="0.6"/>
+    <rect x="-75" y="10" width="20" height="30" rx="2" fill="#60A5FA" opacity="0.5"><animate attributeName="height" values="20;30;20" dur="1.6s" repeatCount="indefinite"/><animate attributeName="y" values="20;10;20" dur="1.6s" repeatCount="indefinite"/></rect><rect x="-47" y="-15" width="20" height="55" rx="2" fill="#60A5FA" opacity="0.58"><animate attributeName="height" values="45;55;45" dur="1.8s" repeatCount="indefinite"/><animate attributeName="y" values="-5;-15;-5" dur="1.8s" repeatCount="indefinite"/></rect><rect x="-19" y="0" width="20" height="40" rx="2" fill="#60A5FA" opacity="0.66"><animate attributeName="height" values="30;40;30" dur="2.0s" repeatCount="indefinite"/><animate attributeName="y" values="10;0;10" dur="2.0s" repeatCount="indefinite"/></rect><rect x="9" y="-30" width="20" height="70" rx="2" fill="#60A5FA" opacity="0.74"><animate attributeName="height" values="60;70;60" dur="2.2s" repeatCount="indefinite"/><animate attributeName="y" values="-20;-30;-20" dur="2.2s" repeatCount="indefinite"/></rect><rect x="37" y="-45" width="20" height="85" rx="2" fill="#60A5FA" opacity="0.8200000000000001"><animate attributeName="height" values="75;85;75" dur="2.4000000000000004s" repeatCount="indefinite"/><animate attributeName="y" values="-35;-45;-35" dur="2.4000000000000004s" repeatCount="indefinite"/></rect><rect x="65" y="-22" width="20" height="62" rx="2" fill="#60A5FA" opacity="0.9"><animate attributeName="height" values="52;62;52" dur="2.6s" repeatCount="indefinite"/><animate attributeName="y" values="-12;-22;-12" dur="2.6s" repeatCount="indefinite"/></rect>
+    <path d="M-78 -8 L-50 -22 L-22 -18 L6 -38 L34 -52 L62 -64" stroke="#93C5FD" stroke-width="1.6" fill="none" stroke-opacity="0.7" stroke-dasharray="3 3">
+      <animate attributeName="stroke-dashoffset" values="0;-12" dur="1.6s" repeatCount="indefinite"/>
+    </path>
+    <polygon points="62,-64 70,-58 64,-50" fill="#93C5FD"/>
+    <g fill="#93C5FD" opacity="0.75">
+      <circle cx="-90" cy="-50" r="1.5"/><circle cx="-90" cy="-25" r="1.5"/><circle cx="-90" cy="0" r="1.5"/>
+    </g>
+    <g fill="#60A5FA" opacity="0.7">
+      <rect x="-95" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></rect>
+      <rect x="-85" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></rect>
+      <rect x="-75" y="-58" width="6" height="2" rx="1"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></rect>
+    </g>
+    <g fill="#93C5FD" opacity="0.65">
+      <circle cx="100" cy="-50" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="-25" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="0" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="100" cy="20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#60A5FA" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-90" y1="48" x2="100" y2="48"><animate attributeName="stroke-opacity" values="0.2;0.6;0.2" dur="2s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-90" y="-56" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#60A5FA" opacity="0.7">peak</text>
+    <text x="100" y="-56" text-anchor="end" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#60A5FA" opacity="0.7">+24%</text>
+    <text y="58" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#93C5FD">ADOPT</text>
+    <text y="72" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#93C5FD" opacity="0.7">6 buckets : qoq trend</text>
   </g>
-  <text x="84" y="170" font-family="Arial,sans-serif" font-size="54" font-weight="700" fill="#f8fafc" letter-spacing="0.5">2026 1 KUBERNETES 82</text>
-  <text x="84" y="232" font-family="Arial,sans-serif" font-size="52" font-weight="700" fill="#dbeafe" letter-spacing="0.5">VS</text>
-  <text x="84" y="288" font-family="Arial,sans-serif" font-size="18" fill="#cbd5e1">DEVSECOPS / KUBERNETES / CLOUD</text>
-  <rect x="84" y="314" width="520" height="1.5" fill="#334155" opacity="0.9"/>
-  <text x="84" y="344" font-family="Arial,sans-serif" font-size="14" font-weight="700" fill="#94a3b8">VISUAL SYSTEM DDD3714EF99B</text>
-  <text x="84" y="372" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">Key cloud security trends and threat signals from January 2026 industry reports.</text>
-  <g transform="translate(84 474)">
-    <rect width="124" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="62.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">DEVSECOPS</text>
+  <g transform="translate(870,105)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#93C5FD">PLATFORM</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">67%</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#BFDBFE">eng growth</text>
   </g>
-  <g transform="translate(222 474)">
-    <rect width="134" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="67.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">KUBERNETES</text>
+  <g transform="translate(1110,105)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1628" stroke="#60A5FA" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#93C5FD">DEFAULT</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#F5F7FA">GitOps</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#BFDBFE">2026</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#60A5FA" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#93C5FD"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
   </g>
-  <g transform="translate(370 474)">
-    <rect width="110" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="55.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">CLOUD</text>
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1628" stroke="#60A5FA" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#93C5FD">K8S PROD</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">82%</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#BFDBFE">adoption</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#60A5FA" stroke-width="0.8" stroke-opacity="0.5"/>
+    
   </g>
-  <g transform="translate(84 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">CATEGORY</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">SECURITY</text>
+  <g transform="translate(990,105)">
+    <circle cx="10" cy="-50" r="3" fill="#60A5FA"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#93C5FD"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#60A5FA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#93C5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
   </g>
-  <g transform="translate(246 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">SIGNALS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">05</text>
+  <g opacity="0.85">
+    <line x1="20" y1="210" x2="1180" y2="210" stroke="#60A5FA" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="210" r="2.2" fill="#60A5FA">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <g transform="translate(408 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">TAGS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">10</text>
+</g>
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandBct22)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#circuitDot)" opacity="0.6"/>
+  <rect x="0" y="210" width="8" height="210" fill="#E63946"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#F87171">VS CODE THREAT</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Tunnel Abuse · RCE</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FBB6BD">Dev-tool tunnel exploited as C2 channel · APT campaigns</text>
+    <text x="30" y="354" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D9C9CE">GitHub Codespaces · remote SSH bypassing perimeter</text>
+    <text x="30" y="372" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FBB6BD">Egress monitoring · DLP rules for dev tooling needed</text><text x="30" y="388" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D9C9CE" fill-opacity="0.85">Endpoint hardening · principle of least privilege dev</text>
+    
   </g>
-  <g transform="translate(1030 74)">
-    <rect width="130" height="34" rx="17" fill="#1d4ed8" opacity="0.18" stroke="#3b82f6" stroke-width="1.2"/>
-    <text x="65" y="22" font-family="Arial,sans-serif" font-size="12" font-weight="700" fill="#bfdbfe" text-anchor="middle">April 14, 2026</text>
+  <g transform="translate(690,315)">
+    <rect x="-75" y="-50" width="150" height="100" rx="8" fill="#E63946" fill-opacity="0.08" stroke="#E63946" stroke-width="1.8" filter="url(#softShadow)"/>
+    <rect x="-75" y="-50" width="150" height="18" rx="8" fill="#E63946" fill-opacity="0.3"/>
+    <g fill="#E63946"><circle cx="-65" cy="-41" r="3"/><circle cx="-55" cy="-41" r="3"/><circle cx="-45" cy="-41" r="3"/></g>
+    <rect x="-30" y="-44" width="100" height="8" rx="3" fill="#FCA5A5" fill-opacity="0.3"/>
+    <rect x="-65" y="-22" width="130" height="6" rx="2" fill="#E63946" fill-opacity="0.25"/>
+    <rect x="-65" y="-10" width="86" height="4" rx="2" fill="#E63946" fill-opacity="0.18"/>
+    <rect x="-65" y="0" width="110" height="4" rx="2" fill="#E63946" fill-opacity="0.18"/>
+    <g transform="translate(0,18)">
+      <polygon points="0,-22 22,18 -22,18" fill="#E63946" stroke="#FCA5A5" stroke-width="1.4" filter="url(#softShadow)"><animate attributeName="opacity" values="0.7;1;0.7" dur="1.4s" repeatCount="indefinite"/></polygon>
+      <text y="10" text-anchor="middle" font-family="Inter, monospace" font-size="16" font-weight="900" fill="#FFF">!</text>
+    </g>
+    <rect x="-75" y="-22" width="6" height="72" fill="#FCA5A5" opacity="0.4">
+      <animate attributeName="x" values="-75;65;-75" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <g fill="#FCA5A5" opacity="0.7">
+      <circle cx="-65" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-35" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="35" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="1.2s" repeatCount="indefinite"/></circle>
+      <circle cx="65" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.5s" begin="1.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#E63946" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-78" y1="-58" x2="-50" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" repeatCount="indefinite"/></line>
+      <line x1="50" y1="-58" x2="78" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.4s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-60" y="-58" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FCA5A5" opacity="0.7">URL</text>
+    <text y="62" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#E63946">VSC</text>
+    <text y="78" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCA5A5" opacity="0.7">scan ack : 1 alert</text>
   </g>
-  <line x1="50" y1="588" x2="1150" y2="588" stroke="#334155" stroke-width="1" opacity="0.5"/>
-  <text x="1150" y="612" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <g transform="translate(870,315)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#F87171">ACTORS</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">APT</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FBB6BD">state-grade</text>
+  </g>
+  <g transform="translate(1110,315)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#F87171">EVASION</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">EDR</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FBB6BD">bypass</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#E63946" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCA5A5"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E0A14" stroke="#E63946" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#F87171">DEV TUNNEL</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">C2</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FBB6BD">abuse</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#E63946" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,315)">
+    <circle cx="10" cy="-50" r="3" fill="#E63946"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g opacity="0.85">
+    <line x1="20" y1="420" x2="1180" y2="420" stroke="#E63946" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="420" r="2.2" fill="#E63946">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandCct22)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#FFB703"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FFB703">AUDIT & DISCLOSURE</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">CRI-O · Net-NTLMv1</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FFD58A">CRI-O completes external security audit · 0 critical</text>
+    <text x="30" y="564" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E0D5B6">Net-NTLMv1 rainbow tables released · legacy auth risk</text>
+    <text x="30" y="582" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FFD58A">GPU scheduler · Multi-Instance GPU support stable</text><text x="30" y="598" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#E0D5B6" fill-opacity="0.85">Disable Net-NTLMv1 · enforce Kerberos AES only</text>
+    
+  </g>
+  <g transform="translate(690,525)">
+    <circle r="78" fill="#FFB703" fill-opacity="0.06"><animate attributeName="r" values="62;82;62" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-22 -20 Q-22 -50 0 -50 Q22 -50 22 -20" stroke="#FFB703" stroke-width="4" fill="none"/>
+    <rect x="-32" y="-22" width="64" height="60" rx="6" fill="#FFB703" fill-opacity="0.2" stroke="#FFB703" stroke-width="2.2" filter="url(#softShadow)"/>
+    <circle r="5" fill="#FCD34D" cy="2"/>
+    <rect x="-3" y="2" width="6" height="18" fill="#FCD34D"/>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="14" font-weight="900" fill="#FFB703">CVSS 7.5</text>
+    <g fill="#FCD34D" opacity="0.85">
+      <circle cx="-55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="-55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FCD34D" stroke-width="0.8" stroke-opacity="0.5" fill="none">
+      <path d="M-44 -30 L-38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.2s" repeatCount="indefinite"/></path>
+      <path d="M44 -30 L38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/></path>
+      <path d="M-44 30 L-38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.0s" repeatCount="indefinite"/></path>
+      <path d="M44 30 L38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.6s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#FCD34D" opacity="0.55">
+      <circle cx="-72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FFB703" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-86" y1="0" x2="-74" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" repeatCount="indefinite"/></line>
+      <line x1="74" y1="0" x2="86" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.5s" repeatCount="indefinite"/></line>
+    </g>
+    <text y="78" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCD34D" opacity="0.7">CVSS : critical scope</text>
+  </g>
+  <g transform="translate(870,525)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#FFB703">SCHEDULER</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">GPU</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFD58A">K8s 1.30+</text>
+  </g>
+  <g transform="translate(1110,525)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#FFB703">DOWNGRADE</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">NTLM</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FFD58A">forced</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#FFB703" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCD34D"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E1805" stroke="#FFB703" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FFB703">CRITICAL</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">0</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD58A">CRI-O audit</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#FFB703" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,525)">
+    <circle cx="10" cy="-50" r="3" fill="#FFB703"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  
+</g>
+<g opacity="0.9">
+  <g fill="#60A5FA">
+    <circle cx="240" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="35" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="175" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="27" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="81" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="129" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.6">
+    <rect x="780" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#93C5FD" opacity="0.85">
+    <rect x="730" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#60A5FA" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 95 L28 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 125 L28 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 155 L28 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 185 L28 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 95 L1172 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 125 L1172 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 155 L1172 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 185 L1172 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#93C5FD" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="105" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="105" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#60A5FA" opacity="0.55">
+    <rect x="120" y="15" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="195" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#E63946">
+    <circle cx="240" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="245" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="385" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="237" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="291" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="339" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.6">
+    <rect x="780" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCA5A5" opacity="0.85">
+    <rect x="730" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#E63946" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 305 L28 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 335 L28 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 365 L28 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 395 L28 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 305 L1172 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 335 L1172 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 365 L1172 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 395 L1172 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCA5A5" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="315" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="315" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.55">
+    <rect x="120" y="225" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="405" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FFB703">
+    <circle cx="240" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="455" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="595" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="447" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="501" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="549" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.6">
+    <rect x="780" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCD34D" opacity="0.85">
+    <rect x="730" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#FFB703" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 515 L28 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 545 L28 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 575 L28 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 605 L28 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 515 L1172 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 545 L1172 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 575 L1172 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 605 L1172 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCD34D" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="525" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="525" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.55">
+    <rect x="120" y="435" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="615" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+<g opacity="0.85">
+  <g fill="#60A5FA" opacity="0.7">
+    <circle cx="500" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="1.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.7">
+    <circle cx="500" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.7">
+    <circle cx="500" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.4s" begin="1.1s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke-width="0.5" stroke-opacity="0.4" fill="none">
+    <rect x="700" y="40" width="36" height="2" fill="#60A5FA" stroke="none"><animate attributeName="x" values="700;1000;700" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.4s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="250" width="36" height="2" fill="#E63946" stroke="none"><animate attributeName="x" values="1000;700;1000" dur="6.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.8s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="460" width="36" height="2" fill="#FFB703" stroke="none"><animate attributeName="x" values="700;1000;700" dur="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="7.2s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#93C5FD" opacity="0.6">
+    <circle cx="60" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="270" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke="#FCA5A5" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+    <line x1="640" y1="200" x2="640" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="200" x2="660" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.4s" repeatCount="indefinite"/></line>
+    <line x1="640" y1="410" x2="640" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.0s" begin="0.7s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="410" x2="660" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="1.1s" repeatCount="indefinite"/></line>
+  </g>
+</g>
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <path fill="#0A1020" d="M0.0 0.0h11.094v1.585h-11.094z M14.264 0.0h3.17v1.585h-3.17z M22.189 0.0h1.585v1.585h-1.585z M25.358 0.0h3.17v1.585h-3.17z M31.698 0.0h4.755v1.585h-4.755z M38.038 0.0h1.585v1.585h-1.585z M41.208 0.0h1.585v1.585h-1.585z M45.962 0.0h4.755v1.585h-4.755z M52.302 0.0h3.17v1.585h-3.17z M58.642 0.0h6.34v1.585h-6.34z M66.566 0.0h1.585v1.585h-1.585z M72.906 0.0h11.094v1.585h-11.094z M0.0 1.585h1.585v1.585h-1.585z M9.509 1.585h1.585v1.585h-1.585z M12.679 1.585h1.585v1.585h-1.585z M22.189 1.585h4.755v1.585h-4.755z M28.528 1.585h6.34v1.585h-6.34z M45.962 1.585h4.755v1.585h-4.755z M52.302 1.585h4.755v1.585h-4.755z M58.642 1.585h3.17v1.585h-3.17z M63.396 1.585h1.585v1.585h-1.585z M66.566 1.585h3.17v1.585h-3.17z M72.906 1.585h1.585v1.585h-1.585z M82.415 1.585h1.585v1.585h-1.585z M0.0 3.17h1.585v1.585h-1.585z M3.17 3.17h4.755v1.585h-4.755z M9.509 3.17h1.585v1.585h-1.585z M14.264 3.17h4.755v1.585h-4.755z M20.604 3.17h3.17v1.585h-3.17z M26.943 3.17h1.585v1.585h-1.585z M31.698 3.17h1.585v1.585h-1.585z M38.038 3.17h1.585v1.585h-1.585z M41.208 3.17h1.585v1.585h-1.585z M44.377 3.17h4.755v1.585h-4.755z M53.887 3.17h4.755v1.585h-4.755z M60.226 3.17h1.585v1.585h-1.585z M68.151 3.17h1.585v1.585h-1.585z M72.906 3.17h1.585v1.585h-1.585z M76.075 3.17h4.755v1.585h-4.755z M82.415 3.17h1.585v1.585h-1.585z M0.0 4.755h1.585v1.585h-1.585z M3.17 4.755h4.755v1.585h-4.755z M9.509 4.755h1.585v1.585h-1.585z M14.264 4.755h4.755v1.585h-4.755z M20.604 4.755h7.925v1.585h-7.925z M31.698 4.755h1.585v1.585h-1.585z M38.038 4.755h1.585v1.585h-1.585z M55.472 4.755h1.585v1.585h-1.585z M58.642 4.755h3.17v1.585h-3.17z M66.566 4.755h1.585v1.585h-1.585z M69.736 4.755h1.585v1.585h-1.585z M72.906 4.755h1.585v1.585h-1.585z M76.075 4.755h4.755v1.585h-4.755z M82.415 4.755h1.585v1.585h-1.585z M0.0 6.34h1.585v1.585h-1.585z M3.17 6.34h4.755v1.585h-4.755z M9.509 6.34h1.585v1.585h-1.585z M12.679 6.34h3.17v1.585h-3.17z M28.528 6.34h4.755v1.585h-4.755z M36.453 6.34h12.679v1.585h-12.679z M53.887 6.34h14.264v1.585h-14.264z M72.906 6.34h1.585v1.585h-1.585z M76.075 6.34h4.755v1.585h-4.755z M82.415 6.34h1.585v1.585h-1.585z M0.0 7.925h1.585v1.585h-1.585z M9.509 7.925h1.585v1.585h-1.585z M19.019 7.925h1.585v1.585h-1.585z M22.189 7.925h3.17v1.585h-3.17z M26.943 7.925h3.17v1.585h-3.17z M31.698 7.925h1.585v1.585h-1.585z M36.453 7.925h3.17v1.585h-3.17z M44.377 7.925h4.755v1.585h-4.755z M50.717 7.925h6.34v1.585h-6.34z M60.226 7.925h1.585v1.585h-1.585z M66.566 7.925h1.585v1.585h-1.585z M72.906 7.925h1.585v1.585h-1.585z M82.415 7.925h1.585v1.585h-1.585z M0.0 9.509h11.094v1.585h-11.094z M12.679 9.509h1.585v1.585h-1.585z M15.849 9.509h1.585v1.585h-1.585z M19.019 9.509h1.585v1.585h-1.585z M22.189 9.509h1.585v1.585h-1.585z M25.358 9.509h1.585v1.585h-1.585z M28.528 9.509h1.585v1.585h-1.585z M31.698 9.509h1.585v1.585h-1.585z M34.868 9.509h1.585v1.585h-1.585z M38.038 9.509h1.585v1.585h-1.585z M41.208 9.509h1.585v1.585h-1.585z M44.377 9.509h1.585v1.585h-1.585z M47.547 9.509h1.585v1.585h-1.585z M50.717 9.509h1.585v1.585h-1.585z M53.887 9.509h1.585v1.585h-1.585z M57.057 9.509h1.585v1.585h-1.585z M60.226 9.509h1.585v1.585h-1.585z M63.396 9.509h1.585v1.585h-1.585z M66.566 9.509h1.585v1.585h-1.585z M69.736 9.509h1.585v1.585h-1.585z M72.906 9.509h11.094v1.585h-11.094z M14.264 11.094h1.585v1.585h-1.585z M28.528 11.094h1.585v1.585h-1.585z M38.038 11.094h1.585v1.585h-1.585z M44.377 11.094h1.585v1.585h-1.585z M47.547 11.094h3.17v1.585h-3.17z M52.302 11.094h1.585v1.585h-1.585z M58.642 11.094h1.585v1.585h-1.585z M61.811 11.094h3.17v1.585h-3.17z M0.0 12.679h1.585v1.585h-1.585z M3.17 12.679h1.585v1.585h-1.585z M6.34 12.679h1.585v1.585h-1.585z M9.509 12.679h1.585v1.585h-1.585z M15.849 12.679h1.585v1.585h-1.585z M22.189 12.679h1.585v1.585h-1.585z M25.358 12.679h3.17v1.585h-3.17z M30.113 12.679h1.585v1.585h-1.585z M33.283 12.679h3.17v1.585h-3.17z M38.038 12.679h9.509v1.585h-9.509z M49.132 12.679h1.585v1.585h-1.585z M53.887 12.679h4.755v1.585h-4.755z M60.226 12.679h4.755v1.585h-4.755z M66.566 12.679h4.755v1.585h-4.755z M76.075 12.679h1.585v1.585h-1.585z M80.83 12.679h1.585v1.585h-1.585z M0.0 14.264h1.585v1.585h-1.585z M3.17 14.264h3.17v1.585h-3.17z M11.094 14.264h1.585v1.585h-1.585z M19.019 14.264h6.34v1.585h-6.34z M34.868 14.264h3.17v1.585h-3.17z M39.623 14.264h1.585v1.585h-1.585z M42.792 14.264h3.17v1.585h-3.17z M49.132 14.264h4.755v1.585h-4.755z M55.472 14.264h4.755v1.585h-4.755z M71.321 14.264h1.585v1.585h-1.585z M76.075 14.264h1.585v1.585h-1.585z M79.245 14.264h1.585v1.585h-1.585z M82.415 14.264h1.585v1.585h-1.585z M6.34 15.849h1.585v1.585h-1.585z M9.509 15.849h4.755v1.585h-4.755z M17.434 15.849h6.34v1.585h-6.34z M28.528 15.849h3.17v1.585h-3.17z M33.283 15.849h1.585v1.585h-1.585z M36.453 15.849h4.755v1.585h-4.755z M42.792 15.849h3.17v1.585h-3.17z M49.132 15.849h1.585v1.585h-1.585z M52.302 15.849h1.585v1.585h-1.585z M55.472 15.849h1.585v1.585h-1.585z M58.642 15.849h1.585v1.585h-1.585z M61.811 15.849h3.17v1.585h-3.17z M68.151 15.849h1.585v1.585h-1.585z M71.321 15.849h1.585v1.585h-1.585z M76.075 15.849h3.17v1.585h-3.17z M80.83 15.849h3.17v1.585h-3.17z M0.0 17.434h1.585v1.585h-1.585z M3.17 17.434h1.585v1.585h-1.585z M11.094 17.434h1.585v1.585h-1.585z M15.849 17.434h1.585v1.585h-1.585z M19.019 17.434h1.585v1.585h-1.585z M28.528 17.434h3.17v1.585h-3.17z M34.868 17.434h1.585v1.585h-1.585z M42.792 17.434h4.755v1.585h-4.755z M49.132 17.434h3.17v1.585h-3.17z M53.887 17.434h1.585v1.585h-1.585z M57.057 17.434h3.17v1.585h-3.17z M63.396 17.434h1.585v1.585h-1.585z M69.736 17.434h1.585v1.585h-1.585z M76.075 17.434h1.585v1.585h-1.585z M80.83 17.434h1.585v1.585h-1.585z M0.0 19.019h4.755v1.585h-4.755z M6.34 19.019h4.755v1.585h-4.755z M19.019 19.019h1.585v1.585h-1.585z M22.189 19.019h3.17v1.585h-3.17z M28.528 19.019h3.17v1.585h-3.17z M34.868 19.019h3.17v1.585h-3.17z M42.792 19.019h1.585v1.585h-1.585z M45.962 19.019h7.925v1.585h-7.925z M57.057 19.019h4.755v1.585h-4.755z M63.396 19.019h1.585v1.585h-1.585z M66.566 19.019h11.094v1.585h-11.094z M0.0 20.604h4.755v1.585h-4.755z M6.34 20.604h3.17v1.585h-3.17z M12.679 20.604h1.585v1.585h-1.585z M15.849 20.604h1.585v1.585h-1.585z M20.604 20.604h1.585v1.585h-1.585z M23.774 20.604h3.17v1.585h-3.17z M30.113 20.604h3.17v1.585h-3.17z M34.868 20.604h3.17v1.585h-3.17z M41.208 20.604h1.585v1.585h-1.585z M45.962 20.604h1.585v1.585h-1.585z M50.717 20.604h1.585v1.585h-1.585z M55.472 20.604h3.17v1.585h-3.17z M61.811 20.604h3.17v1.585h-3.17z M76.075 20.604h6.34v1.585h-6.34z M4.755 22.189h3.17v1.585h-3.17z M9.509 22.189h1.585v1.585h-1.585z M12.679 22.189h1.585v1.585h-1.585z M15.849 22.189h6.34v1.585h-6.34z M30.113 22.189h7.925v1.585h-7.925z M39.623 22.189h1.585v1.585h-1.585z M42.792 22.189h6.34v1.585h-6.34z M50.717 22.189h4.755v1.585h-4.755z M57.057 22.189h3.17v1.585h-3.17z M63.396 22.189h1.585v1.585h-1.585z M68.151 22.189h1.585v1.585h-1.585z M71.321 22.189h1.585v1.585h-1.585z M76.075 22.189h7.925v1.585h-7.925z M1.585 23.774h1.585v1.585h-1.585z M4.755 23.774h1.585v1.585h-1.585z M7.925 23.774h1.585v1.585h-1.585z M15.849 23.774h11.094v1.585h-11.094z M28.528 23.774h1.585v1.585h-1.585z M33.283 23.774h1.585v1.585h-1.585z M42.792 23.774h1.585v1.585h-1.585z M45.962 23.774h1.585v1.585h-1.585z M50.717 23.774h1.585v1.585h-1.585z M53.887 23.774h1.585v1.585h-1.585z M57.057 23.774h3.17v1.585h-3.17z M63.396 23.774h1.585v1.585h-1.585z M66.566 23.774h3.17v1.585h-3.17z M74.491 23.774h3.17v1.585h-3.17z M80.83 23.774h3.17v1.585h-3.17z M0.0 25.358h1.585v1.585h-1.585z M3.17 25.358h4.755v1.585h-4.755z M9.509 25.358h3.17v1.585h-3.17z M19.019 25.358h1.585v1.585h-1.585z M23.774 25.358h1.585v1.585h-1.585z M31.698 25.358h6.34v1.585h-6.34z M39.623 25.358h7.925v1.585h-7.925z M49.132 25.358h3.17v1.585h-3.17z M57.057 25.358h3.17v1.585h-3.17z M63.396 25.358h3.17v1.585h-3.17z M68.151 25.358h1.585v1.585h-1.585z M71.321 25.358h11.094v1.585h-11.094z M0.0 26.943h1.585v1.585h-1.585z M6.34 26.943h3.17v1.585h-3.17z M11.094 26.943h3.17v1.585h-3.17z M15.849 26.943h3.17v1.585h-3.17z M22.189 26.943h1.585v1.585h-1.585z M26.943 26.943h3.17v1.585h-3.17z M34.868 26.943h3.17v1.585h-3.17z M44.377 26.943h1.585v1.585h-1.585z M50.717 26.943h1.585v1.585h-1.585z M53.887 26.943h3.17v1.585h-3.17z M61.811 26.943h3.17v1.585h-3.17z M76.075 26.943h3.17v1.585h-3.17z M0.0 28.528h4.755v1.585h-4.755z M6.34 28.528h4.755v1.585h-4.755z M15.849 28.528h6.34v1.585h-6.34z M23.774 28.528h1.585v1.585h-1.585z M30.113 28.528h1.585v1.585h-1.585z M33.283 28.528h1.585v1.585h-1.585z M36.453 28.528h1.585v1.585h-1.585z M39.623 28.528h6.34v1.585h-6.34z M53.887 28.528h1.585v1.585h-1.585z M57.057 28.528h3.17v1.585h-3.17z M61.811 28.528h1.585v1.585h-1.585z M66.566 28.528h4.755v1.585h-4.755z M76.075 28.528h1.585v1.585h-1.585z M79.245 28.528h4.755v1.585h-4.755z M0.0 30.113h3.17v1.585h-3.17z M4.755 30.113h1.585v1.585h-1.585z M7.925 30.113h1.585v1.585h-1.585z M12.679 30.113h3.17v1.585h-3.17z M17.434 30.113h1.585v1.585h-1.585z M23.774 30.113h6.34v1.585h-6.34z M31.698 30.113h4.755v1.585h-4.755z M44.377 30.113h1.585v1.585h-1.585z M47.547 30.113h3.17v1.585h-3.17z M52.302 30.113h1.585v1.585h-1.585z M57.057 30.113h1.585v1.585h-1.585z M60.226 30.113h6.34v1.585h-6.34z M74.491 30.113h3.17v1.585h-3.17z M82.415 30.113h1.585v1.585h-1.585z M0.0 31.698h1.585v1.585h-1.585z M3.17 31.698h3.17v1.585h-3.17z M9.509 31.698h1.585v1.585h-1.585z M12.679 31.698h1.585v1.585h-1.585z M15.849 31.698h1.585v1.585h-1.585z M19.019 31.698h4.755v1.585h-4.755z M25.358 31.698h1.585v1.585h-1.585z M28.528 31.698h6.34v1.585h-6.34z M36.453 31.698h4.755v1.585h-4.755z M42.792 31.698h1.585v1.585h-1.585z M47.547 31.698h11.094v1.585h-11.094z M60.226 31.698h4.755v1.585h-4.755z M66.566 31.698h3.17v1.585h-3.17z M71.321 31.698h6.34v1.585h-6.34z M80.83 31.698h1.585v1.585h-1.585z M0.0 33.283h3.17v1.585h-3.17z M4.755 33.283h1.585v1.585h-1.585z M11.094 33.283h1.585v1.585h-1.585z M14.264 33.283h6.34v1.585h-6.34z M23.774 33.283h4.755v1.585h-4.755z M30.113 33.283h4.755v1.585h-4.755z M39.623 33.283h4.755v1.585h-4.755z M50.717 33.283h1.585v1.585h-1.585z M55.472 33.283h1.585v1.585h-1.585z M58.642 33.283h1.585v1.585h-1.585z M61.811 33.283h1.585v1.585h-1.585z M74.491 33.283h4.755v1.585h-4.755z M82.415 33.283h1.585v1.585h-1.585z M1.585 34.868h3.17v1.585h-3.17z M6.34 34.868h1.585v1.585h-1.585z M9.509 34.868h6.34v1.585h-6.34z M17.434 34.868h1.585v1.585h-1.585z M20.604 34.868h4.755v1.585h-4.755z M31.698 34.868h1.585v1.585h-1.585z M38.038 34.868h1.585v1.585h-1.585z M41.208 34.868h3.17v1.585h-3.17z M49.132 34.868h1.585v1.585h-1.585z M55.472 34.868h3.17v1.585h-3.17z M60.226 34.868h6.34v1.585h-6.34z M68.151 34.868h1.585v1.585h-1.585z M76.075 34.868h3.17v1.585h-3.17z M80.83 34.868h3.17v1.585h-3.17z M1.585 36.453h1.585v1.585h-1.585z M4.755 36.453h4.755v1.585h-4.755z M11.094 36.453h3.17v1.585h-3.17z M19.019 36.453h3.17v1.585h-3.17z M26.943 36.453h1.585v1.585h-1.585z M30.113 36.453h3.17v1.585h-3.17z M38.038 36.453h1.585v1.585h-1.585z M42.792 36.453h4.755v1.585h-4.755z M49.132 36.453h3.17v1.585h-3.17z M53.887 36.453h3.17v1.585h-3.17z M63.396 36.453h4.755v1.585h-4.755z M69.736 36.453h1.585v1.585h-1.585z M74.491 36.453h3.17v1.585h-3.17z M80.83 36.453h1.585v1.585h-1.585z M1.585 38.038h1.585v1.585h-1.585z M4.755 38.038h11.094v1.585h-11.094z M20.604 38.038h3.17v1.585h-3.17z M25.358 38.038h1.585v1.585h-1.585z M28.528 38.038h1.585v1.585h-1.585z M31.698 38.038h4.755v1.585h-4.755z M38.038 38.038h7.925v1.585h-7.925z M50.717 38.038h3.17v1.585h-3.17z M55.472 38.038h1.585v1.585h-1.585z M60.226 38.038h7.925v1.585h-7.925z M69.736 38.038h7.925v1.585h-7.925z M79.245 38.038h4.755v1.585h-4.755z M0.0 39.623h1.585v1.585h-1.585z M3.17 39.623h4.755v1.585h-4.755z M12.679 39.623h1.585v1.585h-1.585z M15.849 39.623h1.585v1.585h-1.585z M25.358 39.623h1.585v1.585h-1.585z M28.528 39.623h1.585v1.585h-1.585z M31.698 39.623h1.585v1.585h-1.585z M34.868 39.623h1.585v1.585h-1.585z M38.038 39.623h1.585v1.585h-1.585z M44.377 39.623h1.585v1.585h-1.585z M49.132 39.623h4.755v1.585h-4.755z M55.472 39.623h3.17v1.585h-3.17z M61.811 39.623h1.585v1.585h-1.585z M64.981 39.623h1.585v1.585h-1.585z M69.736 39.623h1.585v1.585h-1.585z M76.075 39.623h1.585v1.585h-1.585z M80.83 39.623h3.17v1.585h-3.17z M0.0 41.208h3.17v1.585h-3.17z M6.34 41.208h1.585v1.585h-1.585z M9.509 41.208h1.585v1.585h-1.585z M12.679 41.208h1.585v1.585h-1.585z M15.849 41.208h1.585v1.585h-1.585z M20.604 41.208h1.585v1.585h-1.585z M28.528 41.208h1.585v1.585h-1.585z M34.868 41.208h4.755v1.585h-4.755z M41.208 41.208h1.585v1.585h-1.585z M44.377 41.208h1.585v1.585h-1.585z M49.132 41.208h1.585v1.585h-1.585z M52.302 41.208h1.585v1.585h-1.585z M55.472 41.208h1.585v1.585h-1.585z M58.642 41.208h1.585v1.585h-1.585z M61.811 41.208h3.17v1.585h-3.17z M68.151 41.208h3.17v1.585h-3.17z M72.906 41.208h1.585v1.585h-1.585z M76.075 41.208h1.585v1.585h-1.585z M79.245 41.208h1.585v1.585h-1.585z M82.415 41.208h1.585v1.585h-1.585z M0.0 42.792h3.17v1.585h-3.17z M4.755 42.792h3.17v1.585h-3.17z M12.679 42.792h7.925v1.585h-7.925z M26.943 42.792h3.17v1.585h-3.17z M31.698 42.792h4.755v1.585h-4.755z M38.038 42.792h1.585v1.585h-1.585z M44.377 42.792h1.585v1.585h-1.585z M52.302 42.792h1.585v1.585h-1.585z M55.472 42.792h4.755v1.585h-4.755z M63.396 42.792h1.585v1.585h-1.585z M68.151 42.792h3.17v1.585h-3.17z M76.075 42.792h1.585v1.585h-1.585z M1.585 44.377h1.585v1.585h-1.585z M6.34 44.377h9.509v1.585h-9.509z M19.019 44.377h6.34v1.585h-6.34z M28.528 44.377h1.585v1.585h-1.585z M31.698 44.377h4.755v1.585h-4.755z M38.038 44.377h7.925v1.585h-7.925z M47.547 44.377h1.585v1.585h-1.585z M50.717 44.377h1.585v1.585h-1.585z M55.472 44.377h3.17v1.585h-3.17z M61.811 44.377h6.34v1.585h-6.34z M69.736 44.377h9.509v1.585h-9.509z M0.0 45.962h3.17v1.585h-3.17z M6.34 45.962h3.17v1.585h-3.17z M12.679 45.962h1.585v1.585h-1.585z M17.434 45.962h1.585v1.585h-1.585z M20.604 45.962h7.925v1.585h-7.925z M31.698 45.962h4.755v1.585h-4.755z M38.038 45.962h1.585v1.585h-1.585z M41.208 45.962h1.585v1.585h-1.585z M44.377 45.962h1.585v1.585h-1.585z M52.302 45.962h1.585v1.585h-1.585z M57.057 45.962h3.17v1.585h-3.17z M61.811 45.962h3.17v1.585h-3.17z M69.736 45.962h1.585v1.585h-1.585z M77.66 45.962h6.34v1.585h-6.34z M1.585 47.547h1.585v1.585h-1.585z M9.509 47.547h1.585v1.585h-1.585z M15.849 47.547h3.17v1.585h-3.17z M20.604 47.547h1.585v1.585h-1.585z M39.623 47.547h1.585v1.585h-1.585z M42.792 47.547h3.17v1.585h-3.17z M50.717 47.547h3.17v1.585h-3.17z M55.472 47.547h1.585v1.585h-1.585z M58.642 47.547h1.585v1.585h-1.585z M61.811 47.547h1.585v1.585h-1.585z M71.321 47.547h3.17v1.585h-3.17z M77.66 47.547h1.585v1.585h-1.585z M80.83 47.547h3.17v1.585h-3.17z M3.17 49.132h3.17v1.585h-3.17z M7.925 49.132h1.585v1.585h-1.585z M14.264 49.132h1.585v1.585h-1.585z M19.019 49.132h3.17v1.585h-3.17z M25.358 49.132h1.585v1.585h-1.585z M28.528 49.132h1.585v1.585h-1.585z M31.698 49.132h3.17v1.585h-3.17z M36.453 49.132h6.34v1.585h-6.34z M47.547 49.132h3.17v1.585h-3.17z M57.057 49.132h3.17v1.585h-3.17z M63.396 49.132h1.585v1.585h-1.585z M68.151 49.132h3.17v1.585h-3.17z M72.906 49.132h3.17v1.585h-3.17z M82.415 49.132h1.585v1.585h-1.585z M1.585 50.717h6.34v1.585h-6.34z M9.509 50.717h3.17v1.585h-3.17z M14.264 50.717h3.17v1.585h-3.17z M22.189 50.717h1.585v1.585h-1.585z M26.943 50.717h1.585v1.585h-1.585z M30.113 50.717h3.17v1.585h-3.17z M34.868 50.717h1.585v1.585h-1.585z M39.623 50.717h1.585v1.585h-1.585z M42.792 50.717h1.585v1.585h-1.585z M49.132 50.717h3.17v1.585h-3.17z M57.057 50.717h1.585v1.585h-1.585z M63.396 50.717h4.755v1.585h-4.755z M69.736 50.717h1.585v1.585h-1.585z M74.491 50.717h1.585v1.585h-1.585z M77.66 50.717h1.585v1.585h-1.585z M80.83 50.717h1.585v1.585h-1.585z M3.17 52.302h1.585v1.585h-1.585z M7.925 52.302h1.585v1.585h-1.585z M11.094 52.302h1.585v1.585h-1.585z M14.264 52.302h3.17v1.585h-3.17z M19.019 52.302h3.17v1.585h-3.17z M23.774 52.302h3.17v1.585h-3.17z M28.528 52.302h1.585v1.585h-1.585z M31.698 52.302h1.585v1.585h-1.585z M34.868 52.302h1.585v1.585h-1.585z M38.038 52.302h3.17v1.585h-3.17z M44.377 52.302h1.585v1.585h-1.585z M47.547 52.302h1.585v1.585h-1.585z M50.717 52.302h1.585v1.585h-1.585z M57.057 52.302h1.585v1.585h-1.585z M63.396 52.302h1.585v1.585h-1.585z M68.151 52.302h6.34v1.585h-6.34z M79.245 52.302h3.17v1.585h-3.17z M1.585 53.887h4.755v1.585h-4.755z M7.925 53.887h4.755v1.585h-4.755z M14.264 53.887h1.585v1.585h-1.585z M20.604 53.887h6.34v1.585h-6.34z M28.528 53.887h3.17v1.585h-3.17z M34.868 53.887h1.585v1.585h-1.585z M39.623 53.887h3.17v1.585h-3.17z M47.547 53.887h3.17v1.585h-3.17z M52.302 53.887h4.755v1.585h-4.755z M58.642 53.887h1.585v1.585h-1.585z M61.811 53.887h1.585v1.585h-1.585z M64.981 53.887h1.585v1.585h-1.585z M72.906 53.887h1.585v1.585h-1.585z M76.075 53.887h3.17v1.585h-3.17z M80.83 53.887h3.17v1.585h-3.17z M0.0 55.472h4.755v1.585h-4.755z M7.925 55.472h1.585v1.585h-1.585z M14.264 55.472h3.17v1.585h-3.17z M26.943 55.472h3.17v1.585h-3.17z M31.698 55.472h1.585v1.585h-1.585z M34.868 55.472h4.755v1.585h-4.755z M47.547 55.472h3.17v1.585h-3.17z M52.302 55.472h1.585v1.585h-1.585z M57.057 55.472h1.585v1.585h-1.585z M61.811 55.472h6.34v1.585h-6.34z M69.736 55.472h6.34v1.585h-6.34z M82.415 55.472h1.585v1.585h-1.585z M4.755 57.057h6.34v1.585h-6.34z M12.679 57.057h1.585v1.585h-1.585z M17.434 57.057h1.585v1.585h-1.585z M22.189 57.057h3.17v1.585h-3.17z M30.113 57.057h1.585v1.585h-1.585z M33.283 57.057h3.17v1.585h-3.17z M38.038 57.057h4.755v1.585h-4.755z M45.962 57.057h1.585v1.585h-1.585z M49.132 57.057h6.34v1.585h-6.34z M57.057 57.057h1.585v1.585h-1.585z M60.226 57.057h1.585v1.585h-1.585z M63.396 57.057h1.585v1.585h-1.585z M69.736 57.057h1.585v1.585h-1.585z M72.906 57.057h7.925v1.585h-7.925z M82.415 57.057h1.585v1.585h-1.585z M0.0 58.642h9.509v1.585h-9.509z M12.679 58.642h1.585v1.585h-1.585z M17.434 58.642h1.585v1.585h-1.585z M20.604 58.642h4.755v1.585h-4.755z M26.943 58.642h1.585v1.585h-1.585z M30.113 58.642h3.17v1.585h-3.17z M38.038 58.642h6.34v1.585h-6.34z M50.717 58.642h3.17v1.585h-3.17z M57.057 58.642h1.585v1.585h-1.585z M61.811 58.642h1.585v1.585h-1.585z M68.151 58.642h6.34v1.585h-6.34z M3.17 60.226h1.585v1.585h-1.585z M6.34 60.226h1.585v1.585h-1.585z M9.509 60.226h1.585v1.585h-1.585z M12.679 60.226h1.585v1.585h-1.585z M19.019 60.226h4.755v1.585h-4.755z M28.528 60.226h1.585v1.585h-1.585z M31.698 60.226h1.585v1.585h-1.585z M34.868 60.226h1.585v1.585h-1.585z M41.208 60.226h1.585v1.585h-1.585z M49.132 60.226h1.585v1.585h-1.585z M52.302 60.226h4.755v1.585h-4.755z M69.736 60.226h6.34v1.585h-6.34z M77.66 60.226h6.34v1.585h-6.34z M1.585 61.811h1.585v1.585h-1.585z M14.264 61.811h1.585v1.585h-1.585z M17.434 61.811h1.585v1.585h-1.585z M20.604 61.811h1.585v1.585h-1.585z M23.774 61.811h3.17v1.585h-3.17z M30.113 61.811h3.17v1.585h-3.17z M36.453 61.811h3.17v1.585h-3.17z M41.208 61.811h1.585v1.585h-1.585z M47.547 61.811h4.755v1.585h-4.755z M55.472 61.811h3.17v1.585h-3.17z M60.226 61.811h1.585v1.585h-1.585z M63.396 61.811h3.17v1.585h-3.17z M69.736 61.811h4.755v1.585h-4.755z M76.075 61.811h1.585v1.585h-1.585z M80.83 61.811h3.17v1.585h-3.17z M0.0 63.396h1.585v1.585h-1.585z M3.17 63.396h1.585v1.585h-1.585z M7.925 63.396h3.17v1.585h-3.17z M14.264 63.396h1.585v1.585h-1.585z M17.434 63.396h1.585v1.585h-1.585z M22.189 63.396h1.585v1.585h-1.585z M25.358 63.396h4.755v1.585h-4.755z M34.868 63.396h1.585v1.585h-1.585z M39.623 63.396h7.925v1.585h-7.925z M50.717 63.396h3.17v1.585h-3.17z M55.472 63.396h3.17v1.585h-3.17z M61.811 63.396h3.17v1.585h-3.17z M69.736 63.396h3.17v1.585h-3.17z M77.66 63.396h1.585v1.585h-1.585z M82.415 63.396h1.585v1.585h-1.585z M0.0 64.981h7.925v1.585h-7.925z M14.264 64.981h1.585v1.585h-1.585z M19.019 64.981h1.585v1.585h-1.585z M23.774 64.981h1.585v1.585h-1.585z M28.528 64.981h1.585v1.585h-1.585z M38.038 64.981h4.755v1.585h-4.755z M49.132 64.981h3.17v1.585h-3.17z M57.057 64.981h1.585v1.585h-1.585z M60.226 64.981h3.17v1.585h-3.17z M69.736 64.981h4.755v1.585h-4.755z M82.415 64.981h1.585v1.585h-1.585z M0.0 66.566h3.17v1.585h-3.17z M4.755 66.566h6.34v1.585h-6.34z M12.679 66.566h1.585v1.585h-1.585z M15.849 66.566h1.585v1.585h-1.585z M22.189 66.566h1.585v1.585h-1.585z M25.358 66.566h3.17v1.585h-3.17z M31.698 66.566h3.17v1.585h-3.17z M39.623 66.566h3.17v1.585h-3.17z M45.962 66.566h1.585v1.585h-1.585z M50.717 66.566h1.585v1.585h-1.585z M55.472 66.566h1.585v1.585h-1.585z M60.226 66.566h1.585v1.585h-1.585z M68.151 66.566h6.34v1.585h-6.34z M80.83 66.566h3.17v1.585h-3.17z M1.585 68.151h3.17v1.585h-3.17z M12.679 68.151h1.585v1.585h-1.585z M15.849 68.151h1.585v1.585h-1.585z M19.019 68.151h1.585v1.585h-1.585z M25.358 68.151h4.755v1.585h-4.755z M31.698 68.151h1.585v1.585h-1.585z M34.868 68.151h1.585v1.585h-1.585z M39.623 68.151h1.585v1.585h-1.585z M42.792 68.151h1.585v1.585h-1.585z M49.132 68.151h4.755v1.585h-4.755z M61.811 68.151h3.17v1.585h-3.17z M66.566 68.151h1.585v1.585h-1.585z M71.321 68.151h4.755v1.585h-4.755z M4.755 69.736h1.585v1.585h-1.585z M9.509 69.736h1.585v1.585h-1.585z M12.679 69.736h1.585v1.585h-1.585z M15.849 69.736h4.755v1.585h-4.755z M22.189 69.736h1.585v1.585h-1.585z M25.358 69.736h11.094v1.585h-11.094z M38.038 69.736h14.264v1.585h-14.264z M57.057 69.736h3.17v1.585h-3.17z M61.811 69.736h3.17v1.585h-3.17z M69.736 69.736h11.094v1.585h-11.094z M12.679 71.321h1.585v1.585h-1.585z M17.434 71.321h6.34v1.585h-6.34z M25.358 71.321h9.509v1.585h-9.509z M38.038 71.321h1.585v1.585h-1.585z M44.377 71.321h1.585v1.585h-1.585z M50.717 71.321h3.17v1.585h-3.17z M63.396 71.321h1.585v1.585h-1.585z M69.736 71.321h1.585v1.585h-1.585z M76.075 71.321h1.585v1.585h-1.585z M82.415 71.321h1.585v1.585h-1.585z M0.0 72.906h11.094v1.585h-11.094z M19.019 72.906h7.925v1.585h-7.925z M30.113 72.906h1.585v1.585h-1.585z M33.283 72.906h1.585v1.585h-1.585z M38.038 72.906h1.585v1.585h-1.585z M41.208 72.906h1.585v1.585h-1.585z M44.377 72.906h3.17v1.585h-3.17z M49.132 72.906h1.585v1.585h-1.585z M52.302 72.906h1.585v1.585h-1.585z M57.057 72.906h1.585v1.585h-1.585z M61.811 72.906h1.585v1.585h-1.585z M68.151 72.906h3.17v1.585h-3.17z M72.906 72.906h1.585v1.585h-1.585z M76.075 72.906h1.585v1.585h-1.585z M79.245 72.906h4.755v1.585h-4.755z M0.0 74.491h1.585v1.585h-1.585z M9.509 74.491h1.585v1.585h-1.585z M17.434 74.491h1.585v1.585h-1.585z M20.604 74.491h1.585v1.585h-1.585z M25.358 74.491h3.17v1.585h-3.17z M30.113 74.491h1.585v1.585h-1.585z M33.283 74.491h6.34v1.585h-6.34z M44.377 74.491h1.585v1.585h-1.585z M49.132 74.491h1.585v1.585h-1.585z M55.472 74.491h3.17v1.585h-3.17z M61.811 74.491h4.755v1.585h-4.755z M69.736 74.491h1.585v1.585h-1.585z M76.075 74.491h1.585v1.585h-1.585z M80.83 74.491h1.585v1.585h-1.585z M0.0 76.075h1.585v1.585h-1.585z M3.17 76.075h4.755v1.585h-4.755z M9.509 76.075h1.585v1.585h-1.585z M12.679 76.075h1.585v1.585h-1.585z M15.849 76.075h3.17v1.585h-3.17z M25.358 76.075h3.17v1.585h-3.17z M30.113 76.075h1.585v1.585h-1.585z M33.283 76.075h1.585v1.585h-1.585z M38.038 76.075h12.679v1.585h-12.679z M55.472 76.075h3.17v1.585h-3.17z M61.811 76.075h4.755v1.585h-4.755z M68.151 76.075h11.094v1.585h-11.094z M80.83 76.075h3.17v1.585h-3.17z M0.0 77.66h1.585v1.585h-1.585z M3.17 77.66h4.755v1.585h-4.755z M9.509 77.66h1.585v1.585h-1.585z M14.264 77.66h3.17v1.585h-3.17z M19.019 77.66h1.585v1.585h-1.585z M22.189 77.66h1.585v1.585h-1.585z M28.528 77.66h3.17v1.585h-3.17z M33.283 77.66h1.585v1.585h-1.585z M49.132 77.66h3.17v1.585h-3.17z M58.642 77.66h1.585v1.585h-1.585z M69.736 77.66h1.585v1.585h-1.585z M72.906 77.66h1.585v1.585h-1.585z M76.075 77.66h1.585v1.585h-1.585z M0.0 79.245h1.585v1.585h-1.585z M3.17 79.245h4.755v1.585h-4.755z M9.509 79.245h1.585v1.585h-1.585z M12.679 79.245h9.509v1.585h-9.509z M23.774 79.245h1.585v1.585h-1.585z M28.528 79.245h1.585v1.585h-1.585z M31.698 79.245h3.17v1.585h-3.17z M38.038 79.245h1.585v1.585h-1.585z M42.792 79.245h1.585v1.585h-1.585z M45.962 79.245h4.755v1.585h-4.755z M52.302 79.245h3.17v1.585h-3.17z M63.396 79.245h1.585v1.585h-1.585z M68.151 79.245h3.17v1.585h-3.17z M74.491 79.245h6.34v1.585h-6.34z M0.0 80.83h1.585v1.585h-1.585z M9.509 80.83h1.585v1.585h-1.585z M14.264 80.83h1.585v1.585h-1.585z M17.434 80.83h3.17v1.585h-3.17z M22.189 80.83h1.585v1.585h-1.585z M31.698 80.83h1.585v1.585h-1.585z M34.868 80.83h6.34v1.585h-6.34z M45.962 80.83h1.585v1.585h-1.585z M52.302 80.83h1.585v1.585h-1.585z M58.642 80.83h7.925v1.585h-7.925z M68.151 80.83h3.17v1.585h-3.17z M74.491 80.83h1.585v1.585h-1.585z M80.83 80.83h1.585v1.585h-1.585z M0.0 82.415h11.094v1.585h-11.094z M12.679 82.415h4.755v1.585h-4.755z M22.189 82.415h1.585v1.585h-1.585z M25.358 82.415h3.17v1.585h-3.17z M30.113 82.415h1.585v1.585h-1.585z M36.453 82.415h3.17v1.585h-3.17z M44.377 82.415h9.509v1.585h-9.509z M55.472 82.415h6.34v1.585h-6.34z M63.396 82.415h3.17v1.585h-3.17z M69.736 82.415h3.17v1.585h-3.17z M74.491 82.415h3.17v1.585h-3.17z M80.83 82.415h3.17v1.585h-3.17z"/>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
+++ b/assets/images/2026-01-22-KARA_Ransomware_Trends_2025_Q3.svg
@@ -1,99 +1,465 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
-  <title>2025 3 KARA RANSOMWARE</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="52%" stop-color="#121a2f"/>
-      <stop offset="100%" stop-color="#170f25"/>
-    </linearGradient>
-    <linearGradient id="panel" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.96"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.86"/>
-    </linearGradient>
-    <pattern id="microGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#334155" stroke-width="1" opacity="0.25"/>
-      <circle cx="18" cy="18" r="1.2" fill="#ef4444" opacity="0.15"/>
-    </pattern>
-    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="sg" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="36"/>
-    </filter>
-    <filter id="shadow" x="-30%" y="-30%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#microGrid)"/>
-  <circle cx="202" cy="150" r="190" fill="#ef4444" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="1020" cy="486" r="220" fill="#991b1b" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="920" cy="160" r="140" fill="#38bdf8" opacity="0.04" filter="url(#sg)"/>
-  <path d="M0 96 C224 46 426 44 654 118 L654 630 L0 630 Z" fill="#020617" opacity="0.24"/>
-  <path d="M0 526 C248 490 426 486 654 548" fill="none" stroke="#475569" stroke-width="1.2" opacity="0.22"/>
-  <rect x="736" y="104" width="362" height="326" rx="28" fill="url(#panel)" stroke="#ef4444" stroke-opacity="0.28" stroke-width="1.4" filter="url(#shadow)"/>
-  <rect x="754" y="122" width="326" height="290" rx="22" fill="none" stroke="#334155" stroke-opacity="0.7" stroke-width="1"/>
-  <rect x="758" y="124" width="108" height="12" rx="6" fill="#ef4444" opacity="0.28"/>
-  <rect x="880" y="124" width="72" height="12" rx="6" fill="#334155" opacity="0.55"/>
-  <rect x="964" y="124" width="48" height="12" rx="6" fill="#334155" opacity="0.35"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="KARA Ransomware Trends 2025 Q3 LockBit 5 Akira INC SK Shieldus">
+<title>KARA Q3 2025: LockBit 5.0, Akira, INC Ransomware Defense</title>
+<defs>
+<linearGradient id="bgSpreadkr22" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0A1226"/><stop offset="50%" stop-color="#0C1430"/><stop offset="100%" stop-color="#131038"/></linearGradient>
+<linearGradient id="bandAkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#1A0E2E"/><stop offset="100%" stop-color="#24122F"/></linearGradient>
+<linearGradient id="bandBkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2A1A0C"/><stop offset="100%" stop-color="#1E1F0A"/></linearGradient>
+<linearGradient id="bandCkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#1E0A3A"/><stop offset="100%" stop-color="#2A0E4A"/></linearGradient>
+<linearGradient id="streakAkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#E63946" stop-opacity="0"/><stop offset="50%" stop-color="#E63946" stop-opacity="0.85"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakBkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0"/><stop offset="50%" stop-color="#FFB703" stop-opacity="0.85"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakCkr22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#A78BFA" stop-opacity="0"/><stop offset="50%" stop-color="#A78BFA" stop-opacity="0.85"/><stop offset="100%" stop-color="#A78BFA" stop-opacity="0"/></linearGradient>
+<radialGradient id="glowAkr22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowBkr22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowCkr22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#A78BFA" stop-opacity="0.55"/><stop offset="100%" stop-color="#A78BFA" stop-opacity="0"/></radialGradient>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%"><feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/><feOffset dx="0" dy="1.5"/><feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<pattern id="ledgerGrid" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse"><path d="M0 20 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/><path d="M40 0 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/></pattern>
+<pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/></pattern>
+<pattern id="hexGridkr22" x="0" y="0" width="28" height="32" patternUnits="userSpaceOnUse"><path d="M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+<pattern id="radarRipplekr22" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse"><circle cx="30" cy="30" r="14" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+</defs>
+<rect width="1200" height="630" fill="url(#bgSpreadkr22)"/>
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandAkr22)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#circuitDot)" opacity="0.6"/>
+  <rect x="0" y="0" width="8" height="210" fill="#E63946"/>
   
-  <path d="M724 152 C822 126 922 136 1020 202" fill="none" stroke="#f59e0b" stroke-width="1.3" opacity="0.24"/>
-  <path d="M706 420 C782 454 878 462 968 410" fill="none" stroke="#60a5fa" stroke-width="1.2" opacity="0.22"/>
-
-  <g transform="translate(917,270)" filter="url(#shadow)">
-    <circle r="96" fill="#0f172a" stroke="#ef4444" stroke-width="2.6" opacity="0.94"/>
-    <circle r="124" fill="none" stroke="#ef4444" stroke-opacity="0.15" stroke-width="1.2" stroke-dasharray="8 8"/>
-    <circle r="54" fill="none" stroke="#e2e8f0" stroke-opacity="0.15" stroke-width="1"/>
-
-    <path d="M0,-50 L40,-35 L40,10 C40,35 0,55 0,55 C0,55 -40,35 -40,10 L-40,-35 Z" fill="none" stroke="#ef4444" stroke-width="3"/>
-    <path d="M-12,2 L-4,12 L16,-10" stroke="#ef4444" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <circle cx="-50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <circle cx="50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <line x1="-42" y1="-26" x2="-20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-    <line x1="42" y1="-26" x2="20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#F87171">RANSOMWARE Q3 2025</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">LockBit 5.0 · Akira</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FBB6BD">Top 3 groups · 47% of all observed Q3 attacks</text>
+    <text x="30" y="144" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D9C9CE">LockBit returns post-takedown · INC Ransomware emerges</text>
+    <text x="30" y="162" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FBB6BD">Akira ESXi targeting · double extortion standard</text><text x="30" y="178" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D9C9CE" fill-opacity="0.85">RaaS affiliate pool grew · 2,300+ active operators</text>
+    
   </g>
-  <g transform="translate(84 66)">
-    <rect width="164" height="36" rx="18" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="82" y="23" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SECURITY</text>
+  <g transform="translate(690,105)">
+    <circle r="78" fill="#E63946" fill-opacity="0.06"><animate attributeName="r" values="62;82;62" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-22 -20 Q-22 -50 0 -50 Q22 -50 22 -20" stroke="#E63946" stroke-width="4" fill="none"/>
+    <rect x="-32" y="-22" width="64" height="60" rx="6" fill="#E63946" fill-opacity="0.2" stroke="#E63946" stroke-width="2.2" filter="url(#softShadow)"/>
+    <circle r="5" fill="#FCA5A5" cy="2"/>
+    <rect x="-3" y="2" width="6" height="18" fill="#FCA5A5"/>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="14" font-weight="900" fill="#E63946">CVSS 9.8</text>
+    <g fill="#FCA5A5" opacity="0.85">
+      <circle cx="-55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="-55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FCA5A5" stroke-width="0.8" stroke-opacity="0.5" fill="none">
+      <path d="M-44 -30 L-38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.2s" repeatCount="indefinite"/></path>
+      <path d="M44 -30 L38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/></path>
+      <path d="M-44 30 L-38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.0s" repeatCount="indefinite"/></path>
+      <path d="M44 30 L38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.6s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#FCA5A5" opacity="0.55">
+      <circle cx="-72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#E63946" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-86" y1="0" x2="-74" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" repeatCount="indefinite"/></line>
+      <line x1="74" y1="0" x2="86" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.5s" repeatCount="indefinite"/></line>
+    </g>
+    <text y="78" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCA5A5" opacity="0.7">CVSS : critical scope</text>
   </g>
-  <text x="84" y="170" font-family="Arial,sans-serif" font-size="54" font-weight="700" fill="#f8fafc" letter-spacing="0.5">2025 3 KARA</text>
-  <text x="84" y="232" font-family="Arial,sans-serif" font-size="52" font-weight="700" fill="#dbeafe" letter-spacing="0.5">RANSOMWARE</text>
-  <text x="84" y="288" font-family="Arial,sans-serif" font-size="18" fill="#cbd5e1">RANSOMWARE / DEVSECOPS / SECURITY</text>
-  <rect x="84" y="314" width="520" height="1.5" fill="#334155" opacity="0.9"/>
-  <text x="84" y="344" font-family="Arial,sans-serif" font-size="14" font-weight="700" fill="#94a3b8">VISUAL SYSTEM 29D7C877027A</text>
-  <text x="84" y="372" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">KARA ransomware trend report for Q3 2025: attack vectors, victim sectors, and defenses.</text>
-  <g transform="translate(84 474)">
-    <rect width="134" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="67.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">RANSOMWARE</text>
+  <g transform="translate(870,105)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#F87171">LOCKBIT</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">LB5</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FBB6BD">5.0 build</text>
   </g>
-  <g transform="translate(232 474)">
-    <rect width="124" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="62.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">DEVSECOPS</text>
+  <g transform="translate(1110,105)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#F87171">EMERGING</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">INC</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FBB6BD">new family</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#E63946" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCA5A5"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
   </g>
-  <g transform="translate(370 474)">
-    <rect width="114" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="57.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">SECURITY</text>
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E0A14" stroke="#E63946" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#F87171">TOP 3 SHARE</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">47%</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FBB6BD">Q3 2025</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#E63946" stroke-width="0.8" stroke-opacity="0.5"/>
+    
   </g>
-  <g transform="translate(84 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">CATEGORY</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">SECURITY</text>
+  <g transform="translate(990,105)">
+    <circle cx="10" cy="-50" r="3" fill="#E63946"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
   </g>
-  <g transform="translate(246 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">SIGNALS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">05</text>
+  <g opacity="0.85">
+    <line x1="20" y1="210" x2="1180" y2="210" stroke="#E63946" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="210" r="2.2" fill="#E63946">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <g transform="translate(408 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">TAGS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">10</text>
+</g>
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandBkr22)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="210" width="8" height="210" fill="#FFB703"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FFB703">TTPs & DETECTION</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">YARA · Sigma Rules</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FFD58A">62 new TTPs documented · MITRE ATT&CK mapped</text>
+    <text x="30" y="354" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E0D5B6">Initial access via Citrix Bleed 2 · ESXi mass-encrypt</text>
+    <text x="30" y="372" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FFD58A">Sigma detection · Splunk/Elastic queries published</text><text x="30" y="388" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#E0D5B6" fill-opacity="0.85">YARA signatures · Lazarus binary clusters identified</text>
+    
   </g>
-  <g transform="translate(1030 74)">
-    <rect width="130" height="34" rx="17" fill="#1d4ed8" opacity="0.18" stroke="#3b82f6" stroke-width="1.2"/>
-    <text x="65" y="22" font-family="Arial,sans-serif" font-size="12" font-weight="700" fill="#bfdbfe" text-anchor="middle">April 14, 2026</text>
+  <g transform="translate(690,315)">
+    <rect x="-92" y="-56" width="184" height="116" rx="8" fill="#FFB703" fill-opacity="0.05" stroke="#FFB703" stroke-width="1.2" stroke-opacity="0.5"/>
+    <g stroke="#FFB703" stroke-width="2" opacity="0.85">
+      <line x1="-80" y1="-40" x2="-30" y2="-40"/><line x1="-25" y1="-40" x2="40" y2="-40"/>
+      <line x1="-80" y1="-20" x2="-10" y2="-20"/><line x1="-5" y1="-20" x2="55" y2="-20"/>
+      <line x1="-80" y1="0" x2="-40" y2="0"/><line x1="-35" y1="0" x2="60" y2="0"/>
+      <line x1="-80" y1="20" x2="-20" y2="20"/><line x1="-15" y1="20" x2="30" y2="20"/>
+      <line x1="-80" y1="40" x2="-50" y2="40"/><line x1="-45" y1="40" x2="50" y2="40"/>
+    </g>
+    <rect x="-86" y="-50" width="4" height="104" fill="#FFB703" opacity="0.6"/>
+    <g fill="#FCD34D">
+      <circle cx="74" cy="-40" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="-20" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="0" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="20" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" repeatCount="indefinite"/></circle>
+      <circle cx="74" cy="40" r="3"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <rect x="-86" y="-50" width="178" height="3" fill="#FFB703" opacity="0.4">
+      <animate attributeName="y" values="-50;46;-50" dur="3.2s" repeatCount="indefinite"/>
+    </rect>
+    <g fill="#FCD34D" opacity="0.65">
+      <circle cx="-86" cy="-40" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="-20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.2s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="0" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="20" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-86" cy="40" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FFB703" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+      <path d="M-94 -54 L-78 -54"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="1.8s" repeatCount="indefinite"/></path>
+      <path d="M82 -54 L94 -54"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2s" begin="0.3s" repeatCount="indefinite"/></path>
+    </g>
+    <text x="-86" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FCD34D" opacity="0.7">5 lines</text>
+    <text x="80" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FCD34D" opacity="0.7">live</text>
+    <text y="68" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFB703">TTPs</text>
+    <text y="82" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCD34D" opacity="0.7">cursor : line 5 col 14</text>
   </g>
-  <line x1="50" y1="588" x2="1150" y2="588" stroke="#334155" stroke-width="1" opacity="0.5"/>
-  <text x="1150" y="612" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <g transform="translate(870,315)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#FFB703">ATT&CK</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="24" font-weight="900" fill="#F5F7FA">MITRE</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFD58A">mapped</text>
+  </g>
+  <g transform="translate(1110,315)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#FFB703">HYPERV</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">ESXi</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FFD58A">targeted</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#FFB703" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCD34D"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E1805" stroke="#FFB703" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FFB703">NEW TTPs</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">62</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD58A">quarterly</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#FFB703" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,315)">
+    <circle cx="10" cy="-50" r="3" fill="#FFB703"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g opacity="0.85">
+    <line x1="20" y1="420" x2="1180" y2="420" stroke="#FFB703" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="420" r="2.2" fill="#FFB703">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandCkr22)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#circuitDot)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#A78BFA"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#C4B5FD">ZERO TRUST DEFENSE</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">EQST Strategy</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#DDD6FE">Network segmentation · MFA · backup-isolation 3-2-1-1-0</text>
+    <text x="30" y="564" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D0CCE5">Tabletop exercise · 72-hour incident playbook ready</text>
+    <text x="30" y="582" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#DDD6FE">Immutable backup · air-gapped · WORM storage tier</text><text x="30" y="598" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D0CCE5" fill-opacity="0.85">Incident response · 72hr SLA · cyber insurance coord</text>
+    
+  </g>
+  <g transform="translate(690,525)">
+    <circle r="78" fill="#A78BFA" fill-opacity="0.05"><animate attributeName="r" values="68;84;68" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M0 -60 L55 -40 L50 25 Q40 55 0 65 Q-40 55 -50 25 L-55 -40 Z" fill="#A78BFA" fill-opacity="0.15" stroke="#A78BFA" stroke-width="2.4" filter="url(#softShadow)"/>
+    <path d="M0 -50 L45 -33 L40 22 Q32 46 0 55 Q-32 46 -40 22 L-45 -33 Z" fill="none" stroke="#C4B5FD" stroke-width="1" opacity="0.7"/>
+    <path d="M0 -40 L35 -26 L31 18 Q24 38 0 45 Q-24 38 -31 18 L-35 -26 Z" fill="none" stroke="#C4B5FD" stroke-width="0.6" opacity="0.5"/>
+    <g transform="translate(0,-5)" stroke="#C4B5FD" stroke-width="3" fill="none">
+      <path d="M-18 5 L-4 20 L22 -12"><animate attributeName="stroke-dasharray" values="0 80;80 0" dur="2.4s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#C4B5FD" opacity="0.7">
+      <circle cx="-40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="40" cy="-30" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.2s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="35" r="2"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.9s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#C4B5FD" opacity="0.55">
+      <circle cx="-65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="65" cy="0" r="1.4"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="55" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#A78BFA" stroke-width="0.4" stroke-opacity="0.35" fill="none">
+      <path d="M-78 -68 L-66 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2s" repeatCount="indefinite"/></path>
+      <path d="M66 -68 L78 -68"><animate attributeName="stroke-opacity" values="0;0.6;0" dur="2.3s" begin="0.4s" repeatCount="indefinite"/></path>
+    </g>
+    <text x="-78" y="-72" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#C4B5FD" opacity="0.7">verified</text>
+    <text y="84" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#A78BFA">EQST</text>
+    <text y="98" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#C4B5FD" opacity="0.7">3 rings : signed by CA</text>
+  </g>
+  <g transform="translate(870,525)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#160629" stroke="#A78BFA" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#C4B5FD">BACKUP</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="24" font-weight="900" fill="#F5F7FA">3-2-1</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#DDD6FE">rule</text>
+  </g>
+  <g transform="translate(1110,525)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#160629" stroke="#A78BFA" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#C4B5FD">ENFORCED</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">MFA</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#DDD6FE">all admin</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#A78BFA" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#C4B5FD"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#160629" stroke="#A78BFA" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#C4B5FD">ZERO TRUST</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">ZT</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#DDD6FE">strategy</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#A78BFA" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,525)">
+    <circle cx="10" cy="-50" r="3" fill="#A78BFA"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#C4B5FD"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#C4B5FD"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#A78BFA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#C4B5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#A78BFA" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#C4B5FD" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  
+</g>
+<g opacity="0.9">
+  <g fill="#E63946">
+    <circle cx="240" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="35" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="175" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="27" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="81" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="129" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.6">
+    <rect x="780" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCA5A5" opacity="0.85">
+    <rect x="730" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#E63946" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 95 L28 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 125 L28 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 155 L28 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 185 L28 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 95 L1172 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 125 L1172 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 155 L1172 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 185 L1172 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCA5A5" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="105" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="105" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.55">
+    <rect x="120" y="15" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="195" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FFB703">
+    <circle cx="240" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="245" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="385" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="237" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="291" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="339" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.6">
+    <rect x="780" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCD34D" opacity="0.85">
+    <rect x="730" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#FFB703" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 305 L28 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 335 L28 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 365 L28 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 395 L28 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 305 L1172 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 335 L1172 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 365 L1172 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 395 L1172 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCD34D" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="315" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="315" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.55">
+    <rect x="120" y="225" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="405" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#A78BFA">
+    <circle cx="240" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="455" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="595" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="447" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="501" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="549" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.6">
+    <rect x="780" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#C4B5FD" opacity="0.85">
+    <rect x="730" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#A78BFA" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 515 L28 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 545 L28 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 575 L28 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 605 L28 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 515 L1172 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 545 L1172 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 575 L1172 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 605 L1172 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#C4B5FD" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="525" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="525" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.55">
+    <rect x="120" y="435" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="615" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+<g opacity="0.85">
+  <g fill="#E63946" opacity="0.7">
+    <circle cx="500" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="1.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.7">
+    <circle cx="500" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#A78BFA" opacity="0.7">
+    <circle cx="500" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.4s" begin="1.1s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke-width="0.5" stroke-opacity="0.4" fill="none">
+    <rect x="700" y="40" width="36" height="2" fill="#E63946" stroke="none"><animate attributeName="x" values="700;1000;700" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.4s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="250" width="36" height="2" fill="#FFB703" stroke="none"><animate attributeName="x" values="1000;700;1000" dur="6.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.8s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="460" width="36" height="2" fill="#A78BFA" stroke="none"><animate attributeName="x" values="700;1000;700" dur="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="7.2s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCA5A5" opacity="0.6">
+    <circle cx="60" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="270" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke="#FCD34D" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+    <line x1="640" y1="200" x2="640" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="200" x2="660" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.4s" repeatCount="indefinite"/></line>
+    <line x1="640" y1="410" x2="640" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.0s" begin="0.7s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="410" x2="660" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="1.1s" repeatCount="indefinite"/></line>
+  </g>
+</g>
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <path fill="#0A1020" d="M0.0 0.0h12.0v1.714h-12.0z M15.429 0.0h5.143v1.714h-5.143z M22.286 0.0h1.714v1.714h-1.714z M27.429 0.0h6.857v1.714h-6.857z M39.429 0.0h12.0v1.714h-12.0z M54.857 0.0h1.714v1.714h-1.714z M58.286 0.0h1.714v1.714h-1.714z M68.571 0.0h1.714v1.714h-1.714z M72.0 0.0h12.0v1.714h-12.0z M0.0 1.714h1.714v1.714h-1.714z M10.286 1.714h1.714v1.714h-1.714z M20.571 1.714h3.429v1.714h-3.429z M27.429 1.714h1.714v1.714h-1.714z M30.857 1.714h1.714v1.714h-1.714z M37.714 1.714h5.143v1.714h-5.143z M48.0 1.714h1.714v1.714h-1.714z M51.429 1.714h6.857v1.714h-6.857z M60.0 1.714h1.714v1.714h-1.714z M63.429 1.714h6.857v1.714h-6.857z M72.0 1.714h1.714v1.714h-1.714z M82.286 1.714h1.714v1.714h-1.714z M0.0 3.429h1.714v1.714h-1.714z M3.429 3.429h5.143v1.714h-5.143z M10.286 3.429h1.714v1.714h-1.714z M13.714 3.429h1.714v1.714h-1.714z M17.143 3.429h1.714v1.714h-1.714z M20.571 3.429h3.429v1.714h-3.429z M34.286 3.429h3.429v1.714h-3.429z M41.143 3.429h5.143v1.714h-5.143z M49.714 3.429h1.714v1.714h-1.714z M54.857 3.429h1.714v1.714h-1.714z M60.0 3.429h3.429v1.714h-3.429z M66.857 3.429h3.429v1.714h-3.429z M72.0 3.429h1.714v1.714h-1.714z M75.429 3.429h5.143v1.714h-5.143z M82.286 3.429h1.714v1.714h-1.714z M0.0 5.143h1.714v1.714h-1.714z M3.429 5.143h5.143v1.714h-5.143z M10.286 5.143h1.714v1.714h-1.714z M13.714 5.143h5.143v1.714h-5.143z M24.0 5.143h1.714v1.714h-1.714z M30.857 5.143h1.714v1.714h-1.714z M39.429 5.143h1.714v1.714h-1.714z M42.857 5.143h3.429v1.714h-3.429z M49.714 5.143h1.714v1.714h-1.714z M53.143 5.143h1.714v1.714h-1.714z M58.286 5.143h6.857v1.714h-6.857z M66.857 5.143h1.714v1.714h-1.714z M72.0 5.143h1.714v1.714h-1.714z M75.429 5.143h5.143v1.714h-5.143z M82.286 5.143h1.714v1.714h-1.714z M0.0 6.857h1.714v1.714h-1.714z M3.429 6.857h5.143v1.714h-5.143z M10.286 6.857h1.714v1.714h-1.714z M13.714 6.857h1.714v1.714h-1.714z M17.143 6.857h3.429v1.714h-3.429z M29.143 6.857h17.143v1.714h-17.143z M48.0 6.857h5.143v1.714h-5.143z M54.857 6.857h1.714v1.714h-1.714z M60.0 6.857h5.143v1.714h-5.143z M72.0 6.857h1.714v1.714h-1.714z M75.429 6.857h5.143v1.714h-5.143z M82.286 6.857h1.714v1.714h-1.714z M0.0 8.571h1.714v1.714h-1.714z M10.286 8.571h1.714v1.714h-1.714z M13.714 8.571h3.429v1.714h-3.429z M18.857 8.571h1.714v1.714h-1.714z M25.714 8.571h1.714v1.714h-1.714z M29.143 8.571h3.429v1.714h-3.429z M34.286 8.571h1.714v1.714h-1.714z M37.714 8.571h1.714v1.714h-1.714z M44.571 8.571h3.429v1.714h-3.429z M53.143 8.571h10.286v1.714h-10.286z M65.143 8.571h1.714v1.714h-1.714z M72.0 8.571h1.714v1.714h-1.714z M82.286 8.571h1.714v1.714h-1.714z M0.0 10.286h12.0v1.714h-12.0z M13.714 10.286h1.714v1.714h-1.714z M17.143 10.286h1.714v1.714h-1.714z M20.571 10.286h1.714v1.714h-1.714z M24.0 10.286h1.714v1.714h-1.714z M27.429 10.286h1.714v1.714h-1.714z M30.857 10.286h1.714v1.714h-1.714z M34.286 10.286h1.714v1.714h-1.714z M37.714 10.286h1.714v1.714h-1.714z M41.143 10.286h1.714v1.714h-1.714z M44.571 10.286h1.714v1.714h-1.714z M48.0 10.286h1.714v1.714h-1.714z M51.429 10.286h1.714v1.714h-1.714z M54.857 10.286h1.714v1.714h-1.714z M58.286 10.286h1.714v1.714h-1.714z M61.714 10.286h1.714v1.714h-1.714z M65.143 10.286h1.714v1.714h-1.714z M68.571 10.286h1.714v1.714h-1.714z M72.0 10.286h12.0v1.714h-12.0z M13.714 12.0h6.857v1.714h-6.857z M24.0 12.0h6.857v1.714h-6.857z M32.571 12.0h3.429v1.714h-3.429z M37.714 12.0h1.714v1.714h-1.714z M44.571 12.0h1.714v1.714h-1.714z M48.0 12.0h1.714v1.714h-1.714z M51.429 12.0h3.429v1.714h-3.429z M58.286 12.0h1.714v1.714h-1.714z M0.0 13.714h1.714v1.714h-1.714z M3.429 13.714h8.571v1.714h-8.571z M17.143 13.714h5.143v1.714h-5.143z M29.143 13.714h1.714v1.714h-1.714z M32.571 13.714h3.429v1.714h-3.429z M37.714 13.714h8.571v1.714h-8.571z M53.143 13.714h1.714v1.714h-1.714z M58.286 13.714h1.714v1.714h-1.714z M61.714 13.714h1.714v1.714h-1.714z M66.857 13.714h3.429v1.714h-3.429z M72.0 13.714h8.571v1.714h-8.571z M1.714 15.429h5.143v1.714h-5.143z M8.571 15.429h1.714v1.714h-1.714z M13.714 15.429h1.714v1.714h-1.714z M17.143 15.429h6.857v1.714h-6.857z M25.714 15.429h1.714v1.714h-1.714z M32.571 15.429h1.714v1.714h-1.714z M36.0 15.429h1.714v1.714h-1.714z M42.857 15.429h1.714v1.714h-1.714z M46.286 15.429h8.571v1.714h-8.571z M56.571 15.429h1.714v1.714h-1.714z M60.0 15.429h3.429v1.714h-3.429z M72.0 15.429h1.714v1.714h-1.714z M78.857 15.429h1.714v1.714h-1.714z M3.429 17.143h5.143v1.714h-5.143z M10.286 17.143h1.714v1.714h-1.714z M15.429 17.143h5.143v1.714h-5.143z M22.286 17.143h1.714v1.714h-1.714z M25.714 17.143h3.429v1.714h-3.429z M30.857 17.143h1.714v1.714h-1.714z M37.714 17.143h3.429v1.714h-3.429z M42.857 17.143h3.429v1.714h-3.429z M48.0 17.143h1.714v1.714h-1.714z M51.429 17.143h1.714v1.714h-1.714z M58.286 17.143h1.714v1.714h-1.714z M61.714 17.143h5.143v1.714h-5.143z M73.714 17.143h1.714v1.714h-1.714z M77.143 17.143h6.857v1.714h-6.857z M0.0 18.857h10.286v1.714h-10.286z M15.429 18.857h1.714v1.714h-1.714z M20.571 18.857h5.143v1.714h-5.143z M27.429 18.857h1.714v1.714h-1.714z M30.857 18.857h3.429v1.714h-3.429z M39.429 18.857h3.429v1.714h-3.429z M46.286 18.857h3.429v1.714h-3.429z M51.429 18.857h1.714v1.714h-1.714z M54.857 18.857h1.714v1.714h-1.714z M58.286 18.857h3.429v1.714h-3.429z M63.429 18.857h1.714v1.714h-1.714z M68.571 18.857h1.714v1.714h-1.714z M75.429 18.857h1.714v1.714h-1.714z M0.0 20.571h5.143v1.714h-5.143z M8.571 20.571h5.143v1.714h-5.143z M17.143 20.571h1.714v1.714h-1.714z M20.571 20.571h1.714v1.714h-1.714z M24.0 20.571h1.714v1.714h-1.714z M29.143 20.571h5.143v1.714h-5.143z M36.0 20.571h12.0v1.714h-12.0z M49.714 20.571h5.143v1.714h-5.143z M58.286 20.571h5.143v1.714h-5.143z M68.571 20.571h1.714v1.714h-1.714z M73.714 20.571h1.714v1.714h-1.714z M77.143 20.571h5.143v1.714h-5.143z M5.143 22.286h3.429v1.714h-3.429z M12.0 22.286h3.429v1.714h-3.429z M20.571 22.286h1.714v1.714h-1.714z M24.0 22.286h6.857v1.714h-6.857z M36.0 22.286h1.714v1.714h-1.714z M39.429 22.286h1.714v1.714h-1.714z M42.857 22.286h1.714v1.714h-1.714z M49.714 22.286h6.857v1.714h-6.857z M61.714 22.286h3.429v1.714h-3.429z M72.0 22.286h1.714v1.714h-1.714z M75.429 22.286h1.714v1.714h-1.714z M78.857 22.286h3.429v1.714h-3.429z M5.143 24.0h12.0v1.714h-12.0z M18.857 24.0h6.857v1.714h-6.857z M27.429 24.0h1.714v1.714h-1.714z M30.857 24.0h3.429v1.714h-3.429z M39.429 24.0h1.714v1.714h-1.714z M44.571 24.0h1.714v1.714h-1.714z M48.0 24.0h1.714v1.714h-1.714z M53.143 24.0h1.714v1.714h-1.714z M60.0 24.0h5.143v1.714h-5.143z M66.857 24.0h3.429v1.714h-3.429z M78.857 24.0h5.143v1.714h-5.143z M1.714 25.714h3.429v1.714h-3.429z M12.0 25.714h1.714v1.714h-1.714z M18.857 25.714h5.143v1.714h-5.143z M25.714 25.714h3.429v1.714h-3.429z M30.857 25.714h1.714v1.714h-1.714z M36.0 25.714h1.714v1.714h-1.714z M42.857 25.714h3.429v1.714h-3.429z M51.429 25.714h3.429v1.714h-3.429z M56.571 25.714h1.714v1.714h-1.714z M60.0 25.714h8.571v1.714h-8.571z M70.286 25.714h1.714v1.714h-1.714z M75.429 25.714h1.714v1.714h-1.714z M82.286 25.714h1.714v1.714h-1.714z M0.0 27.429h1.714v1.714h-1.714z M5.143 27.429h1.714v1.714h-1.714z M8.571 27.429h3.429v1.714h-3.429z M15.429 27.429h3.429v1.714h-3.429z M22.286 27.429h1.714v1.714h-1.714z M27.429 27.429h3.429v1.714h-3.429z M34.286 27.429h1.714v1.714h-1.714z M39.429 27.429h8.571v1.714h-8.571z M49.714 27.429h3.429v1.714h-3.429z M61.714 27.429h1.714v1.714h-1.714z M68.571 27.429h1.714v1.714h-1.714z M73.714 27.429h1.714v1.714h-1.714z M77.143 27.429h1.714v1.714h-1.714z M1.714 29.143h3.429v1.714h-3.429z M12.0 29.143h6.857v1.714h-6.857z M22.286 29.143h5.143v1.714h-5.143z M30.857 29.143h3.429v1.714h-3.429z M36.0 29.143h1.714v1.714h-1.714z M39.429 29.143h1.714v1.714h-1.714z M42.857 29.143h1.714v1.714h-1.714z M51.429 29.143h3.429v1.714h-3.429z M56.571 29.143h1.714v1.714h-1.714z M60.0 29.143h3.429v1.714h-3.429z M66.857 29.143h1.714v1.714h-1.714z M70.286 29.143h5.143v1.714h-5.143z M80.571 29.143h3.429v1.714h-3.429z M1.714 30.857h3.429v1.714h-3.429z M10.286 30.857h3.429v1.714h-3.429z M18.857 30.857h3.429v1.714h-3.429z M24.0 30.857h1.714v1.714h-1.714z M29.143 30.857h1.714v1.714h-1.714z M36.0 30.857h8.571v1.714h-8.571z M46.286 30.857h1.714v1.714h-1.714z M49.714 30.857h3.429v1.714h-3.429z M61.714 30.857h1.714v1.714h-1.714z M66.857 30.857h5.143v1.714h-5.143z M73.714 30.857h1.714v1.714h-1.714z M77.143 30.857h1.714v1.714h-1.714z M80.571 30.857h3.429v1.714h-3.429z M0.0 32.571h3.429v1.714h-3.429z M5.143 32.571h3.429v1.714h-3.429z M13.714 32.571h1.714v1.714h-1.714z M17.143 32.571h1.714v1.714h-1.714z M20.571 32.571h1.714v1.714h-1.714z M25.714 32.571h3.429v1.714h-3.429z M32.571 32.571h3.429v1.714h-3.429z M39.429 32.571h1.714v1.714h-1.714z M48.0 32.571h3.429v1.714h-3.429z M54.857 32.571h1.714v1.714h-1.714z M58.286 32.571h3.429v1.714h-3.429z M66.857 32.571h1.714v1.714h-1.714z M70.286 32.571h6.857v1.714h-6.857z M80.571 32.571h1.714v1.714h-1.714z M1.714 34.286h5.143v1.714h-5.143z M8.571 34.286h3.429v1.714h-3.429z M13.714 34.286h5.143v1.714h-5.143z M22.286 34.286h1.714v1.714h-1.714z M25.714 34.286h3.429v1.714h-3.429z M32.571 34.286h12.0v1.714h-12.0z M53.143 34.286h1.714v1.714h-1.714z M58.286 34.286h1.714v1.714h-1.714z M61.714 34.286h12.0v1.714h-12.0z M78.857 34.286h1.714v1.714h-1.714z M82.286 34.286h1.714v1.714h-1.714z M5.143 36.0h5.143v1.714h-5.143z M12.0 36.0h1.714v1.714h-1.714z M17.143 36.0h5.143v1.714h-5.143z M29.143 36.0h5.143v1.714h-5.143z M36.0 36.0h1.714v1.714h-1.714z M39.429 36.0h1.714v1.714h-1.714z M51.429 36.0h3.429v1.714h-3.429z M63.429 36.0h1.714v1.714h-1.714z M70.286 36.0h8.571v1.714h-8.571z M0.0 37.714h1.714v1.714h-1.714z M3.429 37.714h1.714v1.714h-1.714z M6.857 37.714h13.714v1.714h-13.714z M25.714 37.714h3.429v1.714h-3.429z M30.857 37.714h1.714v1.714h-1.714z M37.714 37.714h12.0v1.714h-12.0z M56.571 37.714h3.429v1.714h-3.429z M61.714 37.714h1.714v1.714h-1.714z M65.143 37.714h12.0v1.714h-12.0z M78.857 37.714h5.143v1.714h-5.143z M0.0 39.429h1.714v1.714h-1.714z M5.143 39.429h3.429v1.714h-3.429z M13.714 39.429h1.714v1.714h-1.714z M22.286 39.429h3.429v1.714h-3.429z M27.429 39.429h1.714v1.714h-1.714z M30.857 39.429h3.429v1.714h-3.429z M36.0 39.429h3.429v1.714h-3.429z M44.571 39.429h5.143v1.714h-5.143z M51.429 39.429h1.714v1.714h-1.714z M56.571 39.429h1.714v1.714h-1.714z M60.0 39.429h1.714v1.714h-1.714z M66.857 39.429h3.429v1.714h-3.429z M75.429 39.429h1.714v1.714h-1.714z M80.571 39.429h3.429v1.714h-3.429z M0.0 41.143h1.714v1.714h-1.714z M3.429 41.143h1.714v1.714h-1.714z M6.857 41.143h1.714v1.714h-1.714z M10.286 41.143h1.714v1.714h-1.714z M13.714 41.143h5.143v1.714h-5.143z M24.0 41.143h1.714v1.714h-1.714z M30.857 41.143h1.714v1.714h-1.714z M34.286 41.143h5.143v1.714h-5.143z M41.143 41.143h1.714v1.714h-1.714z M44.571 41.143h1.714v1.714h-1.714z M49.714 41.143h5.143v1.714h-5.143z M56.571 41.143h3.429v1.714h-3.429z M61.714 41.143h1.714v1.714h-1.714z M65.143 41.143h1.714v1.714h-1.714z M68.571 41.143h1.714v1.714h-1.714z M72.0 41.143h1.714v1.714h-1.714z M75.429 41.143h8.571v1.714h-8.571z M3.429 42.857h5.143v1.714h-5.143z M13.714 42.857h1.714v1.714h-1.714z M20.571 42.857h5.143v1.714h-5.143z M27.429 42.857h3.429v1.714h-3.429z M37.714 42.857h1.714v1.714h-1.714z M44.571 42.857h1.714v1.714h-1.714z M49.714 42.857h8.571v1.714h-8.571z M61.714 42.857h1.714v1.714h-1.714z M66.857 42.857h3.429v1.714h-3.429z M75.429 42.857h1.714v1.714h-1.714z M3.429 44.571h18.857v1.714h-18.857z M25.714 44.571h8.571v1.714h-8.571z M37.714 44.571h10.286v1.714h-10.286z M49.714 44.571h3.429v1.714h-3.429z M54.857 44.571h1.714v1.714h-1.714z M58.286 44.571h1.714v1.714h-1.714z M61.714 44.571h17.143v1.714h-17.143z M80.571 44.571h3.429v1.714h-3.429z M1.714 46.286h1.714v1.714h-1.714z M5.143 46.286h1.714v1.714h-1.714z M15.429 46.286h3.429v1.714h-3.429z M20.571 46.286h3.429v1.714h-3.429z M34.286 46.286h1.714v1.714h-1.714z M41.143 46.286h3.429v1.714h-3.429z M46.286 46.286h5.143v1.714h-5.143z M54.857 46.286h3.429v1.714h-3.429z M60.0 46.286h1.714v1.714h-1.714z M63.429 46.286h3.429v1.714h-3.429z M68.571 46.286h3.429v1.714h-3.429z M80.571 46.286h3.429v1.714h-3.429z M5.143 48.0h3.429v1.714h-3.429z M10.286 48.0h1.714v1.714h-1.714z M15.429 48.0h1.714v1.714h-1.714z M22.286 48.0h5.143v1.714h-5.143z M30.857 48.0h1.714v1.714h-1.714z M36.0 48.0h1.714v1.714h-1.714z M39.429 48.0h3.429v1.714h-3.429z M51.429 48.0h3.429v1.714h-3.429z M60.0 48.0h8.571v1.714h-8.571z M70.286 48.0h1.714v1.714h-1.714z M73.714 48.0h1.714v1.714h-1.714z M78.857 48.0h1.714v1.714h-1.714z M1.714 49.714h1.714v1.714h-1.714z M5.143 49.714h1.714v1.714h-1.714z M8.571 49.714h1.714v1.714h-1.714z M12.0 49.714h1.714v1.714h-1.714z M17.143 49.714h3.429v1.714h-3.429z M25.714 49.714h12.0v1.714h-12.0z M41.143 49.714h5.143v1.714h-5.143z M48.0 49.714h6.857v1.714h-6.857z M56.571 49.714h1.714v1.714h-1.714z M66.857 49.714h3.429v1.714h-3.429z M73.714 49.714h1.714v1.714h-1.714z M0.0 51.429h1.714v1.714h-1.714z M3.429 51.429h3.429v1.714h-3.429z M10.286 51.429h1.714v1.714h-1.714z M15.429 51.429h3.429v1.714h-3.429z M20.571 51.429h5.143v1.714h-5.143z M34.286 51.429h1.714v1.714h-1.714z M37.714 51.429h6.857v1.714h-6.857z M48.0 51.429h3.429v1.714h-3.429z M58.286 51.429h1.714v1.714h-1.714z M61.714 51.429h15.429v1.714h-15.429z M80.571 51.429h3.429v1.714h-3.429z M0.0 53.143h1.714v1.714h-1.714z M3.429 53.143h1.714v1.714h-1.714z M6.857 53.143h3.429v1.714h-3.429z M12.0 53.143h10.286v1.714h-10.286z M24.0 53.143h1.714v1.714h-1.714z M29.143 53.143h6.857v1.714h-6.857z M41.143 53.143h1.714v1.714h-1.714z M44.571 53.143h3.429v1.714h-3.429z M49.714 53.143h1.714v1.714h-1.714z M58.286 53.143h1.714v1.714h-1.714z M61.714 53.143h5.143v1.714h-5.143z M68.571 53.143h1.714v1.714h-1.714z M80.571 53.143h3.429v1.714h-3.429z M1.714 54.857h1.714v1.714h-1.714z M8.571 54.857h5.143v1.714h-5.143z M20.571 54.857h5.143v1.714h-5.143z M29.143 54.857h3.429v1.714h-3.429z M34.286 54.857h1.714v1.714h-1.714z M37.714 54.857h8.571v1.714h-8.571z M48.0 54.857h1.714v1.714h-1.714z M53.143 54.857h8.571v1.714h-8.571z M65.143 54.857h6.857v1.714h-6.857z M73.714 54.857h1.714v1.714h-1.714z M80.571 54.857h1.714v1.714h-1.714z M0.0 56.571h3.429v1.714h-3.429z M5.143 56.571h3.429v1.714h-3.429z M12.0 56.571h1.714v1.714h-1.714z M17.143 56.571h1.714v1.714h-1.714z M20.571 56.571h3.429v1.714h-3.429z M29.143 56.571h1.714v1.714h-1.714z M32.571 56.571h1.714v1.714h-1.714z M39.429 56.571h12.0v1.714h-12.0z M54.857 56.571h1.714v1.714h-1.714z M58.286 56.571h1.714v1.714h-1.714z M63.429 56.571h3.429v1.714h-3.429z M68.571 56.571h3.429v1.714h-3.429z M73.714 56.571h1.714v1.714h-1.714z M80.571 56.571h1.714v1.714h-1.714z M3.429 58.286h1.714v1.714h-1.714z M6.857 58.286h1.714v1.714h-1.714z M10.286 58.286h3.429v1.714h-3.429z M15.429 58.286h5.143v1.714h-5.143z M22.286 58.286h8.571v1.714h-8.571z M32.571 58.286h1.714v1.714h-1.714z M36.0 58.286h5.143v1.714h-5.143z M42.857 58.286h1.714v1.714h-1.714z M48.0 58.286h1.714v1.714h-1.714z M51.429 58.286h6.857v1.714h-6.857z M60.0 58.286h1.714v1.714h-1.714z M68.571 58.286h1.714v1.714h-1.714z M72.0 58.286h6.857v1.714h-6.857z M80.571 58.286h3.429v1.714h-3.429z M0.0 60.0h1.714v1.714h-1.714z M5.143 60.0h1.714v1.714h-1.714z M12.0 60.0h1.714v1.714h-1.714z M15.429 60.0h1.714v1.714h-1.714z M18.857 60.0h3.429v1.714h-3.429z M24.0 60.0h1.714v1.714h-1.714z M30.857 60.0h3.429v1.714h-3.429z M44.571 60.0h6.857v1.714h-6.857z M60.0 60.0h1.714v1.714h-1.714z M65.143 60.0h1.714v1.714h-1.714z M73.714 60.0h3.429v1.714h-3.429z M80.571 60.0h3.429v1.714h-3.429z M0.0 61.714h1.714v1.714h-1.714z M5.143 61.714h3.429v1.714h-3.429z M10.286 61.714h1.714v1.714h-1.714z M17.143 61.714h3.429v1.714h-3.429z M22.286 61.714h12.0v1.714h-12.0z M36.0 61.714h1.714v1.714h-1.714z M39.429 61.714h1.714v1.714h-1.714z M53.143 61.714h1.714v1.714h-1.714z M56.571 61.714h1.714v1.714h-1.714z M61.714 61.714h1.714v1.714h-1.714z M66.857 61.714h6.857v1.714h-6.857z M75.429 61.714h1.714v1.714h-1.714z M78.857 61.714h5.143v1.714h-5.143z M0.0 63.429h6.857v1.714h-6.857z M8.571 63.429h1.714v1.714h-1.714z M12.0 63.429h3.429v1.714h-3.429z M24.0 63.429h3.429v1.714h-3.429z M29.143 63.429h1.714v1.714h-1.714z M32.571 63.429h1.714v1.714h-1.714z M36.0 63.429h10.286v1.714h-10.286z M48.0 63.429h8.571v1.714h-8.571z M61.714 63.429h1.714v1.714h-1.714z M68.571 63.429h1.714v1.714h-1.714z M72.0 63.429h3.429v1.714h-3.429z M77.143 63.429h3.429v1.714h-3.429z M1.714 65.143h1.714v1.714h-1.714z M8.571 65.143h5.143v1.714h-5.143z M20.571 65.143h5.143v1.714h-5.143z M27.429 65.143h3.429v1.714h-3.429z M32.571 65.143h3.429v1.714h-3.429z M37.714 65.143h6.857v1.714h-6.857z M46.286 65.143h1.714v1.714h-1.714z M53.143 65.143h3.429v1.714h-3.429z M58.286 65.143h1.714v1.714h-1.714z M61.714 65.143h1.714v1.714h-1.714z M65.143 65.143h1.714v1.714h-1.714z M68.571 65.143h1.714v1.714h-1.714z M72.0 65.143h1.714v1.714h-1.714z M80.571 65.143h3.429v1.714h-3.429z M1.714 66.857h5.143v1.714h-5.143z M12.0 66.857h6.857v1.714h-6.857z M22.286 66.857h6.857v1.714h-6.857z M32.571 66.857h8.571v1.714h-8.571z M46.286 66.857h5.143v1.714h-5.143z M56.571 66.857h1.714v1.714h-1.714z M60.0 66.857h1.714v1.714h-1.714z M63.429 66.857h1.714v1.714h-1.714z M68.571 66.857h1.714v1.714h-1.714z M73.714 66.857h1.714v1.714h-1.714z M0.0 68.571h5.143v1.714h-5.143z M10.286 68.571h1.714v1.714h-1.714z M15.429 68.571h1.714v1.714h-1.714z M27.429 68.571h1.714v1.714h-1.714z M32.571 68.571h3.429v1.714h-3.429z M37.714 68.571h8.571v1.714h-8.571z M49.714 68.571h1.714v1.714h-1.714z M53.143 68.571h1.714v1.714h-1.714z M56.571 68.571h3.429v1.714h-3.429z M61.714 68.571h1.714v1.714h-1.714z M65.143 68.571h15.429v1.714h-15.429z M82.286 68.571h1.714v1.714h-1.714z M13.714 70.286h1.714v1.714h-1.714z M17.143 70.286h3.429v1.714h-3.429z M22.286 70.286h1.714v1.714h-1.714z M25.714 70.286h1.714v1.714h-1.714z M30.857 70.286h3.429v1.714h-3.429z M36.0 70.286h3.429v1.714h-3.429z M44.571 70.286h13.714v1.714h-13.714z M60.0 70.286h1.714v1.714h-1.714z M68.571 70.286h1.714v1.714h-1.714z M75.429 70.286h3.429v1.714h-3.429z M0.0 72.0h12.0v1.714h-12.0z M18.857 72.0h1.714v1.714h-1.714z M25.714 72.0h5.143v1.714h-5.143z M37.714 72.0h1.714v1.714h-1.714z M41.143 72.0h1.714v1.714h-1.714z M44.571 72.0h3.429v1.714h-3.429z M49.714 72.0h12.0v1.714h-12.0z M65.143 72.0h1.714v1.714h-1.714z M68.571 72.0h1.714v1.714h-1.714z M72.0 72.0h1.714v1.714h-1.714z M75.429 72.0h1.714v1.714h-1.714z M78.857 72.0h5.143v1.714h-5.143z M0.0 73.714h1.714v1.714h-1.714z M10.286 73.714h1.714v1.714h-1.714z M13.714 73.714h3.429v1.714h-3.429z M18.857 73.714h3.429v1.714h-3.429z M24.0 73.714h1.714v1.714h-1.714z M27.429 73.714h1.714v1.714h-1.714z M32.571 73.714h1.714v1.714h-1.714z M36.0 73.714h3.429v1.714h-3.429z M44.571 73.714h5.143v1.714h-5.143z M54.857 73.714h3.429v1.714h-3.429z M60.0 73.714h1.714v1.714h-1.714z M68.571 73.714h1.714v1.714h-1.714z M75.429 73.714h1.714v1.714h-1.714z M80.571 73.714h1.714v1.714h-1.714z M0.0 75.429h1.714v1.714h-1.714z M3.429 75.429h5.143v1.714h-5.143z M10.286 75.429h1.714v1.714h-1.714z M13.714 75.429h1.714v1.714h-1.714z M18.857 75.429h1.714v1.714h-1.714z M25.714 75.429h3.429v1.714h-3.429z M32.571 75.429h1.714v1.714h-1.714z M37.714 75.429h8.571v1.714h-8.571z M49.714 75.429h5.143v1.714h-5.143z M58.286 75.429h1.714v1.714h-1.714z M61.714 75.429h1.714v1.714h-1.714z M65.143 75.429h1.714v1.714h-1.714z M68.571 75.429h8.571v1.714h-8.571z M80.571 75.429h1.714v1.714h-1.714z M0.0 77.143h1.714v1.714h-1.714z M3.429 77.143h5.143v1.714h-5.143z M10.286 77.143h1.714v1.714h-1.714z M13.714 77.143h3.429v1.714h-3.429z M25.714 77.143h1.714v1.714h-1.714z M29.143 77.143h1.714v1.714h-1.714z M42.857 77.143h3.429v1.714h-3.429z M48.0 77.143h5.143v1.714h-5.143z M54.857 77.143h1.714v1.714h-1.714z M68.571 77.143h1.714v1.714h-1.714z M72.0 77.143h6.857v1.714h-6.857z M80.571 77.143h1.714v1.714h-1.714z M0.0 78.857h1.714v1.714h-1.714z M3.429 78.857h5.143v1.714h-5.143z M10.286 78.857h1.714v1.714h-1.714z M13.714 78.857h1.714v1.714h-1.714z M17.143 78.857h1.714v1.714h-1.714z M25.714 78.857h1.714v1.714h-1.714z M29.143 78.857h1.714v1.714h-1.714z M32.571 78.857h1.714v1.714h-1.714z M36.0 78.857h6.857v1.714h-6.857z M44.571 78.857h3.429v1.714h-3.429z M49.714 78.857h1.714v1.714h-1.714z M60.0 78.857h1.714v1.714h-1.714z M63.429 78.857h3.429v1.714h-3.429z M72.0 78.857h3.429v1.714h-3.429z M80.571 78.857h3.429v1.714h-3.429z M0.0 80.571h1.714v1.714h-1.714z M10.286 80.571h1.714v1.714h-1.714z M24.0 80.571h1.714v1.714h-1.714z M27.429 80.571h3.429v1.714h-3.429z M39.429 80.571h6.857v1.714h-6.857z M51.429 80.571h3.429v1.714h-3.429z M56.571 80.571h1.714v1.714h-1.714z M60.0 80.571h3.429v1.714h-3.429z M66.857 80.571h1.714v1.714h-1.714z M70.286 80.571h3.429v1.714h-3.429z M82.286 80.571h1.714v1.714h-1.714z M0.0 82.286h12.0v1.714h-12.0z M13.714 82.286h1.714v1.714h-1.714z M18.857 82.286h3.429v1.714h-3.429z M24.0 82.286h1.714v1.714h-1.714z M27.429 82.286h1.714v1.714h-1.714z M30.857 82.286h1.714v1.714h-1.714z M34.286 82.286h1.714v1.714h-1.714z M39.429 82.286h3.429v1.714h-3.429z M46.286 82.286h1.714v1.714h-1.714z M49.714 82.286h3.429v1.714h-3.429z M61.714 82.286h3.429v1.714h-3.429z M66.857 82.286h3.429v1.714h-3.429z M80.571 82.286h3.429v1.714h-3.429z"/>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>

--- a/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
+++ b/assets/images/2026-01-22-KISA_Security_Advisory_Ransomware_Linux_Rootkit.svg
@@ -1,99 +1,465 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
-  <title>RANSOMWARE MALWARE</title>
-  <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0b1120"/>
-      <stop offset="52%" stop-color="#121a2f"/>
-      <stop offset="100%" stop-color="#170f25"/>
-    </linearGradient>
-    <linearGradient id="panel" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0f172a" stop-opacity="0.96"/>
-      <stop offset="100%" stop-color="#111827" stop-opacity="0.86"/>
-    </linearGradient>
-    <pattern id="microGrid" x="0" y="0" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" fill="none" stroke="#334155" stroke-width="1" opacity="0.25"/>
-      <circle cx="18" cy="18" r="1.2" fill="#ef4444" opacity="0.15"/>
-    </pattern>
-    <filter id="glow" x="-40%" y="-40%" width="180%" height="180%">
-      <feGaussianBlur stdDeviation="10" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
-    </filter>
-    <filter id="sg" x="-30%" y="-30%" width="160%" height="160%">
-      <feGaussianBlur stdDeviation="36"/>
-    </filter>
-    <filter id="shadow" x="-30%" y="-30%" width="180%" height="180%">
-      <feDropShadow dx="0" dy="14" stdDeviation="22" flood-color="#020617" flood-opacity="0.42"/>
-    </filter>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#microGrid)"/>
-  <circle cx="202" cy="150" r="190" fill="#ef4444" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="1020" cy="486" r="220" fill="#991b1b" opacity="0.08" filter="url(#sg)"/>
-  <circle cx="920" cy="160" r="140" fill="#38bdf8" opacity="0.04" filter="url(#sg)"/>
-  <path d="M0 96 C224 46 426 44 654 118 L654 630 L0 630 Z" fill="#020617" opacity="0.24"/>
-  <path d="M0 526 C248 490 426 486 654 548" fill="none" stroke="#475569" stroke-width="1.2" opacity="0.22"/>
-  <rect x="736" y="104" width="362" height="326" rx="28" fill="url(#panel)" stroke="#ef4444" stroke-opacity="0.28" stroke-width="1.4" filter="url(#shadow)"/>
-  <rect x="754" y="122" width="326" height="290" rx="22" fill="none" stroke="#334155" stroke-opacity="0.7" stroke-width="1"/>
-  <rect x="758" y="124" width="108" height="12" rx="6" fill="#ef4444" opacity="0.28"/>
-  <rect x="880" y="124" width="72" height="12" rx="6" fill="#334155" opacity="0.55"/>
-  <rect x="964" y="124" width="48" height="12" rx="6" fill="#334155" opacity="0.35"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630" role="img" aria-label="KISA Security Advisory Ransomware Linux Rootkit Backup 3-2-1">
+<title>KISA Advisory: Ransomware 3-2-1 Backup + Linux Rootkit Detection</title>
+<defs>
+<linearGradient id="bgSpreadki22" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#0A1226"/><stop offset="50%" stop-color="#0C1430"/><stop offset="100%" stop-color="#131038"/></linearGradient>
+<linearGradient id="bandAki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#0E2038"/><stop offset="100%" stop-color="#12283F"/></linearGradient>
+<linearGradient id="bandBki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#1A0E2E"/><stop offset="100%" stop-color="#24122F"/></linearGradient>
+<linearGradient id="bandCki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#2A1A0C"/><stop offset="100%" stop-color="#1E1F0A"/></linearGradient>
+<linearGradient id="streakAki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0"/><stop offset="50%" stop-color="#4ADE80" stop-opacity="0.85"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakBki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#E63946" stop-opacity="0"/><stop offset="50%" stop-color="#E63946" stop-opacity="0.85"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></linearGradient>
+<linearGradient id="streakCki22" x1="0%" y1="0%" x2="100%" y2="0%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0"/><stop offset="50%" stop-color="#FFB703" stop-opacity="0.85"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></linearGradient>
+<radialGradient id="glowAki22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#4ADE80" stop-opacity="0.55"/><stop offset="100%" stop-color="#4ADE80" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowBki22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#E63946" stop-opacity="0.55"/><stop offset="100%" stop-color="#E63946" stop-opacity="0"/></radialGradient>
+<radialGradient id="glowCki22" cx="50%" cy="50%" r="50%"><stop offset="0%" stop-color="#FFB703" stop-opacity="0.55"/><stop offset="100%" stop-color="#FFB703" stop-opacity="0"/></radialGradient>
+<filter id="softShadow" x="-10%" y="-10%" width="130%" height="130%"><feGaussianBlur in="SourceAlpha" stdDeviation="2.5"/><feOffset dx="1" dy="3"/><feComponentTransfer><feFuncA type="linear" slope="0.55"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<filter id="textShadow" x="-5%" y="-5%" width="110%" height="110%"><feGaussianBlur in="SourceAlpha" stdDeviation="1.2"/><feOffset dx="0" dy="1.5"/><feComponentTransfer><feFuncA type="linear" slope="0.85"/></feComponentTransfer><feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge></filter>
+<pattern id="ledgerGrid" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse"><path d="M0 20 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/><path d="M40 0 L40 20" stroke="#2A3A56" stroke-width="0.4" opacity="0.5"/></pattern>
+<pattern id="circuitDot" x="0" y="0" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="9" cy="9" r="0.8" fill="#3A2A4E" opacity="0.55"/></pattern>
+<pattern id="hexGridki22" x="0" y="0" width="28" height="32" patternUnits="userSpaceOnUse"><path d="M14 0 L28 8 L28 24 L14 32 L0 24 L0 8 Z" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+<pattern id="radarRippleki22" x="0" y="0" width="60" height="60" patternUnits="userSpaceOnUse"><circle cx="30" cy="30" r="14" fill="none" stroke="#2A3A56" stroke-width="0.3" opacity="0.4"/></pattern>
+</defs>
+<rect width="1200" height="630" fill="url(#bgSpreadki22)"/>
+<g>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#bandAki22)"/>
+  <rect x="0" y="0" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="0" width="8" height="210" fill="#4ADE80"/>
   
-  <path d="M724 152 C822 126 922 136 1020 202" fill="none" stroke="#f59e0b" stroke-width="1.3" opacity="0.24"/>
-  <path d="M706 420 C782 454 878 462 968 410" fill="none" stroke="#60a5fa" stroke-width="1.2" opacity="0.22"/>
-
-  <g transform="translate(917,270)" filter="url(#shadow)">
-    <circle r="96" fill="#0f172a" stroke="#ef4444" stroke-width="2.6" opacity="0.94"/>
-    <circle r="124" fill="none" stroke="#ef4444" stroke-opacity="0.15" stroke-width="1.2" stroke-dasharray="8 8"/>
-    <circle r="54" fill="none" stroke="#e2e8f0" stroke-opacity="0.15" stroke-width="1"/>
-
-    <path d="M0,-50 L40,-35 L40,10 C40,35 0,55 0,55 C0,55 -40,35 -40,10 L-40,-35 Z" fill="none" stroke="#ef4444" stroke-width="3"/>
-    <path d="M-12,2 L-4,12 L16,-10" stroke="#ef4444" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-    <circle cx="-50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <circle cx="50" cy="-30" r="8" fill="#ef4444" opacity="0.3"/>
-    <line x1="-42" y1="-26" x2="-20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
-    <line x1="42" y1="-26" x2="20" y2="-15" stroke="#ef4444" stroke-width="1.5" opacity="0.4"/>
+  <g filter="url(#textShadow)">
+    <text x="30" y="44" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#4ADE80">BACKUP STRATEGY</text>
+    <text x="30" y="86" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">3-2-1 Rule · Immutable</text>
+    <text x="30" y="118" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#9FD3B0">3 copies · 2 media · 1 offsite · ransomware-resistant</text>
+    <text x="30" y="144" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#BFC9D9">WORM storage · object lock · cross-region replication</text>
+    <text x="30" y="162" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#9FD3B0">S3 Object Lock · Glacier Vault Lock · GCS retention</text><text x="30" y="178" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#BFC9D9" fill-opacity="0.85">Restore drill quarterly · RTO 4hr · RPO 15min target</text>
+    
   </g>
-  <g transform="translate(84 66)">
-    <rect width="164" height="36" rx="18" fill="#ef4444" opacity="0.2" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="82" y="23" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#ef4444" text-anchor="middle">SECURITY</text>
+  <g transform="translate(690,105)">
+    <circle r="80" fill="#4ADE80" fill-opacity="0.06"><animate attributeName="r" values="64;86;64" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-60 0 Q-70 -25 -45 -30 Q-40 -50 -10 -45 Q10 -60 30 -45 Q55 -50 60 -20 Q80 -15 70 10 Q65 25 40 25 L-40 25 Q-70 25 -60 0 Z" fill="#4ADE80" fill-opacity="0.12" stroke="#4ADE80" stroke-width="1.8"/>
+    <g fill="#4ADE80" stroke="#86EFAC" stroke-width="1.2">
+      <polygon points="-30,-10 -18,-17 -6,-10 -6,4 -18,11 -30,4"/>
+      <polygon points="0,-10 12,-17 24,-10 24,4 12,11 0,4"/>
+      <polygon points="-15,10 -3,3 9,10 9,24 -3,31 -15,24"/>
+    </g>
+    <g fill="#86EFAC">
+      <circle cx="-18" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="12" cy="-3" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-3" cy="17" r="2.4"><animate attributeName="opacity" values="0.4;1;0.4" dur="2.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#FFF">
+      <circle r="1.6"><animateMotion path="M-18 -3 L12 -3" dur="2.4s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M12 -3 L-3 17" dur="2.2s" repeatCount="indefinite"/></circle>
+      <circle r="1.6"><animateMotion path="M-3 17 L-18 -3" dur="2.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g fill="#86EFAC" opacity="0.6">
+      <circle cx="-50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="-38" r="1.8"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="70" cy="-15" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="-60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="60" cy="32" r="1.4"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="1.2s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#4ADE80" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-90" y1="-58" x2="-78" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" repeatCount="indefinite"/></line>
+      <line x1="78" y1="-58" x2="90" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.4s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-86" y="-58" text-anchor="start" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#86EFAC" opacity="0.7">3 pods</text>
+    <text x="86" y="-58" text-anchor="end" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#86EFAC" opacity="0.7">healthy</text>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#4ADE80">K8s CLOUD</text>
+    <text y="74" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#86EFAC" opacity="0.7">3 nodes : workload identity</text>
   </g>
-  <text x="84" y="170" font-family="Arial,sans-serif" font-size="54" font-weight="700" fill="#f8fafc" letter-spacing="0.5">RANSOMWARE</text>
-  <text x="84" y="232" font-family="Arial,sans-serif" font-size="52" font-weight="700" fill="#dbeafe" letter-spacing="0.5">MALWARE</text>
-  <text x="84" y="288" font-family="Arial,sans-serif" font-size="18" fill="#cbd5e1">RANSOMWARE / MALWARE / PHISHING</text>
-  <rect x="84" y="314" width="520" height="1.5" fill="#334155" opacity="0.9"/>
-  <text x="84" y="344" font-family="Arial,sans-serif" font-size="14" font-weight="700" fill="#94a3b8">VISUAL SYSTEM F9AAC9F0EA64</text>
-  <text x="84" y="372" font-family="Arial,sans-serif" font-size="14" fill="#94a3b8">KISA security advisory on ransomware and Linux rootkit threats with mitigation guidance.</text>
-  <g transform="translate(84 474)">
-    <rect width="134" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="67.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">RANSOMWARE</text>
+  <g transform="translate(870,105)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#4ADE80">IMMUTABLE</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">WORM</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#9FD3B0">storage</text>
   </g>
-  <g transform="translate(232 474)">
-    <rect width="110" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="55.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">MALWARE</text>
+  <g transform="translate(1110,105)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#0A1B2E" stroke="#4ADE80" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#4ADE80">GEO REDUN</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="900" fill="#F5F7FA">OFFSITE</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#9FD3B0">cross-AZ</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#4ADE80" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#86EFAC"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
   </g>
-  <g transform="translate(356 474)">
-    <rect width="114" height="38" rx="19" fill="#ef4444" opacity="0.16" stroke="#ef4444" stroke-width="1.2"/>
-    <text x="57.0" y="24" font-family="Arial,sans-serif" font-size="13" font-weight="700" fill="#e2e8f0" text-anchor="middle">PHISHING</text>
+  <g transform="translate(990,105)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#0A1B2E" stroke="#4ADE80" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#4ADE80">BACKUP</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="60" font-weight="900" fill="#F5F7FA">3-2-1</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#9FD3B0">KISA spec</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#4ADE80" stroke-width="0.8" stroke-opacity="0.5"/>
+    
   </g>
-  <g transform="translate(84 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">CATEGORY</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">SECURITY</text>
+  <g transform="translate(990,105)">
+    <circle cx="10" cy="-50" r="3" fill="#4ADE80"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#86EFAC"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#4ADE80" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#86EFAC" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
   </g>
-  <g transform="translate(246 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">SIGNALS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">05</text>
+  <g opacity="0.85">
+    <line x1="20" y1="210" x2="1180" y2="210" stroke="#4ADE80" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="210" r="2.2" fill="#4ADE80">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
   </g>
-  <g transform="translate(408 536)">
-    <rect width="144" height="58" rx="16" fill="#111827" fill-opacity="0.78" stroke="#ef4444" stroke-opacity="0.35" stroke-width="1.2"/>
-    <text x="18" y="24" font-family="Arial,sans-serif" font-size="11" font-weight="700" fill="#94a3b8">TAGS</text>
-    <text x="18" y="43" font-family="Arial,sans-serif" font-size="16" font-weight="700" fill="#f8fafc">10</text>
+</g>
+<g>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#bandBki22)"/>
+  <rect x="0" y="210" width="1200" height="210" fill="url(#circuitDot)" opacity="0.6"/>
+  <rect x="0" y="210" width="8" height="210" fill="#E63946"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="254" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#F87171">LINUX ROOTKIT</text>
+    <text x="30" y="296" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">chkrootkit · rkhunter</text>
+    <text x="30" y="328" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FBB6BD">Kernel-mode rootkit detection · LKM tampering scan</text>
+    <text x="30" y="354" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#D9C9CE">hidden process · syscall hooking · /proc inconsistency</text>
+    <text x="30" y="372" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FBB6BD">Cron daily scan · alert on syscall table modification</text><text x="30" y="388" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#D9C9CE" fill-opacity="0.85">eBPF telemetry · Falco runtime detection rules</text>
+    
   </g>
-  <g transform="translate(1030 74)">
-    <rect width="130" height="34" rx="17" fill="#1d4ed8" opacity="0.18" stroke="#3b82f6" stroke-width="1.2"/>
-    <text x="65" y="22" font-family="Arial,sans-serif" font-size="12" font-weight="700" fill="#bfdbfe" text-anchor="middle">April 14, 2026</text>
+  <g transform="translate(690,315)">
+    <circle r="78" fill="#E63946" fill-opacity="0.06"><animate attributeName="r" values="62;82;62" dur="3.4s" repeatCount="indefinite"/></circle>
+    <path d="M-22 -20 Q-22 -50 0 -50 Q22 -50 22 -20" stroke="#E63946" stroke-width="4" fill="none"/>
+    <rect x="-32" y="-22" width="64" height="60" rx="6" fill="#E63946" fill-opacity="0.2" stroke="#E63946" stroke-width="2.2" filter="url(#softShadow)"/>
+    <circle r="5" fill="#FCA5A5" cy="2"/>
+    <rect x="-3" y="2" width="6" height="18" fill="#FCA5A5"/>
+    <text y="60" text-anchor="middle" font-family="Inter, monospace" font-size="14" font-weight="900" fill="#E63946">CVSS 8.8</text>
+    <g fill="#FCA5A5" opacity="0.85">
+      <circle cx="-55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="-45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+      <circle cx="-55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" repeatCount="indefinite"/></circle>
+      <circle cx="55" cy="45" r="2.5"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="0" r="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FCA5A5" stroke-width="0.8" stroke-opacity="0.5" fill="none">
+      <path d="M-44 -30 L-38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.2s" repeatCount="indefinite"/></path>
+      <path d="M44 -30 L38 -26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.4s" repeatCount="indefinite"/></path>
+      <path d="M-44 30 L-38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.0s" repeatCount="indefinite"/></path>
+      <path d="M44 30 L38 26"><animate attributeName="stroke-opacity" values="0;0.8;0" dur="2.6s" repeatCount="indefinite"/></path>
+    </g>
+    <g fill="#FCA5A5" opacity="0.55">
+      <circle cx="-72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.6s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="-30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.9s" begin="0.4s" repeatCount="indefinite"/></circle>
+      <circle cx="-72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" begin="0.7s" repeatCount="indefinite"/></circle>
+      <circle cx="72" cy="30" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.3s" begin="1.0s" repeatCount="indefinite"/></circle>
+      <circle cx="-30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="30" cy="-65" r="1.2"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#E63946" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-86" y1="0" x2="-74" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" repeatCount="indefinite"/></line>
+      <line x1="74" y1="0" x2="86" y2="0"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.5s" repeatCount="indefinite"/></line>
+    </g>
+    <text y="78" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCA5A5" opacity="0.7">CVSS : critical scope</text>
   </g>
-  <line x1="50" y1="588" x2="1150" y2="588" stroke="#334155" stroke-width="1" opacity="0.5"/>
-  <text x="1150" y="612" font-family="Arial,sans-serif" font-size="13" fill="#94a3b8" text-anchor="end">tech.2twodragon.com</text>
+  <g transform="translate(870,315)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#F87171">RKHUNTER</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="34" font-weight="900" fill="#F5F7FA">rkh</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FBB6BD">active scan</text>
+  </g>
+  <g transform="translate(1110,315)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E0A14" stroke="#E63946" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#F87171">FILE INT</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">aide</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FBB6BD">baseline</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#E63946" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCA5A5"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,315)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E0A14" stroke="#E63946" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#F87171">ROOTKIT</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">LKM</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FBB6BD">kernel</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#E63946" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,315)">
+    <circle cx="10" cy="-50" r="3" fill="#E63946"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCA5A5"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#E63946" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCA5A5" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  <g opacity="0.85">
+    <line x1="20" y1="420" x2="1180" y2="420" stroke="#E63946" stroke-width="0.7" stroke-opacity="0.55" stroke-dasharray="6 6">
+      <animate attributeName="stroke-dashoffset" values="0;-24" dur="3s" repeatCount="indefinite"/>
+    </line>
+    <circle cx="600" cy="420" r="2.2" fill="#E63946">
+      <animate attributeName="opacity" values="0.25;1;0.25" dur="2.2s" repeatCount="indefinite"/>
+    </circle>
+  </g>
+</g>
+<g>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#bandCki22)"/>
+  <rect x="0" y="420" width="1200" height="210" fill="url(#ledgerGrid)" opacity="0.6"/>
+  <rect x="0" y="420" width="8" height="210" fill="#FFB703"/>
+  
+  <g filter="url(#textShadow)">
+    <text x="30" y="464" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="2.4" fill="#FFB703">PHISHING ADVISORY</text>
+    <text x="30" y="506" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="800" fill="#F5F7FA">Smishing · E-Commerce</text>
+    <text x="30" y="538" font-family="Inter, Helvetica, Arial, sans-serif" font-size="20" font-weight="600" fill="#FFD58A">E-commerce breach data · weaponized in phishing</text>
+    <text x="30" y="564" font-family="Inter, Helvetica, Arial, sans-serif" font-size="15" font-weight="500" fill="#E0D5B6">DMARC enforcement · brand impersonation takedown</text>
+    <text x="30" y="582" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" fill="#FFD58A">User awareness · suspicious-link reporting workflow</text><text x="30" y="598" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="500" fill="#E0D5B6" fill-opacity="0.85">Brand monitoring · phishing domain takedown via CERT</text>
+    
+  </g>
+  <g transform="translate(690,525)">
+    <rect x="-75" y="-50" width="150" height="100" rx="8" fill="#FFB703" fill-opacity="0.08" stroke="#FFB703" stroke-width="1.8" filter="url(#softShadow)"/>
+    <rect x="-75" y="-50" width="150" height="18" rx="8" fill="#FFB703" fill-opacity="0.3"/>
+    <g fill="#FFB703"><circle cx="-65" cy="-41" r="3"/><circle cx="-55" cy="-41" r="3"/><circle cx="-45" cy="-41" r="3"/></g>
+    <rect x="-30" y="-44" width="100" height="8" rx="3" fill="#FCD34D" fill-opacity="0.3"/>
+    <rect x="-65" y="-22" width="130" height="6" rx="2" fill="#FFB703" fill-opacity="0.25"/>
+    <rect x="-65" y="-10" width="86" height="4" rx="2" fill="#FFB703" fill-opacity="0.18"/>
+    <rect x="-65" y="0" width="110" height="4" rx="2" fill="#FFB703" fill-opacity="0.18"/>
+    <g transform="translate(0,18)">
+      <polygon points="0,-22 22,18 -22,18" fill="#FFB703" stroke="#FCD34D" stroke-width="1.4" filter="url(#softShadow)"><animate attributeName="opacity" values="0.7;1;0.7" dur="1.4s" repeatCount="indefinite"/></polygon>
+      <text y="10" text-anchor="middle" font-family="Inter, monospace" font-size="16" font-weight="900" fill="#FFF">!</text>
+    </g>
+    <rect x="-75" y="-22" width="6" height="72" fill="#FCD34D" opacity="0.4">
+      <animate attributeName="x" values="-75;65;-75" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <g fill="#FCD34D" opacity="0.7">
+      <circle cx="-65" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.5s" repeatCount="indefinite"/></circle>
+      <circle cx="-50" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.3s" repeatCount="indefinite"/></circle>
+      <circle cx="-35" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.9s" begin="0.6s" repeatCount="indefinite"/></circle>
+      <circle cx="35" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.1s" begin="0.9s" repeatCount="indefinite"/></circle>
+      <circle cx="50" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.3s" begin="1.2s" repeatCount="indefinite"/></circle>
+      <circle cx="65" cy="44" r="1.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="2.5s" begin="1.5s" repeatCount="indefinite"/></circle>
+    </g>
+    <g stroke="#FFB703" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+      <line x1="-78" y1="-58" x2="-50" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" repeatCount="indefinite"/></line>
+      <line x1="50" y1="-58" x2="78" y2="-58"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.4s" repeatCount="indefinite"/></line>
+    </g>
+    <text x="-60" y="-58" text-anchor="middle" font-family="Inter, monospace" font-size="8" font-weight="700" fill="#FCD34D" opacity="0.7">URL</text>
+    <text y="62" text-anchor="middle" font-family="Inter, monospace" font-size="10" font-weight="800" fill="#FFB703">SMS</text>
+    <text y="78" text-anchor="middle" font-family="Inter, monospace" font-size="9" font-weight="700" fill="#FCD34D" opacity="0.7">scan ack : 1 alert</text>
+  </g>
+  <g transform="translate(870,525)" filter="url(#softShadow)">
+    <rect x="-50" y="-48" width="100" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.6" stroke-opacity="0.75"/>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" letter-spacing="1.4" fill="#FFB703">REJECT</text>
+    <text x="0" y="14" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="24" font-weight="900" fill="#F5F7FA">DMARC</text>
+    <text x="0" y="34" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="600" fill="#FFD58A">policy</text>
+  </g>
+  <g transform="translate(1110,525)" filter="url(#softShadow)">
+    <rect x="-44" y="-48" width="88" height="96" rx="10" fill="#1E1805" stroke="#FFB703" stroke-width="1.4" stroke-opacity="0.7">
+      <animate attributeName="stroke-opacity" values="0.45;0.85;0.45" dur="3.6s" repeatCount="indefinite"/>
+    </rect>
+    <text x="0" y="-26" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="700" letter-spacing="1.2" fill="#FFB703">SMISHING</text>
+    <text x="0" y="12" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="900" fill="#F5F7FA">SMS</text>
+    <text x="0" y="32" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#FFD58A">campaign</text>
+    <line x1="-32" y1="38" x2="32" y2="38" stroke="#FFB703" stroke-width="0.6" stroke-opacity="0.45"/>
+    <circle cx="0" cy="-40" r="1.6" fill="#FCD34D"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g transform="translate(990,525)" filter="url(#softShadow)">
+    <rect x="-80" y="-65" width="180" height="125" rx="14" fill="#1E1805" stroke="#FFB703" stroke-width="2.2"/>
+    <text x="10" y="-38" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700" letter-spacing="2" fill="#FFB703">KISA NOTICE</text>
+    <text x="10" y="22" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="72" font-weight="900" fill="#F5F7FA">ADV</text>
+    <text x="10" y="44" text-anchor="middle" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="600" fill="#FFD58A">2026-01</text>
+    <line x1="-58" y1="50" x2="78" y2="50" stroke="#FFB703" stroke-width="0.8" stroke-opacity="0.5"/>
+    
+  </g>
+  <g transform="translate(990,525)">
+    <circle cx="10" cy="-50" r="3" fill="#FFB703"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="-58" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.8;0.2;0.8" dur="2.2s" repeatCount="indefinite"/></circle>
+    <circle cx="78" cy="-50" r="2" fill="#FCD34D"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" repeatCount="indefinite"/></circle>
+    <rect x="-78" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" repeatCount="indefinite"/></rect>
+    <rect x="-78" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="1.9s" repeatCount="indefinite"/></rect>
+    <rect x="62" y="-62" width="14" height="2" rx="1" fill="#FFB703" opacity="0.7"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.7s" begin="0.5s" repeatCount="indefinite"/></rect>
+    <rect x="65" y="-58" width="9" height="2" rx="1" fill="#FCD34D" opacity="0.5"><animate attributeName="opacity" values="0.2;0.8;0.2" dur="2.1s" begin="0.3s" repeatCount="indefinite"/></rect>
+  </g>
+  
+</g>
+<g opacity="0.9">
+  <g fill="#4ADE80">
+    <circle cx="240" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="63" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="55" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="147" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="35" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="175" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="27" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="81" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="129" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.6">
+    <rect x="780" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="27" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#86EFAC" opacity="0.85">
+    <rect x="730" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="165" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#4ADE80" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 95 L28 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 125 L28 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 155 L28 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 185 L28 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 95 L1172 95"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 125 L1172 125"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 155 L1172 155"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 185 L1172 185"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#86EFAC" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="105" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="105" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#4ADE80" opacity="0.55">
+    <rect x="120" y="15" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="195" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#E63946">
+    <circle cx="240" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="273" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="265" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="357" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="245" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="385" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="237" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="291" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="339" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.6">
+    <rect x="780" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="237" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCA5A5" opacity="0.85">
+    <rect x="730" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="375" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#E63946" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 305 L28 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 335 L28 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 365 L28 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 395 L28 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 305 L1172 305"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 335 L1172 335"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 365 L1172 365"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 395 L1172 395"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCA5A5" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="315" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="315" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.55">
+    <rect x="120" y="225" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="405" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FFB703">
+    <circle cx="240" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.8s" repeatCount="indefinite"/></circle>
+    <circle cx="290" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="340" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="390" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="440" cy="483" r="1.5"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="780" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.6s" repeatCount="indefinite"/></circle>
+    <circle cx="820" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="860" cy="475" r="1.4"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="240" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.7s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="320" cy="567" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.9s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="455" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="180" cy="595" r="1.3"><animate attributeName="opacity" values="0;1;0" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="447" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="1.6s" begin="1.1s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="501" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.3s" begin="0.2s" repeatCount="indefinite"/></circle>
+    <circle cx="900" cy="549" r="1.2"><animate attributeName="opacity" values="0;1;0" dur="2.0s" begin="0.6s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.6">
+    <rect x="780" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="800" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="820" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+    <rect x="840" y="447" width="6" height="2"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.3s" begin="0.9s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#FCD34D" opacity="0.85">
+    <rect x="730" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.4s" repeatCount="indefinite"/></rect>
+    <rect x="746" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.2s" begin="0.3s" repeatCount="indefinite"/></rect>
+    <rect x="762" y="585" width="3" height="3" rx="0.6"><animate attributeName="opacity" values="0.3;1;0.3" dur="1.6s" begin="0.6s" repeatCount="indefinite"/></rect>
+  </g>
+  <g stroke="#FFB703" stroke-width="0.5" stroke-opacity="0.35" fill="none">
+    <path d="M20 515 L28 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2s" repeatCount="indefinite"/></path>
+    <path d="M20 545 L28 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.2s" begin="0.3s" repeatCount="indefinite"/></path>
+    <path d="M20 575 L28 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.8s" begin="0.6s" repeatCount="indefinite"/></path>
+    <path d="M20 605 L28 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.9s" repeatCount="indefinite"/></path>
+    <path d="M1180 515 L1172 515"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" begin="0.2s" repeatCount="indefinite"/></path>
+    <path d="M1180 545 L1172 545"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.9s" begin="0.5s" repeatCount="indefinite"/></path>
+    <path d="M1180 575 L1172 575"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="0.8s" repeatCount="indefinite"/></path>
+    <path d="M1180 605 L1172 605"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="1.7s" begin="1.1s" repeatCount="indefinite"/></path>
+  </g>
+  <g stroke="#FCD34D" stroke-width="0.6" stroke-opacity="0.3" fill="none">
+    <circle cx="500" cy="525" r="100"><animate attributeName="r" values="80;120;80" dur="4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="4s" repeatCount="indefinite"/></circle>
+    <circle cx="500" cy="525" r="60" stroke-dasharray="2 4"><animate attributeName="r" values="40;80;40" dur="3.4s" repeatCount="indefinite"/><animate attributeName="stroke-opacity" values="0.4;0;0.4" dur="3.4s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.55">
+    <rect x="120" y="435" width="40" height="1.6"><animate attributeName="x" values="120;640;120" dur="6s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6s" repeatCount="indefinite"/></rect>
+    <rect x="640" y="615" width="40" height="1.6"><animate attributeName="x" values="640;120;640" dur="6.5s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.6;0.1" dur="6.5s" repeatCount="indefinite"/></rect>
+  </g>
+</g>
+<g opacity="0.85">
+  <g fill="#4ADE80" opacity="0.7">
+    <circle cx="500" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.3s" begin="0.6s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.8s" begin="0.9s" repeatCount="indefinite"/></circle>
+    <circle cx="660" cy="60" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="1.2s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#E63946" opacity="0.7">
+    <circle cx="500" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.2s" begin="0.4s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.6s" begin="0.7s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="270" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.0s" begin="1.0s" repeatCount="indefinite"/></circle>
+  </g>
+  <g fill="#FFB703" opacity="0.7">
+    <circle cx="500" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.7s" repeatCount="indefinite"/></circle>
+    <circle cx="540" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.1s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="580" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="1.9s" begin="0.8s" repeatCount="indefinite"/></circle>
+    <circle cx="620" cy="480" r="1.4"><animate attributeName="opacity" values="0.2;1;0.2" dur="2.4s" begin="1.1s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke-width="0.5" stroke-opacity="0.4" fill="none">
+    <rect x="700" y="40" width="36" height="2" fill="#4ADE80" stroke="none"><animate attributeName="x" values="700;1000;700" dur="6.4s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.4s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="250" width="36" height="2" fill="#E63946" stroke="none"><animate attributeName="x" values="1000;700;1000" dur="6.8s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="6.8s" repeatCount="indefinite"/></rect>
+    <rect x="700" y="460" width="36" height="2" fill="#FFB703" stroke="none"><animate attributeName="x" values="700;1000;700" dur="7.2s" repeatCount="indefinite"/><animate attributeName="opacity" values="0.1;0.7;0.1" dur="7.2s" repeatCount="indefinite"/></rect>
+  </g>
+  <g fill="#86EFAC" opacity="0.6">
+    <circle cx="60" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.1s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="270" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.4s" begin="0.5s" repeatCount="indefinite"/></circle>
+    <circle cx="60" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.7s" begin="1.0s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="60" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.0s" begin="0.3s" repeatCount="indefinite"/></circle>
+    <circle cx="1140" cy="480" r="1.6"><animate attributeName="opacity" values="0.2;0.9;0.2" dur="2.6s" begin="0.8s" repeatCount="indefinite"/></circle>
+  </g>
+  <g stroke="#FCA5A5" stroke-width="0.4" stroke-opacity="0.4" fill="none">
+    <line x1="640" y1="200" x2="640" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.1s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="200" x2="660" y2="220"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.4s" begin="0.4s" repeatCount="indefinite"/></line>
+    <line x1="640" y1="410" x2="640" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.0s" begin="0.7s" repeatCount="indefinite"/></line>
+    <line x1="660" y1="410" x2="660" y2="430"><animate attributeName="stroke-opacity" values="0;0.7;0" dur="2.3s" begin="1.1s" repeatCount="indefinite"/></line>
+  </g>
+</g>
+<g transform="translate(1080,504)" filter="url(#softShadow)">
+  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>
+  <path fill="#0A1020" d="M0.0 0.0h12.0v1.714h-12.0z M15.429 0.0h1.714v1.714h-1.714z M18.857 0.0h1.714v1.714h-1.714z M22.286 0.0h6.857v1.714h-6.857z M30.857 0.0h1.714v1.714h-1.714z M34.286 0.0h1.714v1.714h-1.714z M37.714 0.0h1.714v1.714h-1.714z M41.143 0.0h1.714v1.714h-1.714z M44.571 0.0h3.429v1.714h-3.429z M51.429 0.0h1.714v1.714h-1.714z M54.857 0.0h1.714v1.714h-1.714z M58.286 0.0h1.714v1.714h-1.714z M61.714 0.0h3.429v1.714h-3.429z M68.571 0.0h1.714v1.714h-1.714z M72.0 0.0h12.0v1.714h-12.0z M0.0 1.714h1.714v1.714h-1.714z M10.286 1.714h1.714v1.714h-1.714z M13.714 1.714h3.429v1.714h-3.429z M18.857 1.714h6.857v1.714h-6.857z M27.429 1.714h5.143v1.714h-5.143z M34.286 1.714h8.571v1.714h-8.571z M44.571 1.714h5.143v1.714h-5.143z M58.286 1.714h1.714v1.714h-1.714z M63.429 1.714h6.857v1.714h-6.857z M72.0 1.714h1.714v1.714h-1.714z M82.286 1.714h1.714v1.714h-1.714z M0.0 3.429h1.714v1.714h-1.714z M3.429 3.429h5.143v1.714h-5.143z M10.286 3.429h1.714v1.714h-1.714z M13.714 3.429h6.857v1.714h-6.857z M22.286 3.429h3.429v1.714h-3.429z M27.429 3.429h1.714v1.714h-1.714z M30.857 3.429h5.143v1.714h-5.143z M41.143 3.429h6.857v1.714h-6.857z M49.714 3.429h1.714v1.714h-1.714z M54.857 3.429h1.714v1.714h-1.714z M60.0 3.429h3.429v1.714h-3.429z M66.857 3.429h3.429v1.714h-3.429z M72.0 3.429h1.714v1.714h-1.714z M75.429 3.429h5.143v1.714h-5.143z M82.286 3.429h1.714v1.714h-1.714z M0.0 5.143h1.714v1.714h-1.714z M3.429 5.143h5.143v1.714h-5.143z M10.286 5.143h1.714v1.714h-1.714z M13.714 5.143h1.714v1.714h-1.714z M17.143 5.143h1.714v1.714h-1.714z M22.286 5.143h1.714v1.714h-1.714z M25.714 5.143h3.429v1.714h-3.429z M32.571 5.143h3.429v1.714h-3.429z M37.714 5.143h1.714v1.714h-1.714z M41.143 5.143h3.429v1.714h-3.429z M46.286 5.143h5.143v1.714h-5.143z M53.143 5.143h5.143v1.714h-5.143z M60.0 5.143h5.143v1.714h-5.143z M66.857 5.143h1.714v1.714h-1.714z M72.0 5.143h1.714v1.714h-1.714z M75.429 5.143h5.143v1.714h-5.143z M82.286 5.143h1.714v1.714h-1.714z M0.0 6.857h1.714v1.714h-1.714z M3.429 6.857h5.143v1.714h-5.143z M10.286 6.857h1.714v1.714h-1.714z M18.857 6.857h1.714v1.714h-1.714z M22.286 6.857h1.714v1.714h-1.714z M25.714 6.857h3.429v1.714h-3.429z M36.0 6.857h10.286v1.714h-10.286z M48.0 6.857h6.857v1.714h-6.857z M60.0 6.857h5.143v1.714h-5.143z M72.0 6.857h1.714v1.714h-1.714z M75.429 6.857h5.143v1.714h-5.143z M82.286 6.857h1.714v1.714h-1.714z M0.0 8.571h1.714v1.714h-1.714z M10.286 8.571h1.714v1.714h-1.714z M15.429 8.571h1.714v1.714h-1.714z M18.857 8.571h6.857v1.714h-6.857z M29.143 8.571h5.143v1.714h-5.143z M36.0 8.571h3.429v1.714h-3.429z M44.571 8.571h5.143v1.714h-5.143z M53.143 8.571h1.714v1.714h-1.714z M58.286 8.571h5.143v1.714h-5.143z M65.143 8.571h1.714v1.714h-1.714z M72.0 8.571h1.714v1.714h-1.714z M82.286 8.571h1.714v1.714h-1.714z M0.0 10.286h12.0v1.714h-12.0z M13.714 10.286h1.714v1.714h-1.714z M17.143 10.286h1.714v1.714h-1.714z M20.571 10.286h1.714v1.714h-1.714z M24.0 10.286h1.714v1.714h-1.714z M27.429 10.286h1.714v1.714h-1.714z M30.857 10.286h1.714v1.714h-1.714z M34.286 10.286h1.714v1.714h-1.714z M37.714 10.286h1.714v1.714h-1.714z M41.143 10.286h1.714v1.714h-1.714z M44.571 10.286h1.714v1.714h-1.714z M48.0 10.286h1.714v1.714h-1.714z M51.429 10.286h1.714v1.714h-1.714z M54.857 10.286h1.714v1.714h-1.714z M58.286 10.286h1.714v1.714h-1.714z M61.714 10.286h1.714v1.714h-1.714z M65.143 10.286h1.714v1.714h-1.714z M68.571 10.286h1.714v1.714h-1.714z M72.0 10.286h12.0v1.714h-12.0z M13.714 12.0h6.857v1.714h-6.857z M22.286 12.0h3.429v1.714h-3.429z M27.429 12.0h5.143v1.714h-5.143z M36.0 12.0h3.429v1.714h-3.429z M44.571 12.0h1.714v1.714h-1.714z M48.0 12.0h1.714v1.714h-1.714z M60.0 12.0h1.714v1.714h-1.714z M66.857 12.0h1.714v1.714h-1.714z M0.0 13.714h1.714v1.714h-1.714z M10.286 13.714h1.714v1.714h-1.714z M13.714 13.714h1.714v1.714h-1.714z M20.571 13.714h1.714v1.714h-1.714z M29.143 13.714h1.714v1.714h-1.714z M34.286 13.714h1.714v1.714h-1.714z M37.714 13.714h8.571v1.714h-8.571z M49.714 13.714h5.143v1.714h-5.143z M61.714 13.714h1.714v1.714h-1.714z M65.143 13.714h8.571v1.714h-8.571z M77.143 13.714h5.143v1.714h-5.143z M5.143 15.429h5.143v1.714h-5.143z M13.714 15.429h3.429v1.714h-3.429z M18.857 15.429h17.143v1.714h-17.143z M41.143 15.429h13.714v1.714h-13.714z M58.286 15.429h1.714v1.714h-1.714z M61.714 15.429h1.714v1.714h-1.714z M65.143 15.429h8.571v1.714h-8.571z M75.429 15.429h1.714v1.714h-1.714z M78.857 15.429h3.429v1.714h-3.429z M5.143 17.143h3.429v1.714h-3.429z M10.286 17.143h3.429v1.714h-3.429z M18.857 17.143h1.714v1.714h-1.714z M27.429 17.143h1.714v1.714h-1.714z M30.857 17.143h1.714v1.714h-1.714z M36.0 17.143h1.714v1.714h-1.714z M39.429 17.143h1.714v1.714h-1.714z M42.857 17.143h3.429v1.714h-3.429z M49.714 17.143h3.429v1.714h-3.429z M54.857 17.143h5.143v1.714h-5.143z M61.714 17.143h5.143v1.714h-5.143z M73.714 17.143h1.714v1.714h-1.714z M78.857 17.143h5.143v1.714h-5.143z M1.714 18.857h3.429v1.714h-3.429z M13.714 18.857h1.714v1.714h-1.714z M17.143 18.857h1.714v1.714h-1.714z M24.0 18.857h6.857v1.714h-6.857z M32.571 18.857h1.714v1.714h-1.714z M36.0 18.857h1.714v1.714h-1.714z M39.429 18.857h1.714v1.714h-1.714z M48.0 18.857h3.429v1.714h-3.429z M54.857 18.857h6.857v1.714h-6.857z M63.429 18.857h3.429v1.714h-3.429z M68.571 18.857h1.714v1.714h-1.714z M73.714 18.857h1.714v1.714h-1.714z M77.143 18.857h1.714v1.714h-1.714z M80.571 18.857h3.429v1.714h-3.429z M1.714 20.571h3.429v1.714h-3.429z M6.857 20.571h5.143v1.714h-5.143z M17.143 20.571h1.714v1.714h-1.714z M20.571 20.571h1.714v1.714h-1.714z M24.0 20.571h6.857v1.714h-6.857z M32.571 20.571h3.429v1.714h-3.429z M37.714 20.571h1.714v1.714h-1.714z M41.143 20.571h1.714v1.714h-1.714z M46.286 20.571h5.143v1.714h-5.143z M54.857 20.571h1.714v1.714h-1.714z M61.714 20.571h1.714v1.714h-1.714z M66.857 20.571h1.714v1.714h-1.714z M70.286 20.571h1.714v1.714h-1.714z M75.429 20.571h3.429v1.714h-3.429z M82.286 20.571h1.714v1.714h-1.714z M3.429 22.286h1.714v1.714h-1.714z M6.857 22.286h3.429v1.714h-3.429z M12.0 22.286h1.714v1.714h-1.714z M15.429 22.286h3.429v1.714h-3.429z M20.571 22.286h6.857v1.714h-6.857z M29.143 22.286h1.714v1.714h-1.714z M32.571 22.286h12.0v1.714h-12.0z M46.286 22.286h1.714v1.714h-1.714z M49.714 22.286h8.571v1.714h-8.571z M61.714 22.286h3.429v1.714h-3.429z M66.857 22.286h1.714v1.714h-1.714z M72.0 22.286h6.857v1.714h-6.857z M80.571 22.286h1.714v1.714h-1.714z M3.429 24.0h3.429v1.714h-3.429z M10.286 24.0h1.714v1.714h-1.714z M13.714 24.0h1.714v1.714h-1.714z M22.286 24.0h5.143v1.714h-5.143z M29.143 24.0h1.714v1.714h-1.714z M34.286 24.0h12.0v1.714h-12.0z M48.0 24.0h3.429v1.714h-3.429z M53.143 24.0h1.714v1.714h-1.714z M60.0 24.0h3.429v1.714h-3.429z M65.143 24.0h1.714v1.714h-1.714z M68.571 24.0h1.714v1.714h-1.714z M73.714 24.0h5.143v1.714h-5.143z M80.571 24.0h3.429v1.714h-3.429z M0.0 25.714h5.143v1.714h-5.143z M8.571 25.714h1.714v1.714h-1.714z M12.0 25.714h1.714v1.714h-1.714z M17.143 25.714h1.714v1.714h-1.714z M22.286 25.714h1.714v1.714h-1.714z M25.714 25.714h3.429v1.714h-3.429z M30.857 25.714h3.429v1.714h-3.429z M36.0 25.714h1.714v1.714h-1.714z M39.429 25.714h1.714v1.714h-1.714z M42.857 25.714h1.714v1.714h-1.714z M49.714 25.714h1.714v1.714h-1.714z M56.571 25.714h3.429v1.714h-3.429z M63.429 25.714h1.714v1.714h-1.714z M68.571 25.714h3.429v1.714h-3.429z M77.143 25.714h3.429v1.714h-3.429z M82.286 25.714h1.714v1.714h-1.714z M5.143 27.429h3.429v1.714h-3.429z M10.286 27.429h8.571v1.714h-8.571z M20.571 27.429h1.714v1.714h-1.714z M25.714 27.429h1.714v1.714h-1.714z M29.143 27.429h8.571v1.714h-8.571z M39.429 27.429h3.429v1.714h-3.429z M46.286 27.429h1.714v1.714h-1.714z M51.429 27.429h3.429v1.714h-3.429z M56.571 27.429h1.714v1.714h-1.714z M60.0 27.429h6.857v1.714h-6.857z M68.571 27.429h3.429v1.714h-3.429z M73.714 27.429h1.714v1.714h-1.714z M1.714 29.143h5.143v1.714h-5.143z M18.857 29.143h3.429v1.714h-3.429z M32.571 29.143h1.714v1.714h-1.714z M39.429 29.143h5.143v1.714h-5.143z M46.286 29.143h6.857v1.714h-6.857z M54.857 29.143h3.429v1.714h-3.429z M60.0 29.143h5.143v1.714h-5.143z M70.286 29.143h8.571v1.714h-8.571z M80.571 29.143h1.714v1.714h-1.714z M0.0 30.857h3.429v1.714h-3.429z M8.571 30.857h5.143v1.714h-5.143z M15.429 30.857h1.714v1.714h-1.714z M20.571 30.857h1.714v1.714h-1.714z M24.0 30.857h5.143v1.714h-5.143z M30.857 30.857h1.714v1.714h-1.714z M36.0 30.857h1.714v1.714h-1.714z M39.429 30.857h1.714v1.714h-1.714z M42.857 30.857h1.714v1.714h-1.714z M46.286 30.857h3.429v1.714h-3.429z M56.571 30.857h1.714v1.714h-1.714z M61.714 30.857h3.429v1.714h-3.429z M73.714 30.857h6.857v1.714h-6.857z M82.286 30.857h1.714v1.714h-1.714z M0.0 32.571h3.429v1.714h-3.429z M6.857 32.571h1.714v1.714h-1.714z M13.714 32.571h1.714v1.714h-1.714z M18.857 32.571h1.714v1.714h-1.714z M24.0 32.571h1.714v1.714h-1.714z M27.429 32.571h3.429v1.714h-3.429z M32.571 32.571h5.143v1.714h-5.143z M39.429 32.571h1.714v1.714h-1.714z M44.571 32.571h3.429v1.714h-3.429z M49.714 32.571h1.714v1.714h-1.714z M54.857 32.571h5.143v1.714h-5.143z M66.857 32.571h3.429v1.714h-3.429z M72.0 32.571h6.857v1.714h-6.857z M80.571 32.571h3.429v1.714h-3.429z M1.714 34.286h5.143v1.714h-5.143z M10.286 34.286h8.571v1.714h-8.571z M20.571 34.286h3.429v1.714h-3.429z M29.143 34.286h13.714v1.714h-13.714z M53.143 34.286h1.714v1.714h-1.714z M58.286 34.286h12.0v1.714h-12.0z M78.857 34.286h1.714v1.714h-1.714z M1.714 36.0h3.429v1.714h-3.429z M6.857 36.0h3.429v1.714h-3.429z M15.429 36.0h1.714v1.714h-1.714z M20.571 36.0h1.714v1.714h-1.714z M24.0 36.0h12.0v1.714h-12.0z M39.429 36.0h1.714v1.714h-1.714z M42.857 36.0h3.429v1.714h-3.429z M51.429 36.0h1.714v1.714h-1.714z M56.571 36.0h3.429v1.714h-3.429z M63.429 36.0h12.0v1.714h-12.0z M77.143 36.0h5.143v1.714h-5.143z M0.0 37.714h17.143v1.714h-17.143z M18.857 37.714h3.429v1.714h-3.429z M25.714 37.714h1.714v1.714h-1.714z M29.143 37.714h3.429v1.714h-3.429z M36.0 37.714h10.286v1.714h-10.286z M48.0 37.714h1.714v1.714h-1.714z M53.143 37.714h1.714v1.714h-1.714z M56.571 37.714h3.429v1.714h-3.429z M61.714 37.714h1.714v1.714h-1.714z M65.143 37.714h18.857v1.714h-18.857z M0.0 39.429h3.429v1.714h-3.429z M5.143 39.429h3.429v1.714h-3.429z M13.714 39.429h1.714v1.714h-1.714z M17.143 39.429h3.429v1.714h-3.429z M25.714 39.429h1.714v1.714h-1.714z M32.571 39.429h1.714v1.714h-1.714z M36.0 39.429h3.429v1.714h-3.429z M44.571 39.429h1.714v1.714h-1.714z M48.0 39.429h1.714v1.714h-1.714z M51.429 39.429h1.714v1.714h-1.714z M56.571 39.429h5.143v1.714h-5.143z M68.571 39.429h1.714v1.714h-1.714z M75.429 39.429h3.429v1.714h-3.429z M80.571 39.429h3.429v1.714h-3.429z M0.0 41.143h3.429v1.714h-3.429z M5.143 41.143h3.429v1.714h-3.429z M10.286 41.143h1.714v1.714h-1.714z M13.714 41.143h6.857v1.714h-6.857z M22.286 41.143h1.714v1.714h-1.714z M25.714 41.143h3.429v1.714h-3.429z M32.571 41.143h1.714v1.714h-1.714z M36.0 41.143h3.429v1.714h-3.429z M41.143 41.143h1.714v1.714h-1.714z M44.571 41.143h1.714v1.714h-1.714z M48.0 41.143h1.714v1.714h-1.714z M54.857 41.143h1.714v1.714h-1.714z M60.0 41.143h6.857v1.714h-6.857z M68.571 41.143h1.714v1.714h-1.714z M72.0 41.143h1.714v1.714h-1.714z M75.429 41.143h1.714v1.714h-1.714z M80.571 41.143h1.714v1.714h-1.714z M0.0 42.857h3.429v1.714h-3.429z M5.143 42.857h3.429v1.714h-3.429z M13.714 42.857h3.429v1.714h-3.429z M22.286 42.857h1.714v1.714h-1.714z M36.0 42.857h3.429v1.714h-3.429z M44.571 42.857h12.0v1.714h-12.0z M60.0 42.857h1.714v1.714h-1.714z M68.571 42.857h1.714v1.714h-1.714z M75.429 42.857h5.143v1.714h-5.143z M0.0 44.571h3.429v1.714h-3.429z M6.857 44.571h10.286v1.714h-10.286z M22.286 44.571h5.143v1.714h-5.143z M29.143 44.571h5.143v1.714h-5.143z M36.0 44.571h12.0v1.714h-12.0z M51.429 44.571h5.143v1.714h-5.143z M58.286 44.571h3.429v1.714h-3.429z M63.429 44.571h13.714v1.714h-13.714z M78.857 44.571h5.143v1.714h-5.143z M1.714 46.286h3.429v1.714h-3.429z M6.857 46.286h3.429v1.714h-3.429z M17.143 46.286h1.714v1.714h-1.714z M20.571 46.286h1.714v1.714h-1.714z M24.0 46.286h1.714v1.714h-1.714z M27.429 46.286h5.143v1.714h-5.143z M36.0 46.286h1.714v1.714h-1.714z M41.143 46.286h3.429v1.714h-3.429z M49.714 46.286h3.429v1.714h-3.429z M58.286 46.286h3.429v1.714h-3.429z M63.429 46.286h1.714v1.714h-1.714z M66.857 46.286h1.714v1.714h-1.714z M75.429 46.286h5.143v1.714h-5.143z M82.286 46.286h1.714v1.714h-1.714z M1.714 48.0h1.714v1.714h-1.714z M5.143 48.0h3.429v1.714h-3.429z M10.286 48.0h5.143v1.714h-5.143z M22.286 48.0h1.714v1.714h-1.714z M25.714 48.0h1.714v1.714h-1.714z M30.857 48.0h3.429v1.714h-3.429z M37.714 48.0h1.714v1.714h-1.714z M51.429 48.0h3.429v1.714h-3.429z M56.571 48.0h1.714v1.714h-1.714z M60.0 48.0h5.143v1.714h-5.143z M66.857 48.0h1.714v1.714h-1.714z M70.286 48.0h6.857v1.714h-6.857z M78.857 48.0h5.143v1.714h-5.143z M0.0 49.714h6.857v1.714h-6.857z M8.571 49.714h1.714v1.714h-1.714z M13.714 49.714h3.429v1.714h-3.429z M18.857 49.714h1.714v1.714h-1.714z M24.0 49.714h3.429v1.714h-3.429z M29.143 49.714h1.714v1.714h-1.714z M37.714 49.714h17.143v1.714h-17.143z M56.571 49.714h1.714v1.714h-1.714z M63.429 49.714h1.714v1.714h-1.714z M68.571 49.714h6.857v1.714h-6.857z M77.143 49.714h3.429v1.714h-3.429z M5.143 51.429h6.857v1.714h-6.857z M15.429 51.429h5.143v1.714h-5.143z M25.714 51.429h5.143v1.714h-5.143z M34.286 51.429h3.429v1.714h-3.429z M41.143 51.429h1.714v1.714h-1.714z M44.571 51.429h1.714v1.714h-1.714z M49.714 51.429h1.714v1.714h-1.714z M53.143 51.429h3.429v1.714h-3.429z M60.0 51.429h3.429v1.714h-3.429z M66.857 51.429h1.714v1.714h-1.714z M72.0 51.429h1.714v1.714h-1.714z M75.429 51.429h1.714v1.714h-1.714z M82.286 51.429h1.714v1.714h-1.714z M1.714 53.143h1.714v1.714h-1.714z M5.143 53.143h1.714v1.714h-1.714z M8.571 53.143h1.714v1.714h-1.714z M12.0 53.143h1.714v1.714h-1.714z M15.429 53.143h5.143v1.714h-5.143z M25.714 53.143h1.714v1.714h-1.714z M30.857 53.143h1.714v1.714h-1.714z M37.714 53.143h3.429v1.714h-3.429z M44.571 53.143h5.143v1.714h-5.143z M54.857 53.143h3.429v1.714h-3.429z M60.0 53.143h1.714v1.714h-1.714z M63.429 53.143h6.857v1.714h-6.857z M73.714 53.143h1.714v1.714h-1.714z M77.143 53.143h1.714v1.714h-1.714z M3.429 54.857h5.143v1.714h-5.143z M10.286 54.857h1.714v1.714h-1.714z M17.143 54.857h5.143v1.714h-5.143z M30.857 54.857h1.714v1.714h-1.714z M34.286 54.857h3.429v1.714h-3.429z M39.429 54.857h1.714v1.714h-1.714z M42.857 54.857h1.714v1.714h-1.714z M49.714 54.857h5.143v1.714h-5.143z M60.0 54.857h3.429v1.714h-3.429z M65.143 54.857h3.429v1.714h-3.429z M70.286 54.857h1.714v1.714h-1.714z M73.714 54.857h1.714v1.714h-1.714z M77.143 54.857h1.714v1.714h-1.714z M82.286 54.857h1.714v1.714h-1.714z M1.714 56.571h3.429v1.714h-3.429z M15.429 56.571h6.857v1.714h-6.857z M24.0 56.571h3.429v1.714h-3.429z M30.857 56.571h5.143v1.714h-5.143z M39.429 56.571h22.286v1.714h-22.286z M63.429 56.571h5.143v1.714h-5.143z M70.286 56.571h1.714v1.714h-1.714z M73.714 56.571h6.857v1.714h-6.857z M3.429 58.286h1.714v1.714h-1.714z M10.286 58.286h1.714v1.714h-1.714z M13.714 58.286h10.286v1.714h-10.286z M25.714 58.286h1.714v1.714h-1.714z M30.857 58.286h6.857v1.714h-6.857z M42.857 58.286h1.714v1.714h-1.714z M46.286 58.286h5.143v1.714h-5.143z M60.0 58.286h5.143v1.714h-5.143z M72.0 58.286h3.429v1.714h-3.429z M77.143 58.286h1.714v1.714h-1.714z M80.571 58.286h3.429v1.714h-3.429z M0.0 60.0h1.714v1.714h-1.714z M3.429 60.0h3.429v1.714h-3.429z M8.571 60.0h1.714v1.714h-1.714z M13.714 60.0h1.714v1.714h-1.714z M18.857 60.0h1.714v1.714h-1.714z M24.0 60.0h17.143v1.714h-17.143z M42.857 60.0h3.429v1.714h-3.429z M48.0 60.0h3.429v1.714h-3.429z M53.143 60.0h5.143v1.714h-5.143z M60.0 60.0h1.714v1.714h-1.714z M65.143 60.0h3.429v1.714h-3.429z M75.429 60.0h3.429v1.714h-3.429z M80.571 60.0h1.714v1.714h-1.714z M3.429 61.714h1.714v1.714h-1.714z M10.286 61.714h1.714v1.714h-1.714z M13.714 61.714h1.714v1.714h-1.714z M17.143 61.714h1.714v1.714h-1.714z M24.0 61.714h1.714v1.714h-1.714z M29.143 61.714h5.143v1.714h-5.143z M36.0 61.714h5.143v1.714h-5.143z M42.857 61.714h1.714v1.714h-1.714z M48.0 61.714h3.429v1.714h-3.429z M54.857 61.714h5.143v1.714h-5.143z M61.714 61.714h6.857v1.714h-6.857z M70.286 61.714h5.143v1.714h-5.143z M80.571 61.714h1.714v1.714h-1.714z M1.714 63.429h1.714v1.714h-1.714z M6.857 63.429h1.714v1.714h-1.714z M12.0 63.429h3.429v1.714h-3.429z M18.857 63.429h1.714v1.714h-1.714z M22.286 63.429h1.714v1.714h-1.714z M25.714 63.429h8.571v1.714h-8.571z M37.714 63.429h6.857v1.714h-6.857z M46.286 63.429h8.571v1.714h-8.571z M56.571 63.429h1.714v1.714h-1.714z M60.0 63.429h3.429v1.714h-3.429z M66.857 63.429h1.714v1.714h-1.714z M72.0 63.429h3.429v1.714h-3.429z M1.714 65.143h1.714v1.714h-1.714z M8.571 65.143h5.143v1.714h-5.143z M17.143 65.143h1.714v1.714h-1.714z M22.286 65.143h1.714v1.714h-1.714z M30.857 65.143h3.429v1.714h-3.429z M37.714 65.143h1.714v1.714h-1.714z M42.857 65.143h1.714v1.714h-1.714z M48.0 65.143h1.714v1.714h-1.714z M53.143 65.143h1.714v1.714h-1.714z M58.286 65.143h1.714v1.714h-1.714z M61.714 65.143h1.714v1.714h-1.714z M65.143 65.143h10.286v1.714h-10.286z M78.857 65.143h5.143v1.714h-5.143z M1.714 66.857h5.143v1.714h-5.143z M17.143 66.857h5.143v1.714h-5.143z M24.0 66.857h3.429v1.714h-3.429z M30.857 66.857h1.714v1.714h-1.714z M34.286 66.857h3.429v1.714h-3.429z M41.143 66.857h1.714v1.714h-1.714z M46.286 66.857h3.429v1.714h-3.429z M51.429 66.857h1.714v1.714h-1.714z M58.286 66.857h1.714v1.714h-1.714z M65.143 66.857h3.429v1.714h-3.429z M70.286 66.857h1.714v1.714h-1.714z M73.714 66.857h6.857v1.714h-6.857z M0.0 68.571h5.143v1.714h-5.143z M10.286 68.571h3.429v1.714h-3.429z M15.429 68.571h5.143v1.714h-5.143z M30.857 68.571h5.143v1.714h-5.143z M37.714 68.571h8.571v1.714h-8.571z M49.714 68.571h3.429v1.714h-3.429z M56.571 68.571h3.429v1.714h-3.429z M61.714 68.571h1.714v1.714h-1.714z M65.143 68.571h18.857v1.714h-18.857z M13.714 70.286h1.714v1.714h-1.714z M17.143 70.286h1.714v1.714h-1.714z M22.286 70.286h3.429v1.714h-3.429z M29.143 70.286h1.714v1.714h-1.714z M32.571 70.286h1.714v1.714h-1.714z M36.0 70.286h3.429v1.714h-3.429z M44.571 70.286h8.571v1.714h-8.571z M54.857 70.286h1.714v1.714h-1.714z M66.857 70.286h3.429v1.714h-3.429z M75.429 70.286h1.714v1.714h-1.714z M0.0 72.0h12.0v1.714h-12.0z M22.286 72.0h1.714v1.714h-1.714z M27.429 72.0h1.714v1.714h-1.714z M30.857 72.0h5.143v1.714h-5.143z M37.714 72.0h1.714v1.714h-1.714z M41.143 72.0h1.714v1.714h-1.714z M44.571 72.0h1.714v1.714h-1.714z M51.429 72.0h5.143v1.714h-5.143z M61.714 72.0h1.714v1.714h-1.714z M68.571 72.0h1.714v1.714h-1.714z M72.0 72.0h1.714v1.714h-1.714z M75.429 72.0h3.429v1.714h-3.429z M82.286 72.0h1.714v1.714h-1.714z M0.0 73.714h1.714v1.714h-1.714z M10.286 73.714h1.714v1.714h-1.714z M15.429 73.714h10.286v1.714h-10.286z M30.857 73.714h3.429v1.714h-3.429z M37.714 73.714h1.714v1.714h-1.714z M44.571 73.714h1.714v1.714h-1.714z M48.0 73.714h1.714v1.714h-1.714z M54.857 73.714h1.714v1.714h-1.714z M60.0 73.714h1.714v1.714h-1.714z M63.429 73.714h1.714v1.714h-1.714z M66.857 73.714h3.429v1.714h-3.429z M75.429 73.714h3.429v1.714h-3.429z M80.571 73.714h1.714v1.714h-1.714z M0.0 75.429h1.714v1.714h-1.714z M3.429 75.429h5.143v1.714h-5.143z M10.286 75.429h1.714v1.714h-1.714z M17.143 75.429h5.143v1.714h-5.143z M25.714 75.429h1.714v1.714h-1.714z M29.143 75.429h3.429v1.714h-3.429z M37.714 75.429h8.571v1.714h-8.571z M49.714 75.429h5.143v1.714h-5.143z M56.571 75.429h3.429v1.714h-3.429z M61.714 75.429h5.143v1.714h-5.143z M68.571 75.429h8.571v1.714h-8.571z M78.857 75.429h3.429v1.714h-3.429z M0.0 77.143h1.714v1.714h-1.714z M3.429 77.143h5.143v1.714h-5.143z M10.286 77.143h1.714v1.714h-1.714z M17.143 77.143h1.714v1.714h-1.714z M22.286 77.143h3.429v1.714h-3.429z M27.429 77.143h1.714v1.714h-1.714z M32.571 77.143h1.714v1.714h-1.714z M37.714 77.143h1.714v1.714h-1.714z M42.857 77.143h5.143v1.714h-5.143z M49.714 77.143h3.429v1.714h-3.429z M56.571 77.143h3.429v1.714h-3.429z M63.429 77.143h5.143v1.714h-5.143z M72.0 77.143h3.429v1.714h-3.429z M77.143 77.143h6.857v1.714h-6.857z M0.0 78.857h1.714v1.714h-1.714z M3.429 78.857h5.143v1.714h-5.143z M10.286 78.857h1.714v1.714h-1.714z M17.143 78.857h1.714v1.714h-1.714z M20.571 78.857h1.714v1.714h-1.714z M25.714 78.857h5.143v1.714h-5.143z M34.286 78.857h3.429v1.714h-3.429z M39.429 78.857h3.429v1.714h-3.429z M46.286 78.857h1.714v1.714h-1.714z M56.571 78.857h5.143v1.714h-5.143z M65.143 78.857h1.714v1.714h-1.714z M70.286 78.857h5.143v1.714h-5.143z M77.143 78.857h1.714v1.714h-1.714z M0.0 80.571h1.714v1.714h-1.714z M10.286 80.571h1.714v1.714h-1.714z M22.286 80.571h5.143v1.714h-5.143z M29.143 80.571h1.714v1.714h-1.714z M32.571 80.571h3.429v1.714h-3.429z M37.714 80.571h6.857v1.714h-6.857z M48.0 80.571h1.714v1.714h-1.714z M51.429 80.571h1.714v1.714h-1.714z M56.571 80.571h3.429v1.714h-3.429z M61.714 80.571h12.0v1.714h-12.0z M77.143 80.571h1.714v1.714h-1.714z M82.286 80.571h1.714v1.714h-1.714z M0.0 82.286h12.0v1.714h-12.0z M13.714 82.286h8.571v1.714h-8.571z M24.0 82.286h1.714v1.714h-1.714z M27.429 82.286h1.714v1.714h-1.714z M32.571 82.286h1.714v1.714h-1.714z M37.714 82.286h1.714v1.714h-1.714z M41.143 82.286h3.429v1.714h-3.429z M48.0 82.286h1.714v1.714h-1.714z M54.857 82.286h1.714v1.714h-1.714z M61.714 82.286h1.714v1.714h-1.714z M66.857 82.286h5.143v1.714h-5.143z M73.714 82.286h5.143v1.714h-5.143z M82.286 82.286h1.714v1.714h-1.714z"/>
+</g>
+<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="700" fill="#F5F7FA" text-anchor="middle">scan / full post</text>
 </svg>


### PR DESCRIPTION
## Summary
- Rebuild 5 January 22 post cover SVGs from 98L → 462–465L (ultra-tier)
- Each cover uses `render_bands_svg(tier="ultra")` with content-specific `bands_cfg` derived from the post's actual frontmatter
- Lint: 5/5 clean

## Files
| File | Topic | Lines |
|---|---|---|
| AWS_GCP_Cloud_Updates_January_2026 | EC2 G7e/X8i, Bangkok, EU Sovereign | 462 |
| Cloud_Security_Course_8Batch_8Week_CI_CD_Kubernetes | Trivy/Snyk, NetPolicy/RBAC, AI DevSecOps | 465 |
| Cloud_Security_Trends_January_2026 | K8s 82%, VS Code threat, CRI-O audit | 463 |
| KARA_Ransomware_Trends_2025_Q3 | LockBit 5.0/Akira/INC, MITRE TTPs, EQST | 465 |
| KISA_Security_Advisory_Ransomware_Linux_Rootkit | 3-2-1 backup, rkhunter, DMARC | 465 |

## Spec
Generated via deep-interview pipeline (ambiguity 11%, 3 rounds): `.omc/specs/deep-interview-jan22-svg-batch.md`

## Test plan
- [x] All 5 SVGs ≥ 450 lines (462–465L)
- [x] `lint_svg_compliance.py` passes 5/5
- [x] Visual baselines captured (30/30 — Jan 22 covers outside regression scope set)
- [ ] CI all green (lint, CodeQL, Analyze, Lighthouse, npm/Ruby audit, Vercel)
- [ ] PR squash-merged to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)