### PR TITLE
ci: font drift gate (woff2 changes require matching generator/corpus update)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat woff2 as binary — prevents text-mode diffs and CRLF mangling
+assets/fonts/*.woff2 binary

--- a/.github/workflows/font-drift-gate.yml
+++ b/.github/workflows/font-drift-gate.yml
@@ -1,0 +1,56 @@
+name: Font Drift Gate
+
+on:
+  pull_request:
+    paths:
+      - 'assets/fonts/**'
+  workflow_dispatch:
+
+concurrency:
+  group: font-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  font-drift:
+    name: woff2 drift check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for override label
+        id: label-check
+        run: |
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
+          echo "labels=$LABELS"
+          if echo "$LABELS" | grep -q 'font-drift-allowed'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Label 'font-drift-allowed' is set — skipping font drift gate."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Compute changed files
+        id: diff
+        if: steps.label-check.outputs.skip == 'false'
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          # Fall back to HEAD~1 for workflow_dispatch where no PR base is available
+          if [ -z "$BASE" ]; then
+            BASE="HEAD~1"
+          fi
+          CHANGED=$(git diff --name-only "$BASE".."$HEAD" | tr '\n' ',' | sed 's/,$//')
+          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Changed files: $CHANGED"
+
+      - name: Run font drift gate
+        if: steps.label-check.outputs.skip == 'false'
+        run: |
+          python3 scripts/dev/check_font_drift.py \
+            --changed-files '${{ steps.diff.outputs.changed }}'

--- a/docs/optimization/NOTO_SANS_SELF_HOST_RUNBOOK.md
+++ b/docs/optimization/NOTO_SANS_SELF_HOST_RUNBOOK.md
@@ -193,3 +193,27 @@ NOTO_VF_URL='https://github.com/notofonts/noto-cjk/raw/<commit-sha>/Sans/Variabl
 - `_includes/head.html` — integration point (just after the `theme-init` script)
 - `assets/js/head-runtime.js#loadFontTier2` — lazy tier-2 loader
 - `vercel.json:34` — CSP without Google Fonts hosts; `vercel.json:184-198` — woff2 cache headers
+
+## 9. Why Not Git LFS?
+
+**Short answer:** The four woff2 files (~1.34 MiB total) have been touched in only two commits across the project's entire history. LFS would add per-build bandwidth cost on Vercel (~5–10 s per build, ~400 MiB/month) and contributor friction (`git lfs install` required after clone), with negligible repo-size benefit at today's scale.
+
+The full cost-benefit analysis — including clone time metrics, Vercel build budget, and GitHub LFS bandwidth projections — lives in [`docs/optimization/WOFF2_LFS_DECISION.md`](./WOFF2_LFS_DECISION.md). The recommendation is to stay in the main git pack and enforce the rule that woff2 files may only change when the generator or corpus also changes.
+
+**The CI discipline that replaces LFS migration:**
+
+Instead of LFS, a dedicated CI gate enforces the invariant that no woff2 can enter the history without a corresponding source change:
+
+- **`.gitattributes`** marks `assets/fonts/*.woff2` as `binary` so git never attempts a text diff on font files and CRLF normalization is suppressed on Windows clones.
+- **`.github/workflows/font-drift-gate.yml`** triggers on every PR that touches `assets/fonts/**`. If any `*.woff2` appears in the diff, at least one of the following must also appear:
+  - `scripts/build/generate_noto_2tier_subset.py`
+  - `scripts/build/noto_subset_top1k.txt`
+- **`scripts/dev/check_font_drift.py`** implements the same logic as a pure-stdlib CLI so the gate can be verified locally without CI:
+  ```bash
+  python3 scripts/dev/check_font_drift.py \
+      --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2'
+  # exit 1 — fonts changed without generator/corpus update
+  ```
+- **Override:** For intentional font swaps that don't change the generator (e.g. an upstream Noto upstream bump committed separately), a maintainer can apply the `font-drift-allowed` label to the PR to bypass the gate.
+
+Revisit the LFS decision if any of the triggers in `WOFF2_LFS_DECISION.md §6` becomes true (≥5 woff2-touching commits in 90 days, total woff2 size >5 MiB, etc.). Next scheduled review: 2027-04-30.

--- a/scripts/dev/check_font_drift.py
+++ b/scripts/dev/check_font_drift.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Font drift gate helper.
+
+Reads a comma-separated list of changed files and exits 1 if any
+assets/fonts/*.woff2 file changed without a corresponding change to
+the generator script or the syllable corpus.
+
+Usage:
+    python3 scripts/dev/check_font_drift.py \\
+        --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2'
+    # exit 1 — fonts changed without generator/corpus update
+
+    python3 scripts/dev/check_font_drift.py \\
+        --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2,scripts/build/generate_noto_2tier_subset.py'
+    # exit 0
+
+Override: when the CI label "font-drift-allowed" is present the caller
+should skip running this script entirely (handled in the workflow).
+"""
+
+import argparse
+import re
+import sys
+
+
+WOFF2_PATTERN = re.compile(r"^assets/fonts/.*\.woff2$")
+
+# Source-of-truth files that must accompany any woff2 change
+GENERATOR_FILES = frozenset(
+    [
+        "scripts/build/generate_noto_2tier_subset.py",
+        "scripts/build/noto_subset_top1k.txt",
+    ]
+)
+
+FAILURE_MESSAGE = """\
+## Font Drift Gate Failed
+
+`assets/fonts/*.woff2` changed without a corresponding update to the
+generator or the syllable corpus.
+
+**Allowed source-of-truth files (at least one must also change):**
+- `scripts/build/generate_noto_2tier_subset.py`
+- `scripts/build/noto_subset_top1k.txt`
+
+**Why this gate exists:**
+The woff2 files are committed binaries. Any accidental regeneration
+(e.g. a stale stamp file or a local toolchain upgrade) would silently
+bloat the git history without a meaningful change to the subsetting
+logic. This gate ensures every woff2 commit is intentional and
+traceable to a source change.
+
+**If this change is intentional (e.g. upstream Noto bump):**
+1. Also commit the updated generator/corpus file, OR
+2. Ask a maintainer to apply the `font-drift-allowed` label to this PR.
+
+See `docs/optimization/WOFF2_LFS_DECISION.md` for background and
+`docs/optimization/NOTO_SANS_SELF_HOST_RUNBOOK.md` for regeneration
+instructions.
+"""
+
+
+def check_font_drift(changed_files: list[str]) -> bool:
+    """Return True if the diff is clean (gate passes), False if it fails."""
+    woff2_changed = [f for f in changed_files if WOFF2_PATTERN.match(f)]
+    if not woff2_changed:
+        return True  # no woff2 in diff — nothing to enforce
+
+    generator_changed = bool(GENERATOR_FILES & set(changed_files))
+    return generator_changed
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Check that woff2 changes are accompanied by generator/corpus changes."
+    )
+    parser.add_argument(
+        "--changed-files",
+        required=True,
+        help="Comma-separated list of changed file paths.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    changed = [f.strip() for f in args.changed_files.split(",") if f.strip()]
+    if check_font_drift(changed):
+        return 0
+    print(FAILURE_MESSAGE, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_font_drift_gate.py
+++ b/scripts/tests/test_font_drift_gate.py
@@ -1,0 +1,95 @@
+"""Tests for scripts/dev/check_font_drift.py.
+
+Each test exercises the gate logic either via the public API
+(check_font_drift) or via subprocess to validate the CLI exit codes.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so we can import the helper directly
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "dev"))
+
+from check_font_drift import check_font_drift  # noqa: E402
+
+SCRIPT = Path(__file__).parent.parent / "dev" / "check_font_drift.py"
+
+WOFF2_A = "assets/fonts/noto-sans-kr-400-tier1.woff2"
+WOFF2_B = "assets/fonts/noto-sans-kr-700-tier2.woff2"
+GENERATOR = "scripts/build/generate_noto_2tier_subset.py"
+CORPUS = "scripts/build/noto_subset_top1k.txt"
+UNRELATED = "README.md"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests via check_font_drift()
+# ---------------------------------------------------------------------------
+
+
+def test_empty_diff_passes():
+    """Empty diff should pass — no woff2 changed."""
+    assert check_font_drift([]) is True
+
+
+def test_only_generator_changed_passes():
+    """Only the generator script changed, no woff2 — no enforcement needed."""
+    assert check_font_drift([GENERATOR]) is True
+
+
+def test_only_corpus_changed_passes():
+    """Only the corpus file changed, no woff2 — no enforcement needed."""
+    assert check_font_drift([CORPUS]) is True
+
+
+def test_woff2_plus_generator_passes():
+    """woff2 and generator both changed — gate passes."""
+    assert check_font_drift([WOFF2_A, GENERATOR]) is True
+
+
+def test_woff2_plus_corpus_passes():
+    """woff2 and corpus both changed — gate passes."""
+    assert check_font_drift([WOFF2_A, CORPUS]) is True
+
+
+def test_only_woff2_fails():
+    """Single woff2 changed with no source file — gate fails."""
+    assert check_font_drift([WOFF2_A]) is False
+
+
+def test_multiple_woff2_no_source_fails():
+    """Multiple woff2 files changed with no source file — gate fails."""
+    assert check_font_drift([WOFF2_A, WOFF2_B]) is False
+
+
+def test_woff2_plus_unrelated_file_fails():
+    """woff2 + unrelated file (e.g. README) — gate must still fail."""
+    assert check_font_drift([WOFF2_A, UNRELATED]) is False
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests via subprocess (validates argparse + exit codes)
+# ---------------------------------------------------------------------------
+
+
+def _run(changed_files: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--changed-files", changed_files],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_passes_with_generator():
+    result = _run(f"{WOFF2_A},{GENERATOR}")
+    assert result.returncode == 0
+
+
+def test_cli_fails_woff2_only():
+    result = _run(WOFF2_A)
+    assert result.returncode == 1
+    # Failure message should reference the decision doc
+    assert "WOFF2_LFS_DECISION.md" in result.stderr


### PR DESCRIPTION
## Why

PR #331 (`docs(plan): woff2 → Git LFS migration cost-benefit analysis`) recommended staying in the main git pack **with a small enforcement discipline** instead of migrating to LFS. This PR implements the three discipline items called out in `WOFF2_LFS_DECISION.md §5`:

- §5.1 — binary marker in `.gitattributes`
- §5.2 — CI gate that fails when woff2 changes without a source change
- §5.3 — "Why not LFS?" subsection in the runbook

## What

### 1. `.gitattributes`
- `assets/fonts/*.woff2 binary` — stops git from attempting text diffs on font files; suppresses CRLF normalization on Windows clones.

### 2. `.github/workflows/font-drift-gate.yml`
- Triggers on `pull_request` paths `assets/fonts/**` (and `workflow_dispatch`).
- Concurrency group `font-drift-${{ github.ref }}` with cancel-in-progress.
- Single job on `ubuntu-latest`, no Ruby/Node setup needed.
- Computes changed files via `git diff --name-only base..head`.
- Fails if any `*.woff2` changed without at least one of:
  - `scripts/build/generate_noto_2tier_subset.py`
  - `scripts/build/noto_subset_top1k.txt`
- Prints a Markdown explanation pointing at `docs/optimization/WOFF2_LFS_DECISION.md` on failure (exit 1).
- **Override:** PR label `font-drift-allowed` skips the gate (for intentional upstream Noto bumps that don't touch the generator on the same PR).

### 3. `scripts/dev/check_font_drift.py`
- Pure stdlib helper — same gate logic usable locally:
  ```bash
  python3 scripts/dev/check_font_drift.py \
      --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2'
  # exit 1 — fonts changed without generator/corpus update

  python3 scripts/dev/check_font_drift.py \
      --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2,scripts/build/generate_noto_2tier_subset.py'
  # exit 0
  ```

### 4. `scripts/tests/test_font_drift_gate.py`
10 tests (8 unit + 2 CLI subprocess).

### 5. `docs/optimization/NOTO_SANS_SELF_HOST_RUNBOOK.md §9`
New "Why Not Git LFS?" section linking `WOFF2_LFS_DECISION.md` and documenting the CI gate as the discipline that replaces LFS migration.

## Test matrix

| Scenario | Expected |
|---|---|
| Empty diff | pass |
| Only generator changed | pass |
| Only corpus changed | pass |
| woff2 + generator | pass |
| woff2 + corpus | pass |
| Only woff2 | **fail** |
| Multiple woff2, nothing else | **fail** |
| woff2 + unrelated file (README) | **fail** |
| CLI: woff2 + generator | exit 0 |
| CLI: woff2 only | exit 1 + Markdown explanation |

All 10 tests pass. Full suite: **1066 passed in 1.06 s**.

## Manual override path

For PRs that intentionally swap fonts without changing the generator (e.g. an upstream Noto version bump committed in a separate PR), a maintainer applies the `font-drift-allowed` label. The workflow detects the label in the first step and skips the gate entirely.

## Smoke check results
```
python3 scripts/dev/check_font_drift.py \
    --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2,scripts/build/generate_noto_2tier_subset.py'
# exit=0

python3 scripts/dev/check_font_drift.py \
    --changed-files 'assets/fonts/noto-sans-kr-400-tier1.woff2'
# exit=1
```