### PR TITLE
feat(cover): modernize QR-URL fixer + L20 honesty write-guard

### DIFF
--- a/scripts/fix_qr_url_in_covers.py
+++ b/scripts/fix_qr_url_in_covers.py
@@ -44,16 +44,18 @@ from scripts.news.l20_dispatch import _post_url_from_filename  # noqa: E402
 #     <rect ... fill="#FFFFFF"/>
 #     <path fill="#0A1020" d="..."/>
 #   </g>
-#   <text x="1122" y="614" ...>scan / full post</text>
+#   <text ...>scan / full post</text>
 #
-# The matcher captures both the <g> wrapper and the trailing scan label so
-# the replacement stays atomic. Some upgraded covers tweak the spacing —
-# the regex tolerates leading/trailing whitespace and any text-y caption
-# variant ("scan / full post", "Scan", etc.).
+# The matcher captures both the <g> wrapper and the trailing "scan / full post"
+# label so the replacement stays atomic. The label POSITION changed across
+# QR-geometry revisions: the legacy 84px block placed it at ``x="1122" y="614"``
+# (below the QR), the current 108px block at ``x="1134" y="486"`` (above the
+# enlarged 132x132 white rect). Anchor on the label's text content rather than
+# its coordinates so the fixer upgrades BOTH geometries (and any future tweak).
 _QR_BLOCK_RE = re.compile(
     r"<g transform=\"translate\(1080,504\)\"[^>]*>"
     r".*?</g>\s*"
-    r"<text x=\"1122\" y=\"614\"[^>]*>[^<]*</text>",
+    r"<text[^>]*>scan / full post</text>",
     re.DOTALL,
 )
 

--- a/scripts/tests/test_fix_qr_url_in_covers.py
+++ b/scripts/tests/test_fix_qr_url_in_covers.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for scripts/fix_qr_url_in_covers.py — the cover QR-URL repair tool.
+
+Regression focus: the QR-block matcher must recognise BOTH the legacy 84px
+label position (``x="1122" y="614"``, below the QR) and the current 108px
+position (``x="1134" y="486"``, above the enlarged white rect). Anchoring on
+the old coordinates silently skipped every modern cover ("No QR block found"),
+so a stale-URL 108px cover could never be repaired.
+
+``sys.path`` setup is handled by conftest.py.
+"""
+
+from __future__ import annotations
+
+import fix_qr_url_in_covers as fixmod
+from scripts.lib.svg_l22_generator import gen_qr, qr_block
+from scripts.news.l20_dispatch import _post_url_from_filename
+
+CANONICAL = "https://tech.2twodragon.com/posts/2026/06/05/Test_Digest/"
+
+
+def _wrap(qr_fragment: str) -> str:
+    """Minimal SVG wrapper around a QR block fragment."""
+    return (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">'
+        f"{qr_fragment}</svg>\n"
+    )
+
+
+def _legacy_qr_block(url: str) -> str:
+    """The pre-108px QR block: 100x100 white rect + scan label at y=614."""
+    return (
+        '<g transform="translate(1080,504)" filter="url(#softShadow)">\n'
+        '  <rect x="-8" y="-8" width="100" height="100" rx="6" fill="#FFFFFF"/>\n'
+        f'  <path fill="#0A1020" d="{gen_qr(url)}"/>\n'
+        "</g>\n"
+        '<text x="1122" y="614" font-family="Inter, Helvetica, Arial, sans-serif" '
+        'font-size="10" font-weight="700" fill="#F5F7FA" '
+        'text-anchor="middle">scan / full post</text>'
+    )
+
+
+class TestQrBlockMatcher:
+    def test_matches_current_108px_block(self):
+        """The 108px qr_block (scan label y=486) must be matched."""
+        frag = qr_block(CANONICAL)
+        assert "y=\"486\"" in frag, "fixture drift: qr_block no longer uses y=486"
+        assert fixmod._QR_BLOCK_RE.search(_wrap(frag)) is not None
+
+    def test_matches_legacy_84px_block(self):
+        """The legacy block (scan label y=614) must still be matched."""
+        frag = _legacy_qr_block(CANONICAL)
+        assert fixmod._QR_BLOCK_RE.search(_wrap(frag)) is not None
+
+
+class TestFixOne:
+    def test_upgrades_stale_legacy_block_to_canonical_108px(self, tmp_path):
+        """A legacy block carrying a WRONG url is rewritten to the canonical
+        108px qr_block derived from the filename."""
+        filename = "2026-06-05-Test_Digest.svg"
+        stale = _legacy_qr_block("https://tech.2twodragon.com/posts/2026/06/05/WRONG/")
+        path = tmp_path / filename
+        path.write_text(_wrap(stale), encoding="utf-8")
+
+        changed, _ = fixmod.fix_one(path)
+        assert changed is True
+
+        out = path.read_text(encoding="utf-8")
+        # Upgraded to 108px geometry.
+        assert 'width="132" height="132"' in out
+        assert 'y="486"' in out
+        # QR now encodes the canonical filename-derived URL.
+        canonical = _post_url_from_filename(filename)
+        assert gen_qr(canonical) in out
+        # Exactly one QR block remains (atomic swap, no duplicate label).
+        assert out.count("scan / full post") == 1
+
+    def test_canonical_108px_block_is_left_unchanged(self, tmp_path):
+        """An already-canonical 108px cover needs no fix."""
+        filename = "2026-06-05-Test_Digest.svg"
+        canonical = _post_url_from_filename(filename)
+        path = tmp_path / filename
+        path.write_text(_wrap(qr_block(canonical)), encoding="utf-8")
+
+        changed, reason = fixmod.fix_one(path)
+        assert changed is False
+        assert "already" in reason.lower()

--- a/scripts/tests/test_upgrade_l20_honesty_guard.py
+++ b/scripts/tests/test_upgrade_l20_honesty_guard.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tests for the cover-honesty guard in scripts/upgrade_l20_cover.py.
+
+Most ``_data/l20_covers/*.yml`` specs have drifted from the honest on-disk
+corpus, so a blind ``upgrade_l20_cover.py --all`` re-render reintroduces
+dishonest covers (the regression caught during PR #387). The guard renders
+off-disk, scores each cover for honesty, and aborts the write run if any spec
+would produce a NON-baselined honesty FAIL.
+
+``sys.path`` setup is handled by conftest.py.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import scripts.score_cover_honesty as sch
+import scripts.upgrade_l20_cover as up
+
+
+class _FakeSpec:
+    """Minimal stand-in for upgrade_l20_cover.Spec (only what the guard /
+    write loop touch)."""
+
+    def __init__(self, filename: str, output_path: Path):
+        self._filename = filename
+        self.output_path = output_path
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+
+# ---------------------------------------------------------------------------
+# _honesty_regressions: baseline + verdict filtering
+# ---------------------------------------------------------------------------
+
+
+def test_honesty_regressions_filters_by_baseline_and_verdict(monkeypatch, tmp_path):
+    rendered = [
+        (_FakeSpec("fail_new.svg", tmp_path / "fail_new.svg"), "<svg/>"),
+        (_FakeSpec("fail_baselined.svg", tmp_path / "fail_baselined.svg"), "<svg/>"),
+        (_FakeSpec("clean.svg", tmp_path / "clean.svg"), "<svg/>"),
+    ]
+    verdicts = {
+        "fail_new.svg": "FAIL",
+        "fail_baselined.svg": "FAIL",
+        "clean.svg": "PASS",
+    }
+
+    def fake_score_file(path):
+        return {
+            "verdict": verdicts[Path(path).name],
+            "honesty": {
+                "violations": [
+                    {
+                        "band": "hero",
+                        "visual_id": "cve_chain",
+                        "claim_class": "cve",
+                        "reason": "no cve token",
+                    }
+                ]
+            },
+        }
+
+    # fail_baselined.svg is grandfathered → must NOT be reported.
+    monkeypatch.setattr(sch, "score_file", fake_score_file)
+    monkeypatch.setattr(sch, "load_baseline", lambda p: {"assets/images/fail_baselined.svg"})
+    baseline_file = tmp_path / "baseline.txt"
+    baseline_file.write_text("assets/images/fail_baselined.svg\n", encoding="utf-8")
+    monkeypatch.setattr(up, "_HONESTY_BASELINE", baseline_file)
+
+    regs = up._honesty_regressions(rendered)
+
+    assert len(regs) == 1, regs
+    assert regs[0].startswith("fail_new.svg")
+    assert "hero:cve_chain" in regs[0]
+
+
+def test_honesty_regressions_empty_when_all_pass(monkeypatch, tmp_path):
+    rendered = [(_FakeSpec("a.svg", tmp_path / "a.svg"), "<svg/>")]
+    monkeypatch.setattr(sch, "score_file", lambda p: {"verdict": "PASS", "honesty": {"violations": []}})
+    monkeypatch.setattr(sch, "load_baseline", lambda p: set())
+    monkeypatch.setattr(up, "_HONESTY_BASELINE", tmp_path / "nope.txt")
+    assert up._honesty_regressions(rendered) == []
+
+
+# ---------------------------------------------------------------------------
+# main(): write run aborts on regression; --force / --dry-run skip the guard
+# ---------------------------------------------------------------------------
+
+
+def _stub_render_path(monkeypatch, tmp_path):
+    """Stub spec gathering / loading / rendering so main() runs without real
+    specs. Returns the output path the write loop would touch."""
+    out = tmp_path / "stub-cover.svg"
+    spec = _FakeSpec("stub-cover.svg", out)
+    monkeypatch.setattr(up, "_gather_specs", lambda args: [Path("stub.yml")])
+    monkeypatch.setattr(up, "load_spec", lambda p: spec)
+    monkeypatch.setattr(up, "render", lambda s: "<svg>stub</svg>")
+    return out
+
+
+def test_main_write_aborts_on_regression(monkeypatch, tmp_path):
+    out = _stub_render_path(monkeypatch, tmp_path)
+    monkeypatch.setattr(up, "_honesty_regressions", lambda rendered: ["stub-cover.svg  [hero:cve_chain]"])
+
+    rc = up.main(["--all"])
+
+    assert rc == 1
+    assert not out.exists(), "guard must block the write — no file should be created"
+
+
+def test_main_force_bypasses_guard(monkeypatch, tmp_path):
+    out = _stub_render_path(monkeypatch, tmp_path)
+
+    def _must_not_run(rendered):
+        raise AssertionError("honesty guard must not run under --force")
+
+    monkeypatch.setattr(up, "_honesty_regressions", _must_not_run)
+
+    rc = up.main(["--all", "--force"])
+
+    assert rc == 0
+    assert out.read_text(encoding="utf-8") == "<svg>stub</svg>"
+
+
+def test_main_dry_run_skips_guard_and_writes_nothing(monkeypatch, tmp_path):
+    out = _stub_render_path(monkeypatch, tmp_path)
+
+    def _must_not_run(rendered):
+        raise AssertionError("honesty guard must not run under --dry-run")
+
+    monkeypatch.setattr(up, "_honesty_regressions", _must_not_run)
+
+    rc = up.main(["--all", "--dry-run"])
+
+    assert rc == 0
+    assert not out.exists(), "--dry-run must not write"

--- a/scripts/upgrade_l20_cover.py
+++ b/scripts/upgrade_l20_cover.py
@@ -83,9 +83,10 @@ from __future__ import annotations
 
 import argparse
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import yaml
 
@@ -330,6 +331,58 @@ def check(spec: Spec) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
+# Honesty guard
+# ---------------------------------------------------------------------------
+
+_HONESTY_BASELINE = REPO_ROOT / "scripts" / "cover_honesty_baseline.txt"
+
+
+def _honesty_regressions(rendered: List[Tuple["Spec", str]]) -> List[str]:
+    """Return one line per spec whose freshly-rendered cover would be a
+    NON-baselined honesty FAIL (a band asserting attack/CVE/breach evidence the
+    owning post lacks).
+
+    Scored entirely off-disk: each SVG is written to a temp file under its real
+    ``spec.filename`` so ``score_cover_honesty.find_owning_post`` (matches by
+    basename against each post's ``image:`` field) resolves the correct post.
+    The target path ``assets/images/<filename>`` is matched against the
+    committed honesty baseline so already-grandfathered legacy FAILs do not trip
+    the guard — only NEW honesty regressions do.
+
+    Why this exists: most ``_data/l20_covers/*.yml`` specs have drifted from the
+    honest on-disk corpus, so a blind ``--all`` re-render reintroduces dozens of
+    dishonest covers (the regression caught during PR #387). This guard makes
+    the write path refuse rather than silently corrupt the corpus.
+    """
+    try:
+        from scripts.score_cover_honesty import load_baseline, score_file
+    except Exception as exc:  # pragma: no cover - defensive
+        # Fail OPEN with a visible warning: the guard is defense-in-depth, not
+        # the only honesty gate (svg-lint CI still scores on-disk covers).
+        print(f"  WARN: honesty guard unavailable ({exc}); skipping", file=sys.stderr)
+        return []
+
+    baseline = load_baseline(_HONESTY_BASELINE) if _HONESTY_BASELINE.exists() else set()
+    regressions: List[str] = []
+    with tempfile.TemporaryDirectory() as td:
+        tdir = Path(td)
+        for spec, svg in rendered:
+            tmp = tdir / spec.filename
+            tmp.write_text(svg, encoding="utf-8")
+            result = score_file(tmp)
+            if result.get("verdict") != "FAIL":
+                continue
+            if f"assets/images/{spec.filename}" in baseline:
+                continue
+            viols = "; ".join(
+                f"{v['band']}:{v['visual_id']}"
+                for v in result.get("honesty", {}).get("violations", [])
+            )
+            regressions.append(f"{spec.filename}  [{viols or 'honesty FAIL'}]")
+    return regressions
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -381,6 +434,15 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         action="store_true",
         help="Re-render each spec and exit 1 if any on-disk SVG drifts",
     )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Bypass the cover-honesty guard. By default a write run aborts if "
+            "rendering would introduce a NON-baselined honesty FAIL (e.g. a "
+            "drifted spec asserting attack evidence its post lacks)."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -391,34 +453,62 @@ def main(argv: Optional[List[str]] = None) -> int:
         print("no specs to process")
         return 0
 
-    drift: List[str] = []
-    rendered = 0
+    specs: List[Spec] = []
     for p in paths:
         try:
-            spec = load_spec(p)
+            specs.append(load_spec(p))
         except (ValueError, yaml.YAMLError) as exc:
             print(f"  ERROR loading {_short_path(p)}: {exc}", file=sys.stderr)
             return 2
 
-        if args.check:
+    if args.check:
+        drift: List[str] = []
+        for spec in specs:
             issue = check(spec)
             if issue:
                 print(f"  {issue}", file=sys.stderr)
                 drift.append(issue)
             else:
                 print(f"  OK    {spec.filename}")
-        else:
-            size = write(spec, dry_run=args.dry_run)
-            tag = "[DRY] " if args.dry_run else ""
-            print(f"  {tag}wrote {spec.filename}: {size} bytes")
-            rendered += 1
-
-    if args.check:
         if drift:
             print(f"\n{len(drift)} spec(s) drifted from on-disk SVG", file=sys.stderr)
             return 1
-        print(f"\n{len(paths)} specs OK")
+        print(f"\n{len(specs)} specs OK")
         return 0
+
+    # Write mode: render everything first so the honesty guard can score the
+    # would-be output BEFORE any byte hits disk.
+    rendered_pairs: List[Tuple[Spec, str]] = [(spec, render(spec)) for spec in specs]
+
+    if not args.dry_run and not args.force:
+        regressions = _honesty_regressions(rendered_pairs)
+        if regressions:
+            print(
+                f"\nERROR: honesty guard blocked the write — {len(regressions)} "
+                "spec(s) would render a NON-baselined honesty FAIL:",
+                file=sys.stderr,
+            )
+            for line in regressions:
+                print(f"  FAIL: {line}", file=sys.stderr)
+            print(
+                "\nThese specs have drifted from the honest on-disk corpus. "
+                "Do NOT mass-regenerate via this tool — fix the cover surgically "
+                "on disk (preserving its honest visuals) or reconcile the spec, "
+                "then re-run. Pass --force only if you have verified the render "
+                "is genuinely honest and intend to update the honesty baseline.",
+                file=sys.stderr,
+            )
+            return 1
+
+    rendered = 0
+    for spec, svg in rendered_pairs:
+        if args.dry_run:
+            print(f"  [DRY] wrote {spec.filename}: 0 bytes")
+        else:
+            spec.output_path.write_text(svg, encoding="utf-8")
+            print(f"  wrote {spec.filename}: {len(svg.encode('utf-8'))} bytes")
+        rendered += 1
+
     print(f"\n{rendered} spec(s) rendered")
     return 0
 


### PR DESCRIPTION
## Summary

Two cover-correctness hardenings around the **rotted `_data/l20_covers` specs** (exploration found **164 / 177** specs drift from the honest on-disk corpus). Neither paper-overs the rot with a baseline — they prevent the footgun at the source.

### [A] `fix_qr_url_in_covers.py` — match new **and** legacy QR label
The QR-block matcher anchored on the **legacy** label coordinates (`x="1122" y="614"`, below the old 84px QR). Every modern 108px cover places the label at `x="1134" y="486"` (above the 132×132 rect), so the matcher reported **"no QR block found"** for all of them — a stale-URL 108px cover could never be repaired. Anchor on the label **text** (`scan / full post`) instead of coordinates so the fixer upgrades both geometries (and any future tweak).

Verified: default glob now finds QR blocks in all **124** digest covers, **0** false fixes.

### [B] `upgrade_l20_cover.py` — cover-honesty write guard
A blind `--all` re-render reintroduces dishonest covers because the specs have drifted (the exact regression caught during PR #387). The write path now:
1. renders every spec **off-disk**,
2. scores each via `score_cover_honesty.score_file` (temp file under the real basename so `find_owning_post` resolves the owning post),
3. **aborts before writing** if any spec would produce a **NON-baselined** honesty FAIL — printing the offenders + surgical-fix guidance.

`--force` bypasses; `--check` / `--dry-run` are read-only and unaffected. **CI is untouched** — svg-lint only runs `upgrade_l20_cover.py --all --check`, never a write.

Empirically: `--all --since 2026-05-20` now aborts on 2 rotted specs (`hub_spoke`, `code_injection`) with **zero on-disk writes**.

> Chosen over a CI drift-baseline gate (the other option considered): with 164/177 specs rotted, a drift gate would have to grandfather almost the entire corpus, legitimizing the rot. The script guard prevents the bad write directly without a baseline. The existing `score_cover_honesty --all --strict` svg-lint gate continues to protect merged on-disk covers.

## Tests
- `test_fix_qr_url_in_covers.py` — matcher accepts both geometries; `fix_one` upgrades a stale legacy block to canonical 108px; canonical block left unchanged.
- `test_upgrade_l20_honesty_guard.py` — baseline/verdict filtering; `main` aborts on regression (no file written); `--force` / `--dry-run` skip the guard.

## Verification
- `pytest scripts/tests/` → **2088 passed**
- Guard blocks `--all --since 2026-05-20` with 0 writes; `--check`/`--dry-run`/`--force` behave correctly
- Source/test-only change (no image churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)