### PR TITLE
ci: add Vitest regression gate on tests/js/ + assets/js/ changes

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,0 +1,56 @@
+name: Vitest JS regression
+
+# Runs the Vitest suite under tests/js/ whenever PR / main push touches the
+# scripts under test or the test files themselves. Keeps the gate scoped:
+# unrelated content edits (_posts/**, docs/**) skip CI to save runner time.
+
+on:
+  pull_request:
+    paths:
+      - "tests/js/**"
+      - "assets/js/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - ".github/workflows/vitest.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "tests/js/**"
+      - "assets/js/**"
+      - "package.json"
+      - "package-lock.json"
+      - "vitest.config.js"
+      - ".github/workflows/vitest.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: vitest-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  vitest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Setup Node 22
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Vitest
+        run: npm test


### PR DESCRIPTION
## Summary

Wires the existing 2 vitest files (`tests/js/{home-posts-filter,toc}.test.js`)
into CI so future changes to `assets/js/**` cannot regress them silently.
Once PR #337 lands, this same workflow will cover the additional 5 test
files added there (`ad-optimizer`, `console-filter`, `giscus-init`,
`header-runtime`, `main-search`), giving 7 total test files under CI.

## Trigger gate

PR + push-to-main, scoped to:
- `tests/js/**`
- `assets/js/**`
- `package.json`, `package-lock.json`
- `vitest.config.js`
- `.github/workflows/vitest.yml`

Unrelated content edits (`_posts/**`, `docs/**`, image regenerations)
skip the runner. Concurrency cancels in-progress runs on rebase.

## Cost

5-minute timeout, ubuntu-latest, npm cache. Local run: 11 tests in 664 ms.

## Test plan

- [x] `npm test` passes locally on this branch (2 files, 11 tests).
- [ ] First CI run on this PR — confirm vitest job goes green.
- [ ] After PR #337 merges, verify the workflow auto-runs because PR adds files under `tests/js/**`.