### PR TITLE
feat(build): install librsvg2-tools on Vercel (AL2023, stacked on #353)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "chmod +x build.sh && ./build.sh",
   "outputDirectory": "_site",
   "crons": [],
-  "installCommand": "(python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || pip3 install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || true) && npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
+  "installCommand": "(dnf install -y --quiet librsvg2-tools 2>/dev/null || yum install -y --quiet librsvg2-tools 2>/dev/null || true) && (python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || pip3 install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' || true) && npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
   "build": {
     "env": {
       "LANG": "C.UTF-8",


### PR DESCRIPTION
## Summary

- Prepends `dnf install -y --quiet librsvg2-tools` (with `yum` fallback and `|| true` soft-fail) to the Vercel `installCommand` in `vercel.json`.
- On AL2023 the base library `librsvg2-2.50.7` is pre-installed but the binary package `librsvg2-tools` (which provides the `rsvg-convert` CLI) is not. This PR closes that gap.
- **Stacked on #353** (cairosvg fallback). After both PRs merge the full cascade in `scripts/build/rasterize_svg_covers.py` is:
  1. `rsvg-convert` (system binary, AL2023 dnf — cascade priority 1)
  2. `cairosvg` (pip fallback — cascade priority 2)
  3. soft-fail (no PNG, build continues)

## Changed files

- `vercel.json` — `installCommand` line only (1-line diff)

## Design decisions

- `dnf` first, `yum` fallback: both work on AL2023; `dnf` is the preferred package manager.
- `--quiet` keeps the build log clean.
- `2>/dev/null || true` is a **soft-fail guard**: if the AL2023 image ever changes its repo layout, the build falls through to the `cairosvg` pip step rather than failing the entire install.
- No changes to `scripts/build/rasterize_svg_covers.py` — the cascade logic was already correct.

## Test plan

- [ ] Merge #353 first (or verify this stacks cleanly on it)
- [ ] Trigger a Vercel preview build and confirm `rsvg-convert` resolves in the build log
- [ ] Confirm SVG → PNG rasterization succeeds for at least one post cover image
- [ ] Confirm build does not fail if `librsvg2-tools` install step is skipped (soft-fail path)