### PR TITLE
ci(build): auto-generate missing _og.avif/_og.webp variants on every Vercel build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -69,6 +69,17 @@ if ! python3 scripts/generate_favicon.py; then
     fi
 fi
 
+# ---------------------------------------------------------------------------
+# Backfill _og.avif / _og.webp from any _og.png that lacks modern variants.
+# Idempotent (skip-if-exists), so steady-state builds add zero overhead;
+# only fires when a new post lands an _og.png without companion variants.
+# Soft failure: missing Pillow logs a warning and the build continues.
+# ---------------------------------------------------------------------------
+log "Backfilling _og.avif / _og.webp variants (skip-if-exists)..."
+if ! python3 scripts/build/backfill_og_modern_variants.py; then
+    log "WARN: modern-format backfill reported errors; build continues with whatever variants exist on disk"
+fi
+
 # Inject Sentry DSN from Vercel env var (if set, overrides _config.yml)
 if [ -n "$SENTRY_DSN" ]; then
     log "Injecting Sentry DSN from environment variable..."

--- a/scripts/build/backfill_og_modern_variants.py
+++ b/scripts/build/backfill_og_modern_variants.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Backfill missing _og.avif and _og.webp variants from existing _og.png covers.
+
+Idempotent — skips files that already exist. Designed to be safe to run
+on every Vercel build via build.sh, and also as a one-shot for repo-wide
+backfilling.
+
+Quality settings mirror scripts/regenerate_og_images.py so SVG → PNG
+regenerations and PNG → modern-format passes stay consistent:
+  WebP: quality=80
+  AVIF: quality=60
+
+Exit codes:
+  0  success (or skipped — Pillow not available is a soft warning, not a
+     hard failure, so the build keeps going on machines that lack the
+     dependency)
+  1  one or more conversions raised an exception
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMG_DIR = REPO_ROOT / "assets" / "images"
+
+
+def main() -> int:
+    try:
+        from PIL import Image
+    except ImportError:
+        print(
+            "Pillow not available — skipping _og.avif / _og.webp backfill. "
+            "Install with: pip install Pillow"
+        )
+        return 0
+
+    if not IMG_DIR.is_dir():
+        print(f"ERROR: {IMG_DIR} not found", file=sys.stderr)
+        return 1
+
+    pngs = sorted(IMG_DIR.glob("*_og.png"))
+    avif_made = webp_made = skipped = errors = 0
+
+    for png_path in pngs:
+        base = png_path.name[: -len("_og.png")]
+        avif_path = IMG_DIR / f"{base}_og.avif"
+        webp_path = IMG_DIR / f"{base}_og.webp"
+
+        need_avif = not avif_path.exists()
+        need_webp = not webp_path.exists()
+        if not (need_avif or need_webp):
+            skipped += 1
+            continue
+
+        try:
+            with Image.open(png_path) as src:
+                rgb = src.convert("RGB")
+                if need_webp:
+                    rgb.save(webp_path, "WEBP", quality=80)
+                    webp_made += 1
+                if need_avif:
+                    rgb.save(avif_path, "AVIF", quality=60)
+                    avif_made += 1
+        except Exception as e:  # noqa: BLE001 — keep going on individual failures
+            errors += 1
+            print(f"ERROR: {png_path.name}: {e}", file=sys.stderr)
+
+    print(
+        f"PNG inputs: {len(pngs)} | "
+        f"avif generated: {avif_made} | "
+        f"webp generated: {webp_made} | "
+        f"already complete: {skipped} | "
+        f"errors: {errors}"
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds an idempotent post-favicon, pre-\`jekyll build\` step in \`build.sh\` that scans \`assets/images/*_og.png\` and writes any missing \`_og.avif\` / \`_og.webp\` companion files via Pillow.

Together with PR #343 (conditional \`<source>\` emission) and PR #344 (one-shot backfill of 130 historical posts), this is the **forward-looking** half of the fix: every new post that lands an \`_og.png\` automatically gets modern-format companions on the next Vercel deploy, without anyone having to remember to run a script.

## Behavior

| Scenario | Cost |
|---|---|
| Steady-state build (full coverage) | Zero work — skip-if-exists |
| New post with only \`_og.png\` | Two Pillow encodes per missing variant |
| Pillow not installed | Logs warning, build continues (soft failure) |

Quality settings (\`WebP q=80\`, \`AVIF q=60\`) match \`scripts/regenerate_og_images.py\` so SVG → PNG → modern-format and PNG → modern-format paths produce consistent outputs.

## Files

- \`scripts/build/backfill_og_modern_variants.py\` (new, 80 lines, executable)
- \`build.sh\` (+11 lines, hook between favicon generation and Jekyll build)

No changes to existing scripts, no new CI jobs, no Vercel config changes.

## Test plan

- [x] Idempotency verified locally: re-run on already-complete state writes 0 files.
- [x] Cold-start verified locally: re-run on bare \`_og.png\` set generated 130 AVIF + 129 WebP in 41s.
- [x] Quality budget: AVIF ~12% of PNG bytes, WebP ~18% (matches script defaults elsewhere in the repo).
- [ ] Vercel preview build green on this PR — confirm log line \`PNG inputs: ... | avif generated: ... | webp generated: ...\`.
- [ ] Land after #344 so the steady-state hit is zero from the first deploy.