### PR TITLE
ci(dependabot): group github-actions ecosystem into single weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,11 @@ updates:
       include: "scope"
 
   # GitHub Actions updates
+  #
+  # SHA-pinned third-party actions (peter-evans/*, ruby/setup-ruby) and
+  # GitHub-owned actions/* are bumped automatically. Updates are grouped
+  # so 24+ pinned references don't generate a separate PR per action
+  # each week.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -45,6 +50,10 @@ updates:
       time: "09:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary

Now that PR #341 SHA-pinned a fresh batch of third-party actions (`peter-evans/*`, `ruby/setup-ruby`) on top of the GitHub-owned `actions/*` refs already pinned across the repo, the github-actions ecosystem now contains 24+ pinned references. Without grouping, dependabot would file one PR per action each Monday — easily blowing past `open-pull-requests-limit: 3`.

## Change

Add a `groups:` block to the github-actions ecosystem entry:

```yaml
groups:
  github-actions:
    patterns:
      - "*"
```

All GHA ecosystem updates will roll up into a single consolidated PR per week.

## Why only this ecosystem

`bundler` / `npm` / `pip` keep per-package PRs because their dependency review is independently reviewable per package (CVE diffs, changelog reads). Action updates are mostly Node-runtime bumps and SHA refreshes — bundling reduces review noise without losing signal.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on the new config.
- [ ] Next Monday's dependabot run produces one consolidated `deps(actions)` PR instead of N separate ones (visible at <https://github.com/Twodragon0/tech-blog/network/updates>).