### PR TITLE
fix(blogwatcher): YAML-escape inner quotes in digest frontmatter

### DIFF
--- a/_posts/2026-05-03-Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability.md
+++ b/_posts/2026-05-03-Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability.md
@@ -1,16 +1,16 @@
 ---
 layout: post
-title: "중요한 cPanel 취약점이 "Sorry", Trellix, 승인되지 않은 저장소, ConsentFix v3 공격"
+title: "중요한 cPanel 취약점이 \"Sorry\", Trellix, 승인되지 않은 저장소, ConsentFix v3 공격"
 date: 2026-05-03 11:01:23 +0900
 categories: [security, devsecops]
 tags: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Ransomware, Azure, CVE, Vulnerability]
-excerpt: "중요한 cPanel 취약점이 "Sorry", Trellix, 승인되지 않은 저장소, ConsentFix v3 공격을 중심으로 2026년 05월 03일 주요 보안/기술 뉴스 15건과 대응 우선순위를 정리합니다. Ransomware, Azure, CVE 등 최신 위협 동향과 DevSecOps 실무 대응 방안을 함께 다룹니다."
-description: "2026년 05월 03일 보안 뉴스 요약. BleepingComputer, The Hacker News, Microsoft Security Blog 등 15건을 분석하고 중요한 cPanel 취약점이 "Sorry", Trellix, 승인되지 않은 저장소 등 DevSecOps 대응 포인트를 정리합니다."
+excerpt: "중요한 cPanel 취약점이 \"Sorry\", Trellix, 승인되지 않은 저장소, ConsentFix v3 공격을 중심으로 2026년 05월 03일 주요 보안/기술 뉴스 15건과 대응 우선순위를 정리합니다. Ransomware, Azure, CVE 등 최신 위협 동향과 DevSecOps 실무 대응 방안을 함께 다룹니다."
+description: "2026년 05월 03일 보안 뉴스 요약. BleepingComputer, The Hacker News, Microsoft Security Blog 등 15건을 분석하고 중요한 cPanel 취약점이 \"Sorry\", Trellix, 승인되지 않은 저장소 등 DevSecOps 대응 포인트를 정리합니다."
 keywords: [Security-Weekly, DevSecOps, Cloud-Security, Weekly-Digest, 2026, Ransomware, Azure, CVE]
 author: Twodragon
 comments: true
 image: /assets/images/2026-05-03-Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability.svg
-image_alt: "cPanel "Sorry", Trellix, ConsentFix v3 - security digest overview"
+image_alt: "cPanel \"Sorry\", Trellix, ConsentFix v3 - security digest overview"
 toc: true
 ---
 

--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -49,6 +49,25 @@ def _html_escape_quotes(text: str) -> str:
     return text.replace("&", "&amp;").replace('"', "&quot;").replace("'", "&#x27;")
 
 
+def _yaml_escape_dq(text: str) -> str:
+    """Escape a string for use inside a YAML double-quoted scalar.
+
+    YAML double-quoted scalars require backslash-escaping for both `\\` and
+    `"`. Unescaped inner `"` terminate the string early and Jekyll bails out
+    on the post with `did not find expected key while parsing a block
+    mapping at line 2 column 1`. This bit auto-published digest titles like:
+
+        title: "중요한 cPanel 취약점이 \"Sorry\", Trellix, ..."
+
+    where the inner Korean quote characters survived translation and broke
+    every downstream parser.
+
+    Order matters: escape `\\` first so we don't double-escape backslashes
+    we add for `"`.
+    """
+    return text.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _extract_meaningful_topics(news_items: List[Dict], mode: str = "security") -> str:
     if mode == "tech-blog":
         category_labels = {
@@ -923,19 +942,33 @@ def generate_post_content(
     # a single-quoted arg prematurely). Use double-quoted outer + entity encoding.
     safe_title = _html_escape_quotes(title_keywords)
 
+    # YAML frontmatter values are emitted inside double-quoted scalars; inner `"`
+    # characters (and stray `\`) must be backslash-escaped or Jekyll skips the
+    # whole post. Centralize the escape here rather than inside every builder so
+    # the contract is "builders return the natural string, the frontmatter site
+    # encodes it for YAML."
+    yaml_title = _yaml_escape_dq(title_keywords)
+    yaml_excerpt = _yaml_escape_dq(
+        _build_clean_excerpt(title_keywords, date_str, total, "security", topics)
+    )
+    yaml_description = _yaml_escape_dq(
+        _build_clean_description(title_keywords, source_list, date_str, total, "security")
+    )
+    yaml_image_alt = _yaml_escape_dq(_build_clean_image_alt(title_keywords, "security"))
+
     content = f'''---
 layout: post
-title: "{title_keywords}"
+title: "{yaml_title}"
 date: {date.strftime("%Y-%m-%d %H:%M:%S")} +0900
 categories: [security, devsecops]
 tags: [{", ".join(tags)}]
-excerpt: "{_build_clean_excerpt(title_keywords, date_str, total, "security", topics)}"
-description: "{_build_clean_description(title_keywords, source_list, date_str, total, "security")}"
+excerpt: "{yaml_excerpt}"
+description: "{yaml_description}"
 keywords: [{", ".join(tags[:8])}]
 author: Twodragon
 comments: true
 image: /assets/images/{image_filename}
-image_alt: "{_build_clean_image_alt(title_keywords, "security")}"
+image_alt: "{yaml_image_alt}"
 toc: true
 ---
 
@@ -1296,19 +1329,29 @@ def generate_tech_blog_content(
     # Escape quotes in title before Liquid injection (same guard as security template)
     safe_title = _html_escape_quotes(title_keywords)
 
+    # YAML double-quoted scalar escape — see security-mode block for rationale.
+    yaml_title = _yaml_escape_dq(f"기술 블로그 주간 다이제스트: {title_keywords}")
+    yaml_excerpt = _yaml_escape_dq(
+        _build_clean_excerpt(title_keywords, date_str, total, "tech", topics)
+    )
+    yaml_description = _yaml_escape_dq(
+        _build_clean_description(title_keywords, source_list, date_str, total, "tech")
+    )
+    yaml_image_alt = _yaml_escape_dq(_build_clean_image_alt(title_keywords, "tech"))
+
     content = f'''---
 layout: post
-title: "기술 블로그 주간 다이제스트: {title_keywords}"
+title: "{yaml_title}"
 date: {date.strftime("%Y-%m-%d %H:%M:%S")} +0900
 categories: [tech, devops]
 tags: [{", ".join(tags)}]
-excerpt: "{_build_clean_excerpt(title_keywords, date_str, total, "tech", topics)}"
-description: "{_build_clean_description(title_keywords, source_list, date_str, total, "tech")}"
+excerpt: "{yaml_excerpt}"
+description: "{yaml_description}"
 keywords: [{", ".join(tags[:8])}]
 author: Twodragon
 comments: true
 image: /assets/images/{image_filename}
-image_alt: "{_build_clean_image_alt(title_keywords, "tech")}"
+image_alt: "{yaml_image_alt}"
 toc: true
 ---
 

--- a/scripts/tests/test_blogwatcher_yaml_escape.py
+++ b/scripts/tests/test_blogwatcher_yaml_escape.py
@@ -1,0 +1,152 @@
+"""Regression tests for the YAML-escape fix in scripts.news.content_generator.
+
+Auto-published digest titles can contain Korean post-quoted phrases like
+\"Sorry\" — those inner double-quotes used to land directly inside the YAML
+frontmatter's double-quoted scalars and break Jekyll's parser with
+
+    YAML Exception ... did not find expected key while parsing a block
+    mapping at line 2 column 1
+
+(Real example: 2026-05-03-Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability.md)
+
+These tests pin the contract so the bug can't silently come back.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from news.content_generator import (  # noqa: E402
+    _yaml_escape_dq,
+    generate_post_content,
+)
+
+
+class TestYamlEscapeDq:
+    """The helper itself — quote/backslash escaping in double-quoted scalars."""
+
+    def test_escapes_inner_double_quote(self):
+        assert _yaml_escape_dq('cPanel "Sorry" 취약점') == 'cPanel \\"Sorry\\" 취약점'
+
+    def test_escapes_backslash_first(self):
+        # Backslashes must be escaped before quotes so we don't double-escape
+        # `\"` into `\\\"` and break parsing.
+        assert _yaml_escape_dq('path\\with\\backslash') == 'path\\\\with\\\\backslash'
+
+    def test_escapes_backslash_then_quote(self):
+        # Mixed input — both pass through correctly in either order.
+        assert _yaml_escape_dq(r'a\"b') == 'a\\\\\\"b'
+
+    def test_passes_through_plain_string(self):
+        assert _yaml_escape_dq("normal text without quotes") == "normal text without quotes"
+
+    def test_passes_through_korean_no_quotes(self):
+        # Korean post-quote characters (｜ 「 『 etc.) aren't ASCII " so they
+        # don't need escaping — verify we don't over-escape.
+        assert _yaml_escape_dq("한글 「인용」 텍스트") == "한글 「인용」 텍스트"
+
+
+class TestFrontmatterYamlRoundTrip:
+    """Integration: rendered post must yaml.safe_load cleanly even when the
+    upstream news payload contains adversarial quote characters.
+
+    The historical failure mode is that yaml.safe_load raises and Jekyll
+    silently skips the post — these tests catch that the moment a generator
+    change lets a bare `"` slip through.
+    """
+
+    @staticmethod
+    def _extract_frontmatter(content: str) -> dict:
+        # `---\n...\n---\n` envelope, take the inner block and load as YAML.
+        assert content.startswith("---\n"), "post must start with frontmatter delimiter"
+        end = content.index("\n---\n", 4)
+        return yaml.safe_load(content[4:end])
+
+    @pytest.fixture
+    def quote_laden_payload(self):
+        """News selection that mirrors the 2026-05-03 production failure —
+        title fragments injected from the upstream feed contain inner
+        double-quotes, which used to break the resulting frontmatter."""
+        date = datetime(2026, 5, 3, 11, 1, 23, tzinfo=timezone.utc)
+        selected = [
+            {
+                "title": 'Critical cPanel vulnerability "Sorry" exploit found',
+                "summary": "RCE chain bypassing auth.",
+                "url": "https://example.com/cpanel-sorry",
+                "source": "BleepingComputer",
+                "categories": ["security"],
+                "published": date,
+            },
+            {
+                "title": 'Trellix discovers "ConsentFix v3" attack',
+                "summary": "Adversary-in-the-middle phishing with browser injection.",
+                "url": "https://example.com/trellix",
+                "source": "The Hacker News",
+                "categories": ["security"],
+                "published": date,
+            },
+        ] * 8  # pad to >=15 to satisfy any min-news guards
+        return selected, date
+
+    def test_security_digest_yaml_parses_with_inner_quotes(self, quote_laden_payload):
+        selected, date = quote_laden_payload
+        categorized = {"security": selected, "devsecops": [], "cloud": [], "tech": []}
+        content = generate_post_content(
+            selected, categorized, date, "Ransomware Azure CVE Vulnerability"
+        )
+        # The bug: yaml.safe_load raises on unescaped inner `"`.
+        # The fix: round-trip succeeds and the parsed values still contain
+        # the literal quote characters from the source headlines.
+        fm = self._extract_frontmatter(content)
+        assert fm["layout"] == "post"
+        assert isinstance(fm["title"], str)
+        assert isinstance(fm["excerpt"], str)
+        assert isinstance(fm["description"], str)
+        assert isinstance(fm["image_alt"], str)
+
+    def test_no_bare_double_quote_inside_title_value(self, quote_laden_payload):
+        """Defense-in-depth: even if some other parser besides PyYAML reads
+        the file, the rendered `title:` line should never have an unescaped
+        `"` between its outer quotes."""
+        selected, date = quote_laden_payload
+        categorized = {"security": selected, "devsecops": [], "cloud": [], "tech": []}
+        content = generate_post_content(
+            selected, categorized, date, "Ransomware Azure CVE Vulnerability"
+        )
+        # Pull the literal title line as bytes (not yaml-parsed) and check
+        # quote balance: opening quote + escaped pairs + closing quote.
+        for line_prefix in ("title:", "excerpt:", "description:", "image_alt:"):
+            line = next(
+                line for line in content.splitlines() if line.startswith(line_prefix)
+            )
+            # Strip leading "title: " then check the remaining is a balanced
+            # double-quoted YAML scalar — count unescaped `"`.
+            value = line[len(line_prefix):].strip()
+            assert value.startswith('"') and value.endswith('"'), (
+                f"{line_prefix} value not wrapped in double-quotes: {line!r}"
+            )
+            inner = value[1:-1]
+            # An unescaped `"` is one preceded by zero or an even number of `\`
+            # — find any and assert there are none.
+            i = 0
+            while i < len(inner):
+                if inner[i] == '"':
+                    # walk back across `\` to determine escape parity
+                    bs_run = 0
+                    j = i - 1
+                    while j >= 0 and inner[j] == "\\":
+                        bs_run += 1
+                        j -= 1
+                    assert bs_run % 2 == 1, (
+                        f"unescaped `\"` at offset {i} in {line_prefix} value: {line!r}"
+                    )
+                i += 1


### PR DESCRIPTION
## Symptom

\`\_posts/2026-05-03-Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability.md\` failed every Jekyll build:

\`\`\`
YAML Exception reading _posts/2026-05-03-...
  did not find expected key while parsing a block mapping at line 2 column 1
\`\`\`

Production has been silently missing this post since May 3. Same generator code path emits the security and tech digests every day, so any incoming news headline with an inner \`\"\` is one outage away.

## Root cause

The auto-publish generator interpolates upstream news titles directly into the YAML frontmatter as double-quoted scalars:

\`\`\`yaml
title: \"중요한 cPanel 취약점이 \"Sorry\", Trellix, ...\"
\`\`\`

Inner \`\"\` terminate the scalar. Jekyll bails out and skips the post.

\`scripts/news/content_generator.py\` already had a sibling helper \`\_html_escape_quotes\` for Liquid attribute values, but YAML needs a different escape (backslash, not HTML entity) and was missing entirely.

## Fix

1. **\`\_yaml_escape_dq\` helper** in \`scripts/news/content_generator.py\`. Order-of-operations matters: escape \`\\\\\` first, then \`\"\`, so we don't double-escape backslashes added for quotes.
2. **Wrap interpolations at both frontmatter render sites:**
   - \`generate_post_content\` (security digest) — \`title\`, \`excerpt\`, \`description\`, \`image_alt\`
   - \`generate_tech_blog_content\` (tech digest) — same fields, including the \`\"기술 블로그 주간 다이제스트: \"\` prefix concatenation
3. **Hand-fix the 2026-05-03 post** so production renders it today; the next digest run will produce correct output natively.

## Tests (7 new, all passing)

| Class | Coverage |
|---|---|
| \`TestYamlEscapeDq\` | helper correctness — inner \`\"\`, backslash, mixed, Korean passthrough |
| \`TestFrontmatterYamlRoundTrip\` | full \`generate_post_content\` → \`yaml.safe_load\` round-trip with adversarial payload |
| \`TestFrontmatterYamlRoundTrip\` | defense-in-depth — every double-quoted YAML scalar in the rendered output has properly-balanced escape parity |

\`\`\`
1092 passed in 1.28s
\`\`\`

## Verification

After applying the fix to the existing 2026-05-03 post:

\`\`\`
$ bundle exec jekyll build --quiet --destination /tmp/jekyll-yaml-fix
(no errors)

$ ls /tmp/jekyll-yaml-fix/posts/2026/05/03/
Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability/
\`\`\`