### PR TITLE
fix(ci): grep -c GITHUB_OUTPUT pattern (Monthly Quality Report failing every month)

### DIFF
--- a/.github/workflows/buttondown-notify.yml
+++ b/.github/workflows/buttondown-notify.yml
@@ -60,9 +60,10 @@ jobs:
             echo "$NEW_POSTS"
             echo "has_new_posts=true" >> $GITHUB_OUTPUT
             
-            # Count posts
-            POST_COUNT=$(echo "$NEW_POSTS" | grep -c '^' || echo "0")
-            echo "post_count=$POST_COUNT" >> $GITHUB_OUTPUT
+            # Count posts (grep -c emits "0" + exit 1 on no-match, so chaining
+            # `|| echo 0` writes two lines and breaks GITHUB_OUTPUT parsing)
+            POST_COUNT=$(echo "$NEW_POSTS" | grep -c '^' || true)
+            echo "post_count=${POST_COUNT:-0}" >> $GITHUB_OUTPUT
             
             # Encode all posts as JSON array (more reliable than multiline)
             # Convert each post path to base64 and store as JSON array

--- a/.github/workflows/monthly-quality-report.yml
+++ b/.github/workflows/monthly-quality-report.yml
@@ -44,13 +44,17 @@ jobs:
         run: |
           echo "🖼️ Running image verification..."
           python3 scripts/verify_images_unified.py --all 2>&1 | tee /tmp/image-report.txt || true
-          echo "image_issues=$(grep -c '❌\|⚠️' /tmp/image-report.txt || echo 0)" >> $GITHUB_OUTPUT
+          # grep -c emits "0" + exit 1 on no-match, so a `|| echo 0` chain
+          # writes two lines and breaks GITHUB_OUTPUT parsing. Use `|| true`.
+          IMAGE_ISSUES=$(grep -c '❌\|⚠️' /tmp/image-report.txt 2>/dev/null || true)
+          echo "image_issues=${IMAGE_ISSUES:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Check posts
         run: |
           echo "📝 Running post quality check..."
           python3 scripts/check_posts.py 2>&1 | tee /tmp/post-report.txt || true
-          echo "post_issues=$(grep -c '⚠️' /tmp/post-report.txt || echo 0)" >> $GITHUB_OUTPUT
+          POST_ISSUES=$(grep -c '⚠️' /tmp/post-report.txt 2>/dev/null || true)
+          echo "post_issues=${POST_ISSUES:-0}" >> "$GITHUB_OUTPUT"
 
       - name: Generate quality report and issue body
         id: report

--- a/.github/workflows/slack-post-notify.yml
+++ b/.github/workflows/slack-post-notify.yml
@@ -50,8 +50,8 @@ jobs:
             exit 0
           fi
           echo "has_posts=true" >> "$GITHUB_OUTPUT"
-          POST_COUNT=$(echo "$NEW_POSTS" | grep -c '^' || echo "0")
-          echo "count=$POST_COUNT" >> "$GITHUB_OUTPUT"
+          POST_COUNT=$(echo "$NEW_POSTS" | grep -c '^' || true)
+          echo "count=${POST_COUNT:-0}" >> "$GITHUB_OUTPUT"
           python3 scripts/build_slack_post_message.py "$NEW_POSTS" >> "$GITHUB_OUTPUT"
 
       - name: Post to Slack via Bot API


### PR DESCRIPTION
## Summary

`Monthly Post Quality Report` has been failing every month with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '0'
```

(see [run 25198300738](https://github.com/Twodragon0/tech-blog/actions/runs/25198300738), 2026-05-01).

## Root cause

```yaml
echo "image_issues=$(grep -c '❌\|⚠️' /tmp/image-report.txt || echo 0)" >> $GITHUB_OUTPUT
```

When the file exists but matches zero lines, `grep -c` emits `0` to stdout
**and** exits with code 1. The `|| echo 0` then runs and appends a **second**
`0`. Final captured value is two lines:

```
image_issues=0
0
```

GitHub Actions parses each newline as a separate `key=value` directive and
chokes on the bare `0`.

## Fix

```bash
IMAGE_ISSUES=$(grep -c '❌\|⚠️' /tmp/image-report.txt 2>/dev/null || true)
echo "image_issues=${IMAGE_ISSUES:-0}" >> "$GITHUB_OUTPUT"
```

`|| true` swallows grep's non-zero exit without writing to stdout, then
`${VAR:-0}` covers the file-not-found case where grep emitted nothing.

Verified locally — see commit body for the reproduction trace.

## Scope

Fixes the actual production failure in `monthly-quality-report.yml` (lines 47, 53).

Defensive same-pattern cleanup in `buttondown-notify.yml` (line 64) and
`slack-post-notify.yml` (line 53). These are currently masked by a guard
(`if [ -z "$NEW_POSTS" ]`) but had the same anti-pattern.

## Test plan

- [x] Reproduce double-`0` output locally with `bash + grep`.
- [x] Verify single-`0` output with the new pattern, both no-match and 3-match cases.
- [ ] Wait for next scheduled `Monthly Post Quality Report` run (1st of month, 00:00 UTC) — or trigger via `workflow_dispatch` after merge.