### PR TITLE
fix(build): move install logic to build.sh (vercel installCommand 256-char limit, supersedes #353 #354)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,26 @@ log "  LANG: $LANG"
 log "  LC_ALL: $LC_ALL"
 
 # ---------------------------------------------------------------------------
+# Vercel-side build dependencies (AL2023 / RPM-based image only).
+# Moved out of vercel.json installCommand to stay under its 256-char hard
+# limit. The dnf/yum guard means this block silently skips on macOS / CI
+# Ubuntu runners where the same dependencies are pre-installed via Homebrew
+# (rsvg) or the workflow's apt-get step.
+# ---------------------------------------------------------------------------
+if command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+    log "Installing Vercel build dependencies (RPM-based runtime detected)..."
+    # rsvg-convert (cascade priority 1 for rasterize_svg_covers.py)
+    (dnf install -y --quiet librsvg2-tools 2>/dev/null \
+     || yum install -y --quiet librsvg2-tools 2>/dev/null \
+     || true)
+    # Pillow (favicon) + cairosvg (cascade priority 2 fallback)
+    (python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' 2>/dev/null \
+     || pip3 install --quiet --no-cache-dir --break-system-packages Pillow 'cairosvg>=2.7.0,<3.0' 2>/dev/null \
+     || true)
+    log "  rsvg-convert: $(command -v rsvg-convert 2>/dev/null || echo 'not installed (cascade falls through to cairosvg)')"
+fi
+
+# ---------------------------------------------------------------------------
 # Noto Sans KR woff2 subset regeneration (conditional, graceful failure)
 # ---------------------------------------------------------------------------
 if [ -f "scripts/build/generate_noto_2tier_subset.py" ]; then

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -25,7 +25,7 @@ TTS>=0.20.0; python_version < "3.14"
 
 # 비디오/SVG 처리 (선택적)
 moviepy>=1.0.3
-cairosvg>=2.5.0
+cairosvg>=2.7.0,<3.0
 
 # AWS 아키텍처 다이어그램 생성
 diagrams>=0.23.0

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "chmod +x build.sh && ./build.sh",
   "outputDirectory": "_site",
   "crons": [],
-  "installCommand": "(python3 -m pip install --quiet --no-cache-dir --break-system-packages Pillow || pip3 install --quiet --no-cache-dir --break-system-packages Pillow || true) && npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
+  "installCommand": "npm ci || npm install && bundle install --full-index --jobs 4 --retry 3",
   "build": {
     "env": {
       "LANG": "C.UTF-8",


### PR DESCRIPTION
## Issue

PR #353 (`feat/cairosvg-fallback`) Vercel preview 빌드 실패. 조사 결과 **Vercel `vercel.json` 의 `installCommand` 는 256자 하드 리밋**이 있고, cairosvg 추가로 277자가 되어 schema validation 단계에서 거부됨.

| Branch | installCommand 길이 | 결과 |
|--------|--------------------|------|
| main (이전) | 231자 | OK |
| #353 (cairosvg 추가) | **277자** | ❌ schema fail |
| #354 (#353 + dnf librsvg2-tools) | **393자** | ❌ schema fail |

Vercel 응답: \`The vercel.json schema validation failed with the following message: installCommand should NOT be longer than 256 characters\`

## Solution

설치 로직을 \`build.sh\` 로 이전. \`vercel.json\` \`installCommand\` 는 npm/bundle 만 남겨 71자로 축소.

### Changes

1. **`vercel.json` `installCommand`**: 231자 → **71자**
   ```diff
   - "installCommand": "(python3 -m pip install --quiet ... Pillow || pip3 install ... Pillow || true) && npm ci || npm install && bundle install ..."
   + "installCommand": "npm ci || npm install && bundle install --full-index --jobs 4 --retry 3"
   ```

2. **`build.sh`**: 환경 정보 출력 직후, Noto 폰트 단계 전에 dnf/yum 가드된 설치 블록 추가
   ```bash
   if command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
       # AL2023 / RPM-based image only — local/Ubuntu CI 는 자동 skip
       (dnf install -y --quiet librsvg2-tools || yum ... || true)
       (python3 -m pip install ... Pillow 'cairosvg>=2.7.0,<3.0' || pip3 ... || true)
   fi
   ```

3. **`scripts/requirements.txt`**: \`cairosvg>=2.5.0\` → \`cairosvg>=2.7.0,<3.0\` (build.sh 와 일치, major lock)

## Result

- Vercel installCommand: 71자 (headroom 185자)
- AL2023 환경에서: rsvg-convert + cairosvg 둘 다 설치되어 \`rasterize_svg_covers.py\` cascade priority 1 (rsvg-convert) 적중
- 로컬 macOS / Ubuntu CI: dnf/yum 부재로 install 블록 자동 skip — 회귀 없음

## Test plan

- [x] \`bash -n build.sh\` — syntax OK
- [x] \`python3 -c \"import json; json.load(open('vercel.json'))\"\` — JSON valid
- [x] installCommand 길이: 71자 (256 한도 이내)
- [ ] Vercel preview 빌드 통과 확인 (이 PR 의 preview 빌드)
- [ ] preview 빌드 로그에서 \`rsvg-convert: /usr/bin/rsvg-convert\` 출력 확인
- [ ] CI green 확인 후 머지

## Disposition for #353 / #354

- **PR #353**: close (이 PR 로 superseded)
- **PR #354**: close (이 PR 로 superseded, AL2023 dnf 로직 포함됨)

## References

- Investigation: 256-char 한도는 Vercel schema 에러로 확인 (Vercel bot 의 PR #354 코멘트)
- AL2023 OS 사실: \`probe/vercel-os\` 검증 결과 (memory: \`vercel_build_env.md\`)