### PR TITLE
ci: Lighthouse perf gate on PR (LCP +200ms vs base = fail)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,165 @@
+# Lighthouse perf gate
+#
+# Runs Lighthouse against the PR head AND the PR base, computes the median
+# LCP per URL across 3 runs, and fails when head_LCP - base_LCP exceeds
+# the threshold (default: 200 ms). CLS / TBT / FCP shown for context only.
+#
+# Coexists with .github/workflows/lighthouse.yml (which runs absolute
+# threshold checks on push to main); this workflow is a *regression* gate
+# scoped to PR diffs.
+
+name: Lighthouse perf gate
+
+on:
+  pull_request:
+    paths:
+      - "_includes/**"
+      - "_layouts/**"
+      - "_sass/**"
+      - "assets/**"
+      - "_config.yml"
+      - "Gemfile.lock"
+      - "vercel.json"
+      - "_plugins/**"
+      - "scripts/dev/compare_lighthouse_runs.py"
+      - ".github/workflows/lighthouse-ci.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: lighthouse-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  lighthouse-perf-gate:
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'perf-regression-allowed')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Cache lhci + npm
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/lhci
+            ~/.npm
+          key: lhci-${{ runner.os }}-${{ hashFiles('**/package.json', '**/Gemfile.lock') }}
+          restore-keys: |
+            lhci-${{ runner.os }}-
+
+      - name: Install Lighthouse CLI
+        run: |
+          npm install -g lighthouse@12.x @lhci/cli@0.14.x serve@14
+          lighthouse --version
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build PR head site
+        run: bundle exec jekyll build --destination _site_head
+        env:
+          JEKYLL_ENV: production
+
+      - name: Run Lighthouse on head
+        run: |
+          mkdir -p lhci-head
+          npx serve _site_head -l 4000 --single &
+          SERVER_PID=$!
+          for _ in $(seq 1 15); do
+            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          for url in http://localhost:4000/ http://localhost:4000/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/; do
+            for run_id in 1 2 3; do
+              lighthouse "$url" \
+                --output=json \
+                --output-path="lhci-head/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
+                --quiet \
+                --chrome-flags="--headless --no-sandbox --disable-gpu" \
+                --preset=desktop || true
+            done
+          done
+          kill $SERVER_PID 2>/dev/null || true
+
+      - name: Checkout PR base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-checkout
+          fetch-depth: 1
+
+      - name: Build PR base site
+        working-directory: base-checkout
+        run: |
+          bundle install
+          bundle exec jekyll build --destination ../_site_base
+        env:
+          JEKYLL_ENV: production
+
+      - name: Run Lighthouse on base
+        run: |
+          mkdir -p lhci-base
+          npx serve _site_base -l 4000 --single &
+          SERVER_PID=$!
+          for _ in $(seq 1 15); do
+            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          for url in http://localhost:4000/ http://localhost:4000/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/; do
+            for run_id in 1 2 3; do
+              lighthouse "$url" \
+                --output=json \
+                --output-path="lhci-base/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
+                --quiet \
+                --chrome-flags="--headless --no-sandbox --disable-gpu" \
+                --preset=desktop || true
+            done
+          done
+          kill $SERVER_PID 2>/dev/null || true
+
+      - name: Compare LCP head vs base
+        id: compare
+        run: |
+          python3 scripts/dev/compare_lighthouse_runs.py \
+            --base-dir lhci-base \
+            --head-dir lhci-head \
+            --threshold-lcp-ms 200 \
+            --output-md lighthouse-comparison.md
+          # The script's exit code IS the gate.
+
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-${{ github.run_id }}
+          path: |
+            lhci-base/
+            lhci-head/
+            lighthouse-comparison.md
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Comment on PR with results
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: lighthouse-comparison.md
+          edit-mode: replace
+          comment-id: lighthouse-perf-gate

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -1,0 +1,105 @@
+# Lighthouse Perf Gate
+
+Per-PR Lighthouse comparison that fails when LCP regresses by more than 200 ms vs the base branch.
+
+## What it does
+
+`.github/workflows/lighthouse-ci.yml` runs on every PR that touches files which can affect rendering performance. For each gated PR it:
+
+1. Builds the PR head and the PR base (`bundle exec jekyll build`).
+2. Serves each build on `localhost:4000` and runs Lighthouse 3 times against each of two URLs:
+   - `/` (homepage)
+   - `/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/` (representative post page)
+3. Computes the median LCP per URL across the 3 runs.
+4. Calls `scripts/dev/compare_lighthouse_runs.py --threshold-lcp-ms 200`, which compares head-median vs base-median per URL and exits 1 if any URL exceeds the threshold.
+5. Uploads both LHR JSON sets + the Markdown comparison as a workflow artifact (`lighthouse-{run_id}`).
+6. Comments on the PR with the comparison table (deduplicated via `comment-id: lighthouse-perf-gate` so re-runs update the same comment).
+
+CLS, TBT, FCP are reported alongside LCP for context but are **informational only** — they do not gate the workflow.
+
+## Trigger paths
+
+The workflow runs only when the PR touches files that can plausibly affect rendering:
+
+- `_includes/**`, `_layouts/**`, `_sass/**`, `assets/**`
+- `_config.yml`, `Gemfile.lock`, `vercel.json`
+- `_plugins/**`
+- `scripts/dev/compare_lighthouse_runs.py`
+- `.github/workflows/lighthouse-ci.yml`
+
+PRs that only touch posts, docs, or unrelated scripts skip the gate entirely.
+
+## Threshold
+
+| Metric | Threshold | Gating? |
+|--------|-----------|---------|
+| LCP    | head − base ≤ 200 ms | yes |
+| CLS    | informational only | no |
+| TBT    | informational only | no |
+| FCP    | informational only | no |
+
+The 200 ms LCP threshold matches the Core Web Vitals "good"-range tolerance (LCP < 2.5 s, with ~10% jitter expected between runs even at constant code).
+
+## How to read the artifact
+
+After the workflow runs, download the `lighthouse-{run_id}` artifact from the workflow run page:
+
+- `lighthouse-comparison.md` — the same Markdown table posted as a PR comment
+- `lhci-base/` — raw Lighthouse JSON for each base-branch run
+- `lhci-head/` — raw Lighthouse JSON for each head-branch run
+
+The raw LHRs include the full audit set (network, render, JS coverage, etc.) so you can drill into the cause of any regression.
+
+## How to override the threshold for a single PR
+
+Apply the label `perf-regression-allowed` to the PR. The workflow's `if:` clause skips the entire job when this label is present:
+
+```yaml
+if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'perf-regression-allowed')
+```
+
+Use this only when an intentional tradeoff regresses LCP (e.g., shipping a heavy interactive widget that the product accepts as net-positive). Document the rationale in the PR description.
+
+## How to re-run after fixing a regression
+
+Push a new commit to the PR branch — the workflow re-runs automatically and the comment updates in place (replacement, not append). Or trigger manually:
+
+```bash
+gh workflow run lighthouse-ci.yml --ref <branch>
+```
+
+## Runner cost estimate
+
+Per gated PR:
+
+- 2 Jekyll builds × ~60 s = ~2 min
+- 2 URLs × 2 builds × 3 Lighthouse runs × ~30 s = ~6 min
+- Setup / caching / artifact upload = ~2 min
+- **Total: ~10–15 min CI minutes per gated PR**
+
+For repos near the 2,000-minutes-per-month free GitHub Actions tier this adds ~50 minutes per 5 perf-touching PRs.
+
+## Local diagnosis
+
+You can run the comparison script directly against any two Lighthouse output directories:
+
+```bash
+python3 scripts/dev/compare_lighthouse_runs.py \
+  --base-dir lhci-base \
+  --head-dir lhci-head \
+  --threshold-lcp-ms 200 \
+  --output-md /tmp/lh.md
+```
+
+Exit code 0 = no regression. Exit code 1 = at least one URL exceeded the threshold.
+
+## Files
+
+- `.github/workflows/lighthouse-ci.yml` — the workflow
+- `scripts/dev/compare_lighthouse_runs.py` — the comparison script
+- `scripts/tests/test_compare_lighthouse_runs.py` — unit tests for the script
+- `docs/optimization/LIGHTHOUSE_PERF_GATE.md` — this document
+
+## Related
+
+- `.github/workflows/lighthouse.yml` — the existing absolute-threshold check (Performance ≥ 0.5, etc.) that runs on push to main. Coexists with this workflow; covers different concern.

--- a/scripts/dev/compare_lighthouse_runs.py
+++ b/scripts/dev/compare_lighthouse_runs.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Compare Lighthouse LHR JSON reports from two builds and gate on LCP regression.
+
+Inputs are two directories of Lighthouse CLI output (the ``lhci collect`` shape
+or ``lighthouse --output=json --output-path=...`` shape). For each URL that
+appears in both directories the script computes the median LCP across runs
+and compares ``head`` against ``base``.
+
+If any URL's ``head_LCP - base_LCP`` exceeds ``--threshold-lcp-ms`` the
+script exits with code 1 and writes a Markdown comparison table summarising
+every URL. CLS / TBT / FCP are reported alongside LCP for context but are
+informational only — they do not gate.
+
+Usage::
+
+    python3 scripts/dev/compare_lighthouse_runs.py \\
+        --base-dir lhci-base --head-dir lhci-head \\
+        --threshold-lcp-ms 200 --output-md lighthouse-comparison.md
+
+Designed to be invoked by ``.github/workflows/lighthouse-ci.yml`` after a
+``lhci collect`` run on each build, but also runs locally for manual
+diagnosis. Pure stdlib — no extra pip dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+# Lighthouse audit ids we read.
+LCP_AUDIT = "largest-contentful-paint"
+CLS_AUDIT = "cumulative-layout-shift"
+TBT_AUDIT = "total-blocking-time"
+FCP_AUDIT = "first-contentful-paint"
+
+
+def _lhr_files(report_dir: Path) -> list[Path]:
+    """Return Lighthouse-report JSON files inside ``report_dir``.
+
+    Matches the ``lhci collect`` output convention (``lhr-<timestamp>.json``)
+    and the bare ``lighthouse --output=json --output-path=...`` convention.
+    """
+    if not report_dir.exists():
+        return []
+    candidates = list(report_dir.glob("lhr-*.json"))
+    if not candidates:
+        candidates = [
+            p for p in report_dir.glob("*.json")
+            if p.name not in {"manifest.json", "links.json"}
+        ]
+    return sorted(candidates)
+
+
+def _load_metric(audit_data: dict, audit_id: str) -> float | None:
+    """Read ``audits[audit_id].numericValue`` from a parsed LHR dict."""
+    audits = audit_data.get("audits", {})
+    audit = audits.get(audit_id) or {}
+    value = audit.get("numericValue")
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _collect_metrics(report_dir: Path) -> dict[str, dict[str, list[float]]]:
+    """Group metric samples by URL across every LHR file in ``report_dir``."""
+    by_url: dict[str, dict[str, list[float]]] = {}
+    for path in _lhr_files(report_dir):
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        url = data.get("finalDisplayedUrl") or data.get("finalUrl") or data.get("requestedUrl")
+        if not url:
+            continue
+        bucket = by_url.setdefault(url, {"lcp": [], "cls": [], "tbt": [], "fcp": []})
+        for key, audit in (("lcp", LCP_AUDIT), ("cls", CLS_AUDIT), ("tbt", TBT_AUDIT), ("fcp", FCP_AUDIT)):
+            metric = _load_metric(data, audit)
+            if metric is not None:
+                bucket[key].append(metric)
+    return by_url
+
+
+def _median(samples: list[float]) -> float | None:
+    return statistics.median(samples) if samples else None
+
+
+def _normalise_url(url: str) -> str:
+    """Strip the localhost scheme+host so ``http://localhost:4000/foo/`` and
+    ``http://127.0.0.1:4000/foo/`` compare equal across base/head runs."""
+    for prefix in ("http://localhost:4000", "http://127.0.0.1:4000", "http://localhost", "http://127.0.0.1"):
+        if url.startswith(prefix):
+            return url[len(prefix):] or "/"
+    return url
+
+
+def _format_ms(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.0f} ms"
+
+
+def _format_unitless(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.3f}"
+
+
+def compare(base_dir: Path, head_dir: Path, threshold_ms: float) -> tuple[list[dict], int]:
+    """Compute per-URL deltas. Returns (rows, exit_code)."""
+    base_metrics = _collect_metrics(base_dir)
+    head_metrics = _collect_metrics(head_dir)
+
+    base_norm = {_normalise_url(u): v for u, v in base_metrics.items()}
+    head_norm = {_normalise_url(u): v for u, v in head_metrics.items()}
+
+    urls = sorted(set(base_norm) & set(head_norm))
+    rows: list[dict] = []
+    failed = False
+    for url in urls:
+        base_lcp = _median(base_norm[url]["lcp"])
+        head_lcp = _median(head_norm[url]["lcp"])
+        delta = None
+        verdict = "skip"
+        if base_lcp is not None and head_lcp is not None:
+            delta = head_lcp - base_lcp
+            if delta > threshold_ms:
+                verdict = f"FAIL (+{threshold_ms:.0f}ms threshold)"
+                failed = True
+            else:
+                verdict = "PASS"
+        rows.append({
+            "url": url,
+            "base_lcp": base_lcp,
+            "head_lcp": head_lcp,
+            "delta_lcp": delta,
+            "base_cls": _median(base_norm[url]["cls"]),
+            "head_cls": _median(head_norm[url]["cls"]),
+            "base_tbt": _median(base_norm[url]["tbt"]),
+            "head_tbt": _median(head_norm[url]["tbt"]),
+            "base_fcp": _median(base_norm[url]["fcp"]),
+            "head_fcp": _median(head_norm[url]["fcp"]),
+            "verdict": verdict,
+        })
+    return rows, (1 if failed else 0)
+
+
+def render_markdown(rows: list[dict], threshold_ms: float) -> str:
+    """Render a Markdown report of the comparison."""
+    lines = [
+        "# Lighthouse perf gate",
+        "",
+        f"LCP regression threshold: **+{threshold_ms:.0f} ms** (head vs base, median of N runs).",
+        "CLS, TBT, FCP shown for context only — they are not gating.",
+        "",
+        "| URL | Base LCP | Head LCP | Δ LCP | Δ CLS | Δ TBT | Verdict |",
+        "|-----|----------|----------|-------|-------|-------|---------|",
+    ]
+    for row in rows:
+        delta_lcp = row["delta_lcp"]
+        delta_cls = (
+            row["head_cls"] - row["base_cls"]
+            if row["head_cls"] is not None and row["base_cls"] is not None
+            else None
+        )
+        delta_tbt = (
+            row["head_tbt"] - row["base_tbt"]
+            if row["head_tbt"] is not None and row["base_tbt"] is not None
+            else None
+        )
+        delta_lcp_str = "n/a" if delta_lcp is None else f"{delta_lcp:+.0f} ms"
+        delta_cls_str = "n/a" if delta_cls is None else f"{delta_cls:+.3f}"
+        delta_tbt_str = "n/a" if delta_tbt is None else f"{delta_tbt:+.0f} ms"
+        lines.append(
+            "| {url} | {base_lcp} | {head_lcp} | {delta_lcp} | {delta_cls} | {delta_tbt} | {verdict} |".format(
+                url=row["url"],
+                base_lcp=_format_ms(row["base_lcp"]),
+                head_lcp=_format_ms(row["head_lcp"]),
+                delta_lcp=delta_lcp_str,
+                delta_cls=delta_cls_str,
+                delta_tbt=delta_tbt_str,
+                verdict=row["verdict"],
+            )
+        )
+    if not rows:
+        lines.append("| (no comparable URLs found) |  |  |  |  |  |  |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-dir", type=Path, required=True, help="Directory of base-branch LHR JSON files")
+    parser.add_argument("--head-dir", type=Path, required=True, help="Directory of head-branch LHR JSON files")
+    parser.add_argument(
+        "--threshold-lcp-ms",
+        type=float,
+        default=200.0,
+        help="Fail if head_LCP - base_LCP exceeds this (default: 200 ms)",
+    )
+    parser.add_argument("--output-md", type=Path, default=None, help="Optional Markdown output path")
+    parser.add_argument("--quiet", action="store_true", help="Suppress stdout summary")
+    args = parser.parse_args()
+
+    rows, exit_code = compare(args.base_dir, args.head_dir, args.threshold_lcp_ms)
+    md = render_markdown(rows, args.threshold_lcp_ms)
+    if args.output_md is not None:
+        args.output_md.parent.mkdir(parents=True, exist_ok=True)
+        args.output_md.write_text(md, encoding="utf-8")
+    if not args.quiet:
+        print(md)
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_compare_lighthouse_runs.py
+++ b/scripts/tests/test_compare_lighthouse_runs.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Tests for scripts/dev/compare_lighthouse_runs.py.
+
+Tests the pure logic by writing synthetic LHR JSON fixtures into temp
+directories and asserting on rows + exit codes + Markdown output.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+_RUN_PY = REPO_ROOT / "scripts" / "dev" / "compare_lighthouse_runs.py"
+spec = importlib.util.spec_from_file_location("compare_lighthouse_runs", _RUN_PY)
+clr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clr)
+
+
+def _write_lhr(target_dir: Path, url: str, lcp_ms: float, cls: float = 0.05,
+               tbt_ms: float = 100.0, fcp_ms: float = 800.0, run_id: int = 1) -> Path:
+    """Write a synthetic Lighthouse-report JSON file into ``target_dir``."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    path = target_dir / f"lhr-{run_id}.json"
+    payload = {
+        "finalDisplayedUrl": url,
+        "finalUrl": url,
+        "audits": {
+            "largest-contentful-paint": {"numericValue": lcp_ms},
+            "cumulative-layout-shift": {"numericValue": cls},
+            "total-blocking-time": {"numericValue": tbt_ms},
+            "first-contentful-paint": {"numericValue": fcp_ms},
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_passes_when_within_threshold(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=1900)  # +100 ms, under 200 threshold
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 0
+    assert len(rows) == 1
+    assert rows[0]["delta_lcp"] == pytest.approx(100.0)
+    assert rows[0]["verdict"] == "PASS"
+
+
+def test_fails_when_threshold_exceeded(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=2100)  # +300 ms, over 200 threshold
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 1
+    assert "FAIL" in rows[0]["verdict"]
+    assert rows[0]["delta_lcp"] == pytest.approx(300.0)
+
+
+def test_median_of_multiple_runs(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    for run_id, lcp in enumerate([1700, 1800, 1900], start=1):
+        _write_lhr(base, "http://localhost:4000/", lcp_ms=lcp, run_id=run_id)
+    for run_id, lcp in enumerate([2200, 2400, 2300], start=1):
+        _write_lhr(head, "http://localhost:4000/", lcp_ms=lcp, run_id=run_id)
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 1  # 2300 - 1800 = 500 > 200
+    assert rows[0]["base_lcp"] == pytest.approx(1800)
+    assert rows[0]["head_lcp"] == pytest.approx(2300)
+
+
+def test_url_normalisation_across_localhost_and_loopback(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/post/", lcp_ms=1800)
+    _write_lhr(head, "http://127.0.0.1:4000/post/", lcp_ms=1850)
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 0
+    assert len(rows) == 1
+    assert rows[0]["url"] == "/post/"
+    assert rows[0]["delta_lcp"] == pytest.approx(50.0)
+
+
+def test_no_comparable_urls(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/page-a/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/page-b/", lcp_ms=1900)
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 0  # no failures, but also no rows
+    assert rows == []
+
+
+def test_markdown_output_structure(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800, cls=0.05, tbt_ms=120, fcp_ms=900)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=2100, cls=0.06, tbt_ms=180, fcp_ms=950)
+
+    rows, _ = clr.compare(base, head, threshold_ms=200.0)
+    md = clr.render_markdown(rows, 200.0)
+    assert "Lighthouse perf gate" in md
+    assert "Base LCP" in md and "Head LCP" in md and "Δ LCP" in md
+    assert "+300 ms" in md
+    assert "FAIL" in md
+    # CLS / TBT columns present
+    assert "Δ CLS" in md
+    assert "Δ TBT" in md
+
+
+def test_main_writes_markdown_and_returns_exit_code(tmp_path, capsys, monkeypatch):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    out = tmp_path / "report.md"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=2100)  # +300 ms
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "compare_lighthouse_runs.py",
+            "--base-dir", str(base),
+            "--head-dir", str(head),
+            "--threshold-lcp-ms", "200",
+            "--output-md", str(out),
+            "--quiet",
+        ],
+    )
+    exit_code = clr.main()
+    assert exit_code == 1
+    assert out.exists()
+    text = out.read_text(encoding="utf-8")
+    assert "FAIL" in text
+    assert "+300 ms" in text
+
+
+def test_main_quiet_flag_silences_stdout(tmp_path, capsys, monkeypatch):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=1850)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "compare_lighthouse_runs.py",
+            "--base-dir", str(base),
+            "--head-dir", str(head),
+            "--threshold-lcp-ms", "200",
+            "--quiet",
+        ],
+    )
+    clr.main()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_missing_base_dir_returns_no_rows(tmp_path):
+    head = tmp_path / "head"
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=1800)
+    rows, exit_code = clr.compare(tmp_path / "nonexistent-base", head, threshold_ms=200.0)
+    assert rows == []
+    assert exit_code == 0
+
+
+def test_threshold_zero_fails_any_regression(tmp_path):
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=1801)  # +1 ms
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=0.0)
+    assert exit_code == 1
+    assert "FAIL" in rows[0]["verdict"]
+
+
+def test_negative_delta_passes(tmp_path):
+    """Improvement (negative delta) must always pass."""
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    _write_lhr(base, "http://localhost:4000/", lcp_ms=2000)
+    _write_lhr(head, "http://localhost:4000/", lcp_ms=1500)  # 500 ms improvement
+
+    rows, exit_code = clr.compare(base, head, threshold_ms=200.0)
+    assert exit_code == 0
+    assert rows[0]["delta_lcp"] == pytest.approx(-500.0)
+    assert rows[0]["verdict"] == "PASS"


### PR DESCRIPTION
## Summary

Adds a regression-only Lighthouse gate that fires on every PR touching rendering-relevant files. Compares the PR head's median LCP against the PR base's median LCP per URL and fails the workflow when any URL regresses by more than 200 ms. Coexists with the existing `lighthouse.yml` absolute-threshold check (which runs on push to main).

## What's added

- **`scripts/dev/compare_lighthouse_runs.py`** — pure-stdlib comparison tool. Reads LHR JSON from two directories, computes median LCP per URL across N runs, exits 1 if `head_LCP - base_LCP > threshold`. Also reports CLS / TBT / FCP deltas (informational only).
- **`scripts/tests/test_compare_lighthouse_runs.py`** — 11 unit tests covering pass/fail thresholds, median, URL normalisation (localhost vs 127.0.0.1), missing data, Markdown structure, threshold=0, negative deltas. **All 11 pass in 0.04s.**
- **`.github/workflows/lighthouse-ci.yml`** — workflow that builds both head and base, runs Lighthouse 3x per URL on each, compares medians, uploads artifacts, comments on the PR.
- **`docs/optimization/LIGHTHOUSE_PERF_GATE.md`** — threshold rationale, trigger paths, override procedure, runner cost.

## Trigger paths

Workflow only runs when the PR touches:

- `_includes/**`, `_layouts/**`, `_sass/**`, `assets/**`
- `_config.yml`, `Gemfile.lock`, `vercel.json`, `_plugins/**`
- `scripts/dev/compare_lighthouse_runs.py`, `.github/workflows/lighthouse-ci.yml`

PRs that only touch posts / docs / unrelated scripts skip the gate entirely.

## Threshold

| Metric | Threshold | Gating |
|--------|-----------|--------|
| LCP | head − base ≤ 200 ms | yes |
| CLS / TBT / FCP | reported, not gated | no |

The 200 ms threshold accommodates ~10% Lighthouse run-to-run jitter while still catching real regressions.

## Override for intentional perf tradeoffs

Apply the label `perf-regression-allowed` to the PR. Workflow `if:` clause skips when label present.

## Sample comparison output (synthetic, from unit tests)

| URL | Base LCP | Head LCP | Δ LCP | Δ CLS | Δ TBT | Verdict |
|-----|----------|----------|-------|-------|-------|---------|
| / | 1800 ms | 2100 ms | +300 ms | +0.010 | +60 ms | FAIL (+200ms threshold) |

## Runner cost

~10–15 min CI minutes per gated PR (2 builds + 6 Lighthouse runs + setup).

## Test plan

- [x] YAML parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/lighthouse-ci.yml'))"`)
- [x] 11/11 unit tests pass
- [x] Comparison script CLI: `python3 scripts/dev/compare_lighthouse_runs.py --help` works
- [ ] First real run on this PR (the workflow will trigger because the PR touches `.github/workflows/lighthouse-ci.yml`)

## Rollback

`git revert <sha>` removes the workflow + script + docs in one commit. No data, no schema, no migration.