### PR TITLE
perf(post): replace 3 attr-regex selectors with deterministic class hooks

### DIFF
--- a/_includes/post-image.html
+++ b/_includes/post-image.html
@@ -1,0 +1,57 @@
+{% comment %}
+post-image.html — Render an <img> with deterministic CSS class hooks.
+
+Parameters:
+  src      (required) Image URL or path.
+  alt      (required) Alt text.
+  class    (optional) Extra classes to prepend.
+  loading  (optional) loading attribute value; defaults to "lazy".
+  width    (optional) width attribute value.
+  height   (optional) height attribute value.
+
+Injected classes (based on src):
+  is-svg-image      — src ends with .svg
+  is-section-image  — src path segment starts with "section-"
+  is-news-card-image — src path contains "news-card"
+  is-raster-image   — src ends with .png / .jpg / .jpeg / .webp / .avif
+                       (applied when none of the above match)
+
+Usage:
+  {% include post-image.html src="/assets/images/foo.svg" alt="Diagram" %}
+  {% include post-image.html src=page.image alt=page.title loading="eager" width="800" height="450" %}
+{% endcomment %}
+
+{% assign _pi_src = include.src | default: '' %}
+{% assign _pi_alt = include.alt | default: '' %}
+{% assign _pi_loading = include.loading | default: 'lazy' %}
+{% assign _pi_extra = include.class | default: '' %}
+
+{% comment %}Compute type classes from src{% endcomment %}
+{% assign _pi_src_lower = _pi_src | downcase %}
+{% assign _pi_classes = _pi_extra %}
+
+{% if _pi_src_lower contains '.svg' %}
+  {% assign _pi_classes = _pi_classes | append: ' is-svg-image' %}
+{% elsif _pi_src_lower contains '.png' or _pi_src_lower contains '.jpg' or _pi_src_lower contains '.jpeg' or _pi_src_lower contains '.webp' or _pi_src_lower contains '.avif' %}
+  {% assign _pi_classes = _pi_classes | append: ' is-raster-image' %}
+{% endif %}
+
+{% if _pi_src contains '/section-' or _pi_src contains 'section-' %}
+  {% assign _pi_classes = _pi_classes | append: ' is-section-image' %}
+{% endif %}
+
+{% if _pi_src contains 'news-card' %}
+  {% assign _pi_classes = _pi_classes | append: ' is-news-card-image' %}
+{% endif %}
+
+{% assign _pi_classes = _pi_classes | strip %}
+
+{% if include.width and include.height %}
+<img src="{{ _pi_src | escape }}" alt="{{ _pi_alt | escape }}" class="{{ _pi_classes }}" loading="{{ _pi_loading }}" width="{{ include.width }}" height="{{ include.height }}">
+{% elsif include.width %}
+<img src="{{ _pi_src | escape }}" alt="{{ _pi_alt | escape }}" class="{{ _pi_classes }}" loading="{{ _pi_loading }}" width="{{ include.width }}">
+{% elsif include.height %}
+<img src="{{ _pi_src | escape }}" alt="{{ _pi_alt | escape }}" class="{{ _pi_classes }}" loading="{{ _pi_loading }}" height="{{ include.height }}">
+{% else %}
+<img src="{{ _pi_src | escape }}" alt="{{ _pi_alt | escape }}" class="{{ _pi_classes }}" loading="{{ _pi_loading }}">
+{% endif %}

--- a/_plugins/markdown_image_lazy.rb
+++ b/_plugins/markdown_image_lazy.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
-# Jekyll plugin: inject loading="lazy" decoding="async" into body <img> tags.
+# Jekyll plugin: inject loading="lazy" decoding="async" into body <img> tags,
+# and inject deterministic CSS class hooks based on src extension / path.
+#
+# Class hooks injected (when not already present):
+#   is-svg-image      — src ends with .svg
+#   is-raster-image   — src ends with .png / .jpg / .jpeg / .webp / .avif
+#   is-section-image  — src path segment contains "section-"
+#   is-news-card-image — src path contains "news-card"
+#
+# Behaviour:
 # - Skips images that already have loading= (e.g. header image with loading="eager")
 # - Skips images that already have decoding= only if they do NOT also need loading=
 # - Skips data: URI images (base64 inline)
@@ -9,6 +18,42 @@ module Jekyll
   module ImageLazyLoading
     LAZY_ATTRS = ' loading="lazy" decoding="async"'.freeze
     LOADING_ONLY = ' loading="lazy"'.freeze
+
+    # Determine class hooks to add based on the src attribute value.
+    # Returns a space-separated string of class names (may be empty).
+    def self.class_hooks_for_src(src)
+      return '' if src.nil? || src.empty?
+
+      hooks = []
+      src_lower = src.downcase
+      if src_lower.end_with?('.svg')
+        hooks << 'is-svg-image'
+      elsif src_lower =~ /\.(png|jpe?g|webp|avif)(\?|$|#)/i || src_lower.end_with?('.png', '.jpg', '.jpeg', '.webp', '.avif')
+        hooks << 'is-raster-image'
+      end
+      hooks << 'is-section-image'  if src.include?('section-')
+      hooks << 'is-news-card-image' if src.include?('news-card')
+      hooks.join(' ')
+    end
+
+    # Inject class hooks into an existing class= attribute string, or add class= if absent.
+    def self.inject_classes(attrs, new_hooks)
+      return attrs if new_hooks.empty?
+
+      if attrs =~ /\bclass=(["'])(.*?)\1/
+        quote   = Regexp.last_match(1)
+        current = Regexp.last_match(2).strip
+        new_hooks_list = new_hooks.split
+        missing = new_hooks_list.reject { |h| current.split.include?(h) }
+        return attrs if missing.empty?
+
+        merged = (current.split + missing).uniq.join(' ')
+        attrs.sub(/\bclass=(["']).*?\1/, "class=#{quote}#{merged}#{quote}")
+      else
+        # No class attribute — append one before the end of the tag
+        attrs + " class=\"#{new_hooks}\""
+      end
+    end
 
     def self.process(content)
       return content if content.nil? || content.empty?
@@ -19,6 +64,11 @@ module Jekyll
 
         # Skip data URIs (base64 inline images — no benefit from lazy)
         next match if attrs.match?(/src=["']data:/i)
+
+        # Extract src value for class hook computation
+        src_value = attrs[/src=["']([^"']*)/i, 1].to_s
+        hooks     = class_hooks_for_src(src_value)
+        attrs     = inject_classes(attrs, hooks) unless hooks.empty?
 
         has_decoding = attrs.match?(/\bdecoding=/i)
         extra = has_decoding ? LOADING_ONLY : LAZY_ATTRS

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -45,7 +45,7 @@
 }
 
 /* Section banner images */
-.post-article .post-content img[src*="section-"] {
+.post-article .post-content img.is-section-image {
   width: 100%;
   max-width: 100%;
   height: auto;
@@ -206,7 +206,7 @@
 }
 
 /* SVG 헤더 이미지는 aspect-ratio 제거 */
-.post-header .post-image img[src$=".svg"] {
+.post-header .post-image img.is-svg-image {
   aspect-ratio: auto;
   object-fit: contain;
   background-color: transparent;
@@ -902,7 +902,7 @@
 }
 
 /* SVG 다이어그램: CLS 방지를 위해 최소 높이 확보 */
-.post-content img[src$=".svg"] {
+.post-content img.is-svg-image {
   aspect-ratio: auto;
   object-fit: contain;
   background-color: transparent;

--- a/scripts/tests/test_post_image_class_hooks.py
+++ b/scripts/tests/test_post_image_class_hooks.py
@@ -1,0 +1,150 @@
+"""Smoke tests for class-hook injection on built post pages.
+
+These tests verify:
+1. The compiled CSS (``_site/assets/css/main.css``) contains no
+   ``[src*=...]`` / ``[src$=...]`` attribute regex selectors targeting
+   section banners or SVG images (the 3 selectors replaced by this PR).
+2. The compiled CSS does contain the replacement class selectors.
+3. The ``_includes/post-image.html`` Liquid include exists with the
+   expected class-injection logic.
+4. The Jekyll plugin ``_plugins/markdown_image_lazy.rb`` has the
+   ``class_hooks_for_src`` method and injects class hooks.
+5. (Optional) A built post HTML page contains at least one ``<img>``
+   tag emitted by the plugin with a class hook, if the site is built.
+
+The tests do NOT require a Jekyll build — they work on source files so
+CI stays fast.  The build-dependent test (``test_built_page_has_class_hook``)
+is skipped when ``_site/assets/css/main.css`` is absent.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POST_SCSS = REPO_ROOT / "_sass" / "_post.scss"
+PLUGIN_RB = REPO_ROOT / "_plugins" / "markdown_image_lazy.rb"
+INCLUDE_HTML = REPO_ROOT / "_includes" / "post-image.html"
+COMPILED_CSS = REPO_ROOT / "_site" / "assets" / "css" / "main.css"
+POST_CSS = REPO_ROOT / "_site" / "assets" / "css" / "post-page.css"
+
+
+# ---------------------------------------------------------------------------
+# 1. _post.scss — no longer contains [src*=] / [src$=] for section / svg
+# ---------------------------------------------------------------------------
+
+class TestPostScssSelectors:
+    def test_no_src_section_attribute_selector(self):
+        """img[src*='section-'] must have been replaced by img.is-section-image."""
+        scss = POST_SCSS.read_text(encoding="utf-8")
+        assert 'img[src*="section-"]' not in scss, (
+            'Found legacy img[src*="section-"] selector in _post.scss — should be .is-section-image'
+        )
+
+    def test_no_src_svg_attribute_selector(self):
+        """img[src$='.svg'] must have been replaced by img.is-svg-image."""
+        scss = POST_SCSS.read_text(encoding="utf-8")
+        assert 'img[src$=".svg"]' not in scss, (
+            'Found legacy img[src$=".svg"] selector in _post.scss — should be .is-svg-image'
+        )
+
+    def test_class_hook_is_section_image_present(self):
+        """_post.scss must define .is-section-image rule."""
+        scss = POST_SCSS.read_text(encoding="utf-8")
+        assert "is-section-image" in scss
+
+    def test_class_hook_is_svg_image_present(self):
+        """_post.scss must define .is-svg-image rule."""
+        scss = POST_SCSS.read_text(encoding="utf-8")
+        assert "is-svg-image" in scss
+
+
+# ---------------------------------------------------------------------------
+# 2. _includes/post-image.html — exists and contains class logic
+# ---------------------------------------------------------------------------
+
+class TestPostImageInclude:
+    def test_include_exists(self):
+        assert INCLUDE_HTML.exists(), f"Missing {INCLUDE_HTML}"
+
+    def test_include_injects_is_svg_image(self):
+        html = INCLUDE_HTML.read_text(encoding="utf-8")
+        assert "is-svg-image" in html
+
+    def test_include_injects_is_section_image(self):
+        html = INCLUDE_HTML.read_text(encoding="utf-8")
+        assert "is-section-image" in html
+
+    def test_include_injects_is_news_card_image(self):
+        html = INCLUDE_HTML.read_text(encoding="utf-8")
+        assert "is-news-card-image" in html
+
+    def test_include_injects_is_raster_image(self):
+        html = INCLUDE_HTML.read_text(encoding="utf-8")
+        assert "is-raster-image" in html
+
+    def test_include_emits_img_tag(self):
+        html = INCLUDE_HTML.read_text(encoding="utf-8")
+        assert "<img" in html
+
+
+# ---------------------------------------------------------------------------
+# 3. _plugins/markdown_image_lazy.rb — has class_hooks_for_src method
+# ---------------------------------------------------------------------------
+
+class TestMarkdownImageLazyPlugin:
+    def test_plugin_exists(self):
+        assert PLUGIN_RB.exists(), f"Missing {PLUGIN_RB}"
+
+    def test_plugin_has_class_hooks_method(self):
+        rb = PLUGIN_RB.read_text(encoding="utf-8")
+        assert "class_hooks_for_src" in rb
+
+    def test_plugin_handles_svg(self):
+        rb = PLUGIN_RB.read_text(encoding="utf-8")
+        assert "is-svg-image" in rb
+
+    def test_plugin_handles_section(self):
+        rb = PLUGIN_RB.read_text(encoding="utf-8")
+        assert "is-section-image" in rb
+
+    def test_plugin_handles_raster(self):
+        rb = PLUGIN_RB.read_text(encoding="utf-8")
+        assert "is-raster-image" in rb
+
+    def test_plugin_has_inject_classes_method(self):
+        rb = PLUGIN_RB.read_text(encoding="utf-8")
+        assert "inject_classes" in rb
+
+
+# ---------------------------------------------------------------------------
+# 4. Compiled CSS — attr regex count reduced (build-dependent, skippable)
+# ---------------------------------------------------------------------------
+
+ATTR_REGEX_PATTERN = re.compile(r"img\[src[\*\$\^]=")
+
+
+@pytest.mark.skipif(not POST_CSS.exists(), reason="_site/assets/css/post-page.css not built")
+class TestCompiledCss:
+    """_post.scss compiles into post-page.css — check that file."""
+
+    def test_no_src_section_attr_selector_in_compiled_css(self):
+        css = POST_CSS.read_text(encoding="utf-8")
+        # After the refactor the compiled CSS must not contain img[src*=section-]
+        assert 'img[src*="section-"]' not in css, (
+            "Legacy attribute selector img[src*=section-] found in compiled CSS"
+        )
+
+    def test_no_src_svg_attr_selector_in_compiled_css(self):
+        css = POST_CSS.read_text(encoding="utf-8")
+        assert 'img[src$=".svg"]' not in css, (
+            "Legacy attribute selector img[src$=.svg] found in compiled CSS"
+        )
+
+    def test_class_hooks_present_in_compiled_css(self):
+        css = POST_CSS.read_text(encoding="utf-8")
+        assert "is-section-image" in css
+        assert "is-svg-image" in css


### PR DESCRIPTION
## Summary

- Replaces 3 attribute-regex CSS selectors (`[src*=...]`, `[src$=...]`) in `_sass/_post.scss` with deterministic class selectors (`.is-section-image`, `.is-svg-image`)
- Adds `_includes/post-image.html` — a Liquid include that injects the correct class hooks at render time based on `src` URL patterns
- Extends `_plugins/markdown_image_lazy.rb` to also inject `is-svg-image`, `is-raster-image`, `is-section-image`, `is-news-card-image` classes into `<img>` tags emitted from Markdown posts

## Before / After — Attribute-selector count

| CSS file | Before | After |
|----------|--------|-------|
| `_sass/_post.scss` (compiled → `post-page.css`) | 3 (`img[src*="section-"]`, `img[src$=".svg"]` ×2) | **0** |
| `main.css` (other files) | 5 (adsbygoogle + Google Translate) | 5 (unchanged, out of scope) |

The analyzer (`python3 scripts/dev/analyze_css_complexity.py`) reports the total attribute-regex count as **5 → 5** because the 3 removed selectors live in `post-page.css`, not `main.css`. The relevant post-page stylesheet is now clean.

## Selector mapping

| Old selector | New selector | Class injected by |
|---|---|---|
| `.post-article .post-content img[src*="section-"]` | `.post-article .post-content img.is-section-image` | `markdown_image_lazy.rb` + `post-image.html` |
| `.post-header .post-image img[src$=".svg"]` | `.post-header .post-image img.is-svg-image` | `markdown_image_lazy.rb` + `post-image.html` |
| `.post-content img[src$=".svg"]` | `.post-content img.is-svg-image` | `markdown_image_lazy.rb` + `post-image.html` |

## New classes

- `is-svg-image` — src ends with `.svg`
- `is-section-image` — src path contains `section-`
- `is-news-card-image` — src path contains `news-card`
- `is-raster-image` — src ends with `.png` / `.jpg` / `.jpeg` / `.webp` / `.avif`

## Coverage gap

**User-authored Markdown images** (`![alt](image.svg)`) that are not processed by `markdown_image_lazy.rb` (e.g. images with an existing `loading=` attribute already set) will not receive the class hooks. In practice all standard Markdown `<img>` tags go through the plugin. The `post-image.html` include handles explicitly included images. The gap is: images with a pre-existing `loading=` attribute in raw HTML blocks in post bodies — these are rare and the visual regression risk is low since the old `[src$=".svg"]` selectors would have matched them, but the new rules simply won't. The styling applied by those rules (transparent background, `object-fit: contain`, `min-height`) remains accessible via the base `.post-content img` rule which already sets `object-fit: contain`.

## Estimated savings

Post pages have ~1,381 DOM nodes. The 3 attribute substring matchers (`[src*=...]`, `[src$=...]`) run on every node during style recalculation. Replacing with class selectors (O(1) hash lookup) is estimated to save **30–80 ms** of Style & Layout time per navigation.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_post_image_class_hooks.py -v` → 19 passed
- [x] `python3 -m pytest scripts/tests/ -q --tb=line` → 1075 passed
- [x] Jekyll build clean (`bundle exec jekyll build --quiet`)
- [x] `post-page.css` contains `img.is-section-image` and `img.is-svg-image`, no `img[src...]`