### PR TITLE
fix(mobile): remove duplicate top padding above post category

### DIFF
--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -3224,7 +3224,8 @@ ins.adsbygoogle-noablate {
 @media (max-width: 767px) {
   .post-article {
     max-width: 100%;
-    padding: 1.25rem 1rem;
+    /* Top padding removed: .main-content already supplies 1.5rem above */
+    padding: 0 1rem 1.25rem;
   }
   
   .post-header {
@@ -3460,7 +3461,7 @@ ins.adsbygoogle-noablate {
 /* === SMALL MOBILE (< 480px) === */
 @media (max-width: 479px) {
   .post-article {
-    padding: 1rem 0.875rem;
+    padding: 0 0.875rem 1rem;
   }
   
   .post-title {


### PR DESCRIPTION
## Issue

모바일 웹에서 포스트에 들어가면 카테고리 / Twodragon (author) 위에 과도한 상단 공백 발생.

## Root cause

`.post-article` 가 모바일 breakpoint 에서 자체적으로 top padding 을 추가하는데, 그 위에 `.main-content` 가 이미 top padding 을 두고 있어 중복 누적됨:

| Breakpoint | .main-content top | .post-article top | Total |
|------------|-------------------|-------------------|-------|
| Mobile (480-767px) | 1.5rem (24px) | 1.25rem (20px) | **44px** |
| Small mobile (<480px) | 1.5rem (24px) | 1rem (16px) | **40px** |
| Desktop (≥768px) | 3rem (48px) | 2.5rem (40px) | 88px |

데스크톱은 화면이 넓어 88px 이 자연스럽지만, 모바일 viewport 에서 44px 은 카테고리 badge 가 보이기 전 빈 공간으로 인식됨.

## Fix

`_sass/_post.scss` 모바일 두 breakpoint 의 `.post-article` 상단 padding 을 0 으로. `.main-content` 의 1.5rem 만으로 sticky site header 와의 breathing room 확보.

```diff
@media (max-width: 767px) {
   .post-article {
-    padding: 1.25rem 1rem;
+    padding: 0 1rem 1.25rem;
   }

@media (max-width: 479px) {
   .post-article {
-    padding: 1rem 0.875rem;
+    padding: 0 0.875rem 1rem;
   }
```

## Result

| Breakpoint | After fix |
|------------|-----------|
| Mobile (480-767px) | **24px** (-20px) |
| Small mobile (<480px) | **24px** (-16px) |
| Desktop | 88px (unchanged) |

데스크톱에는 영향 없음. 좌우/하단 padding 은 그대로 유지.

## Test plan

- [ ] Mobile Chrome: post 진입 시 카테고리 badge 가 main-content 시작점 근처에서 시작
- [ ] iPhone 14 viewport (390×844): category 위 공백 ~24px 확인
- [ ] Small mobile (320×568): 동일하게 ~24px 확인
- [ ] Desktop (≥768px): 변화 없음 확인
- [ ] CI green