### PR TITLE
ci(build): rasterize SVG covers without _og.png in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,6 +70,21 @@ if ! python3 scripts/generate_favicon.py; then
 fi
 
 # ---------------------------------------------------------------------------
+# Rasterize SVG cover images (image: /assets/images/foo.svg in any post's
+# front matter) that lack an _og.png companion. Must run BEFORE the modern-
+# variants step below — that one derives _og.{webp,avif} from _og.png, so
+# fresh PNGs from this step feed it within the same build.
+#
+# Backend cascade (rsvg-convert → cairosvg → soft-fail). A thin runtime
+# without librsvg keeps building; the only consequence is SVG-only posts
+# fall through to <img src="...svg"> via the is-svg-image class hook.
+# ---------------------------------------------------------------------------
+log "Rasterizing SVG covers without _og.png (skip-if-exists)..."
+if ! python3 scripts/build/rasterize_svg_covers.py; then
+    log "WARN: SVG → PNG rasterization reported errors; build continues with whatever covers exist on disk"
+fi
+
+# ---------------------------------------------------------------------------
 # Backfill _og.avif / _og.webp from any _og.png that lacks modern variants.
 # Idempotent (skip-if-exists), so steady-state builds add zero overhead;
 # only fires when a new post lands an _og.png without companion variants.

--- a/scripts/build/rasterize_svg_covers.py
+++ b/scripts/build/rasterize_svg_covers.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Rasterize SVG cover images that lack an _og.png companion.
+
+Idempotent — skips covers whose _og.png already exists. Designed to run
+in build.sh between favicon generation and backfill_og_modern_variants.py
+so the modern-variants hook then derives _og.{webp,avif} from the fresh
+PNGs in the same build.
+
+Backend cascade (first available wins):
+  1. `rsvg-convert` CLI (librsvg) — preferred. Local dev usually has it
+     via Homebrew (`brew install librsvg`). CI runners install with
+     `apt-get install -y librsvg2-bin` (Debian/Ubuntu).
+  2. `cairosvg` Python — works when system libcairo is available.
+  3. Soft-fail with a warning and zero exit. The build keeps going on
+     thin runtimes (e.g. Vercel without librsvg) — the only consequence
+     is that SVG-only posts ship without an _og.png that build, and the
+     <picture> in _layouts/post.html falls through to the SVG via the
+     existing `is-svg-image` class hook (PR #348).
+
+"Cover" definition: an SVG referenced by `image:` in a post's front
+matter. This is intentionally narrower than just "any SVG without an
+_og.png" — the repo also ships dozens of inline diagram SVGs used in
+post bodies (devsecops-learning-path, EC2_G7e_GPU_Architecture, etc.)
+that should NOT get an _og.png companion.
+
+Output dimensions are 1200×630 — matches Open Graph spec, the SVG cover
+viewBox we ship for L20 Hero+2-Card, and what scripts/regenerate_og_images.py
+already uses, so downstream PNG → AVIF/WebP encodings stay consistent.
+
+Exit codes:
+  0  success or no work to do
+  1  one or more conversions raised an exception (other covers still
+     produced)
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMG_DIR = REPO_ROOT / "assets" / "images"
+POSTS_DIR = REPO_ROOT / "_posts"
+
+OG_WIDTH = 1200
+OG_HEIGHT = 630
+
+# Match `image: /assets/images/foo.svg` (with or without surrounding quotes)
+# as a top-level YAML scalar in the first ~3000 bytes of a post.
+_IMAGE_FRONTMATTER_RE = re.compile(
+    r"^image:\s*['\"]?(?P<path>[^\s'\"]+\.svg)['\"]?\s*$",
+    re.MULTILINE,
+)
+
+
+def _cover_svgs_from_frontmatter() -> set[Path]:
+    """Collect every SVG referenced as `image:` in any post's front matter.
+
+    This is the authoritative cover set — anything else under
+    assets/images/*.svg is an inline diagram or section asset and must
+    NOT receive an _og.png companion.
+    """
+    covers: set[Path] = set()
+    if not POSTS_DIR.is_dir():
+        return covers
+    for post in POSTS_DIR.glob("*.md"):
+        try:
+            head = post.read_text(errors="replace")[:3000]
+        except OSError:
+            continue
+        m = _IMAGE_FRONTMATTER_RE.search(head)
+        if not m:
+            continue
+        # Front-matter paths are site-absolute (start with /); resolve
+        # relative to repo root.
+        rel = m.group("path").lstrip("/")
+        covers.add(REPO_ROOT / rel)
+    return covers
+
+
+def _candidates() -> list[Path]:
+    """Return SVG covers that exist on disk but lack an _og.png companion."""
+    out = []
+    for svg in sorted(_cover_svgs_from_frontmatter()):
+        if not svg.is_file():
+            continue  # broken front-matter reference; not our problem
+        png = IMG_DIR / f"{svg.stem}_og.png"
+        if not png.exists():
+            out.append(svg)
+    return out
+
+
+def _convert_via_rsvg(svg: Path, png: Path) -> None:
+    subprocess.run(
+        [
+            "rsvg-convert",
+            "-w", str(OG_WIDTH),
+            "-h", str(OG_HEIGHT),
+            "-o", str(png),
+            str(svg),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _convert_via_cairosvg(svg: Path, png: Path) -> None:
+    import cairosvg  # imported lazily so missing libcairo is a soft fail
+    cairosvg.svg2png(
+        url=str(svg),
+        write_to=str(png),
+        output_width=OG_WIDTH,
+        output_height=OG_HEIGHT,
+    )
+
+
+def _pick_backend():
+    if shutil.which("rsvg-convert"):
+        return "rsvg-convert", _convert_via_rsvg
+    try:
+        import cairosvg  # noqa: F401  — probe only
+        return "cairosvg", _convert_via_cairosvg
+    except Exception:  # noqa: BLE001 — libcairo missing is the common case
+        return None, None
+
+
+def main() -> int:
+    if not IMG_DIR.is_dir():
+        print(f"ERROR: {IMG_DIR} not found", file=sys.stderr)
+        return 1
+
+    candidates = _candidates()
+    if not candidates:
+        print("SVG covers: 0 missing _og.png (nothing to do)")
+        return 0
+
+    backend, convert = _pick_backend()
+    if backend is None:
+        print(
+            f"WARN: rsvg-convert and cairosvg both unavailable — "
+            f"skipping SVG → PNG rasterization for {len(candidates)} cover(s). "
+            f"Install librsvg2-bin (apt) / librsvg (brew) to enable. "
+            f"Posts will fall through to <img src=\"...svg\"> via the "
+            f"is-svg-image hero class hook."
+        )
+        return 0
+
+    generated = errors = 0
+    for svg in candidates:
+        png = IMG_DIR / f"{svg.stem}_og.png"
+        try:
+            convert(svg, png)
+            generated += 1
+        except subprocess.CalledProcessError as e:
+            errors += 1
+            stderr = (e.stderr or "").strip().splitlines()
+            tail = stderr[-1] if stderr else "(no stderr)"
+            print(f"ERROR: {svg.name}: {tail}", file=sys.stderr)
+        except Exception as e:  # noqa: BLE001
+            errors += 1
+            print(f"ERROR: {svg.name}: {e}", file=sys.stderr)
+
+    print(
+        f"SVG → PNG rasterization via {backend}: "
+        f"candidates={len(candidates)} generated={generated} errors={errors}"
+    )
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_rasterize_svg_covers.py
+++ b/scripts/tests/test_rasterize_svg_covers.py
@@ -1,0 +1,136 @@
+"""Tests for scripts/build/rasterize_svg_covers.py.
+
+The script must:
+  1. Treat as a "cover" only an SVG that some post references via
+     `image:` in its front matter — never an inline diagram SVG.
+  2. Skip when the _og.png companion already exists (idempotent).
+  3. Soft-fail when no rasterization backend is available, so the
+     build.sh hook keeps the deploy moving on Vercel-style runtimes
+     that lack librsvg + system libcairo.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "build" / "rasterize_svg_covers.py"
+
+
+@pytest.fixture
+def rasterize_module(tmp_path, monkeypatch):
+    """Load rasterize_svg_covers.py with REPO_ROOT pointed at a temp tree."""
+    posts = tmp_path / "_posts"
+    images = tmp_path / "assets" / "images"
+    posts.mkdir(parents=True)
+    images.mkdir(parents=True)
+
+    spec = importlib.util.spec_from_file_location("rasterize_svg_covers", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["rasterize_svg_covers"] = module
+    spec.loader.exec_module(module)
+
+    monkeypatch.setattr(module, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "IMG_DIR", images)
+    monkeypatch.setattr(module, "POSTS_DIR", posts)
+    return module, tmp_path
+
+
+class TestCoverDiscovery:
+    """Front-matter scan must isolate covers from inline-diagram SVGs."""
+
+    def test_only_svgs_referenced_in_frontmatter_are_covers(
+        self, rasterize_module
+    ):
+        module, root = rasterize_module
+        # Post with an SVG cover
+        (root / "_posts" / "2026-05-01-foo.md").write_text(
+            "---\n"
+            "layout: post\n"
+            "title: foo\n"
+            "image: /assets/images/2026-05-01-foo.svg\n"
+            "---\n"
+        )
+        # Inline diagram SVG (NOT referenced by any image:)
+        (root / "assets" / "images" / "2026-05-01-foo.svg").write_text("<svg/>")
+        (root / "assets" / "images" / "inline-diagram.svg").write_text("<svg/>")
+
+        covers = module._cover_svgs_from_frontmatter()
+
+        assert {p.name for p in covers} == {"2026-05-01-foo.svg"}
+        assert "inline-diagram.svg" not in {p.name for p in covers}
+
+    def test_quoted_frontmatter_paths_are_picked_up(self, rasterize_module):
+        module, root = rasterize_module
+        (root / "_posts" / "p.md").write_text(
+            '---\nimage: "/assets/images/quoted.svg"\n---\n'
+        )
+        (root / "assets" / "images" / "quoted.svg").write_text("<svg/>")
+        covers = module._cover_svgs_from_frontmatter()
+        assert {p.name for p in covers} == {"quoted.svg"}
+
+    def test_png_image_does_not_produce_cover(self, rasterize_module):
+        module, root = rasterize_module
+        (root / "_posts" / "p.md").write_text(
+            "---\nimage: /assets/images/already-png.png\n---\n"
+        )
+        covers = module._cover_svgs_from_frontmatter()
+        assert covers == set()
+
+    def test_candidates_excludes_covers_with_existing_png(self, rasterize_module):
+        module, root = rasterize_module
+        # Cover that already has _og.png — skip
+        (root / "_posts" / "p.md").write_text(
+            "---\nimage: /assets/images/done.svg\n---\n"
+        )
+        (root / "assets" / "images" / "done.svg").write_text("<svg/>")
+        (root / "assets" / "images" / "done_og.png").write_bytes(b"\x89PNG\r\n")
+
+        # Cover that does not — include
+        (root / "_posts" / "q.md").write_text(
+            "---\nimage: /assets/images/todo.svg\n---\n"
+        )
+        (root / "assets" / "images" / "todo.svg").write_text("<svg/>")
+
+        candidate_names = [p.name for p in module._candidates()]
+        assert candidate_names == ["todo.svg"]
+
+
+class TestSoftFailWithoutBackend:
+    """Build.sh contract: missing librsvg + cairosvg must NOT fail the build."""
+
+    def test_main_returns_zero_when_no_backend_available(
+        self, rasterize_module, monkeypatch, capsys
+    ):
+        module, root = rasterize_module
+        # One real candidate
+        (root / "_posts" / "p.md").write_text(
+            "---\nimage: /assets/images/cold.svg\n---\n"
+        )
+        (root / "assets" / "images" / "cold.svg").write_text("<svg/>")
+
+        # Pretend neither backend is installed
+        monkeypatch.setattr(module, "_pick_backend", lambda: (None, None))
+
+        rc = module.main()
+        out = capsys.readouterr().out
+
+        assert rc == 0, "must soft-fail so build.sh doesn't abort the deploy"
+        assert "WARN" in out
+        assert "cold.svg" not in out  # don't dump the candidate list — just the count
+        assert "1 cover" in out or "1 cover(s)" in out
+
+
+class TestNoWorkPath:
+    """Steady-state: nothing missing → no backend probe needed."""
+
+    def test_main_returns_zero_when_nothing_to_do(self, rasterize_module, capsys):
+        module, _ = rasterize_module
+        rc = module.main()
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "nothing to do" in out


### PR DESCRIPTION
## Summary

Forward-looking complement to PR #348 (which hand-backfilled \`_og.png\` for 3 May 2026 SVG-only posts). This PR adds a build.sh step that does the same automatically on every deploy, so a future SVG-only post never ships broken.

## Hook order

\`\`\`
favicon
  ↓
rasterize_svg_covers  (NEW — generates _og.png from cover SVGs)
  ↓
backfill_og_modern_variants  (existing — derives _og.{webp,avif} from _og.png)
  ↓
jekyll build
\`\`\`

The order matters: PNG → modern-variants happens in the same build, so a brand-new SVG cover ends up with all four files (\`.svg\`, \`_og.png\`, \`_og.webp\`, \`_og.avif\`) without anyone running scripts manually.

## Cover scoping (subtle)

\"Cover\" = an SVG whose path appears as \`image: /assets/images/foo.svg\` in some post's front matter.

The naive scope (\"any SVG without an \`_og.png\`\") would have generated **31 unwanted PNGs** in a local dry-run for inline diagram SVGs (\`devsecops-learning-path\`, \`EC2_G7e_GPU_Architecture\`, \`Network_Segmentation_Architecture\`, ...) that are used in post bodies, not as covers. The frontmatter scan is the discriminator.

## Backend cascade with soft-fail

| Backend | Where it works | Trigger |
|---|---|---|
| \`rsvg-convert\` CLI | local dev (\`brew install librsvg\`), Debian/Ubuntu CI (\`apt-get install -y librsvg2-bin\`) | always preferred |
| \`cairosvg\` Python | environments with system libcairo | fallback if rsvg-convert missing |
| WARN + zero exit | Vercel-style thin runtimes | both above missing |

On the soft-fail path the build keeps going. SVG-only posts then ship as \`<img src=\"...svg\">\` via the \`is-svg-image\` hero hook from #348 — visible, just no native AVIF/WebP for that one cover.

## Tests (6 new)

| Test | Why |
|---|---|
| \`test_only_svgs_referenced_in_frontmatter_are_covers\` | the 31-unwanted-PNGs bug |
| \`test_quoted_frontmatter_paths_are_picked_up\` | \`image: \"...\"\` form |
| \`test_png_image_does_not_produce_cover\` | non-SVG \`image:\` short-circuits |
| \`test_candidates_excludes_covers_with_existing_png\` | idempotency |
| \`test_main_returns_zero_when_no_backend_available\` | build.sh contract |
| \`test_main_returns_zero_when_nothing_to_do\` | steady-state |

\`\`\`
1098 passed in 1.14s
\`\`\`

## Local verification

\`\`\`
$ python3 scripts/build/rasterize_svg_covers.py
SVG covers: 0 missing _og.png (nothing to do)

$ mv assets/images/2026-04-30-..._og.png /tmp/bak
$ python3 scripts/build/rasterize_svg_covers.py
SVG → PNG rasterization via rsvg-convert: candidates=1 generated=1 errors=0
\`\`\`