### PR TITLE
docs(cover): correct stale redirect_from counts in rollup spec audit comments

### DIFF
--- a/_data/rollup_covers/2026-01-31.yml
+++ b/_data/rollup_covers/2026-01-31.yml
@@ -2,7 +2,8 @@
 # Source: _posts/2026-01-31-January_2026_Security_Digest_Monthly_Index.md
 #
 # Audit (see .omc/plans/rollup-cover-design-audit.md):
-#   - No redirect_from in this post. daily_count_source: index_table.
+#   - redirect_from has 2 entries (self-canonical variants only; a monthly index
+#     does not redirect the dailies). daily_count_source: index_table.
 #   - January digests are W4-only: 1/23..1/31 = 9 daily digests.
 #   - summary_card.highlights has 3 generic editorial items; we replace
 #     them with concrete monthly-trend headlines pulled from the

--- a/_data/rollup_covers/2026-02-28.yml
+++ b/_data/rollup_covers/2026-02-28.yml
@@ -2,7 +2,8 @@
 # Source: _posts/2026-02-28-February_2026_Security_Digest_Monthly_Index.md
 #
 # Audit:
-#   - No redirect_from. daily_count_source: index_table.
+#   - redirect_from has 2 entries (self-canonical variants only; a monthly index
+#     does not redirect the dailies). daily_count_source: index_table.
 #   - 22 daily digests across 4 weeks (W1=6, W2=3, W3=6, W4=7).
 #   - Render as 4 week-aggregated cells (not 22 day cells) to keep the
 #     strip readable. Each week-cell carries the dominant theme of its

--- a/_data/rollup_covers/2026-04-05.yml
+++ b/_data/rollup_covers/2026-04-05.yml
@@ -2,8 +2,8 @@
 # Source: _posts/2026-04-05-Week1_April_2026_Security_Digest.md
 #
 # Audit:
-#   - redirect_from has 5 entries (4/1..4/5). daily_count = 5.
-#   - daily_count_source: redirect_from.
+#   - redirect_from has 7 entries: 5 daily URLs (4/1..4/5) + 2 self-canonical
+#     variants. daily_count = 5 (the daily URLs). daily_count_source: redirect_from.
 #   - Schema permits weekly_rollup with 5..7 days (audit-driven relaxation
 #     from plan's strict ==7; April Week 1 only spans Tue..Fri).
 date: '2026-04-05'

--- a/_data/rollup_covers/2026-04-12.yml
+++ b/_data/rollup_covers/2026-04-12.yml
@@ -2,8 +2,8 @@
 # Source: _posts/2026-04-12-Week2_April_2026_Security_Digest.md
 #
 # Audit:
-#   - redirect_from has 7 entries (4/6..4/12). daily_count = 7.
-#   - daily_count_source: redirect_from.
+#   - redirect_from has 9 entries: 7 daily URLs (4/6..4/12) + 2 self-canonical
+#     variants. daily_count = 7 (the daily URLs). daily_count_source: redirect_from.
 date: '2026-04-12'
 slug: Week2_April_2026_Security_Digest
 kind: weekly_rollup

--- a/_data/rollup_covers/2026-04-19.yml
+++ b/_data/rollup_covers/2026-04-19.yml
@@ -2,8 +2,8 @@
 # Source: _posts/2026-04-19-Week3_April_2026_Security_Digest.md
 #
 # Audit:
-#   - redirect_from has 7 entries (4/13..4/19). daily_count = 7.
-#   - daily_count_source: redirect_from.
+#   - redirect_from has 9 entries: 7 daily URLs (4/13..4/19) + 2 self-canonical
+#     variants. daily_count = 7 (the daily URLs). daily_count_source: redirect_from.
 date: '2026-04-19'
 slug: Week3_April_2026_Security_Digest
 kind: weekly_rollup

--- a/_data/rollup_covers/2026-04-30.yml
+++ b/_data/rollup_covers/2026-04-30.yml
@@ -2,8 +2,8 @@
 # Source: _posts/2026-04-30-Week4_April_2026_Security_Digest.md
 #
 # Audit:
-#   - redirect_from has 11 entries (4/20..4/30). daily_count = 11.
-#   - daily_count_source: redirect_from.
+#   - redirect_from has 13 entries: 11 daily URLs (4/20..4/30) + 2 self-canonical
+#     variants. daily_count = 11 (the daily URLs). daily_count_source: redirect_from.
 #   - weekly_rollup caps at 7 days; this post spans 11 days so kind = monthly_index.
 #   - Previously force-fit into digest_covers/ L22 3-band format — now corrected.
 date: '2026-04-30'


### PR DESCRIPTION
## Summary
The `# Audit:` comments in `_data/rollup_covers/*.yml` under-counted `redirect_from`. Each weekly rollup's `redirect_from` = N daily URLs **+ 2 self-canonical variants**, but the comments listed only the daily count (e.g. 2026-04-19 said "7 entries" — actual is 9). The two monthly-index specs said "No redirect_from" though 2 self-variants exist.

Corrected all 6 to state the real count + composition, which also documents *why* `daily_count` < `redirect_from` (the basis for the `daily_count <= redirect_from` accuracy gate from #402).

## Scope / safety
**Comments only** — `yaml.safe_load` ignores them, so rendered SVGs are byte-identical. Verified: `upgrade_rollup_cover.py --all --check` = 6 specs OK (0 drift); `check_rollup_spec_consistency.py --strict` = 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)