### PR TITLE
perf: remove duplicate eager GTM, add preconnects, fix tab-count contrast

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,13 +5,13 @@
 
   <!-- FOUC prevention: apply theme immediately before first paint (inline required) -->
   <script id="theme-init">(function(){var t=localStorage.getItem('theme');if(!t||t==='system'){t=matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';}document.documentElement.setAttribute('data-theme',t);})();</script>
-  <!-- Google Analytics (gtag.js) -->
-  {% if site.google_analytics and site.google_analytics != "" %}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
-  <script>
-    window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','{{ site.google_analytics }}');
-  </script>
-  {% endif %}
+  <!-- Google Analytics: lazy-loaded by assets/js/head-runtime.js#loadGoogleAnalytics
+       via requestIdleCallback so it does not block LCP. PageSpeed report flagged
+       eager + idle dual-load as 305 KiB unused JS / 1374ms script-eval; the
+       eager <script async src="gtag/js?id=..."> tag was removed 2026-05 to keep
+       only the deferred idle path. The head-runtime.js script element retains
+       the data-ga-id attribute used by loadGoogleAnalytics(). -->
+
 
   <!-- Console Filter Module (deferred to reduce FID impact) -->
   <script src="{{ '/assets/js/console-filter.js' | relative_url }}" defer></script>
@@ -261,7 +261,11 @@
   <!-- DNS Prefetch and Preconnect for External Resources (TTFB 최적화) -->
   {% if site.sentry_dsn and site.sentry_dsn != "" %}
   <link rel="preconnect" href="https://browser.sentry-cdn.com" crossorigin>
+  <!-- Sentry ingest endpoint: actual error reporting target (PageSpeed: 310ms LCP savings) -->
+  <link rel="preconnect" href="https://o4510686170710016.ingest.us.sentry.io" crossorigin>
   {% endif %}
+  <!-- Vercel Analytics & Speed Insights endpoint (PageSpeed: 340ms LCP savings) -->
+  <link rel="preconnect" href="https://va.vercel-scripts.com" crossorigin>
   <!-- Google Translate: dns-prefetch only (script lazy-loaded on user interaction) -->
   <link rel="dns-prefetch" href="https://translate.google.com">
   <link rel="dns-prefetch" href="https://translate.googleapis.com">

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -533,8 +533,10 @@
 }
 
 [data-theme="dark"] .tab-count {
-  background: var(--color-bg-tertiary);
-  color: var(--color-text-tertiary);
+  /* WCAG AA: dark-theme override matching the light-theme contrast lift. */
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
 }
 
 [data-theme="dark"] .posts-empty,

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -620,15 +620,24 @@ div.post-card-excerpt {
   padding: 0 5px;
   border-radius: 9px;
   font-size: 0.7rem;
-  font-weight: var(--font-weight-semibold);
-  background: var(--color-bg-tertiary);
-  color: var(--color-text-tertiary);
+  font-weight: var(--font-weight-bold);
+  /* WCAG AA fix: previous bg=--color-bg-tertiary + color=--color-text-tertiary
+     produced ~3.2:1 contrast on light theme. Use --color-text-primary on a
+     stronger tinted background to reach >=4.5:1 in both light and dark. */
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
   line-height: 1;
 }
 
 .posts-tab.active .tab-count {
-  background: rgba(255, 255, 255, 0.25);
-  color: white;
+  /* Active state: full white text on translucent overlay over --color-primary.
+     0.25 alpha overlay + white text dropped to ~3.0:1 against typical primary
+     blues; lift to 0.35 alpha and remove the white-on-color blend ambiguity by
+     forcing solid color text. */
+  background: rgba(255, 255, 255, 0.35);
+  color: #ffffff;
+  border-color: transparent;
 }
 
 /* View Toggle */


### PR DESCRIPTION
## Summary

Three concrete fixes for issues surfaced by Google PageSpeed Insights on https://tech.2twodragon.com.

## Changes

### 1. Eliminate duplicate eager GTM load (~107 KiB / ~1.3s main thread)

`_includes/head.html` previously loaded `gtag/js?id=...` twice:
- Eagerly via `<script async>` in head (blocked LCP, 1374ms script eval)
- Idle-injected via `assets/js/head-runtime.js#loadGoogleAnalytics()` using `requestIdleCallback`

PageSpeed report flagged GTM listed twice (305 KiB total transfer, 169 KiB unused). Removed the eager copy; the idle-injected one remains, so GA4 events still fire but LCP and TBT are unblocked.

### 2. Add missing preconnects (~650ms combined LCP)

PageSpeed candidate-preconnect insight requested:
- `https://va.vercel-scripts.com` — 340ms LCP savings
- `https://o4510686170710016.ingest.us.sentry.io` — 310ms LCP savings

Both added in `_includes/head.html`. The Sentry ingest preconnect is gated on `site.sentry_dsn` so it only emits when error tracking is configured.

### 3. Fix `.tab-count` color contrast (WCAG AA)

Audit flagged 30 elements failing color contrast — all `.tab-count` badges. Default state went from `bg-tertiary + text-tertiary` (~3.2:1) to `bg-secondary + text-primary` with a `border` outline (>=4.5:1). Active-state overlay lifted from `rgba(255,255,255,0.25)` to `0.35`. Mirrored the dark-theme override in `_sass/_archive.scss`.

## Files changed

- `_includes/head.html`: removed eager GTM block; added 2 preconnects
- `_sass/_components.scss`: `.tab-count` palette + active-state overlay alpha
- `_sass/_archive.scss`: matching dark-theme override

## Test plan

- [x] `bundle exec jekyll build` succeeds
- [x] Built `_site/index.html` shows: preconnect for `va.vercel-scripts.com`; no eager `<script async src="gtag/js?id=...">`; only `dns-prefetch` for googletagmanager (idle path)
- [x] Compiled `_site/assets/css/main.css` shows new `.tab-count` rule with `--color-text-primary` and border
- [ ] Post-merge: re-run PageSpeed on https://tech.2twodragon.com to verify LCP/TBT improvements

## Out of scope (deferred)

- Lazy-load AdSense per-page (currently loads on every page via head-runtime.js even when no ad slots present); would save ~123 KiB unused JS but requires intersection-observer rewrite of the loader.
- Self-host or subset Noto Sans KR (45 KiB unused CSS); requires font subset pipeline.
- Inline critical CSS to reduce 986ms `main.css` chain; needs critical-path extraction tooling.