### PR TITLE
feat(build): --backend CLI flag + cascade unit tests for rasterize_svg_covers.py

### DIFF
--- a/scripts/build/rasterize_svg_covers.py
+++ b/scripts/build/rasterize_svg_covers.py
@@ -34,6 +34,7 @@ Exit codes:
 """
 from __future__ import annotations
 
+import argparse
 import re
 import shutil
 import subprocess
@@ -117,17 +118,79 @@ def _convert_via_cairosvg(svg: Path, png: Path) -> None:
     )
 
 
-def _pick_backend():
-    if shutil.which("rsvg-convert"):
+def _pick_backend(force: str | None = None):
+    """Return (backend_name, convert_callable) for the requested backend.
+
+    Parameters
+    ----------
+    force:
+        ``None`` or ``"auto"``  — existing cascade: rsvg-convert → cairosvg
+                                  → (None, None) soft-fail.
+        ``"rsvg-convert"``       — only try rsvg; hard-fail (SystemExit 1) if
+                                   rsvg-convert is not on PATH.
+        ``"cairosvg"``           — only try cairosvg; hard-fail (SystemExit 1)
+                                   if the import fails.
+    """
+    if force in (None, "auto"):
+        # Original cascade — soft-fail when neither is available.
+        if shutil.which("rsvg-convert"):
+            return "rsvg-convert", _convert_via_rsvg
+        try:
+            import cairosvg  # noqa: F401  — probe only
+            return "cairosvg", _convert_via_cairosvg
+        except Exception:  # noqa: BLE001 — libcairo missing is the common case
+            return None, None
+
+    if force == "rsvg-convert":
+        if not shutil.which("rsvg-convert"):
+            print(
+                "ERROR: --backend rsvg-convert requested but rsvg-convert is not "
+                "on PATH. Install librsvg2-bin (apt) or librsvg (brew).",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
         return "rsvg-convert", _convert_via_rsvg
-    try:
-        import cairosvg  # noqa: F401  — probe only
-        return "cairosvg", _convert_via_cairosvg
-    except Exception:  # noqa: BLE001 — libcairo missing is the common case
-        return None, None
+
+    if force == "cairosvg":
+        try:
+            import cairosvg  # noqa: F401  — probe only
+            return "cairosvg", _convert_via_cairosvg
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"ERROR: --backend cairosvg requested but import failed: {exc}. "
+                "Install cairosvg (pip) and ensure libcairo is available.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    # Should never reach here; argparse choices= guards this.
+    raise ValueError(f"Unknown backend: {force!r}")
 
 
-def main() -> int:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rasterize SVG cover images to _og.png companions.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--backend",
+        choices=["auto", "rsvg-convert", "cairosvg"],
+        default="auto",
+        help=(
+            "Rasterization backend to use. "
+            "'auto' (default) tries rsvg-convert then cairosvg and soft-fails "
+            "if neither is available. "
+            "'rsvg-convert' and 'cairosvg' force that backend and exit 1 if "
+            "it is unavailable."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    force = None if args.backend == "auto" else args.backend
+
     if not IMG_DIR.is_dir():
         print(f"ERROR: {IMG_DIR} not found", file=sys.stderr)
         return 1
@@ -137,7 +200,7 @@ def main() -> int:
         print("SVG covers: 0 missing _og.png (nothing to do)")
         return 0
 
-    backend, convert = _pick_backend()
+    backend, convert = _pick_backend(force=force)
     if backend is None:
         print(
             f"WARN: rsvg-convert and cairosvg both unavailable — "
@@ -171,4 +234,4 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tests/test_rasterize_svg_covers.py
+++ b/scripts/tests/test_rasterize_svg_covers.py
@@ -7,13 +7,17 @@ The script must:
   3. Soft-fail when no rasterization backend is available, so the
      build.sh hook keeps the deploy moving on Vercel-style runtimes
      that lack librsvg + system libcairo.
+  4. --backend flag forces a specific tier (rsvg-convert, cairosvg, auto)
+     and hard-fails (exit 1) when the forced backend is unavailable.
 """
 
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -38,6 +42,21 @@ def rasterize_module(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "IMG_DIR", images)
     monkeypatch.setattr(module, "POSTS_DIR", posts)
     return module, tmp_path
+
+
+def _make_cover_post(root: Path, stem: str) -> Path:
+    """Write a minimal post with an SVG cover and return the SVG path."""
+    posts = root / "_posts"
+    images = root / "assets" / "images"
+    posts.mkdir(parents=True, exist_ok=True)
+    images.mkdir(parents=True, exist_ok=True)
+    (posts / f"2026-05-01-{stem}.md").write_text(
+        f"---\nlayout: post\ntitle: {stem}\n"
+        f"image: /assets/images/{stem}.svg\n---\n"
+    )
+    svg = images / f"{stem}.svg"
+    svg.write_text("<svg xmlns='http://www.w3.org/2000/svg'><rect width='1' height='1'/></svg>")
+    return svg
 
 
 class TestCoverDiscovery:
@@ -113,10 +132,10 @@ class TestSoftFailWithoutBackend:
         )
         (root / "assets" / "images" / "cold.svg").write_text("<svg/>")
 
-        # Pretend neither backend is installed
-        monkeypatch.setattr(module, "_pick_backend", lambda: (None, None))
+        # Pretend neither backend is installed (force=None → auto cascade)
+        monkeypatch.setattr(module, "_pick_backend", lambda force=None: (None, None))
 
-        rc = module.main()
+        rc = module.main([])
         out = capsys.readouterr().out
 
         assert rc == 0, "must soft-fail so build.sh doesn't abort the deploy"
@@ -130,7 +149,196 @@ class TestNoWorkPath:
 
     def test_main_returns_zero_when_nothing_to_do(self, rasterize_module, capsys):
         module, _ = rasterize_module
-        rc = module.main()
+        rc = module.main([])
         out = capsys.readouterr().out
         assert rc == 0
         assert "nothing to do" in out
+
+
+# ---------------------------------------------------------------------------
+# New tests for --backend flag
+# ---------------------------------------------------------------------------
+
+
+class TestPickBackendAuto:
+    """_pick_backend(force=None) / force='auto' — cascade behaviour."""
+
+    def test_auto_picks_rsvg_when_available(self, rasterize_module, monkeypatch):
+        """Test 1: auto with rsvg available → picks rsvg."""
+        module, _ = rasterize_module
+        monkeypatch.setattr(module.shutil, "which", lambda name: "/usr/bin/rsvg-convert" if name == "rsvg-convert" else None)
+        name, fn = module._pick_backend(force=None)
+        assert name == "rsvg-convert"
+        assert fn is module._convert_via_rsvg
+
+    def test_auto_falls_through_to_cairosvg_when_rsvg_missing(
+        self, rasterize_module, monkeypatch
+    ):
+        """Test 2: auto with rsvg unavailable, cairosvg available → picks cairosvg."""
+        module, _ = rasterize_module
+        monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+        fake_cairosvg = MagicMock()
+        with patch.dict(sys.modules, {"cairosvg": fake_cairosvg}):
+            name, fn = module._pick_backend(force=None)
+
+        assert name == "cairosvg"
+        assert fn is module._convert_via_cairosvg
+
+    def test_auto_returns_none_when_both_unavailable(
+        self, rasterize_module, monkeypatch
+    ):
+        """Test 3: auto with both unavailable → soft-fail returns (None, None)."""
+        module, _ = rasterize_module
+        monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+        # Ensure cairosvg import fails
+        with patch.dict(sys.modules, {"cairosvg": None}):
+            # Remove cairosvg from sys.modules to force ImportError
+            sys.modules.pop("cairosvg", None)
+            name, fn = module._pick_backend(force=None)
+
+        assert name is None
+        assert fn is None
+
+
+class TestPickBackendForced:
+    """_pick_backend(force=...) — hard-fail when backend is unavailable."""
+
+    def test_force_rsvg_exits_1_when_rsvg_missing(
+        self, rasterize_module, monkeypatch, capsys
+    ):
+        """Test 4: --backend rsvg-convert with rsvg unavailable → exit 1 with clear stderr."""
+        module, _ = rasterize_module
+        monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            module._pick_backend(force="rsvg-convert")
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "rsvg-convert" in err
+        assert "ERROR" in err
+
+    def test_force_cairosvg_exits_1_when_import_fails(
+        self, rasterize_module, monkeypatch, capsys
+    ):
+        """Test 5: --backend cairosvg with cairosvg import failing → exit 1 with clear stderr."""
+        module, _ = rasterize_module
+
+        # Patch the builtins.__import__ to raise ImportError for cairosvg
+        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "cairosvg":
+                raise ImportError("No module named 'cairosvg'")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            # Remove cairosvg from sys.modules cache so import is attempted fresh
+            sys.modules.pop("cairosvg", None)
+            with pytest.raises(SystemExit) as exc_info:
+                module._pick_backend(force="cairosvg")
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "cairosvg" in err
+        assert "ERROR" in err
+
+    def test_force_rsvg_succeeds_and_returns_callable(
+        self, rasterize_module, monkeypatch
+    ):
+        """Test 6: --backend rsvg-convert with rsvg available → returns correct callable."""
+        module, _ = rasterize_module
+        monkeypatch.setattr(
+            module.shutil, "which", lambda name: "/usr/bin/rsvg-convert" if name == "rsvg-convert" else None
+        )
+
+        name, fn = module._pick_backend(force="rsvg-convert")
+
+        assert name == "rsvg-convert"
+        assert fn is module._convert_via_rsvg
+
+
+class TestBackendFlagArgparse:
+    """Argparse integration — --backend flag is wired end-to-end."""
+
+    def test_invalid_backend_exits_2(self, rasterize_module):
+        """Test 7: invalid --backend foo → argparse error exit 2."""
+        module, _ = rasterize_module
+
+        with pytest.raises(SystemExit) as exc_info:
+            module._parse_args(["--backend", "foo"])
+
+        assert exc_info.value.code == 2
+
+    def test_help_flag_shows_backend_choices(self, rasterize_module, capsys):
+        """--help output includes the --backend flag and its choices."""
+        module, _ = rasterize_module
+
+        with pytest.raises(SystemExit):
+            module._parse_args(["--help"])
+
+        out = capsys.readouterr().out
+        assert "--backend" in out
+        assert "rsvg-convert" in out
+        assert "cairosvg" in out
+
+    def test_default_backend_is_auto(self, rasterize_module):
+        """Passing no flags gives backend='auto'."""
+        module, _ = rasterize_module
+        args = module._parse_args([])
+        assert args.backend == "auto"
+
+    def test_main_with_backend_rsvg_and_no_rsvg_exits_1(
+        self, rasterize_module, monkeypatch, capsys
+    ):
+        """End-to-end: main(--backend rsvg-convert) with rsvg absent → exit 1."""
+        module, root = rasterize_module
+        _make_cover_post(root, "cover-a")
+        monkeypatch.setattr(module.shutil, "which", lambda name: None)
+
+        with pytest.raises(SystemExit) as exc_info:
+            module.main(["--backend", "rsvg-convert"])
+
+        assert exc_info.value.code == 1
+
+    def test_main_with_backend_auto_and_rsvg_available_converts(
+        self, rasterize_module, monkeypatch, capsys, tmp_path
+    ):
+        """End-to-end: main(--backend auto) with rsvg available → calls convert fn."""
+        module, root = rasterize_module
+        svg = _make_cover_post(root, "cover-b")
+
+        monkeypatch.setattr(
+            module.shutil, "which",
+            lambda name: "/usr/bin/rsvg-convert" if name == "rsvg-convert" else None,
+        )
+
+        # Mock the convert function so we don't actually invoke rsvg-convert
+        converted_calls = []
+
+        def fake_convert(s, p):
+            converted_calls.append((s, p))
+            p.write_bytes(b"\x89PNG\r\n\x1a\n")  # minimal PNG header
+
+        monkeypatch.setattr(module, "_convert_via_rsvg", fake_convert)
+
+        # Re-patch _pick_backend to use the fake converter
+        orig_pick = module._pick_backend
+
+        def patched_pick(force=None):
+            name, fn = orig_pick(force=force)
+            if name == "rsvg-convert":
+                return name, fake_convert
+            return name, fn
+
+        monkeypatch.setattr(module, "_pick_backend", patched_pick)
+
+        rc = module.main(["--backend", "auto"])
+        out = capsys.readouterr().out
+
+        assert rc == 0
+        assert len(converted_calls) == 1
+        assert converted_calls[0][0] == svg
+        assert "rsvg-convert" in out


### PR DESCRIPTION
## Summary

- Add `--backend {auto,rsvg-convert,cairosvg}` CLI flag to `scripts/build/rasterize_svg_covers.py`
- `auto` (default) preserves existing soft-fail cascade unchanged
- `rsvg-convert` / `cairosvg` force that backend and exit 1 if unavailable
- Refactor `_pick_backend()` to accept `force: str | None` parameter; extract `_parse_args()` for testability
- Add 11 new pytest tests in `test_rasterize_svg_covers.py` covering every cascade tier and edge case

## Test plan

- [ ] `pytest scripts/tests/test_rasterize_svg_covers.py -v` — 17 passed (6 pre-existing + 11 new)
- [ ] `pytest scripts/tests/` — 1131 passed, 0 failed, no regression
- [ ] `python3 scripts/build/rasterize_svg_covers.py --help` — flag visible with choices
- [ ] `python3 scripts/build/rasterize_svg_covers.py --backend auto` — exits 0
- [ ] `python3 scripts/build/rasterize_svg_covers.py --backend rsvg-convert` — exits 0 on macOS with Homebrew librsvg
- [ ] `python3 scripts/build/rasterize_svg_covers.py --backend foo` — exits 2 (argparse error)