### PR TITLE
perf(kakao): defer Kakao SDK to first user interaction (~30 KB savings on bouncers)

### DIFF
--- a/assets/js/head-runtime.js
+++ b/assets/js/head-runtime.js
@@ -256,28 +256,70 @@
     }
   }
 
+  /**
+   * Lazy-loads the Kakao JavaScript SDK on the first user interaction with a
+   * 10-12 s idle safety-net fallback. Mirrors loadGoogleAnalytics (PR #322).
+   *
+   * Rationale: the only reason we ship Kakao SDK is the Kakao share button.
+   * Clicking the share button is itself an interaction event, so deferring
+   * the SDK behind the same interaction-listener cluster never blocks the
+   * actual user flow. Bots and bouncers (no interaction) skip the ~30 KB
+   * SDK transfer + Kakao.init() entirely.
+   *
+   * Concurrency: __kakaoLoadInitiated guards against double-fetch when the
+   * idle fallback races with a real interaction.
+   */
   function loadKakaoSdk() {
     if (!kakaoAppKey) {
       return;
     }
+    if (window.__kakaoLoadInitiated) {
+      return;
+    }
 
     var load = function () {
+      if (window.__kakaoLoadInitiated) {
+        return;
+      }
+      window.__kakaoLoadInitiated = true;
       var script = document.createElement('script');
       script.src = 'https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js';
       script.integrity = 'sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4kykhOQv0b17OH4S';
       script.crossOrigin = 'anonymous';
       script.onload = function () {
-        if (window.Kakao && !window.Kakao.isInitialized()) {
-          window.Kakao.init(kakaoAppKey);
-        }
+        try {
+          if (window.Kakao && !window.Kakao.isInitialized()) {
+            window.Kakao.init(kakaoAppKey);
+          }
+        } catch (_e) { /* ignore init errors */ }
       };
       document.head.appendChild(script);
     };
 
+    var INTERACTION_EVENTS = ['pointermove', 'scroll', 'keydown', 'touchstart', 'click'];
+    var fired = false;
+    var loadOnce = function () {
+      if (fired) {
+        return;
+      }
+      fired = true;
+      INTERACTION_EVENTS.forEach(function (ev) {
+        window.removeEventListener(ev, loadOnce, { passive: true, capture: true });
+      });
+      load();
+    };
+    INTERACTION_EVENTS.forEach(function (ev) {
+      window.addEventListener(ev, loadOnce, { passive: true, capture: true });
+    });
+
+    // 10-12 s idle safety-net so non-interactive readers can still share
+    // (the share button itself counts as interaction, so this rarely fires)
     if ('requestIdleCallback' in window) {
-      requestIdleCallback(load, { timeout: 3000 });
+      requestIdleCallback(function () {
+        setTimeout(loadOnce, 10000);
+      }, { timeout: 5000 });
     } else {
-      window.addEventListener('load', load, { once: true });
+      setTimeout(loadOnce, 12000);
     }
   }
 


### PR DESCRIPTION
## Summary

Mirrors the loadGoogleAnalytics first-interaction defer pattern (PR #322) onto the Kakao SDK loader. Kakao SDK is only needed for the share button — clicking the share button is itself a user interaction, so deferring the SDK behind the same listener cluster never blocks the actual share flow.

## Behavior matrix

| Visitor | Old behavior (PR #322 baseline) | New behavior |
|---------|---------------------------------|--------------|
| Bot / bouncer (no interaction in 12s) | SDK loads on idle (~30 KB) | **SDK never loaded** |
| Real reader (any pointermove/scroll/keydown/touchstart/click) | SDK loads on idle | SDK loads immediately on first interaction |

## Why this is safe

Clicking the Kakao share button is itself a `click` event in the listener cluster, so the SDK loads in time for the actual share flow. Even fully passive readers (no scroll/click/touch) hit the 10-12 s idle safety net and get the SDK ready in case they later open the share UI.

## Concurrency

`__kakaoLoadInitiated` guards against double-fetch when the idle fallback races with a real interaction event. All listeners use `{ passive: true, capture: true }` to avoid blocking scroll responsiveness.

## Companion

Builds on PR #322 (GA defer to first user interaction). The two functions now share an identical idle-plus-interaction trigger pattern.

## Test plan

- [x] `bundle exec jekyll build --quiet` succeeds
- [x] `loadKakaoSdk` no longer calls `requestIdleCallback(load, ...)` directly (line ~315)
- [x] `__kakaoLoadInitiated` guard present at function entry + inside `load`
- [ ] Post-merge: verify Kakao share button still works on a post page (manual smoke test)

## Rollback

`git revert <sha>` restores the prior `requestIdleCallback`-on-idle behavior. No schema, no data, no migration.