### PR TITLE
ci: pin 3rd-party action SHAs + Node 24 opt-in across 24 workflows

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -69,6 +69,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   auto-publish:

--- a/.github/workflows/ai-ops-on-demand.yml
+++ b/.github/workflows/ai-ops-on-demand.yml
@@ -60,6 +60,9 @@ concurrency:
   group: ai-ops-on-demand
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ops-on-demand:
     runs-on: ubuntu-latest

--- a/.github/workflows/buttondown-notify.yml
+++ b/.github/workflows/buttondown-notify.yml
@@ -22,6 +22,9 @@ concurrency:
   group: buttondown-notify-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-svg.yml
+++ b/.github/workflows/check-svg.yml
@@ -14,6 +14,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-svg:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -35,6 +35,7 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.11'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   collect-and-publish:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -28,6 +28,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/font-drift-gate.yml
+++ b/.github/workflows/font-drift-gate.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   font-drift:
     name: woff2 drift check

--- a/.github/workflows/generate-images.yml
+++ b/.github/workflows/generate-images.yml
@@ -38,6 +38,9 @@ concurrency:
   group: generate-images-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   generate-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -34,6 +34,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lighthouse-perf-gate:
     if: github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'perf-regression-allowed')
@@ -67,7 +70,7 @@ jobs:
           lighthouse --version
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a  # v1
         with:
           ruby-version: "3.3"
           bundler-cache: true
@@ -174,7 +177,7 @@ jobs:
 
       - name: Comment on PR with results
         if: always() && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: lighthouse-comparison.md

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,6 +18,9 @@ concurrency:
   group: lighthouse-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -12,6 +12,9 @@ permissions:
   issues: write
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/ops-multi-agent-loop.yml
+++ b/.github/workflows/ops-multi-agent-loop.yml
@@ -21,6 +21,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   roundtable:
     if: github.event_name != 'schedule' || vars.OPS_MULTI_AGENT_SCHEDULE != 'false'

--- a/.github/workflows/ops-priority-loop.yml
+++ b/.github/workflows/ops-priority-loop.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ops-priority-loop
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ops-checks:
     if: github.event_name != 'schedule' || vars.OPS_PRIORITY_LOOP_SCHEDULE == 'true'

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -22,6 +22,9 @@ concurrency:
   group: security-audit-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/sentry-healthcheck.yml
+++ b/.github/workflows/sentry-healthcheck.yml
@@ -19,6 +19,9 @@ permissions:
   checks: read
   actions: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sentry-healthcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -34,6 +34,9 @@ concurrency:
   group: sentry-release-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   create-sentry-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/slack-category-digest.yml
+++ b/.github/workflows/slack-category-digest.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   post-category-digest:
     if: github.event_name != 'schedule' || vars.SLACK_CATEGORY_DIGEST_SCHEDULE != 'false'

--- a/.github/workflows/slack-post-notify.yml
+++ b/.github/workflows/slack-post-notify.yml
@@ -16,6 +16,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/sns-share.yml
+++ b/.github/workflows/sns-share.yml
@@ -15,6 +15,9 @@ concurrency:
   group: sns-share-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   share:
     runs-on: ubuntu-latest

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -14,6 +14,9 @@ concurrency:
   group: svg-lint-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ultrawork-loop.yml
+++ b/.github/workflows/ultrawork-loop.yml
@@ -64,6 +64,9 @@ concurrency:
   group: ultrawork-loop
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ultrawork:
     if: github.event_name != 'schedule' || vars.ULTRAWORK_LOOP_SCHEDULE == 'true'

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,6 +17,9 @@ on:
 
 permissions: {}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   notify-sentry:
     # 프로덕션 배포 시에만 실행

--- a/.github/workflows/visual-baseline-refresh.yml
+++ b/.github/workflows/visual-baseline-refresh.yml
@@ -32,6 +32,9 @@ concurrency:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   refresh-baselines:
     runs-on: ubuntu-22.04

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -17,6 +17,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   visual-regression:
     runs-on: ubuntu-latest
@@ -57,7 +60,7 @@ jobs:
           always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e  # v3.1.0
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions[bot]
@@ -83,7 +86,7 @@ jobs:
           always() &&
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  # v4.0.0
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Two related GitHub Actions hardening changes ahead of the **Node 20 → Node 24 forced cutover on 2026-06-02** (announcement: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/>).

## 1. Pin floating third-party action tags to commit SHAs

| Action | Before | After |
|---|---|---|
| `peter-evans/create-or-update-comment` | `@v4` | `@71345be0265236311c031f5c7866368bd1eff043` (v4.0.0) — `lighthouse-ci.yml`, `visual-regression.yml` |
| `peter-evans/find-comment` | `@v3` | `@3eae4d37986fb5a8592848f6a574fdf654e61f9e` (v3.1.0) — `visual-regression.yml` |
| `ruby/setup-ruby` | `@v1` | `@7372622e62b60b3cb750dcd2b9e32c247ffec26a` — `lighthouse-ci.yml` only (matches SHA already pinned in jekyll/lighthouse/deploy-pages/security-audit) |

GitHub-owned `actions/*` refs were already commit-pinned across the repo and are unchanged.

## 2. Propagate `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`

Previously set on only 2 workflows (`jekyll.yml`, `monthly-quality-report.yml`). The Lighthouse perf gate run [25208103787](https://github.com/Twodragon0/tech-blog/actions/runs/25208103787) emitted the explicit deprecation warning naming `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`, `peter-evans/create-or-update-comment@v4` — proving the opt-in was missing where it mattered.

Now propagated to **24 workflows**:
- 2 had a pre-existing top-level `env:` (PYTHON_VERSION) — appended in place: `ai-blogwatcher.yml`, `daily-news.yml`
- 22 got a fresh top-level `env:` block inserted between `concurrency`/`permissions:` and `jobs:`

Already-set workflows skipped (3): `jekyll.yml`, `monthly-quality-report.yml`, `vitest.yml` (the new one in PR #340).

## Validation

- [x] All 26 workflow YAMLs parse cleanly with PyYAML round-trip after edits.
- [x] Sample diffs reviewed for both insertion modes (`extended-env`, `new-env`).
- [x] SHA values cross-checked via `gh api repos/<owner>/<repo>/git/matching-refs/tags/<tag>`.

## Risk

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` is purely additive — workflows that don't invoke JS actions are unaffected. If a JS action breaks under Node 24, the revert is a single-line removal per file.

## Test plan

- [ ] `Lighthouse perf gate` run on this PR: confirm the Node 20 deprecation warning no longer appears in the post-job log.
- [ ] `L20 Visual Regression Gate` run: confirm SHA-pinned `peter-evans/*` actions still resolve and post comments correctly.