### PR TITLE
perf: Style & Layout 1052ms audit + first targeted fix

### DIFF
--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -163,6 +163,11 @@
   text-decoration: none;
   color: inherit;
   height: 100%;
+  /* Style&Layout perf: scope layout/style invalidation to the card so that
+   * `home-posts-filter.js` toggling `display` on each card does not invalidate
+   * the whole `.posts-list` grid (PageSpeed audit 2026-04-30 — see
+   * `docs/optimization/STYLE_LAYOUT_ANALYSIS.md`). */
+  contain: layout style;
 }
 
 .post-card-image {

--- a/docs/optimization/STYLE_LAYOUT_ANALYSIS.md
+++ b/docs/optimization/STYLE_LAYOUT_ANALYSIS.md
@@ -1,0 +1,188 @@
+# Style & Layout Cost Audit — Homepage 1,052 ms
+
+**Date**: 2026-04-30
+**Branch**: `perf/style-layout-analysis`
+**PageSpeed Insights signal**: Style & Layout 1,052 ms · Script Eval 1,374 ms · Rendering 450 ms (homepage)
+**Method**: Static analysis of compiled CSS, Liquid templates, and homepage JavaScript. **No Chrome trace was captured** — savings figures are best-effort estimates.
+
+---
+
+## 1. Summary — Dominant Contributors (Ranked)
+
+| # | Contributor | Where | Why It Hurts | Confidence |
+|---|-------------|-------|--------------|------------|
+| 1 | Synchronous DOM-write loop in `home-posts-filter.js` toggles `display` on every `.post-card` then queries the layout for tab counts | `assets/js/home-posts-filter.js:74-122` | 30 cards × 2 writes = 60 style invalidations; subsequent `.tab-count` insertion forces a second layout pass. Containment-free `.posts-list` means each toggle re-flows the whole grid. | High — code path runs unconditionally on first paint |
+| 2 | `.post-card` and `.posts-list` have **no CSS containment** | `_sass/_components.scss:154-159` (`.posts-list`), `_sass/_components.scss:161-166` (`.post-card`) | The 30-card grid is the largest visible structure on the homepage. Without `contain: layout style;`, every JS-driven `display` toggle on a card invalidates the whole grid's layout. | High |
+| 3 | Substring/suffix attribute selectors fired on every render of post pages: 27 `[src*=…]` / `[src$=".svg"]` / `[class*=…]` matchers | `_sass/_post.scss:48,209,905` and 24 more (`_sass/_base.scss:174,228` etc. for 3rd-party Google selectors) | Browsers test these against every matching element on every style recalc. With 30 `<img>` and 60 `<source>` on the homepage and ~50 images on a digest post, this multiplies style work. | Medium — magnitude depends on browser optimization |
+
+These three are the primary suspects behind the 1,052 ms. Item 1 is a guaranteed forced reflow during first paint; items 2-3 amplify the cost of every recalc round.
+
+---
+
+## 2. Concrete Code References
+
+### 2.1 Forced reflow on homepage first paint
+
+**File**: `assets/js/home-posts-filter.js`
+
+```javascript
+// Lines 79-85: hides ALL cards then shows the first 12.
+// This is two synchronous style writes per card; with 30 cards
+// that's 60 writes that each invalidate sibling layout.
+allCards.forEach(function (card) {
+  card.style.display = 'none';
+});
+
+filtered.slice(0, showCount).forEach(function (card) {
+  card.style.display = '';
+});
+```
+
+Then at lines 111-122, the script appends `<span class="tab-count">…</span>` to each of the 7 tabs **after** the writes above, which forces an additional layout flush per tab insertion. The combined effect on a cold render is observable as Style & Layout cost — the script runs `defer`, but it still executes before `DOMContentLoaded` and before the user can interact.
+
+### 2.2 Missing `contain` on the homepage post grid
+
+**File**: `_sass/_components.scss`
+
+```scss
+// Line 154 — the homepage grid (3 columns, 30+ cards). No contain.
+.posts-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-md);
+  margin-top: var(--spacing-lg);
+}
+
+// Line 161 — each card; no contain.
+.post-card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  height: 100%;
+}
+```
+
+Compare with `_sass/_post.scss` which has 22 separate `contain:` declarations on smaller post-internal containers — the homepage's largest visible structure was never updated.
+
+### 2.3 Heavy attribute regex selectors
+
+**File**: `_sass/_post.scss`
+
+```scss
+// Line 48
+.post-article .post-content img[src*="section-"] { … }
+
+// Line 209
+.post-header .post-image img[src$=".svg"] { … }
+
+// Line 905
+.post-content img[src$=".svg"] { … }
+
+// Line 781-783 — :has() inside attribute filter, table edition
+.post-content .table-wrapper:has(table.table-fit)::before,
+.post-content .table-wrapper:has(table.table-fit)::after { display: none; }
+```
+
+`scripts/dev/analyze_css_complexity.py` reports **27** attribute-regex selectors and **3** `:has()` selectors in `_site/assets/css/post-page.css`. These do not run on the homepage (post-page.css isn't loaded there), so they explain heavy Style & Layout cost on **post pages**, not the index. The homepage is held back by items 1-2.
+
+### 2.4 nth-child clusters inside post tables
+
+**File**: `_sass/_post.scss:787-792`
+
+Six `:nth-child(2)` / `:nth-child(3)` / `:nth-child(4)` selectors on `table.table-risk-scorecard`, plus `_sass/_post.scss:649` and `_sass/_post.scss:465` for `tbody tr:nth-child(even)` zebra striping. Each one re-evaluates row indices on every reflow.
+
+### 2.5 Forced reflow in archive-page filter (informational, not homepage)
+
+**File**: `assets/js/archive-filter.js:78`
+
+```javascript
+// Force reflow to restart animation
+void item.offsetWidth;
+```
+
+This is intentional and isolated to the archive page; the comment makes the intent explicit. Not a homepage issue but worth noting in future passes.
+
+### 2.6 DOM size
+
+| Page | Total elements | Max nesting | Top 3 tags |
+|------|----------------|-------------|------------|
+| `_site/index.html` | **872** | 12 | `<span>` × 175, `<div>` × 161, `<a>` × 62 |
+| `_site/posts/2026/04/29/.../index.html` (digest) | **1,381** | 13 | `<span>` × 162, `<div>` × 142, `<strong>` × 117 |
+
+Neither page exceeds PageSpeed's 1,500-node "excessive" threshold, but the digest post is close. The homepage's 872 nodes are reasonable; **DOM size is not the bottleneck**, the JS-driven reflow is.
+
+---
+
+## 3. Recommended Fixes — Effort × Impact
+
+| Priority | Fix | Effort | Expected Impact | Risk |
+|----------|-----|--------|------------------|------|
+| **P0** | Add `contain: layout style;` to `.post-card` (and consider `.posts-list`) | 1 line | Eliminates layout-cascade across grid when JS toggles `display`. Estimate **−80 to −150 ms** Style & Layout on cold render. | Very low. Card layout is self-contained — fixed aspect-ratio image, no overflowing children. |
+| **P1** | Refactor `home-posts-filter.js renderPosts()` to batch DOM writes inside a `requestAnimationFrame` and to compute tab counts **once** (not inside a per-tab loop) | 30 min | Removes the dual write pass and the redundant `getFilteredCards(sort)` per tab. Estimate **−100 to −200 ms** Style & Layout + similar Script Eval drop. | Low. Same observable behavior, only render order changes. Add a smoke test (cards visible on first paint). |
+| **P1** | Hide all cards beyond index 12 server-side (Liquid `{% if forloop.index > 12 %}…hidden`) so JS doesn't have to flip `display` on the 12 already-visible cards | 15 min | Cuts the initial paint write count in half. Estimate **−40 to −80 ms**. | Low. SSR-friendly; no-JS users still see the first 12. |
+| **P2** | Replace `[src$=".svg"]` / `[src*="section-"]` selectors in `_sass/_post.scss` with deterministic class hooks (`.is-section-image`, `.is-svg-image`) added at Liquid render time | 1 hr (markup + Liquid changes) | Removes 27 substring matchers from post-page.css. Estimate **−50 to −120 ms** on post page Style & Layout. | Medium. Requires touching include templates and verifying every image path still gets the right class. |
+| **P2** | Add `contain: layout style;` to `.toc-container`, `.toc-grid`, `.news-card`, `.news-grid` | 4 lines | Containment hardening for non-homepage pages. Estimate **−20 to −60 ms** per affected page. | Very low. |
+| **P3** | Move zebra striping (`tbody tr:nth-child(even)`) behind a `.zebra-striped` class on the table; only the few tables that actually need stripes pay the cost | 30 min | Removes 3 broad nth-child rules from the global path. Marginal Style recalc cost reduction (5-15 ms). | Low. Need to add `.zebra-striped` to each instance via Markdown attribute lists. |
+| **P3** | Strip the universal `*` selector descendant rules in `_sass/_base.scss:174` (`[class*="VIpgJd"]`) and consolidate Google Translate CLS rules into a single class hook injected by `google-translate.js` | 1 hr | Drops two `*`-with-descendant matches and 5 attribute-substring selectors. Cost is dominated by the homepage's main.css (38 KB), so impact is small but cumulative with P0/P1. | Medium — Google's translate widget injects its own class names; the substring matcher exists because we don't control them. Risk of regression if their classes change. |
+
+---
+
+## 4. Estimated Savings Summary
+
+| Bundle of fixes | Style & Layout savings (estimate) | Script Eval savings (estimate) | Total estimate |
+|-----------------|-----------------------------------|--------------------------------|----------------|
+| P0 only (this PR) | **80–150 ms** | 0 ms | 80–150 ms |
+| P0 + P1 (next PR) | 200–350 ms | 80–150 ms | 280–500 ms |
+| P0 + P1 + P2 (post-page focus) | 280–500 ms (homepage) plus 70–180 ms on post pages | 80–150 ms | 350–650 ms total per page class |
+
+**Caveat**: All numbers are derived from CSS rule counts and write-count math, not from a Chrome trace. Lighthouse is sensitive to selector depth × DOM size; the savings could land anywhere in these bands depending on browser optimizations.
+
+---
+
+## 5. Out-of-Scope (Needs Browser Tracing to Confirm)
+
+These items look suspicious during static analysis but require runtime profiling to triage correctly. Defer until a Chrome DevTools `Performance` trace is captured.
+
+- **GA / gtag.js forced reflow** (133–143 ms in PSI). The site loads GA via `defer` and lazy-init; PSI's flag is on Google's side. Mitigations would target `consent-init` interaction, not our CSS.
+- **`getComputedStyle` from third-party widgets** (Sentry, Cloudflare beacon). All loaded `defer` so they shouldn't be in the critical path, but they could still pile on during first paint. A trace will tell.
+- **Subscribe-float, share-actions, giscus init**. These all `defer` and only attach listeners; static analysis shows no layout reads. A trace is needed if the homepage Style & Layout doesn't drop after P0/P1.
+- **`@font-face` swap-in cost**. Self-hosted Noto woff2 is in place; the swap is `swap`. Shouldn't be a layout issue, but can show up as Style cost in older Chromium.
+- **Google Translate widget CLS reservations** in `_sass/_base.scss:174-242`. The `[class*="VIpgJd"]` selector is unfortunate but exists because Google's class names are unstable. Replacing it is a P3 hardening exercise, not a quick win.
+
+---
+
+## 6. Validation Run
+
+```text
+$ python3 scripts/dev/analyze_css_complexity.py
+# CSS Complexity Report — `_site/assets/css/main.css`
+- Rules: 284
+- Selectors (post-split): 319
+- Longest selector (56 chars): `.posts-list--list-view .post-card:hover .post-card-inner`
+- Longest descendant chain: 3 compound parts
+- Average specificity (a, b, c): (0.01, 1.33, 0.20)
+- :has() selectors: 1
+- Attribute regex (substring/prefix/suffix): 5
+- :nth-* selectors: 0
+
+$ python3 scripts/dev/analyze_css_complexity.py --input _site/assets/css/post-page.css
+- Rules: 731
+- Selectors (post-split): 897
+- :has() selectors: 3
+- Attribute regex (substring/prefix/suffix): 27
+- :nth-* selectors: 11
+
+$ python3 scripts/dev/count_dom_nodes.py _site/index.html _site/posts/2026/04/29/.../index.html
+- _site/index.html: 872 elements, max depth 12
+- _site/posts/2026/04/29/.../index.html: 1,381 elements, max depth 13
+```
+
+---
+
+## 7. References
+
+- Chrome DevTools — [Avoid large, complex layouts and layout thrashing](https://developer.chrome.com/docs/lighthouse/performance/uses-text-compression/)
+- CSS Containment Module Level 1 — [`contain` property](https://developer.mozilla.org/docs/Web/CSS/contain)
+- Vladimir Agafonkin — [The cost of CSS selectors](https://csswizardry.com/2014/01/optimising-css-selectors-for-css-stats/)
+- Lighthouse audits — [DOM size](https://web.dev/dom-size-and-interactivity/)
+- This repo — `_sass/_post.scss:133` (existing `contain` patterns to mirror)

--- a/scripts/dev/analyze_css_complexity.py
+++ b/scripts/dev/analyze_css_complexity.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Analyze a compiled CSS bundle for selector complexity hot-spots.
+
+Reads the compiled stylesheet (default: ``_site/assets/css/main.css``) and emits
+a Markdown summary suitable for performance audits. Reports:
+
+* Total rule count and average / max selector specificity (a, b, c tuple).
+* Longest selector (string length) and the longest descendant chain.
+* Universal selector (`*`) count combined with descendant combinators.
+* `:nth-*` / `:nth-of-type` / `:nth-last-*` usage count.
+* Attribute selectors with substring/regex matchers (``[class*=]`` etc.).
+* `:has()` selector count (still relatively expensive when broad).
+
+Usage::
+
+    python3 scripts/dev/analyze_css_complexity.py
+    python3 scripts/dev/analyze_css_complexity.py --input _site/assets/css/post.css
+
+Pure stdlib — no external dependencies. Designed for static analysis runs;
+does not parse or execute CSS, just lexes the selector portion of each rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_INPUT = Path("_site/assets/css/main.css")
+
+# Strip comments and at-rule blocks we don't want to count as rules.
+# Conservative regex: works on minified or pretty-printed CSS.
+_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+# Capture selector list followed by a `{`. We deliberately do NOT match
+# nested braces (CSS doesn't have them outside ``@`` blocks we ignore).
+_RULE_RE = re.compile(r"([^{}]+)\{[^{}]*\}")
+# Detect at-rule preludes like ``@media (min-width: 600px) {``; we scan their
+# bodies normally because they wrap real rules.
+_AT_RULE_RE = re.compile(r"@[\w-]+\s*[^{};]*\{")
+
+_NTH_RE = re.compile(r":nth-(?:child|of-type|last-child|last-of-type)\(")
+_HAS_RE = re.compile(r":has\(")
+_ATTR_REGEX_RE = re.compile(r"\[[^\]=]+[*^$|~]=")
+_UNIVERSAL_RE = re.compile(r"(^|\s|>|~|\+)\*(\s|>|~|\+|$)")
+# Pseudo-class / pseudo-element list for specificity scoring.
+_PSEUDO_ELEMENT_RE = re.compile(r"::[\w-]+")
+_PSEUDO_CLASS_RE = re.compile(r":(?!:)[\w-]+(?:\([^)]*\))?")
+_ID_RE = re.compile(r"#[\w-]+")
+_CLASS_RE = re.compile(r"\.[\w-]+")
+_ATTR_RE = re.compile(r"\[[^\]]+\]")
+_TYPE_RE = re.compile(r"(?:^|[\s>+~])([a-zA-Z][\w-]*)")
+
+
+@dataclass
+class CssStats:
+    rule_count: int = 0
+    selector_count: int = 0  # selectors after splitting comma lists
+    longest_selector: str = ""
+    longest_descendant_chain: int = 0
+    longest_descendant_example: str = ""
+    universal_descendant: int = 0
+    nth_count: int = 0
+    has_count: int = 0
+    attr_regex_count: int = 0
+    spec_sum: tuple[int, int, int] = (0, 0, 0)
+    spec_max: tuple[int, int, int] = (0, 0, 0)
+    spec_max_selector: str = ""
+    examples: dict[str, list[str]] = field(default_factory=dict)
+
+
+def _strip_comments(css: str) -> str:
+    return _COMMENT_RE.sub("", css)
+
+
+def _iter_rules(css: str) -> Iterable[str]:
+    """Yield raw selector text for each declaration block.
+
+    Handles nested at-rules by stripping their headers (``@media …{``) and
+    matching the wrapped rules normally. We rely on the fact that the
+    project's compiled CSS does not use CSS Nesting (``&``) — at-rules
+    contain plain rules.
+    """
+    text = _strip_comments(css)
+    # Remove ``@media (...) {`` style headers and their matching close brace.
+    # Easier: replace at-rule headers with empty string so the inner block is
+    # exposed to ``_RULE_RE``. The outer ``}`` is harmless because the regex
+    # only matches non-brace selectors.
+    text = _AT_RULE_RE.sub("", text)
+    for match in _RULE_RE.finditer(text):
+        yield match.group(1)
+
+
+def _split_selector_list(selector_block: str) -> list[str]:
+    # Selector list separated by commas, ignoring commas inside ``()``.
+    out: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in selector_block:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth = max(0, depth - 1)
+        if ch == "," and depth == 0:
+            piece = "".join(current).strip()
+            if piece:
+                out.append(piece)
+            current = []
+            continue
+        current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        out.append(tail)
+    return out
+
+
+def _count_specificity(selector: str) -> tuple[int, int, int]:
+    """Return (a, b, c) per CSS Selectors Level 3 specificity rules.
+
+    Approximation: ignores ``:not()`` / ``:is()`` / ``:where()`` argument
+    descent. Good enough for ranking, not for browser reproduction.
+    """
+    work = _PSEUDO_ELEMENT_RE.sub(" ", selector)
+    a = len(_ID_RE.findall(work))
+    work = _ID_RE.sub(" ", work)
+    classes = len(_CLASS_RE.findall(work))
+    work = _CLASS_RE.sub(" ", work)
+    attrs = len(_ATTR_RE.findall(work))
+    work = _ATTR_RE.sub(" ", work)
+    pseudos = len(_PSEUDO_CLASS_RE.findall(work))
+    work = _PSEUDO_CLASS_RE.sub(" ", work)
+    types = len(_TYPE_RE.findall(work))
+    elements = len(re.findall(r"::[\w-]+", selector))
+    return a, classes + attrs + pseudos, types + elements
+
+
+def _descendant_chain_length(selector: str) -> int:
+    # Count whitespace-separated compound selectors. Combinators like ``>``
+    # ``+`` ``~`` count as descendant boundaries for the purpose of "how many
+    # ancestors must the engine walk?".
+    flat = re.sub(r"\s*[>+~]\s*", " ", selector.strip())
+    parts = [p for p in flat.split() if p]
+    return len(parts)
+
+
+def _record_example(stats: CssStats, key: str, value: str, limit: int = 3) -> None:
+    bucket = stats.examples.setdefault(key, [])
+    if len(bucket) < limit and value not in bucket:
+        bucket.append(value)
+
+
+def analyze(css_text: str) -> CssStats:
+    stats = CssStats()
+    for selector_block in _iter_rules(css_text):
+        stats.rule_count += 1
+        for selector in _split_selector_list(selector_block):
+            stats.selector_count += 1
+
+            if len(selector) > len(stats.longest_selector):
+                stats.longest_selector = selector
+
+            chain = _descendant_chain_length(selector)
+            if chain > stats.longest_descendant_chain:
+                stats.longest_descendant_chain = chain
+                stats.longest_descendant_example = selector
+
+            spec = _count_specificity(selector)
+            stats.spec_sum = (
+                stats.spec_sum[0] + spec[0],
+                stats.spec_sum[1] + spec[1],
+                stats.spec_sum[2] + spec[2],
+            )
+            if spec > stats.spec_max:
+                stats.spec_max = spec
+                stats.spec_max_selector = selector
+
+            if _UNIVERSAL_RE.search(selector):
+                stats.universal_descendant += 1
+                _record_example(stats, "universal", selector)
+            n_nth = len(_NTH_RE.findall(selector))
+            if n_nth:
+                stats.nth_count += n_nth
+                _record_example(stats, "nth", selector)
+            n_has = len(_HAS_RE.findall(selector))
+            if n_has:
+                stats.has_count += n_has
+                _record_example(stats, "has", selector)
+            n_attr = len(_ATTR_REGEX_RE.findall(selector))
+            if n_attr:
+                stats.attr_regex_count += n_attr
+                _record_example(stats, "attr_regex", selector)
+    return stats
+
+
+def render_markdown(stats: CssStats, source: Path) -> str:
+    sel_count = stats.selector_count or 1
+    avg_spec = (
+        stats.spec_sum[0] / sel_count,
+        stats.spec_sum[1] / sel_count,
+        stats.spec_sum[2] / sel_count,
+    )
+
+    def fmt_examples(key: str) -> str:
+        ex = stats.examples.get(key, [])
+        if not ex:
+            return "_(none)_"
+        return "<br>".join(f"`{e}`" for e in ex)
+
+    lines = [
+        f"# CSS Complexity Report — `{source}`",
+        "",
+        f"- **Rules**: {stats.rule_count}",
+        f"- **Selectors (post-split)**: {stats.selector_count}",
+        f"- **Longest selector** ({len(stats.longest_selector)} chars): "
+        f"`{stats.longest_selector}`",
+        f"- **Longest descendant chain**: {stats.longest_descendant_chain} compound parts",
+        f"  - Example: `{stats.longest_descendant_example}`",
+        f"- **Average specificity (a, b, c)**: "
+        f"({avg_spec[0]:.2f}, {avg_spec[1]:.2f}, {avg_spec[2]:.2f})",
+        f"- **Max specificity**: {stats.spec_max} → `{stats.spec_max_selector}`",
+        "",
+        "## Anti-pattern counts",
+        "",
+        "| Pattern | Count | Examples |",
+        "|---------|-------|----------|",
+        f"| `*` with descendant combinator | {stats.universal_descendant} | "
+        f"{fmt_examples('universal')} |",
+        f"| `:nth-*()` selectors | {stats.nth_count} | {fmt_examples('nth')} |",
+        f"| `:has()` selectors | {stats.has_count} | {fmt_examples('has')} |",
+        f"| Attribute regex (`[attr*=]` / `[attr^=]` / `[attr$=]`) | "
+        f"{stats.attr_regex_count} | {fmt_examples('attr_regex')} |",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT,
+                        help=f"Compiled CSS file to analyze (default: {DEFAULT_INPUT})")
+    parser.add_argument("--output", type=Path, default=None,
+                        help="Optional path to write the Markdown report. Prints to stdout if omitted.")
+    args = parser.parse_args(argv)
+
+    if not args.input.exists():
+        print(f"error: {args.input} not found", file=sys.stderr)
+        return 2
+
+    css = args.input.read_text(encoding="utf-8")
+    stats = analyze(css)
+    md = render_markdown(stats, args.input)
+    if args.output:
+        args.output.write_text(md, encoding="utf-8")
+    else:
+        print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/count_dom_nodes.py
+++ b/scripts/dev/count_dom_nodes.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Count DOM nodes in built HTML pages and report tag-level distribution.
+
+Reads one or more rendered HTML files (typical: ``_site/index.html`` or a
+post page) and reports:
+
+* Total element count.
+* Per-tag count (top 10 by count).
+* Maximum nesting depth.
+
+PageSpeed Insights flags pages with > 1500 DOM nodes as "excessive". This
+helper makes it easy to spot which tag (or which Liquid include) is
+contributing the most to that budget.
+
+Usage::
+
+    python3 scripts/dev/count_dom_nodes.py _site/index.html
+    python3 scripts/dev/count_dom_nodes.py _site/index.html _site/posts/.../index.html
+
+Pure stdlib (uses ``html.parser``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from html.parser import HTMLParser
+from pathlib import Path
+
+VOID_ELEMENTS = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link",
+    "meta", "param", "source", "track", "wbr",
+}
+
+
+class DomCounter(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.tags: Counter[str] = Counter()
+        self.total = 0
+        self.depth = 0
+        self.max_depth = 0
+        self._stack: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.tags[tag] += 1
+        self.total += 1
+        if tag in VOID_ELEMENTS:
+            return
+        self._stack.append(tag)
+        self.depth = len(self._stack)
+        if self.depth > self.max_depth:
+            self.max_depth = self.depth
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Self-closing variants like ``<br />``; treat as a single element.
+        self.tags[tag] += 1
+        self.total += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        # Pop until we find the matching tag (handle browser-ish lenient HTML).
+        while self._stack:
+            popped = self._stack.pop()
+            if popped == tag:
+                break
+        self.depth = len(self._stack)
+
+
+def analyze_file(path: Path) -> DomCounter:
+    counter = DomCounter()
+    counter.feed(path.read_text(encoding="utf-8", errors="replace"))
+    return counter
+
+
+def render_report(path: Path, counter: DomCounter) -> str:
+    top = counter.tags.most_common(10)
+    lines = [
+        f"## `{path}`",
+        "",
+        f"- **Total elements**: {counter.total}",
+        f"- **Max nesting depth**: {counter.max_depth}",
+        "- **Top 10 tags**:",
+    ]
+    for tag, count in top:
+        lines.append(f"  - `<{tag}>` × {count}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path, help="HTML files to analyze")
+    parser.add_argument("--threshold", type=int, default=1500,
+                        help="Warn (exit 1) if any page exceeds this node count.")
+    args = parser.parse_args(argv)
+
+    over = []
+    chunks: list[str] = ["# DOM Node Report", ""]
+    for path in args.paths:
+        if not path.exists():
+            print(f"error: {path} not found", file=sys.stderr)
+            return 2
+        counter = analyze_file(path)
+        chunks.append(render_report(path, counter))
+        if counter.total > args.threshold:
+            over.append((path, counter.total))
+
+    print("\n".join(chunks))
+    if over:
+        print("\n**Warnings (over threshold)**:")
+        for path, count in over:
+            print(f"- {path}: {count} > {args.threshold}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_css_complexity_analyzer.py
+++ b/scripts/tests/test_css_complexity_analyzer.py
@@ -1,0 +1,153 @@
+"""Tests for ``scripts/dev/analyze_css_complexity.py``.
+
+We feed synthetic CSS through the analyzer (rather than asserting against the
+shipped bundle) so the suite is hermetic — small regressions in the
+production stylesheet will not break these tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ANALYZER_PATH = REPO_ROOT / "scripts" / "dev" / "analyze_css_complexity.py"
+
+
+@pytest.fixture(scope="module")
+def analyzer():
+    spec = importlib.util.spec_from_file_location("analyze_css_complexity", ANALYZER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_simple_rule_counts(analyzer):
+    css = """
+    .alpha { color: red; }
+    .beta { color: blue; }
+    .alpha, .gamma { color: green; }
+    """
+    stats = analyzer.analyze(css)
+    assert stats.rule_count == 3
+    # ``.alpha, .gamma`` splits into two selectors.
+    assert stats.selector_count == 4
+
+
+def test_nth_pseudo_classes_are_counted(analyzer):
+    css = """
+    .table tr:nth-child(even) { background: gray; }
+    ul li:nth-of-type(2n+1) { color: red; }
+    .none { color: blue; }
+    """
+    stats = analyzer.analyze(css)
+    assert stats.nth_count == 2
+    assert stats.examples["nth"]
+
+
+def test_has_selector_is_counted(analyzer):
+    css = ".card:has(img.loaded) { opacity: 1; } .other { opacity: 0; }"
+    stats = analyzer.analyze(css)
+    assert stats.has_count == 1
+
+
+def test_universal_with_descendant_combinator(analyzer):
+    # Plain ``* {}`` matches our universal pattern; ``.x *`` does too.
+    # ``.x *p`` would be invalid CSS so we don't worry about it.
+    css = """
+    * { box-sizing: border-box; }
+    .container * { margin: 0; }
+    .scoped { color: red; }
+    """
+    stats = analyzer.analyze(css)
+    assert stats.universal_descendant >= 2
+
+
+def test_attribute_regex_selectors(analyzer):
+    css = """
+    [class*="VIpgJd"] { display: none; }
+    a[href^="https://"] { color: blue; }
+    img[src$=".svg"] { width: 100%; }
+    [data-id] { display: block; }
+    """
+    stats = analyzer.analyze(css)
+    # First three use substring/prefix/suffix matchers; ``[data-id]`` does not.
+    assert stats.attr_regex_count == 3
+
+
+def test_descendant_chain_length(analyzer):
+    css = ".a .b .c .d { color: red; } .e { color: blue; }"
+    stats = analyzer.analyze(css)
+    assert stats.longest_descendant_chain == 4
+
+
+def test_specificity_calculation(analyzer):
+    # ``#id .class p`` → (1, 1, 1)
+    a, b, c = analyzer._count_specificity("#id .class p")
+    assert (a, b, c) == (1, 1, 1)
+    # Two classes → (0, 2, 0)
+    a, b, c = analyzer._count_specificity(".a.b")
+    assert (a, b, c) == (0, 2, 0)
+
+
+def test_render_markdown_contains_required_sections(analyzer, tmp_path):
+    css_file = tmp_path / "sample.css"
+    css_file.write_text(".x { color: red; } .y :has(img) { color: blue; }", encoding="utf-8")
+    stats = analyzer.analyze(css_file.read_text(encoding="utf-8"))
+    md = analyzer.render_markdown(stats, css_file)
+    assert "# CSS Complexity Report" in md
+    assert "Rules" in md
+    assert "Anti-pattern counts" in md
+    assert ":has()" in md
+
+
+def test_main_writes_to_output_file(analyzer, tmp_path, capsys):
+    css_file = tmp_path / "in.css"
+    css_file.write_text(".a { color: red; }", encoding="utf-8")
+    out_file = tmp_path / "out.md"
+    rc = analyzer.main(["--input", str(css_file), "--output", str(out_file)])
+    assert rc == 0
+    assert out_file.exists()
+    body = out_file.read_text(encoding="utf-8")
+    assert "Rules" in body
+    captured = capsys.readouterr()
+    # When ``--output`` is set we don't print the report to stdout.
+    assert "Rules" not in captured.out
+
+
+def test_main_prints_to_stdout_when_no_output(analyzer, tmp_path, capsys):
+    css_file = tmp_path / "in.css"
+    css_file.write_text(".a { color: red; }", encoding="utf-8")
+    rc = analyzer.main(["--input", str(css_file)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "Rules" in captured.out
+
+
+def test_main_returns_nonzero_for_missing_file(analyzer, tmp_path, capsys):
+    rc = analyzer.main(["--input", str(tmp_path / "nope.css")])
+    assert rc == 2
+
+
+def test_at_rule_blocks_are_traversed(analyzer):
+    # Rules nested inside ``@media`` should still be counted.
+    css = """
+    @media (max-width: 600px) {
+      .alpha { color: red; }
+      .beta { color: blue; }
+    }
+    .gamma { color: green; }
+    """
+    stats = analyzer.analyze(css)
+    assert stats.rule_count == 3
+
+
+def test_comments_are_stripped(analyzer):
+    css = "/* this should not be a rule */ .real { color: red; }"
+    stats = analyzer.analyze(css)
+    assert stats.rule_count == 1

--- a/scripts/tests/test_dom_node_counter.py
+++ b/scripts/tests/test_dom_node_counter.py
@@ -1,0 +1,108 @@
+"""Tests for ``scripts/dev/count_dom_nodes.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COUNTER_PATH = REPO_ROOT / "scripts" / "dev" / "count_dom_nodes.py"
+
+
+@pytest.fixture(scope="module")
+def counter_module():
+    spec = importlib.util.spec_from_file_location("count_dom_nodes", COUNTER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    import sys
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_basic_tag_counts(counter_module, tmp_path):
+    html = tmp_path / "page.html"
+    html.write_text(
+        "<html><body><div><p>hi</p><p>there</p></div><span>x</span></body></html>",
+        encoding="utf-8",
+    )
+    result = counter_module.analyze_file(html)
+    assert result.tags["html"] == 1
+    assert result.tags["body"] == 1
+    assert result.tags["div"] == 1
+    assert result.tags["p"] == 2
+    assert result.tags["span"] == 1
+    # 1+1+1+2+1 = 6
+    assert result.total == 6
+
+
+def test_void_elements_do_not_increase_depth(counter_module, tmp_path):
+    html = tmp_path / "page.html"
+    html.write_text(
+        "<html><body><div><img src=x><br><p>x</p></div></body></html>",
+        encoding="utf-8",
+    )
+    result = counter_module.analyze_file(html)
+    # html > body > div > p   →  depth 4
+    assert result.max_depth == 4
+    assert result.tags["img"] == 1
+    assert result.tags["br"] == 1
+
+
+def test_max_depth_tracks_deepest_branch(counter_module, tmp_path):
+    html = tmp_path / "page.html"
+    html.write_text(
+        "<html><body><a><b><c><d><e>x</e></d></c></b></a><span>x</span></body></html>",
+        encoding="utf-8",
+    )
+    result = counter_module.analyze_file(html)
+    # html > body > a > b > c > d > e  → depth 7
+    assert result.max_depth == 7
+
+
+def test_main_under_threshold_returns_zero(counter_module, tmp_path, capsys):
+    html = tmp_path / "small.html"
+    html.write_text("<html><body><p>x</p></body></html>", encoding="utf-8")
+    rc = counter_module.main([str(html)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "DOM Node Report" in captured.out
+    assert "Total elements" in captured.out
+
+
+def test_main_over_threshold_returns_one(counter_module, tmp_path, capsys):
+    html = tmp_path / "big.html"
+    body = "".join(f"<div>{i}</div>" for i in range(50))
+    html.write_text(f"<html><body>{body}</body></html>", encoding="utf-8")
+    rc = counter_module.main([str(html), "--threshold", "10"])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "Warnings (over threshold)" in captured.out
+
+
+def test_main_missing_file_returns_two(counter_module, tmp_path):
+    rc = counter_module.main([str(tmp_path / "missing.html")])
+    assert rc == 2
+
+
+def test_render_report_lists_top_tags(counter_module, tmp_path):
+    html = tmp_path / "page.html"
+    html.write_text(
+        "<html><body>" + "<div></div>" * 5 + "<span></span>" * 3 + "</body></html>",
+        encoding="utf-8",
+    )
+    result = counter_module.analyze_file(html)
+    report = counter_module.render_report(html, result)
+    assert "`<div>` × 5" in report
+    assert "`<span>` × 3" in report
+    assert "Top 10 tags" in report
+
+
+def test_handles_self_closing_tags(counter_module, tmp_path):
+    html = tmp_path / "page.html"
+    # ``<br />`` style — handle_startendtag path.
+    html.write_text("<html><body><br /><br /><p>x</p></body></html>", encoding="utf-8")
+    result = counter_module.analyze_file(html)
+    assert result.tags["br"] == 2


### PR DESCRIPTION
## Summary

PageSpeed Insights flagged 1,052 ms Style & Layout cost on the homepage (vs. 1,374 ms Script Eval and 450 ms Rendering). This PR is mostly an **audit**: it ships the analysis doc and two reusable analyzer scripts, plus **one targeted, low-risk fix** so we have a measurable baseline change without a wide blast radius.

Static analysis only — no Chrome trace was captured. Savings estimates are best-effort.

## Top 3 contributors identified

1. **`home-posts-filter.js renderPosts()` forced reflow** — `assets/js/home-posts-filter.js:74-122`. Toggles `display` on every `.post-card` (30 cards × 2 writes per render) and then re-queries each tab to insert `<span class="tab-count">`. This is unconditional first-paint cost.
2. **Missing CSS containment on `.post-card` / `.posts-list`** — `_sass/_components.scss:154-166`. Without `contain: layout style`, every JS-driven `display` toggle invalidates the whole 30-card grid.
3. **27 attribute-regex selectors in `_site/assets/css/post-page.css`** — `_sass/_post.scss:48,209,905` and 24 more. `[src*="section-"]`, `[src$=".svg"]`, `[class*="…"]`. These run on post pages (not homepage), but they explain Style cost on the digest post (which has 1,381 DOM elements, near PSI's 1,500-node warning).

Full file:line analysis with examples in `docs/optimization/STYLE_LAYOUT_ANALYSIS.md`.

## Recommended fix order (effort × impact)

| Priority | Fix | Effort | Estimated Style&Layout savings |
|---|---|---|---|
| **P0 — shipped here** | `contain: layout style` on `.post-card` | 1 line | 80–150 ms |
| **P1 — follow-up** | Refactor `renderPosts()` to batch writes inside rAF + compute tab counts once | ~30 min | +100–200 ms |
| **P1 — follow-up** | Hide cards beyond index 12 server-side via Liquid | ~15 min | +40–80 ms |
| **P2 — follow-up** | Replace `[src$=".svg"]` matchers with deterministic `.is-svg-image` class | ~1 hr | 50–120 ms on post pages |
| **P2 — follow-up** | Add `contain: layout style` to `.toc-container`, `.news-grid`, etc. | ~4 lines | 20–60 ms per affected page |
| **P3** | Remove zebra striping `:nth-child(even)` from global path | ~30 min | 5–15 ms |
| **P3** | Consolidate Google Translate CLS rules behind one class | ~1 hr | marginal |

## The one fix shipped in this PR

`_sass/_components.scss:161-171` — added 4 lines (3 of comment, 1 directive):

```scss
.post-card {
  display: block;
  text-decoration: none;
  color: inherit;
  height: 100%;
+  /* Style&Layout perf: scope layout/style invalidation to the card so that
+   * `home-posts-filter.js` toggling `display` on each card does not invalidate
+   * the whole `.posts-list` grid (PageSpeed audit 2026-04-30 — see
+   * `docs/optimization/STYLE_LAYOUT_ANALYSIS.md`). */
+  contain: layout style;
}
```

Confirmed in compiled output: `.post-card{…contain:layout style}` is in `_site/assets/css/main.css`.

**Expected savings**: 80–150 ms Style & Layout on homepage cold render.
**Risk**: very low — `.post-card` is self-contained (fixed aspect-ratio image, no overflowing positioned children).

## Future-work checklist (deferred)

- [ ] P1: Refactor `assets/js/home-posts-filter.js renderPosts()` to batch DOM writes via `requestAnimationFrame` and avoid per-tab `getFilteredCards()` recomputation.
- [ ] P1: Hide cards beyond index 12 server-side in `index.html` Liquid loop so JS doesn't have to flip 12 cards on first paint.
- [ ] P2: Replace `[src$=".svg"]` / `[src*="section-"]` selectors with explicit class hooks added at Liquid render time.
- [ ] P2: Add `contain: layout style;` to `.toc-container`, `.toc-grid`, `.news-card`, `.news-grid` (see _sass/_post.scss for the existing pattern at line 133).
- [ ] P3: Move `:nth-child(even)` zebra striping behind an opt-in `.zebra-striped` class.
- [ ] Capture a Chrome DevTools Performance trace to validate the savings band before/after each fix.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_css_complexity_analyzer.py scripts/tests/test_dom_node_counter.py -q` — 21 passed.
- [x] `python3 -m pytest scripts/tests/ -q --tb=line` — 1,056 passed (no regression).
- [x] `bundle exec jekyll build` succeeds; `_site/assets/css/main.css` contains the new `contain` directive.
- [x] `python3 scripts/dev/analyze_css_complexity.py` reports rule counts unchanged on main.css (284 rules → 284 rules).
- [x] `python3 scripts/dev/count_dom_nodes.py _site/index.html` reports 872 elements (unchanged).
- [ ] Lighthouse CI must run with `perf-regression-allowed` label so jitter on a no-op-rendering PR doesn't block (note: shipped PR is rendering-neutral; only Style&Layout cost is expected to drop).