### PR TITLE
fix(images): stop AVIF/WEBP 404 noise on home + post pages

### DIFF
--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -4,15 +4,42 @@
     {% if post.image and post.image != "" %}
     <div class="post-card-image">
       {% comment %}CLS 최적화: aspect-ratio를 CSS에서 이미 처리하므로 width/height는 생략{% endcomment %}
-      {% comment %}OG format variants (plugin already converts .svg→_og.png){% endcomment %}
+      {% comment %}
+        OG format variants. The svg_to_png_og.rb plugin rewrites SVG inputs to
+        _og.png at pre_render. AVIF/WEBP/_card variants are only emitted when
+        the file actually exists in the build, so missing variants don't fire
+        404s in the browser console.
+      {% endcomment %}
       {% assign card_img = post.image | relative_url %}
-      {% assign card_webp = card_img | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
-      {% assign card_avif = card_img | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
-      {% assign card_sm_avif = card_img | replace: '_og.png', '_card.avif' | replace: '.png', '_card.avif' %}
-      {% assign card_sm_webp = card_img | replace: '_og.png', '_card.webp' | replace: '.png', '_card.webp' %}
+      {% if post.image contains '.png' %}
+        {% assign avif_path = post.image | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
+        {% assign webp_path = post.image | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
+        {% assign card_avif_path = post.image | replace: '_og.png', '_card.avif' | replace: '.png', '_card.avif' %}
+        {% assign card_webp_path = post.image | replace: '_og.png', '_card.webp' | replace: '.png', '_card.webp' %}
+        {% assign avif_file = site.static_files | where: 'path', avif_path | first %}
+        {% assign webp_file = site.static_files | where: 'path', webp_path | first %}
+        {% assign card_avif_file = site.static_files | where: 'path', card_avif_path | first %}
+        {% assign card_webp_file = site.static_files | where: 'path', card_webp_path | first %}
+        {% assign card_avif = avif_path | relative_url %}
+        {% assign card_webp = webp_path | relative_url %}
+        {% assign card_sm_avif = card_avif_path | relative_url %}
+        {% assign card_sm_webp = card_webp_path | relative_url %}
+      {% endif %}
       <picture>
+        {% if avif_file %}
+          {% if card_avif_file %}
         <source srcset="{{ card_sm_avif }} 525w, {{ card_avif }} 1120w" type="image/avif" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
+          {% else %}
+        <source srcset="{{ card_avif }}" type="image/avif">
+          {% endif %}
+        {% endif %}
+        {% if webp_file %}
+          {% if card_webp_file %}
         <source srcset="{{ card_sm_webp }} 525w, {{ card_webp }} 1120w" type="image/webp" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px">
+          {% else %}
+        <source srcset="{{ card_webp }}" type="image/webp">
+          {% endif %}
+        {% endif %}
         <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="525" height="276" style="aspect-ratio: 525/276" sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 525px" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
       </picture>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -81,13 +81,28 @@ layout: default
       {% else %}
         {% assign image_alt_text = page.title | escape %}
       {% endif %}
-      {% comment %}OG format variants (plugin already converts .svg→_og.png){% endcomment %}
+      {% comment %}
+        OG format variants. The svg_to_png_og.rb plugin rewrites SVG inputs to
+        _og.png at pre_render. AVIF/WEBP variants are only emitted when the
+        file actually exists in the build to avoid 404s in the browser
+        console; <picture> falls through to <img> for the available format.
+      {% endcomment %}
       {% assign svg_path = page.image_svg | default: "" | relative_url %}
-      {% assign webp_path = image_path | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
-      {% assign avif_path = image_path | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
+      {% if page.image contains '.png' %}
+        {% assign webp_check = page.image | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
+        {% assign avif_check = page.image | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
+        {% assign webp_file = site.static_files | where: 'path', webp_check | first %}
+        {% assign avif_file = site.static_files | where: 'path', avif_check | first %}
+        {% assign webp_path = webp_check | relative_url %}
+        {% assign avif_path = avif_check | relative_url %}
+      {% endif %}
       <picture>
+        {% if avif_file %}
         <source srcset="{{ avif_path }}" type="image/avif">
+        {% endif %}
+        {% if webp_file %}
         <source srcset="{{ webp_path }}" type="image/webp">
+        {% endif %}
         <img src="{{ image_path }}" alt="{{ image_alt_text }}" class="clickable-image" data-full-src="{{ image_path }}" data-original-src="{{ page.image }}" data-svg-src="{{ svg_path }}" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}" loading="eager" decoding="async" fetchpriority="high" width="1200" height="675" sizes="(max-width: 768px) 100vw, (max-width: 1200px) 800px, 1200px">
       </picture>
     </div>

--- a/index.html
+++ b/index.html
@@ -152,13 +152,30 @@ title: Home
           <a href="{{ post.url | relative_url }}" class="post-card-inner" aria-label="{{ post.title | escape }}">
             {% if post.image and post.image != "" %}
             <div class="post-card-image">
-              {% comment %}OG format variants (plugin already converts .svg→_og.png){% endcomment %}
+              {% comment %}
+                OG format variants. The svg_to_png_og.rb plugin rewrites SVG
+                inputs to _og.png at pre_render. Modern-format <source>s only
+                emit when the corresponding file exists, so missing variants
+                don't fire 404s in the browser console.
+              {% endcomment %}
               {% assign card_img = post.image | relative_url %}
-              {% assign card_webp = card_img | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
-              {% assign card_avif = card_img | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
+              {% assign avif_file = nil %}
+              {% assign webp_file = nil %}
+              {% if post.image contains '.png' %}
+                {% assign avif_check = post.image | replace: '_og.png', '_og.avif' | replace: '.png', '_og.avif' %}
+                {% assign webp_check = post.image | replace: '_og.png', '_og.webp' | replace: '.png', '_og.webp' %}
+                {% assign avif_file = site.static_files | where: 'path', avif_check | first %}
+                {% assign webp_file = site.static_files | where: 'path', webp_check | first %}
+                {% assign card_avif = avif_check | relative_url %}
+                {% assign card_webp = webp_check | relative_url %}
+              {% endif %}
               <picture>
+                {% if avif_file %}
                 <source srcset="{{ card_avif }}" type="image/avif">
+                {% endif %}
+                {% if webp_file %}
                 <source srcset="{{ card_webp }}" type="image/webp">
+                {% endif %}
                 <img src="{{ card_img }}" alt="{{ post.title | escape }}" loading="lazy" decoding="async" width="400" height="225" data-fallback="{{ '/assets/images/og-default.png' | relative_url }}">
               </picture>
             </div>


### PR DESCRIPTION
## Symptom

Production console (e.g. https://tech.2twodragon.com/posts/2026/04/28/Tech_Security_Weekly_Digest_Data_AI_Malware_AWS/) is firing many 404s like:

```
/assets/images/2026-04-28-..._og.avif:1   Failed to load resource: 404
/assets/images/2026-...-..._og.avif:1     Failed to load resource: 404
... (×N per page on home + post pages)
```

## Root cause

Coverage gap is structural:

| Variant | Files in repo |
|---|---|
| `.svg` (source) | **198** |
| `_og.png` | 173 |
| `_og.webp` | **44** |
| `_og.avif` | **43** |
| `_card.webp` | **0** |
| `_card.avif` | **0** |

`_includes/post-card.html`, `_layouts/post.html`, and the inline post-card loop in `index.html` all emit `<source srcset="...og.avif" type="image/avif">` unconditionally, so any post without an AVIF variant fires a 404 before `<picture>` falls through to the `<img>`. The card template additionally references `*_card.avif` / `*_card.webp` breakpoint variants that never existed in the repo — **every** homepage card was generating four 404s.

## Fix

Gate each `<source>` on `site.static_files | where: 'path', X | first`. The `svg_to_png_og.rb` plugin already rewrites the `image:` front-matter from `.svg` to `_og.png` at pre_render, so we key the existence checks off `post.image` directly. When a variant file isn't on disk, the `<source>` is skipped. `<picture>` falls through to `<img>`, which already points at the existing `_og.png` (or, for posts where only the SVG exists, the SVG itself — so "SVG visible" is now the literal default).

## Verification

Rebuilt `_site` locally and walked every emitted HTML for missing-file references:

```
_og.webp:   refs=27, files=44, missing=0
_og.avif:   refs=27, files=43, missing=0
_card.webp: refs=0,  files=0,  missing=0
_card.avif: refs=0,  files=0,  missing=0
```

**Zero 404-prone references remain.** Posts that DO have all variants (e.g. `2025-12-24-Cloud_Security_Course_8Batch_5Week_AWS_*`) still emit both `<source>` tags as before.

## Scope

- 3 templates touched. No image generation; no front-matter changes; no runtime JS impact.
- AVIF/WEBP coverage can grow asynchronously via the existing image scripts (`scripts/generate_post_images.py`); this template will pick them up automatically on next build.

## Test plan

- [x] Local Jekyll build clean, audit script confirms zero missing references.
- [ ] Vercel preview build green on this PR.
- [ ] Open the failing post URL in browser DevTools → Network tab on the preview deploy → confirm zero `_og.avif` 404s.
- [ ] Open the homepage on the preview deploy → confirm zero `_card.{avif,webp}` 404s.