### PR TITLE
feat(blogwatcher): diversify weekly digest excerpts (5 theme variants for GSC near-duplicate signal reduction)

### DIFF
--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -76,6 +76,7 @@ from scripts.news.config import (  # noqa: E402,F401
 # Re-export content generator functions
 from scripts.news.content_generator import (  # noqa: E402,F401
     _apply_trend_kr_map,
+    _build_clean_excerpt,
     _build_digest_title,
     _html_escape_quotes,
     _determine_severity,
@@ -97,6 +98,7 @@ from scripts.news.content_generator import (  # noqa: E402,F401
     _korean_brief_summary,
     _korean_display_title,
     _run_post_quality_gate,
+    _select_excerpt_variant,
     _table_summary,
     _translate_to_korean_deepseek,
     _truncate_korean_sentence,

--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -369,6 +369,118 @@ def _extract_digest_title_labels(
     return normalized_labels[:3]
 
 
+# ---------------------------------------------------------------------------
+# Excerpt theme detection — 5 variants keyed on dominant signal keywords.
+# Priority order: more specific keywords first to avoid over-matching.
+# ---------------------------------------------------------------------------
+
+_EXCERPT_THEME_KEYWORDS: list[tuple[str, list[str]]] = [
+    # Variant A: Ransomware / active threat-heavy
+    (
+        "ransomware",
+        [
+            "랜섬웨어", "ransomware", "멀웨어", "malware", "botnet", "봇넷",
+            "trojan", "트로이", "worm", "웜",
+        ],
+    ),
+    # Variant B: AI / LLM-heavy
+    (
+        "ai_llm",
+        [
+            "llm", "ai 에이전트", "ai agent", "생성형 ai", "generative ai",
+            "gpt", "claude", "gemini", "langchain", "rag", "프롬프트",
+        ],
+    ),
+    # Variant C: CVE / Patch-heavy
+    (
+        "cve_patch",
+        [
+            "cve-", "취약점", "vulnerability", "patch", "패치", "exploit",
+            "익스플로잇", "zero-day", "제로데이", "rce",
+        ],
+    ),
+    # Variant D: Cloud / Kubernetes-heavy
+    (
+        "cloud_k8s",
+        [
+            "kubernetes", "k8s", "쿠버네티스", "aws", "azure", "gcp",
+            "클라우드", "cloud", "eks", "aks", "gke", "terraform",
+        ],
+    ),
+    # Variant E: generic fallback (no theme match needed — lowest priority)
+    ("generic", []),
+]
+
+# Second sentences for security mode (indexed by theme)
+_EXCERPT_SECOND_SECURITY: dict[str, str] = {
+    "ransomware": (
+        " 랜섬웨어 감염 경로·피해 규모·복구 절차와 함께 조직 방어를 위한"
+        " 우선순위 대응 체크리스트를 제시합니다."
+    ),
+    "ai_llm": (
+        " AI 에이전트 보안, LLM 공급망 위협, 프롬프트 인젝션 대응 전략과"
+        " DevSecOps 파이프라인 통합 방안을 다룹니다."
+    ),
+    "cve_patch": (
+        " 이번 주 긴급 CVE·패치 현황, 공격 벡터 분석, CVSS 우선순위별"
+        " 신속 적용 가이드를 함께 정리합니다."
+    ),
+    "cloud_k8s": (
+        " AWS·Azure·GCP 신규 보안 기능, 쿠버네티스 클러스터 강화 포인트와"
+        " 클라우드 설정 오류 방지 체크리스트를 다룹니다."
+    ),
+    "generic": (
+        " 공격 경로·영향 자산·탐지 포인트를 기술 관점에서 정리하고,"
+        " 경영진 보고용 우선순위·대응 체크리스트를 함께 제시합니다."
+    ),
+}
+
+# Second sentences for tech mode (indexed by theme)
+_EXCERPT_SECOND_TECH: dict[str, str] = {
+    "ransomware": (
+        " 보안 사고 대응 자동화, 인시던트 리포팅, 복구 파이프라인 구축 등"
+        " DevSecOps 실무 적용 사례를 함께 다룹니다."
+    ),
+    "ai_llm": (
+        " LLM 기반 개발 도구, AI 코딩 어시스턴트 활용법과 엔지니어링 팀의"
+        " AI 도입 모범 사례를 함께 다룹니다."
+    ),
+    "cve_patch": (
+        " 취약점 스캔 자동화, 의존성 패치 파이프라인, SCA·SAST 도구 통합 등"
+        " 실무 보안 DevOps 가이드를 다룹니다."
+    ),
+    "cloud_k8s": (
+        " 클라우드 네이티브 아키텍처, 쿠버네티스 운영 최적화, IaC 보안 모범 사례와"
+        " 비용 절감 전략을 함께 정리합니다."
+    ),
+    "generic": (
+        " 오픈소스, 클라우드 인프라, AI 도구 등 최신 개발 트렌드와"
+        " 실무 적용 사례를 함께 다룹니다."
+    ),
+}
+
+
+def _select_excerpt_variant(
+    title_keywords: str,
+    topics: list[str] | None,
+) -> str:
+    """주제 신호를 분석해 5가지 excerpt 변형 중 하나를 선택한다.
+
+    입력이 같으면 항상 같은 변형을 반환한다(결정론적). 우선순위 순서로
+    키워드를 탐색하며, 첫 번째 매칭된 테마를 반환한다. 매칭이 없으면
+    'generic'을 반환한다.
+    """
+    signal = " ".join(
+        [title_keywords.lower()] + [t.lower() for t in (topics or [])]
+    )
+    for theme, keywords in _EXCERPT_THEME_KEYWORDS:
+        if theme == "generic":
+            return "generic"
+        if any(kw in signal for kw in keywords):
+            return theme
+    return "generic"
+
+
 def _build_clean_excerpt(
     title_keywords: str,
     date_str: str,
@@ -376,20 +488,23 @@ def _build_clean_excerpt(
     mode: str,
     topics: list[str] | None = None,
 ) -> str:
-    """품질 검증된 excerpt 생성 - 조사 자동 보정, 150-200자 보장"""
+    """품질 검증된 excerpt 생성 - 조사 자동 보정, 150-200자 보장, 5가지 테마 변형"""
     # 조사 보정: 받침 여부에 따라 을/를 선택
     last_char = title_keywords.rstrip()[-1] if title_keywords.rstrip() else ""
     particle = "을" if _has_batchim(last_char) else "를"
 
+    # 테마 기반 second 문장 선택 (결정론적)
+    theme = _select_excerpt_variant(title_keywords, topics)
+
     if mode == "tech":
         first = f"{title_keywords}{particle} 중심으로 {date_str} 주요 기술 블로그 뉴스 {total}건과 개발자 관점의 적용 포인트를 정리합니다."
-        # 보충 문장: topics에서 키워드 추가 또는 고정 확장
+        # 보충 문장: topics에서 키워드 추가 또는 테마 기반 선택
         extra_topics = [t for t in (topics or []) if t not in title_keywords][:3]
         if extra_topics:
             kw = ", ".join(extra_topics)
             second = f" {kw} 등 최신 개발 트렌드와 실무 적용 사례를 함께 다룹니다."
         else:
-            second = " 오픈소스, 클라우드 인프라, AI 도구 등 실무 관련 개발 트렌드와 적용 사례를 함께 다룹니다."
+            second = _EXCERPT_SECOND_TECH[theme]
     else:
         first = f"{title_keywords}{particle} 중심으로 {date_str} 주요 보안/기술 뉴스 {total}건과 대응 우선순위를 정리합니다."
         extra_topics = [t for t in (topics or []) if t not in title_keywords][:3]
@@ -399,7 +514,7 @@ def _build_clean_excerpt(
                 f" {kw} 등 최신 위협 동향과 DevSecOps 실무 대응 방안을 함께 다룹니다."
             )
         else:
-            second = " 취약점 패치, 클라우드 보안, 공급망 위협 등 DevSecOps 실무 대응 방안을 함께 다룹니다."
+            second = _EXCERPT_SECOND_SECURITY[theme]
 
     excerpt = first + second
 

--- a/scripts/tests/test_news_templates.py
+++ b/scripts/tests/test_news_templates.py
@@ -12,6 +12,7 @@ from auto_publish_news import (
     SVG_TEMPLATE_HUB_SPOKE,
     SVG_TEMPLATE_TIMELINE,
     _apply_trend_kr_map,
+    _build_clean_excerpt,
     _deduplicate_crypto_stories,
     _escape_svg_text,
     _extract_key_topics,
@@ -26,6 +27,7 @@ from auto_publish_news import (
     _generate_security_analysis_template,
     _generate_security_brief_template,
     _generate_trend_analysis,
+    _select_excerpt_variant,
     _select_svg_template,
     _table_summary,
     _to_english_svg_text,
@@ -3096,4 +3098,223 @@ class TestPracticalPointsUniqueness:
         outputs = [_generate_devops_template(it) for it in items]
         assert len(set(outputs)) >= 5, (
             f"Weekly digest bullets lack diversity: only {len(set(outputs))} unique"
+        )
+
+
+# ===========================================================================
+# _select_excerpt_variant + _build_clean_excerpt
+# ===========================================================================
+
+
+class TestSelectExcerptVariant:
+    """Tests for _select_excerpt_variant() — theme detection and determinism."""
+
+    # ------------------------------------------------------------------
+    # Variant A: ransomware / malware-heavy
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "title,topics",
+        [
+            ("랜섬웨어 공격 그룹 분석 및 대응", None),
+            ("Ransomware group targets critical infrastructure", None),
+            ("악성코드 멀웨어 변종 탐지", ["malware", "botnet"]),
+        ],
+    )
+    def test_ransomware_variant(self, title, topics):
+        variant = _select_excerpt_variant(title, topics)
+        assert variant == "ransomware", f"Expected ransomware, got {variant!r}"
+
+    # ------------------------------------------------------------------
+    # Variant B: AI / LLM-heavy
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "title,topics",
+        [
+            ("LLM 공급망 공격 탐지 기법", None),
+            ("AI 에이전트 보안 취약점 분석", None),
+            ("GPT 기반 프롬프트 인젝션 공격", ["llm", "rag"]),
+        ],
+    )
+    def test_ai_llm_variant(self, title, topics):
+        variant = _select_excerpt_variant(title, topics)
+        assert variant == "ai_llm", f"Expected ai_llm, got {variant!r}"
+
+    # ------------------------------------------------------------------
+    # Variant C: CVE / patch-heavy
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "title,topics",
+        [
+            ("CVE-2026-1234 긴급 패치 권고", None),
+            ("취약점 패치 적용 가이드라인", None),
+            ("Zero-day exploit in popular library", ["exploit", "rce"]),
+        ],
+    )
+    def test_cve_patch_variant(self, title, topics):
+        variant = _select_excerpt_variant(title, topics)
+        assert variant == "cve_patch", f"Expected cve_patch, got {variant!r}"
+
+    # ------------------------------------------------------------------
+    # Variant D: cloud / Kubernetes-heavy
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "title,topics",
+        [
+            ("Kubernetes RBAC 설정 오류 보안 강화", None),
+            ("AWS S3 보안 설정 모범 사례", None),
+            ("GCP 클라우드 네이티브 보안 가이드", ["k8s", "terraform"]),
+        ],
+    )
+    def test_cloud_k8s_variant(self, title, topics):
+        variant = _select_excerpt_variant(title, topics)
+        assert variant == "cloud_k8s", f"Expected cloud_k8s, got {variant!r}"
+
+    # ------------------------------------------------------------------
+    # Variant E: generic fallback
+    # ------------------------------------------------------------------
+    def test_generic_fallback_variant(self):
+        variant = _select_excerpt_variant("주간 보안 뉴스 다이제스트", None)
+        assert variant == "generic", f"Expected generic, got {variant!r}"
+
+    # ------------------------------------------------------------------
+    # Determinism — same input always yields same variant
+    # ------------------------------------------------------------------
+    def test_same_input_same_variant(self):
+        title = "CVE-2026-9999 패치 권고"
+        v1 = _select_excerpt_variant(title, None)
+        v2 = _select_excerpt_variant(title, None)
+        assert v1 == v2, "Non-deterministic: same input produced different variants"
+
+    # ------------------------------------------------------------------
+    # Diversity — 5 distinct inputs produce at least 4 different variants
+    # ------------------------------------------------------------------
+    def test_diversity_across_themes(self):
+        inputs = [
+            ("랜섬웨어 botnet 탐지", None),
+            ("LLM 기반 공격 분석", ["ai agent"]),
+            ("CVE-2026-5678 긴급 패치", None),
+            ("kubernetes 클러스터 보안", None),
+            ("주간 보안 동향 요약", None),
+        ]
+        variants = [_select_excerpt_variant(t, top) for t, top in inputs]
+        unique_variants = set(variants)
+        assert len(unique_variants) >= 4, (
+            f"Expected at least 4 distinct variants, got {len(unique_variants)}: {variants}"
+        )
+
+
+class TestBuildCleanExcerptVariants:
+    """Tests for _build_clean_excerpt() — theme-keyword variant selection."""
+
+    _DATE = "2026-05-04"
+    _TOTAL = 15
+
+    # ------------------------------------------------------------------
+    # Variant A keywords appear for ransomware-heavy input (security mode)
+    # ------------------------------------------------------------------
+    def test_ransomware_excerpt_security_mode(self):
+        excerpt = _build_clean_excerpt(
+            "랜섬웨어 공격 분석",
+            self._DATE,
+            self._TOTAL,
+            "security",
+            topics=None,
+        )
+        assert any(
+            kw in excerpt
+            for kw in ("랜섬웨어", "감염 경로", "복구")
+        ), f"Variant A keywords missing in: {excerpt!r}"
+        assert len(excerpt) <= 200
+
+    # ------------------------------------------------------------------
+    # Variant B keywords appear for AI/LLM-heavy input (security mode)
+    # ------------------------------------------------------------------
+    def test_ai_llm_excerpt_security_mode(self):
+        excerpt = _build_clean_excerpt(
+            "LLM 공급망 위협 분석",
+            self._DATE,
+            self._TOTAL,
+            "security",
+            topics=None,
+        )
+        assert any(
+            kw in excerpt
+            for kw in ("AI 에이전트", "LLM", "프롬프트")
+        ), f"Variant B keywords missing in: {excerpt!r}"
+        assert len(excerpt) <= 200
+
+    # ------------------------------------------------------------------
+    # Variant C keywords appear for CVE/patch-heavy input (security mode)
+    # ------------------------------------------------------------------
+    def test_cve_patch_excerpt_security_mode(self):
+        excerpt = _build_clean_excerpt(
+            "CVE-2026-1234 취약점 패치",
+            self._DATE,
+            self._TOTAL,
+            "security",
+            topics=None,
+        )
+        assert any(
+            kw in excerpt
+            for kw in ("CVE", "패치", "긴급")
+        ), f"Variant C keywords missing in: {excerpt!r}"
+        assert len(excerpt) <= 200
+
+    # ------------------------------------------------------------------
+    # Variant D keywords appear for cloud/K8s-heavy input (security mode)
+    # ------------------------------------------------------------------
+    def test_cloud_k8s_excerpt_security_mode(self):
+        excerpt = _build_clean_excerpt(
+            "kubernetes 클러스터 보안 강화",
+            self._DATE,
+            self._TOTAL,
+            "security",
+            topics=None,
+        )
+        assert any(
+            kw in excerpt
+            for kw in ("AWS", "쿠버네티스", "클라우드", "GCP", "Azure")
+        ), f"Variant D keywords missing in: {excerpt!r}"
+        assert len(excerpt) <= 200
+
+    # ------------------------------------------------------------------
+    # Variant E (generic) used for non-matching input (security mode)
+    # ------------------------------------------------------------------
+    def test_generic_excerpt_security_mode(self):
+        excerpt = _build_clean_excerpt(
+            "주간 보안 다이제스트",
+            self._DATE,
+            self._TOTAL,
+            "security",
+            topics=None,
+        )
+        assert any(
+            kw in excerpt
+            for kw in ("공격 경로", "영향 자산", "체크리스트", "우선순위")
+        ), f"Variant E keywords missing in: {excerpt!r}"
+        assert len(excerpt) <= 200
+
+    # ------------------------------------------------------------------
+    # All excerpts respect 150-200 char bounds (spot-check across variants)
+    # ------------------------------------------------------------------
+    @pytest.mark.parametrize(
+        "title,mode",
+        [
+            ("랜섬웨어 botnet 대응", "security"),
+            ("LLM 에이전트 보안", "security"),
+            ("CVE-2026-0001 패치", "security"),
+            ("AWS kubernetes 설정", "security"),
+            ("주간 보안 요약", "security"),
+            ("LLM 개발 트렌드", "tech"),
+            ("kubernetes 운영 최적화", "tech"),
+            ("주간 기술 블로그", "tech"),
+        ],
+    )
+    def test_excerpt_length_bounds(self, title, mode):
+        excerpt = _build_clean_excerpt(title, self._DATE, self._TOTAL, mode)
+        assert len(excerpt) >= 150, (
+            f"Excerpt too short ({len(excerpt)}): {excerpt!r}"
+        )
+        assert len(excerpt) <= 200, (
+            f"Excerpt too long ({len(excerpt)}): {excerpt!r}"
         )


### PR DESCRIPTION
## Summary

- **Problem**: 2026-05-04 Google Search Console analysis found 126 pages marked "Crawled - currently not indexed", traced to near-duplicate excerpt boilerplate (5 excerpt pairs with Jaccard similarity ≥ 0.750) in auto-generated weekly digest posts
- **Fix**: Added 5 deterministic theme-keyword variants to `_build_clean_excerpt()` in `scripts/news/content_generator.py` — `ransomware`, `ai_llm`, `cve_patch`, `cloud_k8s`, `generic` — chosen by first-match priority scan of title/topic signal
- **Scope**: Surgical 3-file change — `content_generator.py`, `auto_publish_news.py` (re-exports), `tests/test_news_templates.py` (28 new tests); no `_posts/`, layouts, or unrelated files touched

## Changes

- `scripts/news/content_generator.py` — Added `_EXCERPT_THEME_KEYWORDS` priority list, `_EXCERPT_SECOND_SECURITY` / `_EXCERPT_SECOND_TECH` theme maps, `_select_excerpt_variant()` helper; modified `_build_clean_excerpt()` to route to themed second-sentence when `extra_topics` is empty
- `scripts/auto_publish_news.py` — Added `_build_clean_excerpt` and `_select_excerpt_variant` to re-export block so tests can import via the module
- `scripts/tests/test_news_templates.py` — `TestSelectExcerptVariant` (15 tests) + `TestBuildCleanExcerptVariants` (13 tests): per-variant keyword routing, determinism, diversity, and ≤200-char length bounds

## Test plan

- [x] 1156 passed, 3 skipped (pre-commit hook confirmed)
- [x] Coverage remains 79.72% (well above 40% CI floor)
- [x] All 28 new tests green: variant routing, determinism, Korean char bounds
- [x] No randomness — same input always selects same variant (determinism test)
- [x] `_posts/`, `vercel.json`, and unrelated files untouched