### PR TITLE
fix(blogwatcher): clean ASCII cover title + canonical-QR/ASCII/quality cron gates

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -117,6 +117,9 @@ jobs:
           pip install feedparser requests beautifulsoup4 python-frontmatter PyYAML
           pip install pytest pytest-cov
           pip install "Pillow>=10.0"
+          # qrcode is required by svg_l22_generator.gen_qr (cover QR) and by the
+          # check_cover_qr_urls.py canonical-URL gate below.
+          pip install "qrcode[pil]"
 
       - name: Create directories
         run: mkdir -p _data data _posts assets/images
@@ -290,6 +293,21 @@ jobs:
             exit 1
           fi
           echo "OK: L20 cover with QR block confirmed (${SIZE} bytes)."
+
+          # --- Correctness gates (mirror the PR-side svg-lint / check-svg CI so
+          # auto-published covers can never regress what those gates enforce).
+          # Scoped to today's cover via the resolved $SVG path (no glob no-match
+          # risk). check_cover_qr_urls.py = QR encodes the canonical permalink;
+          # check_svg_title_ascii.py = <title>/<desc> ASCII-only; check_svg_quality
+          # = no Korean / banned chars in body <text>. These caught the
+          # 2026-06-03..05 cron covers (non-canonical QR + "Cisco FMC·" title)
+          # only after the fact on a PR merge; running them here fails the cron
+          # before the bad cover is committed.
+          echo "Running cover correctness gates on ${SVG} ..."
+          python3 scripts/check_cover_qr_urls.py --glob "${SVG}"
+          python3 scripts/check_svg_title_ascii.py "${SVG}"
+          python3 scripts/check_svg_quality.py --ci "${SVG}"
+          echo "OK: canonical QR URL + ASCII <title> + body-text quality gates passed."
 
       - name: Validate new post
         if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'

--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -199,7 +199,7 @@ def _render_l20_svg_string(post_info: Dict) -> str:
     back to the legacy generator without crashing the publisher.
     """
     try:
-        from scripts.lib.svg_l20_hero import render_l20_hero
+        from scripts.lib.svg_l20_hero import build_cover_title, render_l20_hero
         from scripts.news.l20_dispatch import (
             _action_for,
             _build_story,
@@ -236,13 +236,26 @@ def _render_l20_svg_string(post_info: Dict) -> str:
             index=2,
             severity_label="MEDIUM",
         )
+        date_str = _date_str_from_filename(filename) or ""
+        # Build a clean, ASCII <title> from the (often Korean) post title the
+        # same way the L20 dispatch path does (l20_dispatch.py). Passing the
+        # raw ``title`` straight through left non-ASCII residue such as
+        # "2026 06 05 Cisco FMC· (29 )" in <title>, tripping the title-ASCII
+        # gate (the 2026-06-05 cron cover). build_cover_title emits a fixed
+        # ASCII template like "Weekly Security Digest - 2026.06.05".
+        cover_title = build_cover_title(
+            post_title=title,
+            date_str=date_str,
+            category=str(post_info.get("category", "") or ""),
+            filename=filename,
+        )
         return render_l20_hero(
-            date_str=_date_str_from_filename(filename) or "",
+            date_str=date_str,
             hero=hero_story,
             top_right=tr_story,
             bottom_right=br_story,
             url=_post_url_from_filename(filename),
-            post_title=title or "Weekly Digest",
+            post_title=cover_title or "Weekly Digest",
         )
     except Exception as _exc:
         logging.warning(f"L20 SVG render failed, falling back: {_exc}")

--- a/scripts/tests/test_l20_hero_dispatch.py
+++ b/scripts/tests/test_l20_hero_dispatch.py
@@ -14,6 +14,7 @@ API disabling and ``sys.path`` setup are handled by ``conftest.py``.
 
 import importlib
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -508,3 +509,37 @@ class TestAutoPublishDispatchBranch:
 
         assert called["legacy"] == 1
         assert svg == "<svg>legacy</svg>"
+
+
+# =====================================================================
+# Regression: cron cover <title> must be ASCII (build_cover_title wiring)
+# =====================================================================
+class TestRenderL20SvgStringCleanTitle:
+    """The blogwatcher cron path ``auto_publish_news._render_l20_svg_string``
+    must build the SVG ``<title>`` via ``build_cover_title`` (clean ASCII
+    template), not pass the raw — often Korean — post title straight through.
+
+    Regression for the 2026-06-05 auto-published cover that shipped
+    ``<title>2026 06 05 Cisco FMC· (29 )</title>`` (U+00B7 middle dot +
+    Hangul-strip residue), which only failed the title-ASCII gate after the
+    PR merge because the cron itself had no ASCII gate.
+    """
+
+    def test_korean_post_title_yields_ascii_clean_title(self):
+        ap = importlib.import_module("auto_publish_news")
+        post_info = {
+            "title": "2026년 06월 05일 주간 보안 다이제스트: 제로데이·Cisco FMC·패치 (29건)",
+            "excerpt": "Cisco FMC 제로데이 패치 및 주간 보안 동향 요약입니다.",
+            "filename": "2026-06-05-Tech_Security_Weekly_Digest_CVE_Patch_Go_AI.md",
+            "category": "security",
+        }
+        svg = ap._render_l20_svg_string(post_info)
+        assert svg, "_render_l20_svg_string returned empty (L20 import failed)"
+        m = re.search(r"<title>([^<]*)</title>", svg)
+        assert m, "no <title> element in rendered SVG"
+        title = m.group(1)
+        # Core regression: <title> is ASCII-only (no U+00B7, no Hangul).
+        non_ascii = [c for c in title if ord(c) >= 128]
+        assert not non_ascii, f"non-ASCII codepoint(s) {non_ascii!r} in <title>: {title!r}"
+        # Clean fixed template, topic derived from the filename slug.
+        assert title == "Weekly Security Digest - 2026.06.05", title


### PR DESCRIPTION
## Summary

Root-cause fix for the blogwatcher cron covers (2026-06-03..05) that shipped with **non-canonical QR URLs** and a **non-ASCII `<title>`** (`2026 06 05 Cisco FMC· (29 )`). These were the two pre-existing main bugs surfaced (and patched after-the-fact) during PR #387.

### Root cause
The cron path `auto_publish_news._render_l20_svg_string` passed the raw (Korean) post title straight into `render_l20_hero`'s `<title>`, whereas the L20 dispatch path (`l20_dispatch.py:897`) first builds a clean title via `build_cover_title`. The cron's verify step only checked QR-block presence + size — no canonical-URL / ASCII / quality gate — so the bad cover was committed and only failed on a later PR merge.

### Source fix (surgical — mirrors `l20_dispatch`)
`_render_l20_svg_string` now derives the `<title>` via `build_cover_title(post_title, date_str, category, filename)`, producing the fixed ASCII template (e.g. `Weekly Security Digest - 2026.06.05`) instead of the raw Korean title. Verified empirically: `<title>` is ASCII-only and the QR is canonical.

### Recurrence gates (`ai-blogwatcher.yml` verify step, scoped to today's `$SVG`)
- `check_cover_qr_urls.py` → QR encodes the canonical permalink
- `check_svg_title_ascii.py` → `<title>`/`<desc>` ASCII-only
- `check_svg_quality.py` → no Korean / banned chars in body `<text>`
- add `qrcode[pil]` dependency (needed by `gen_qr` and the QR-URL gate)

These mirror the PR-side `svg-lint` / `check-svg` CI so an auto-published cover can never regress what those gates enforce — the cron now **fails before committing** a bad cover instead of leaking it to main.

### Test
`TestRenderL20SvgStringCleanTitle` asserts the cron path emits an ASCII-only, fixed-template `<title>` for a Korean post title (regression lock for the 2026-06-05 cover).

## Verification
- `pytest scripts/tests/` → **2079 passed**
- Source fix reproduced clean: `<title>Weekly Security Digest - 2026.06.05`, QR canonical = True
- All three new gates pass on the 2026-06-05 cover
- Source-only change (no image/raster churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)