### PR TITLE
fix(ci): resolve the 5 ruff blockers failing the Ops Multi Agent Loop

### DIFF
--- a/scripts/lib/svg_l20_hero.py
+++ b/scripts/lib/svg_l20_hero.py
@@ -25,7 +25,7 @@ THEMES palette.
 from __future__ import annotations
 
 import re
-from typing import Dict
+from typing import Dict, Tuple
 
 from scripts.lib import svg_l22_generator as l22
 

--- a/scripts/tests/test_svg_l25_single.py
+++ b/scripts/tests/test_svg_l25_single.py
@@ -19,7 +19,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from scripts.lib import svg_l25_single as l25  # noqa: E402
 from scripts.upgrade_l25_cover import (  # noqa: E402
-    SPECS_DIR, check, load_spec, main, render, write,
+    SPECS_DIR,
+    check,
+    load_spec,
+    main,
+    render,
+    write,
 )
 
 MARKER = "<!-- profile: high-quality-cover (2025 upgraded L25-single) -->"
@@ -176,12 +181,14 @@ class TestLoadSpec:
         assert len(spec.tag_chips) == 3 and len(spec.kpi_strip) == 3
 
     def test_rejects_unknown_top_level(self, tmp_path):
-        data = _minimal_spec(); data["nonsense"] = "v"
+        data = _minimal_spec()
+        data["nonsense"] = "v"
         with pytest.raises(ValueError, match="unknown top-level"):
             load_spec(_write_spec(tmp_path, data))
 
     def test_rejects_missing_required(self, tmp_path):
-        data = _minimal_spec(); del data["headline"]
+        data = _minimal_spec()
+        del data["headline"]
         with pytest.raises(ValueError, match="missing required"):
             load_spec(_write_spec(tmp_path, data))
 
@@ -207,7 +214,8 @@ class TestLoadSpec:
             load_spec(_write_spec(tmp_path, data))
 
     def test_omitting_url_uses_canonical(self, tmp_path):
-        data = _minimal_spec(); del data["url"]
+        data = _minimal_spec()
+        del data["url"]
         spec = load_spec(_write_spec(tmp_path, data))
         assert spec.url == (
             "https://tech.2twodragon.com/posts/2026/06/01/"


### PR DESCRIPTION
## Diagnosis

The scheduled **Ops Multi Agent Loop** workflow exits 1 every run. Root cause traced through `scripts/ops_health_orchestrator.py`:

- Its **only blocking check** is `lint-and-types` (line 524: *"Only lint-and-types is blocking; external service checks are advisory"*).
- That check runs `ruff check scripts/ --fix` (ephemeral) then a **verify** pass. `ruff` reports 81 errors — **76 auto-fixable, 5 not**. After the ephemeral `--fix`, the **5 non-auto-fixable** errors keep verify failing → exit 1.
- **mypy is advisory** (line 88, "94 legacy errors need gradual fixing") — not the cause. The **Sentry 403 Forbidden** is also advisory (not in the blocking set) — a separate secrets issue (`SENTRY_AUTH_TOKEN`), not addressed here.

## The 5 non-auto-fixable errors (fixed)
- `scripts/lib/svg_l20_hero.py:682,688` — **F821 undefined name `Tuple`**: the module imported only `Dict` but annotates `Dict[str, Tuple[...]]`. A latent bug masked today only by `from __future__ import annotations`. → import `Tuple`.
- `scripts/tests/test_svg_l25_single.py:179,184,210` — **E702** multiple statements on one line (`a; b`). → split into separate lines.

## Minimal by design
The other 76 errors are **auto-fixed by the orchestrator's own ephemeral `ruff --fix`** each run, so they don't need committing. Fixing only the 5 blockers is sufficient and keeps the diff tiny.

## Verification
- After the change: `ruff check scripts/` → 76 errors, **all auto-fixable** (0 non-fixable); simulated orchestrator flow (`ruff --fix` then verify) → **exit 0** → `lint-and-types` OK → workflow green.
- `pytest` 2113 passing; 134 cover/L25 tests pass (no regression from the `Tuple` import or the test edits).

Unrelated to the cover campaign (#396–#399); surfaced during that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)