### PR TITLE
docs: escape-sink matrix (YAML / HTML attr / SVG text) + .cursorrules rule

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -395,6 +395,24 @@ aws ec2 describe-instances --region us-east-1 --profile my-secret-profile
 - 비교표: Before/After, 솔루션 비교
 - 차트: 데이터 시각화 (필요시)
 
+### Escape 정책: 하나의 sink, 하나의 인코딩 (Karpathy rule)
+
+자동 발행 파이프라인은 같은 포스트 안에서 세 개의 서로 다른 파서로 텍스트를 흘려보냅니다. 각 sink 의 grammar 가 다르므로 인코딩을 섞으면 silent build failure 또는 깨진 렌더가 발생합니다.
+
+| Sink | Helper | 적용 위치 |
+|---|---|---|
+| YAML scalar (frontmatter) | `_yaml_escape_dq` | `title:` `excerpt:` `description:` `image_alt:` |
+| HTML attribute (Liquid include arg) | `_html_escape_quotes` | `{% include card.html title="..." %}` |
+| SVG `<text>` element | `_escape_svg_text` | `<text>...</text>` `<title>` `<desc>` `aria-label="..."` |
+
+**규칙:**
+1. **Sink 의 경계에서 단 한 번만 escape**. 빌더 내부에서 escape 하지 않음 — 같은 값이 두 sink 에 들어갈 때 한 sink 의 인코딩이 다른 sink 에 새는 걸 방지.
+2. **`.replace('"', '\\"')` 같은 inline escape 금지** — 위의 helper 만 사용. helper 가 escape 순서 (backslash 먼저, ampersand 먼저) 를 캡슐화함.
+3. **HTML entity 를 YAML 에 넣지 않음**. `&quot;Sorry&quot;` 가 그대로 렌더됨 — 독자에게 보이는 문자가 됨.
+4. **새 필드 추가 시**: 목적지 sink 식별 → 표에서 helper 선택 → adversarial 입력으로 yaml/xml/html 라운드트립 회귀 테스트 추가 (`scripts/tests/test_blogwatcher_yaml_escape.py` 참고).
+
+상세 매트릭스, 과거 실패 사례, anti-pattern 은 `docs/guides/escape-policy.md` 참조.
+
 ## 보안 관련 작성 규칙
 
 ### 민감 정보 처리

--- a/docs/guides/escape-policy.md
+++ b/docs/guides/escape-policy.md
@@ -1,0 +1,133 @@
+# Escape policy: which sink, which encoding
+
+**Last updated:** 2026-05-04
+
+The auto-publish pipeline (`scripts/news/content_generator.py`) injects
+upstream news headlines and AI-generated text into three different parsers
+in the same generated post. Each parser has its own grammar; mixing the
+encodings up has produced silent build failures (Jekyll skipping a post)
+and broken image renders in the past.
+
+This page is the canonical reference for which encoding to use where.
+**One rule:** values get encoded once, *at the boundary between the
+generator and the sink* — never inside the data pipeline itself.
+
+## The three sinks
+
+| # | Sink | Helper | Maps |
+|---|---|---|---|
+| 1 | **YAML scalar** (post frontmatter) | `_yaml_escape_dq` | `\` → `\\`, then `"` → `\"` |
+| 2 | **HTML attribute** (Liquid `{% include %}` arg) | `_html_escape_quotes` | `&` → `&amp;`, `"` → `&quot;`, `'` → `&#x27;` |
+| 3 | **SVG `<text>` element** | `_escape_svg_text` | `&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `'` → `&#39;` |
+
+The helpers all live in `scripts/news/content_generator.py` (or
+`scripts/news/svg_generator.py` for #3), keep them imported from there
+rather than reinventing per file.
+
+## When to use which
+
+### 1) YAML scalar — frontmatter
+
+```yaml
+---
+title: "{{ value }}"
+excerpt: "{{ value }}"
+---
+```
+
+The Jekyll YAML parser terminates a double-quoted scalar at the first
+unescaped `"`. **Korean post-quoted phrases like `"Sorry"` and `"퇴행적"`
+flow straight through translation and break the scalar.** When that
+happens Jekyll silently skips the entire post:
+
+```
+YAML Exception ... did not find expected key while parsing a block
+mapping at line 2 column 1
+```
+
+The fix is `_yaml_escape_dq`: `\` first (so we don't double-escape
+backslashes added later for `"`), then `"`.
+
+**Apply to**: `title`, `excerpt`, `description`, `image_alt`, and any
+other free-text frontmatter field.
+
+### 2) HTML attribute — Liquid include args
+
+```liquid
+{% include ai-summary-card.html
+  title="{{ value }}"
+  ...
+%}
+```
+
+The Liquid parser terminates a double-quoted attribute on the first
+unescaped `"`. Single quotes break the same way in `'…'` form. The
+blast radius is smaller than YAML because Jekyll only fails the
+include, not the post — but the rendered card breaks visually.
+
+The fix is `_html_escape_quotes`: HTML entity encode all four risky
+characters at once. Order matters: `&` first so existing entities don't
+get double-escaped into `&amp;quot;` etc.
+
+**Apply to**: every value injected into a Liquid `include` attribute,
+HTML attribute, or anywhere else where HTML entities are decoded for
+you by the consumer (i.e. browsers and Liquid).
+
+### 3) SVG `<text>` — banner / cover graphics
+
+```xml
+<text x="60" y="120">{{ value }}</text>
+```
+
+SVG is XML, so the parser cares about `<` and `>` as well as the quote
+characters. An unescaped `<` cuts the `<text>` content short and the
+SVG either renders garbled or fails to parse altogether. CI's SVG XML
+well-formedness gate catches this before commit, but only if the
+generator escapes correctly.
+
+The fix is `_escape_svg_text`: full XML entity set. **In addition**,
+`_to_english_svg_text` strips non-ASCII letters because the SVG cover
+templates only embed Latin-script fonts — Korean text inside `<text>`
+nodes would render as tofu boxes.
+
+**Apply to**: every dynamic value emitted inside an SVG element body,
+including `<title>`, `<text>`, `<desc>`, and any attribute that contains
+text content (`aria-label="..."`, `data-*="..."`).
+
+## Anti-patterns
+
+- **HTML entities into YAML.** A `&quot;` in a YAML title shows up as
+  the literal six characters in the rendered page — readers see
+  "&quot;Sorry&quot;" instead of "\"Sorry\"". HTML entity encoding
+  belongs only in the HTML / Liquid / SVG sinks, never in YAML.
+- **Single-pass escape across multiple sinks.** Don't try to construct
+  an escape that satisfies all three at once — there's no single
+  encoding that's safe for both YAML scalars (which want backslashes)
+  and HTML/SVG (which want entities). Keep the value untouched in the
+  builder, encode at the sink.
+- **Hand-coding `.replace('"', '\\"')`.** Use the helpers; they centralize
+  the escape order (backslash before quote, ampersand before
+  quote-as-entity) so a future contributor can't get the order wrong
+  in copy-paste.
+
+## Real failure modes (history)
+
+| Date | Sink | Symptom | Fix |
+|---|---|---|---|
+| 2026-05-03 | YAML | Whole post skipped: "did not find expected key while parsing block mapping" | PR #349 — `_yaml_escape_dq` |
+| (ongoing) | HTML | Liquid include rendered with truncated arg when title contains `'` | `_html_escape_quotes` |
+| (CI gate) | SVG | Pre-commit hook fails: "not well-formed XML" | `_escape_svg_text` + `_to_english_svg_text` |
+
+## When adding a new field
+
+1. Identify the **destination sink** of the rendered output:
+   - `_posts/*.md` frontmatter → YAML
+   - `<picture>` / `<source>` / Liquid `include` arg → HTML attribute
+   - `assets/images/*.svg` `<text>` → SVG/XML
+2. Pick the matching helper from the table above.
+3. Wrap the value at the single point where it crosses into the sink:
+   `f'title: "{_yaml_escape_dq(value)}"'`, not deeper in the builder.
+4. Add a regression test that round-trips an adversarial input through
+   the relevant parser (`yaml.safe_load`, `xml.etree.ElementTree.fromstring`,
+   etc.). See `scripts/tests/test_blogwatcher_yaml_escape.py` for the
+   shape that's worked well in this repo.


### PR DESCRIPTION
## Why

The auto-publish pipeline (\`scripts/news/content_generator.py\`) injects upstream news headlines into **three different parsers in the same generated post**:

| Sink | Parser | Helper |
|---|---|---|
| YAML scalar (post frontmatter) | Jekyll/PyYAML | \`_yaml_escape_dq\` |
| HTML attribute (Liquid \`include\` arg) | Liquid | \`_html_escape_quotes\` |
| SVG \`<text>\` element | XML | \`_escape_svg_text\` |

Each parser has its own grammar. Mixing the encodings up has **already** produced silent build failures in production:

- **2026-05-03** — \`\"Sorry\"\` in a title leaked into a YAML scalar → Jekyll skipped the whole post for a week (PR #349 fixed the helper, but the rule was nowhere written down)
- **HTML attr** — the same kind of bug for inner \`'\` in titles is currently risky every time a non-engineer edits Liquid templates
- **SVG \`<text>\`** — XML well-formedness gate at pre-commit is the only thing keeping that one honest today

This PR makes the policy **discoverable before the next bug**.

## What

1. **\`docs/guides/escape-policy.md\`** — canonical reference (~130 lines). Three-sink matrix, why-each-character-differs explanation, history of real failure modes, anti-patterns, and a 4-step add-a-new-field checklist.

2. **\`.cursorrules\`** — short Karpathy-style rule appended to the existing SVG section. Encoded matrix table, four do/don't lines, pointer to the long doc. This puts the policy in the LLM's working context whenever someone is editing \`content_generator.py\` or templates.

3. **No code changes.** The three helpers (\`_yaml_escape_dq\`, \`_html_escape_quotes\`, \`_escape_svg_text\`) are already in place from earlier PRs (#349 + the existing SVG generator). This PR only makes the policy explicit.

## The rule (one-line version)

> One sink, one encoding, applied at the boundary between the generator and the sink — never inside the data pipeline itself.

## Test plan

Documentation-only — no runnable tests. The existing test suites that pin each helper's behavior (\`scripts/tests/test_blogwatcher_yaml_escape.py\` for YAML, the SVG XML well-formedness gate for SVG) continue to enforce the contract.