### PR TITLE
perf(ads): scope + IntersectionObserver-defer AdSense (~123 KiB unused JS)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,7 +15,7 @@
 
   <!-- Console Filter Module (deferred to reduce FID impact) -->
   <script src="{{ '/assets/js/console-filter.js' | relative_url }}" defer></script>
-  <script src="{{ '/assets/js/head-runtime.js' | relative_url }}" id="head-runtime-script" data-ga-id="{{ site.google_analytics | default: '' }}" data-adsense-client="{{ site.google_adsense | default: '' }}" data-kakao-app-key="{{ site.kakao_app_key | default: '' }}" defer></script>
+  <script src="{{ '/assets/js/head-runtime.js' | relative_url }}" id="head-runtime-script" data-ga-id="{{ site.google_analytics | default: '' }}" data-adsense-client="{% if page.layout == 'post' %}{{ site.google_adsense | default: '' }}{% endif %}" data-kakao-app-key="{{ site.kakao_app_key | default: '' }}" defer></script>
 
   <!-- Security Headers -->
   <!--

--- a/assets/js/head-runtime.js
+++ b/assets/js/head-runtime.js
@@ -149,6 +149,11 @@
     }
 
     var load = function () {
+      if (window.__adsenseLoadInitiated) {
+        return;
+      }
+      window.__adsenseLoadInitiated = true;
+
       try {
         window.adsbygoogle = window.adsbygoogle || [];
         window.adsbygoogle.pauseAdRequests = 0;
@@ -180,7 +185,44 @@
       }
     };
 
-    if ('requestIdleCallback' in window) {
+    function installIntersectionObserver(el) {
+      var io = new IntersectionObserver(function (entries) {
+        if (entries[0].isIntersecting) {
+          io.disconnect();
+          load();
+        }
+      }, { rootMargin: '200px 0px' });
+      io.observe(el);
+    }
+
+    if ('IntersectionObserver' in window) {
+      var slot = document.querySelector('.adsbygoogle');
+      if (slot) {
+        // Slot already in DOM — observe it directly.
+        installIntersectionObserver(slot);
+      } else {
+        // Slot not yet in DOM — watch for its insertion, bail after 30 s.
+        var mutationTimeout = setTimeout(function () {
+          mo.disconnect();
+          // No slot appeared within 30 s; fall back to idle / load event.
+          if ('requestIdleCallback' in window) {
+            requestIdleCallback(load, { timeout: 5000 });
+          } else {
+            window.addEventListener('load', load, { once: true });
+          }
+        }, 30000);
+
+        var mo = new MutationObserver(function () {
+          var found = document.querySelector('.adsbygoogle');
+          if (found) {
+            mo.disconnect();
+            clearTimeout(mutationTimeout);
+            installIntersectionObserver(found);
+          }
+        });
+        mo.observe(document.body, { childList: true, subtree: true });
+      }
+    } else if ('requestIdleCallback' in window) {
       requestIdleCallback(load, { timeout: 5000 });
     } else {
       window.addEventListener('load', load, { once: true });


### PR DESCRIPTION
## Summary

- **Commit 1** (`perf(ads): scope AdSense client to post layout pages only`): The `data-adsense-client` attribute on the `head-runtime.js` script element now emits a non-empty value only when `page.layout == 'post'`. All other pages (home, tags, archive, discussion, certifications) receive an empty string, causing `loadAdsense()` to return immediately — the `pagead/js/adsbygoogle.js` bundle is never fetched.
- **Commit 2** (`perf(ads): defer AdSense load via IntersectionObserver`): `loadAdsense()` now dispatches loading via an `IntersectionObserver` (rootMargin `200px 0px`) watching the first `.adsbygoogle` slot. Loading begins only when the user scrolls within 200px of the first ad slot, preserving fill rate while avoiding unused-JS cost on page load.

## Estimated Performance Impact

| Metric | Before | After (non-post pages) | After (post pages) |
|--------|--------|------------------------|--------------------|
| AdSense JS transferred | ~123 KiB | **0 KiB** | ~123 KiB (deferred) |
| AdSense script eval | ~270 ms | **0 ms** | ~270 ms (off critical path) |
| LCP impact | eager/idle race | none | none (IO triggers off-screen) |

Non-post pages (home, archive, tags) now save the full ~123 KiB AdSense bundle. Post pages still load AdSense, but only when the user scrolls near the first ad slot rather than unconditionally on idle.

## Behavior Matrix

| Page type | `data-adsense-client` | `loadAdsense()` path | AdSense loaded? |
|-----------|----------------------|---------------------|-----------------|
| Post (`layout: post`) | Non-empty client ID | IO watches `.adsbygoogle`; loads on near-viewport scroll | Yes, when scrolled into view |
| Non-post (home, tags, archive, …) | Empty string | Returns immediately (`if (!adsenseClient) return`) | Never |
| Post, no IntersectionObserver support | Non-empty client ID | `requestIdleCallback(load, {timeout:5000})` fallback | Yes, on idle |
| Post, no IO + no rIC | Non-empty client ID | `window.addEventListener('load', load)` fallback | Yes, on load |
| Post, `.adsbygoogle` not in DOM at script execution | Non-empty client ID | MutationObserver watches body; on insertion, IO installed; 30s auto-disconnect | Yes, when slot inserted and scrolled near |
| Double-invoke race (idle + IO) | Non-empty client ID | `window.__adsenseLoadInitiated` guard prevents double-fetch | Exactly once |

## Rollback Path

- **Remove layout scoping only**: `git revert def71436` — restores `data-adsense-client` on all pages, preserving the IO deferral.
- **Remove IO deferral only**: `git revert 4dce83e8` — reverts to unconditional `requestIdleCallback` while keeping layout scoping.
- **Full rollback**: `git revert 4dce83e8 def71436` — restores original behavior exactly.

## JS Smoke Test Status

No Node.js test runner is configured (`package.json` `test` script is a stub; no Jest/Vitest/Mocha setup). Adding a JS test framework is out of scope per the task spec. Manual reasoning confirms `loadAdsense()` does not crash when `IntersectionObserver` is mocked: all code paths guard on `'IntersectionObserver' in window` before constructing the observer, and `load()` is never called with a null element.

## AdSense Trigger Verification (Manual Reasoning)

When a visitor opens a post:
1. `head-runtime.js` executes after DOM parse (via `defer`).
2. `loadAdsense()` reads a non-empty `adsenseClient` from the script element.
3. `'IntersectionObserver' in window` is true on all modern browsers.
4. `document.querySelector('.adsbygoogle')` finds the first ad slot (rendered by the post layout).
5. An IO is installed with `rootMargin: '200px 0px'` — fires before the slot enters the visible viewport.
6. `load()` appends `adsbygoogle.js` to `<head>`; onload calls `__adsenseSlotInitializer` and dispatches `adsense:ready`.
7. The `__adsenseLoadInitiated` guard ensures any concurrent idle-callback is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)