### PR TITLE
feat(build): cairosvg OS-independent SVG rasterizer fallback

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -25,7 +25,7 @@ TTS>=0.20.0; python_version < "3.14"
 
 # 비디오/SVG 처리 (선택적)
 moviepy>=1.0.3
-cairosvg>=2.5.0
+cairosvg>=2.7.0,<3.0
 
 # AWS 아키텍처 다이어그램 생성
 diagrams>=0.23.0

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "chmod +x build.sh && ./build.sh",
   "outputDirectory": "_site",
   "crons": [],
-  "installCommand": "(python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow || pip3 install --quiet --no-cache-dir --break-system-packages Pillow || true) && npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
+  "installCommand": "(python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || pip3 install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || true) && npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
   "build": {
     "env": {
       "LANG": "C.UTF-8",


### PR DESCRIPTION
## Summary

Vercel 빌드 환경 확정 결과(AL2023, no apt)에 따라 `cairosvg`를 OS-독립 폴백으로 핀합니다.

## Verified build environment (probe/vercel-os branch, deleted)

| Item | Result |
|------|--------|
| OS | **Amazon Linux 2023** (`PRETTY_NAME="Amazon Linux 2023"`) |
| Package managers | `dnf` + `yum` 존재, ❌ `apt-get` / `dpkg` 없음 |
| `librsvg2-tools` | NOT pre-installed (rsvg-convert 부재) |
| `cairosvg` | NOT pre-installed |
| `librsvg2` 베이스 | `librsvg2-2.50.7` 설치되어 있음 (도구만 부재) |

## Changes

- `scripts/requirements.txt`: `cairosvg>=2.5.0` → `cairosvg>=2.7.0,<3.0` (lower bound 상향, 메이저 락)
- `vercel.json` `installCommand`: pip 인스톨에 `'cairosvg>=2.7.0,<3.0'` 추가 (Pillow 옆)

## Why cairosvg

PR #350 (`scripts/build/rasterize_svg_covers.py`) 의 backend cascade:
1. `rsvg-convert` (librsvg2-tools, OS 패키지) — 부재
2. `cairosvg` (Python, pip 으로 OS-독립 설치) — **이 PR 로 활성화**
3. soft-fail (SVG 그대로 fallthrough)

cairosvg 는 시스템 `libcairo` 에 의존하지만, AL2023 base image 에 이미 `libcairo` 가 포함되어 있어(`yum`/`dnf`로 설치된 시스템 라이브러리) pip 설치 후 즉시 동작합니다.

## Test plan

- [x] `pip install 'cairosvg>=2.7.0,<3.0'` — 로컬 macOS 정상
- [x] `python3 scripts/build/rasterize_svg_covers.py` — rsvg-convert 우선 경로 정상 (1 generated)
- [ ] Vercel preview 빌드에서 cairosvg 폴백 동작 확인 (이 PR 의 preview 빌드 로그)
- [ ] CI 통과 후 머지

## Related

- Probe branch (deleted): `probe/vercel-os`
- 후속 작업 (별도 PR 예정): Vercel installCommand 에 `dnf install -y librsvg2-tools` 추가하여 rsvg-convert 도 1순위로 활성화