### PR TITLE
chore(seo): googlebot access probe script for Attack Challenge Mode

### DIFF
--- a/.github/workflows/googlebot-access-monitor.yml
+++ b/.github/workflows/googlebot-access-monitor.yml
@@ -1,0 +1,109 @@
+name: Googlebot Access Monitor
+
+# Daily probe of the production site as Googlebot. Alerts via Slack when
+# Vercel Attack Challenge Mode (or any other crawler-blocking config) is
+# detected, since that silently kills GSC indexing.
+#
+# Background: 2026-05-04 incident — Attack Challenge Mode was re-enabled
+# in the Vercel dashboard, blocking Googlebot with HTTP 429 + challenge
+# header on every URL including sitemap.xml. GSC reported 0 impressions
+# until the mode was disabled. See
+# docs/troubleshooting/VERCEL_SECURITY_CHECKPOINT_FIX.md.
+
+on:
+  schedule:
+    - cron: "0 2 * * *"  # 02:00 UTC = 11:00 KST daily
+  workflow_dispatch:
+
+concurrency:
+  group: googlebot-access-monitor
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          fetch-depth: 1
+
+      - name: Probe production site as Googlebot
+        id: probe
+        shell: bash
+        run: |
+          set +e
+          bash scripts/check_googlebot_access.sh "https://tech.2twodragon.com" \
+            > /tmp/probe.txt 2>&1
+          status=$?
+          set -e
+          {
+            echo 'output<<PROBE_EOF'
+            cat /tmp/probe.txt
+            echo 'PROBE_EOF'
+          } >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          cat /tmp/probe.txt
+          exit $status
+
+      - name: Notify Slack on failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          PROBE_OUTPUT: ${{ steps.probe.outputs.output }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
+            echo "::warning::SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not configured, skipping notification"
+            exit 0
+          fi
+          payload=$(python3 -c '
+          import json, os
+          probe = os.environ.get("PROBE_OUTPUT", "(no output)")
+          run_url = os.environ.get("RUN_URL", "")
+          channel = os.environ.get("SLACK_CHANNEL_ID", "")
+          message = (
+              ":rotating_light: *Googlebot access probe failed*\n"
+              "tech.2twodragon.com is returning HTTP 429 / challenge to "
+              "Googlebot. Likely cause: Vercel Attack Challenge Mode is "
+              "enabled — disable at "
+              "https://vercel.com/twodragon0s-projects/tech-blog/settings/security\n"
+              f"Run: {run_url}\n"
+              f"```\n{probe[-1500:]}\n```"
+          )
+          print(json.dumps({
+              "channel": channel,
+              "text": message,
+              "unfurl_links": False,
+              "unfurl_media": False,
+          }, ensure_ascii=False))
+          ')
+          HTTP_STATUS=$(curl -sS -o /tmp/slack_resp.txt -w "%{http_code}" \
+            "https://slack.com/api/chat.postMessage" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$payload")
+          echo "Slack response: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            ok=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("ok",""))')
+            if [ "$ok" = "True" ]; then
+              echo "Slack notification sent successfully"
+            else
+              error=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("error","unknown"))')
+              echo "::warning::Slack API error: $error"
+            fi
+          else
+            echo "::warning::Slack HTTP error (HTTP $HTTP_STATUS)"
+            cat /tmp/slack_resp.txt || true
+          fi

--- a/scripts/check_googlebot_access.sh
+++ b/scripts/check_googlebot_access.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Verify the production site is accessible to Googlebot.
+#
+# Run after disabling Vercel Attack Challenge Mode to confirm GSC will be
+# able to crawl and index pages. Exits 0 when all probes return HTTP 200,
+# non-zero when any probe returns 429/challenge or other error.
+#
+# Usage:
+#   bash scripts/check_googlebot_access.sh
+#
+# Background:
+#   When Attack Challenge Mode is enabled, every URL returns
+#   `HTTP 429` + `x-vercel-mitigated: challenge`, blocking Googlebot from
+#   reading the sitemap or any post page. See
+#   docs/troubleshooting/VERCEL_SECURITY_CHECKPOINT_FIX.md.
+
+set -uo pipefail
+
+DOMAIN="${1:-https://tech.2twodragon.com}"
+UA="Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+
+# Probe paths: homepage, sitemap, robots.txt, one recent post.
+declare -a PATHS=(
+  "/"
+  "/sitemap.xml"
+  "/robots.txt"
+  "/posts/2026/05/03/Tech_Security_Weekly_Digest_Ransomware_Azure_CVE_Vulnerability/"
+)
+
+fail=0
+echo "Probing ${DOMAIN} as Googlebot..."
+echo
+
+for path in "${PATHS[@]}"; do
+  url="${DOMAIN}${path}"
+  # Capture status code and the mitigation header in one request.
+  response="$(curl -sIL -A "$UA" -o /dev/null -w "%{http_code}" "$url" 2>/dev/null || echo "000")"
+  mitigation="$(curl -sIL -A "$UA" "$url" 2>/dev/null | grep -i "^x-vercel-mitigated" | tr -d '\r' || true)"
+
+  if [ "$response" = "200" ]; then
+    printf "  [OK]    %s  %s\n" "$response" "$path"
+  else
+    printf "  [FAIL]  %s  %s\n" "$response" "$path"
+    if [ -n "$mitigation" ]; then
+      printf "          %s\n" "$mitigation"
+    fi
+    fail=1
+  fi
+done
+
+echo
+if [ "$fail" = "0" ]; then
+  echo "All probes 200. Googlebot can crawl the site."
+  exit 0
+else
+  cat <<'EOF'
+At least one probe failed.
+If responses include x-vercel-mitigated: challenge, Attack Challenge Mode
+is still enabled. Disable it at:
+  https://vercel.com/<team>/<project>/settings/security
+See docs/troubleshooting/VERCEL_SECURITY_CHECKPOINT_FIX.md for details.
+EOF
+  exit 1
+fi


### PR DESCRIPTION
## Why

2026-05-04 GSC 보고: `tech.2twodragon.com` 노출 0회. 동일 계정의 `investing.2twodragon.com` 는 정상.

진단 결과:
- 모든 URL 이 `HTTP 429` + `x-vercel-mitigated: challenge` 응답
- Googlebot 도 sitemap.xml 조차 읽지 못함 → 신규 콘텐츠 발견 불가
- 원인: **Vercel Attack Challenge Mode 가 재활성화됨**

이 이슈는 이미 `docs/troubleshooting/VERCEL_SECURITY_CHECKPOINT_FIX.md` (2026-01-26) 에 문서화되어 있고, 사용자가 Vercel 대시보드에서 끄면 해결됨. 이 PR 은 **재발 자동 탐지** 수단을 추가합니다.

## What

### 1. `scripts/check_googlebot_access.sh`

홈/sitemap/robots.txt/최근 포스트 4개 URL 을 Googlebot UA 로 호출. 모두 200 이면 exit 0, 하나라도 challenge 응답이면 exit 1 + 진단 메시지.

```bash
bash scripts/check_googlebot_access.sh
```

### 2. `.github/workflows/googlebot-access-monitor.yml`

매일 02:00 UTC (11:00 KST) 에 1번 자동 probe + 실패 시 Slack 알림. `workflow_dispatch` 로 수동 실행도 가능.

- 기존 `slack-post-notify.yml` 와 동일한 `SLACK_BOT_TOKEN` / `SLACK_CHANNEL_ID` 시크릿 사용 — 추가 자격증명 불필요
- 시크릿 미설정 시 graceful skip (워크플로우는 여전히 Actions 탭에서 fail 표시)
- 알림 메시지에 Vercel 보안 설정 페이지 deep link 포함

## Test

- [x] 현재 (Challenge Mode 켜진 상태): 4개 URL 모두 FAIL 보고 ✅ 의도대로
- [x] YAML lint: `python3 -c "import yaml; yaml.safe_load(...)"` 통과
- [ ] 사용자가 Vercel 대시보드에서 Disable → 재실행 시 모두 OK
- [ ] CI 통과
- [ ] Manual workflow_dispatch 1회 트리거 후 Actions 탭에서 동작 확인

## Related

- `docs/troubleshooting/VERCEL_SECURITY_CHECKPOINT_FIX.md` (기존 가이드, 2026-01-26)
- `docs/seo/GSC_INDEXING_FIXES.md` (2026-04-30 색인 실패 분석)
- Memory: `feedback_vercel_challenge_mode.md` (이 세션 추가)

## Follow-up (사용자 작업)

1. https://vercel.com/twodragon0s-projects/tech-blog/settings/security → **Attack Challenge Mode: Disabled**
2. `bash scripts/check_googlebot_access.sh` 로 검증 (모두 200)
3. GSC > Sitemaps > `https://tech.2twodragon.com/sitemap.xml` 재제출
4. GSC > URL 검사 → 우선순위 포스트 5-10건 색인 요청
5. 본 PR 머지 후 Actions 탭에서 `Googlebot Access Monitor` workflow_dispatch 1회 실행해 알림 동작 검증

## 후속 (별도 PR)

126 not-indexed digest 분석 결과 (이 세션):
- Weekly digest **93건** 중 H2 boilerplate 13개가 ≥50% 포스트에서 반복
- excerpt Jaccard 0.75+ 페어 5건 발견 (auto generator 의 boilerplate 문장 재사용)
- **Strategy B (월간 rollup, 4/month)** 채택 시 93 → 20건 (-78%) 압축 가능
- 별도 PR 로 March Monthly_Index 패턴을 1/2월에 백필 + auto_publish_news.py excerpt 다양화 예정