### PR TITLE
feat(content): backfill January & February 2026 monthly digest index posts

### DIFF
--- a/_posts/2026-01-31-January_2026_Security_Digest_Monthly_Index.md
+++ b/_posts/2026-01-31-January_2026_Security_Digest_Monthly_Index.md
@@ -1,0 +1,72 @@
+---
+layout: post
+title: "2026년 1월 보안 다이제스트 월간 인덱스"
+date: 2026-01-31 23:59:00 +0900
+categories: [security, devsecops]
+tags: [monthly-index, security-news, weekly-digest, 2026]
+excerpt: "2026년 1월 한 달간 발행된 보안 주간 다이제스트 종합 인덱스. Microsoft AitM 피싱·VMware KEV·Zero-Day 긴급 패치부터 AI 에이전트 보안 위협·OT 공격까지 총 9개 다이제스트를 주차별로 정리하여 월간 보안 트렌드와 핵심 대응 포인트를 실무 관점에서 한눈에 파악할 수 있도록 구성합니다."
+description: "2026년 1월 한 달간 발행된 보안 주간 다이제스트 종합 인덱스. Microsoft AitM 피싱·VMware KEV·Zero-Day 긴급 패치부터 AI 에이전트 보안 위협·OT 공격까지 총 9개 다이제스트를 주차별로 정리하여 월간 보안 트렌드와 핵심 대응 포인트를 실무 관점에서 한눈에 파악할 수 있도록 구성합니다."
+keywords: [monthly-index, security-news, weekly-digest, 2026, DevSecOps, Cloud-Security, Zero-Trust, AI-Security]
+author: Twodragon
+comments: true
+image: /assets/images/2026-01-31-January_2026_Security_Digest_Monthly_Index.svg
+toc: true
+---
+
+{% include ai-summary-card.html
+  title='2026년 1월 보안 다이제스트 월간 인덱스'
+  categories_html='<span class="category-tag security">보안</span> <span class="category-tag devsecops">DevSecOps</span>'
+  tags_html='<span class="tag">monthly-index</span>
+      <span class="tag">security-news</span>
+      <span class="tag">weekly-digest</span>
+      <span class="tag">2026</span>'
+  highlights_html='<li><strong>월간 종합</strong>: 2026년 1월 발행 보안 다이제스트 핵심 이슈 인덱싱</li>
+      <li><strong>위협 동향</strong>: AitM 피싱, VMware KEV, IoT 봇넷, OT 시스템 공격 집중 정리</li>
+      <li><strong>운영 포인트</strong>: Zero-Day 긴급 패치, AI 에이전트 NHI 관리, Kubernetes 보안 대응 확인</li>'
+  period='2026년 1월 월간 인덱스'
+  audience='보안 담당자, DevSecOps 엔지니어, SRE, 클라우드 아키텍트'
+%}
+
+---
+
+## 개요
+
+2026년 1월은 AI 에이전트 보안이 실무 어젠다로 본격 부상한 달이었습니다. HashiCorp의 비인간 ID(NHI) Zero Trust 전략 발표, OpenAI PostgreSQL 8억 사용자 스케일링 아키텍처 공개와 맞물려 인프라 공격 표면이 확장되는 추세가 뚜렷했습니다. 동시에 VMware vCenter KEV 긴급 패치, Microsoft Office Zero-Day CVE-2026-21509, Sandworm APT의 폴란드 전력망 공격, ShinyHunters 비싱(Vishing) MFA 우회 등 재래식 위협도 한층 정교해졌습니다. 총 9개 다이제스트를 통해 기술 취약점, APT 동향, AI 보안 거버넌스, OT/ICS 공격 등 다층적 위협을 다뤘습니다.
+
+---
+
+## 4주차 (1/23 ~ 1/31)
+
+> 1월 다이제스트는 월말 집중 발행 패턴으로 구성되어 있습니다.
+
+| 날짜 | 주제 | 링크 |
+|------|------|------|
+| 1월 23일 | Microsoft AitM 피싱, HashiCorp Agentic AI Zero Trust NHI 관리, OpenAI PostgreSQL 스케일링 | [바로가기](/posts/2026/01/23/Tech_Security_Weekly_Digest_Microsoft_AitM_Phishing_Agentic_AI_Zero_Trust_OpenAI_PostgreSQL/) |
+| 1월 24일 | Microsoft FBI BitLocker 암호화 복구 키 논란, Cloudflare BGP Route Leak, CNCF 자율 기업 플랫폼 제어 | [바로가기](/posts/2026/01/24/Tech_Security_Weekly_Digest_BitLocker_FBI_Cloudflare_Route_Leak_Agentic_Enterprise_Docker/) |
+| 1월 25일 | CISA KEV VMware vCenter CVE-2024-37079 긴급 패치, Fortinet FortiCloud SSO 우회 제로데이, Sandworm DynoWiper | [바로가기](/posts/2026/01/25/Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents/) |
+| 1월 26일 | HashiCorp NHI Zero Trust 전략, Chrome Gemini Nano 온디바이스 기술지원 사기 탐지, Terraform Stacks | [바로가기](/posts/2026/01/26/Tech_Security_Weekly_Digest_Zero_Trust_Agentic_AI_Chrome_Tech_Support_Scam_Terraform_Stacks/) |
+| 1월 27일 | Microsoft Office CVE-2026-21509 Zero-Day 긴급 패치, Kimwolf/Badbox 2.0 IoT 봇넷 200만 기기 감염, AWS EC2 G7e | [바로가기](/posts/2026/01/27/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_Kimi_K25_Kimwolf_Botnet_AWS_G7e/) |
+| 1월 28일 | CVE-2026-21509 긴급 패치 방법, CTEM 5단계 프레임워크 실무 적용, Grist-Core RCE 취약점 분석 | [바로가기](/posts/2026/01/28/Tech_Security_Weekly_Digest_MS_Office_Zero_Day_CTEM_Grist_Core_RCE/) |
+| 1월 29일 | n8n 워크플로우 RCE(CVE-2026-1470, CVSS 9.9), D-Link 단종 장비 Zero-Day, Kubernetes AI 에이전트 보안 | [바로가기](/posts/2026/01/29/Tech_Security_Weekly_Digest_n8n_RCE_D_Link_Zero_Day_Kubernetes_AI_Agent/) |
+| 1월 30일 | Ollama AI 서버 175,000대 인터넷 노출(LLMjacking), SolarWinds Web Help Desk RCE 6건, Google IPIDEA 차단 | [바로가기](/posts/2026/01/30/Tech_Security_Weekly_Digest_Ollama_AI_SolarWinds_RCE_Google_IPIDEA/) |
+| 1월 31일 | ShinyHunters 비싱 MFA 우회, 악성 Chrome 확장 ChatGPT 토큰 탈취, CERT Polska OT 시스템 공격 탐지 | [바로가기](/posts/2026/01/31/Tech_Security_Weekly_Digest_ShinyHunters_Vishing_Chrome_Extension_OT_Attack/) |
+
+---
+
+## 월간 주요 트렌드
+
+- **AI 에이전트 보안의 실무화**: HashiCorp의 NHI(비인간 ID) Zero Trust 발표와 Chrome Gemini Nano 온디바이스 탐지 출시로 AI 에이전트가 단순 개발 도구를 넘어 보안 아키텍처의 핵심 변수로 자리잡기 시작했습니다. Kubernetes AI 에이전트 보안 과제도 병행 등장하며 에이전트 권한 최소화와 토큰 수명 관리가 현안 과제로 부각됐습니다.
+- **LLMjacking 위협 구체화**: Ollama AI 서버 175,000대가 인터넷에 무방비로 노출된 사실이 확인되면서, 공격자가 노출된 AI 추론 엔드포인트를 무단으로 점유해 GPU 연산 비용을 전가하는 LLMjacking 수법이 실제 위협으로 가시화됐습니다. AI 인프라를 운영하는 조직이라면 인터넷 노출 포트 감사를 즉시 수행해야 합니다.
+- **국가 지원 APT의 OT 공격 확대**: Sandworm APT가 DynoWiper를 활용해 폴란드 전력망을 공격한 사례는 OT/ICS 환경의 사이버-물리 위협이 유럽 전반으로 확산 중임을 보여줍니다. CERT Polska가 30개 이상 풍력·태양광 시스템 공격을 탐지·보고하면서 에너지 인프라 보안 강화의 시급성이 재확인됐습니다.
+- **MFA 우회와 소셜 엔지니어링 고도화**: ShinyHunters의 비싱(Vishing) 공격은 전화 기반 MFA 우회 기법을 Mandiant가 공식 발표한 첫 사례로, 기업 MFA 정책 설계가 음성 채널 공격을 고려해야 함을 시사합니다. 악성 Chrome 확장을 통한 ChatGPT 인증 토큰 탈취 사례도 함께 부각되며 브라우저 확장 관리 정책의 강화가 필요합니다.
+- **CVE 패치 속도 경쟁 심화**: VMware vCenter KEV 추가, Fortinet FortiCloud SSO 우회, Microsoft Office CVE-2026-21509, n8n RCE(CVSS 9.9), SolarWinds RCE 6건이 1주일 안에 집중되면서 패치 우선순위 결정 프레임워크(CVSS + KEV 여부 + 노출 범위) 운영이 실무 필수 역량이 됐습니다.
+
+---
+
+## 통계
+
+- **총 발행 포스트**: 9개
+- **커버 기간**: 2026년 1월 23일 ~ 1월 31일
+- **주요 키워드**: AitM 피싱, VMware KEV, Zero-Trust, AI 에이전트, LLMjacking, OT 공격, MFA 우회, IoT 봇넷, n8n RCE, CTEM
+- **주요 위협 행위자**: Sandworm APT, ShinyHunters, Kimwolf/Badbox 2.0 운영자
+- **주요 CVE/취약점**: CVE-2024-37079 (VMware vCenter), CVE-2026-21509 (Microsoft Office), CVE-2026-1470 (n8n CVSS 9.9), CVE-2026-0625 (D-Link), SolarWinds Web Help Desk RCE(CVSS 9.8 x4)

--- a/_posts/2026-02-28-February_2026_Security_Digest_Monthly_Index.md
+++ b/_posts/2026-02-28-February_2026_Security_Digest_Monthly_Index.md
@@ -1,0 +1,104 @@
+---
+layout: post
+title: "2026년 2월 보안 다이제스트 월간 인덱스"
+date: 2026-02-28 23:59:00 +0900
+categories: [security, devsecops]
+tags: [monthly-index, security-news, weekly-digest, 2026]
+excerpt: "2026년 2월 한 달간 발행된 보안 주간 다이제스트 종합 인덱스. OpenSSL AI 자동 탐지·공급망 공격·랜섬웨어 진화부터 APT28·Lazarus·UAC-0050 위협 행위자 분석까지 총 22개 다이제스트를 주차별로 정리하여 월간 보안 트렌드와 핵심 대응 포인트를 실무 관점에서 한눈에 파악할 수 있도록 구성합니다."
+description: "2026년 2월 한 달간 발행된 보안 주간 다이제스트 종합 인덱스. OpenSSL AI 자동 탐지·공급망 공격·랜섬웨어 진화부터 APT28·Lazarus·UAC-0050 위협 행위자 분석까지 총 22개 다이제스트를 주차별로 정리하여 월간 보안 트렌드와 핵심 대응 포인트를 실무 관점에서 한눈에 파악할 수 있도록 구성합니다."
+keywords: [monthly-index, security-news, weekly-digest, 2026, DevSecOps, Cloud-Security, AI-Security, Supply-Chain, Ransomware]
+author: Twodragon
+comments: true
+image: /assets/images/2026-02-28-February_2026_Security_Digest_Monthly_Index.svg
+toc: true
+---
+
+{% include ai-summary-card.html
+  title='2026년 2월 보안 다이제스트 월간 인덱스'
+  categories_html='<span class="category-tag security">보안</span> <span class="category-tag devsecops">DevSecOps</span>'
+  tags_html='<span class="tag">monthly-index</span>
+      <span class="tag">security-news</span>
+      <span class="tag">weekly-digest</span>
+      <span class="tag">2026</span>'
+  highlights_html='<li><strong>월간 종합</strong>: 2026년 2월 발행 보안 다이제스트 핵심 이슈 인덱싱</li>
+      <li><strong>위협 동향</strong>: AI 기반 취약점 탐지, 공급망 공격 고도화, 랜섬웨어 진화, APT 캠페인 집중 정리</li>
+      <li><strong>운영 포인트</strong>: OWASP Agentic AI 프레임워크, Kubernetes 보안, LLM 운영 리스크 대응 확인</li>'
+  period='2026년 2월 월간 인덱스'
+  audience='보안 담당자, DevSecOps 엔지니어, SRE, 클라우드 아키텍트'
+%}
+
+---
+
+## 개요
+
+2026년 2월은 AI가 보안 방어의 주체로 첫 성과를 낸 달이었습니다. AI 시스템이 OpenSSL에서 제로데이 12건을 전량 자동 발견한 사례는 취약점 탐지 패러다임 전환을 알리는 상징적 사건으로 기록됐습니다. 동시에 공격자 진영에서도 AI 활용이 가속화되어, Gemini·Codespaces·Copilot 등 AI 개발 도구가 공격 벡터로 악용되는 이중 구조가 뚜렷해졌습니다. Lazarus의 npm/PyPI 공급망 캠페인, APT28 웹훅 멀웨어, UAC-0050 유럽 금융기관 공격, Aeternum 블록체인 C2 봇넷 등 국가 지원 위협 행위자의 활동이 집중된 달이기도 했습니다. 총 22개 다이제스트가 발행된 2월 보안 이슈를 주차별로 정리합니다.
+
+---
+
+## 1주차 (2/1 ~ 2/8)
+
+| 날짜 | 주제 | 링크 |
+|------|------|------|
+| 2월 1일 | AI 시스템이 OpenSSL 제로데이 12건 전량 발견, OWASP Agentic AI 보안 프레임워크, Fortinet FortiCloud SSO 제로데이 | [바로가기](/posts/2026/02/01/Tech_Security_Weekly_Digest_AI_OpenSSL_Zero_Day_OWASP_Agentic_Fortinet/) |
+| 2월 4일 | DockerDash AI 비서 코드 실행 취약점, React Native Metro4Shell RCE(CVE-2025-11953), AWS IAM Identity Center 멀티리전 보안 | [바로가기](/posts/2026/02/04/Tech_Security_Weekly_Digest_AI_Docker_Data_Go/) |
+| 2월 5일 | CVE 긴급 패치, AI 악용 멀웨어 캠페인, Go 언어 기반 공격 도구 동향 등 28건 심층 분석 | [바로가기](/posts/2026/02/05/Tech_Security_Weekly_Digest_CVE_AI_Malware_Go/) |
+| 2월 6일 | CrashFix ClickFix Python RAT 배포, AISURU/Kimwolf 31.4Tbps DDoS 기록 경신, Codespaces RCE·BYOVD 복합 위협 | [바로가기](/posts/2026/02/06/Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat/) |
+| 2월 7일 | AI 기반 멀웨어 캠페인, Go 언어 공격 도구 동향, 최신 보안 취약점 패치 현황 25건 분석 | [바로가기](/posts/2026/02/07/Tech_Security_Weekly_Digest_AI_Malware_Go_Security/) |
+| 2월 8일 | 독일 BfV/BSI 러시아 연계 Signal 피싱(정치인·군인 표적), BlackField 랜섬웨어 코드 재활용, 제로트러스트 데이터 보안전략 | [바로가기](/posts/2026/02/08/Tech_Security_Weekly_Digest_AI_Ransomware_Data/) |
+
+---
+
+## 2주차 (2/11 ~ 2/13)
+
+| 날짜 | 주제 | 링크 |
+|------|------|------|
+| 2월 11일 | 보안 랜섬웨어 패치 AI 26건, DevSecOps 실무 위협 분석 및 공격 경로·탐지 포인트 대응 가이드 | [바로가기](/posts/2026/02/11/Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI/) |
+| 2월 12일 | 공급망 침해 사례, Windows 보안 업데이트, APT36 분석 등 27건 실무 분석 | [바로가기](/posts/2026/02/12/Tech_Security_Weekly_Digest_AI_Cloud_Security_Agent/) |
+| 2월 13일 | Gemini AI 악용 정찰, Lazarus npm·PyPI 공급망 캠페인, Copilot Studio 에이전트 리스크, FinOps CUD 업데이트 | [바로가기](/posts/2026/02/13/Tech_Security_Weekly_Digest_AI_Go_Security_Agent/) |
+
+---
+
+## 3주차 (2/17 ~ 2/21)
+
+| 날짜 | 주제 | 링크 |
+|------|------|------|
+| 2월 17일 | Infostealer AI 에이전트 설정·토큰 탈취, Bitwarden/LastPass 25개 패스워드 복구 공격, AWS 서버리스 방어 아키텍처 | [바로가기](/posts/2026/02/17/Tech_Security_Weekly_Digest_AI_Agent_Cloud_Security/) |
+| 2월 18일 | 클라우드 보안 위협, 안드로이드 악성코드, 업데이트 리스크 분석 20건 DevSecOps 실무 분석 | [바로가기](/posts/2026/02/18/Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update/) |
+| 2월 19일 | Dell RecoverPoint VM CVE-2026-22769 제로데이 실제 악용, VS Code 확장 4종(1.25억 설치) 치명적 취약점, Cellebrite 활동가 감시 적발 | [바로가기](/posts/2026/02/19/Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE/) |
+| 2월 20일 | AI 정렬 연구, EKS Flyte 워크플로, Docker 보안, Cloud Native 동향 기술 블로그 주간 다이제스트 | [바로가기](/posts/2026/02/20/Tech_Blog_Weekly_Digest_AI_Data_Cloud/) |
+| 2월 20일 | Gemini 3.1 Pro 출시, AI 공급망 공격 신규 벡터, Kubernetes Ingress NGINX 은퇴 이슈 29건 분석 | [바로가기](/posts/2026/02/20/Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes/) |
+| 2월 21일 | CVE-2025-49113 심층 분석, 실무 랜섬웨어 대응 전략, Rust 공급망 보안 | [바로가기](/posts/2026/02/21/Tech_Security_Weekly_Digest_Data_Rust_AI_Threat/) |
+
+---
+
+## 4주차 (2/22 ~ 2/28)
+
+| 날짜 | 주제 | 링크 |
+|------|------|------|
+| 2월 22일 | AI 활용 위협 행위자 55개국 FortiGate 대규모 침해, CISA Roundcube 웹메일 KEV 긴급 추가, Claude Code Security 출시 | [바로가기](/posts/2026/02/22/Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security/) |
+| 2월 23일 | SK쉴더스 Vertical AI 보안 전략, BlackField 랜섬웨어 상세 분석, 제로트러스트 데이터 보호, OT 보안 강화 | [바로가기](/posts/2026/02/23/Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin/) |
+| 2월 24일 | APT28 유럽 타겟 웹훅 멀웨어, XMRig 웜 BYOVD 캠페인, Docker Gordon AI, KubeCon Europe SecurityCon 핵심 내용 | [바로가기](/posts/2026/02/24/Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM/) |
+| 2월 25일 | GitHub Codespaces RoguePilot RCE, UAC-0050 유럽 금융기관 공격, 악성 Next.js C2 캠페인 | [바로가기](/posts/2026/02/25/Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM/) |
+| 2월 26일 | UNC2814 GRIDTIDE 캠페인, Claude Code RCE 취약점, 음성 피싱 동향 | [바로가기](/posts/2026/02/26/Tech_Security_Weekly_Digest_AI_Go_AWS_API/) |
+| 2월 27일 | Aeternum 블록체인 C2 봇넷, AWS ISO 42001 AI 감사, Go 공급망 보안 | [바로가기](/posts/2026/02/27/Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go/) |
+| 2월 28일 | Go Crypto 백도어, Pig Butchering $6100만 압수, FreePBX 대규모 침해 | [바로가기](/posts/2026/02/28/Tech_Security_Weekly_Digest_Go_AI_Malware/) |
+
+---
+
+## 월간 주요 트렌드
+
+- **AI의 공수 양면 보안 전환점**: OpenSSL 제로데이 12건 전량을 AI가 발견한 사례는 자동화 취약점 탐지의 실용화를 알렸습니다. 반면 Gemini 정찰 악용, Codespaces RoguePilot RCE, Copilot Studio 에이전트 리스크, Claude Code RCE 취약점이 연달아 보고되면서 AI 개발 도구 자체가 공격 표면으로 부상했습니다. 방어와 공격 모두에서 AI가 주요 변수가 된 첫 달로 기록됩니다.
+- **공급망 공격의 다층화**: Lazarus의 npm·PyPI 악성 패키지 캠페인, Docker 컨테이너 레지스트리 취약점, Rust 공급망 보안, Aeternum 블록체인 C2를 통한 명령·제어 인프라 위장 등 공급망 침해 경로가 오픈소스 생태계 전반으로 확장됐습니다. SLSA 공급망 보안 프레임워크와 서명 검증 정책 강화가 실질적 대응 수단으로 주목받았습니다.
+- **국가 지원 APT의 복합 전술**: APT28의 유럽 타겟 웹훅 멀웨어, UAC-0050의 금융기관 타겟 캠페인, UNC2814 GRIDTIDE 캠페인, AI를 활용한 55개국 FortiGate 대규모 침해 등 국가 지원 위협 행위자가 AI·합법적 플랫폼·BYOVD를 결합한 복합 전술을 구사하는 사례가 집중됐습니다.
+- **랜섬웨어와 데이터 탈취의 이중 압박**: BlackField 랜섬웨어의 코드 재활용 및 지속적 업데이트, Pig Butchering 사기 네트워크 6,100만 달러 압수 사례는 금전적 동기 위협이 기술적 정교함과 규모 모두에서 고도화되고 있음을 보여줍니다. 데이터 중심 제로트러스트와 암호화 전략을 결합한 방어 체계가 필수 요건으로 확인됐습니다.
+- **Kubernetes·클라우드 보안 가시성 강화 필요**: Kubernetes Ingress NGINX 은퇴 이슈, AWS IAM Identity Center 멀티리전 보안 영향, VS Code 확장 대규모 취약점, Dell RecoverPoint VM 제로데이 실제 악용 등 클라우드 네이티브 운영 환경 전반에서 보안 가시성과 패치 관리 속도가 핵심 과제로 반복 등장했습니다.
+
+---
+
+## 통계
+
+- **총 발행 포스트**: 22개
+- **커버 기간**: 2026년 2월 1일 ~ 2월 28일
+- **주요 키워드**: AI 보안, 공급망 공격, 랜섬웨어, APT 캠페인, LLMjacking, BYOVD, Kubernetes, 제로트러스트, LLM 보안, 블록체인 C2
+- **주요 위협 행위자**: Lazarus, APT28, UAC-0050, UNC2814, Aeternum 봇넷 운영자, BlackField 랜섬웨어 그룹
+- **주요 CVE/취약점**: CVE-2025-11953 (React Native Metro4Shell RCE), CVE-2026-22769 (Dell RecoverPoint), CVE-2025-49113, Roundcube KEV 2건, FortiGate 대규모 침해, Codespaces RoguePilot RCE


### PR DESCRIPTION
## Summary

- GSC currently has 126 \"Crawled - currently not indexed\" pages, the majority being weekly security digest posts
- This implements **Strategy B** from the near-duplicate analysis: add monthly index posts that anchor each week's digest, providing a single high-quality canonical landing page per month and reducing near-duplicate crawl signals
- March 2026 index already exists (`2026-03-30-March_2026_Security_Digest_Monthly_Index.md`); this PR backfills January and February

## Changes

- `_posts/2026-01-31-January_2026_Security_Digest_Monthly_Index.md` — 72 lines, indexes 9 January weekly digests (2026-01-23 through 2026-01-31) with original 5-bullet trend roll-up
- `_posts/2026-02-28-February_2026_Security_Digest_Monthly_Index.md` — 104 lines, indexes 22 February weekly digests (2026-02-01 through 2026-02-28, all 4 weeks) with original 5-bullet trend roll-up

## Verification

- YAML frontmatter: valid (parsed cleanly with `yaml.safe_load`)
- All 9 January links: resolved to existing `_posts/` files
- All 22 February links: resolved to existing `_posts/` files
- No existing post files modified
- `check_posts.py`: only expected warning is missing SVG cover images (out of scope; SVG generation handled separately by `build.sh`)

## Test plan

- [ ] Verify Jekyll builds locally without errors (`bundle exec jekyll build`)
- [ ] Confirm both new posts appear in `_site/posts/2026/01/31/` and `_site/posts/2026/02/28/`
- [ ] Confirm all anchor links render correctly to existing weekly digest pages
- [ ] Submit both URLs to Google Search Console for indexing after merge