### PR TITLE
feat(news): topic diversity — keep ai/blockchain in digest + blockchain section template

### DIFF
--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -86,6 +86,7 @@ from scripts.news.content_generator import (  # noqa: E402,F401
     _extract_meaningful_topics,
     _extract_trend_keyword,
     _generate_ai_analysis_template,
+    _generate_blockchain_template,
     _generate_contextual_action_point,
     _generate_devops_template,
     _generate_executive_and_risk_sections,

--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -2810,6 +2810,8 @@ def generate_news_section(
         section += _generate_ai_analysis_template(item)
     elif category in ("cloud", "devops", "kubernetes"):
         section += _generate_devops_template(item)
+    elif category == "blockchain":
+        section += _generate_blockchain_template(item)
 
     section += "\n---\n\n"
     return section
@@ -3730,6 +3732,84 @@ def _pick_generic_devops_bullets(item: Optional[Dict]) -> str:
     # Non-crypto stable hash — stdlib hash() varies per run, so use a sum
     bucket = sum(ord(c) for c in seed) % len(_DEVOPS_FALLBACK_POOLS)
     return "\n".join(_DEVOPS_FALLBACK_POOLS[bucket]) + "\n"
+
+
+def _generate_blockchain_template(item: Optional[Dict] = None) -> str:
+    """Blockchain "실무 적용 포인트" block.
+
+    Keyword-routed like the security/devops templates (specific keywords before
+    general), so a blockchain story renders substantive, security-relevant
+    guidance instead of bare summary text. ``item is None`` returns a generic
+    fallback. Mirrors :func:`_generate_devops_template`."""
+    if item is None:
+        return """
+#### 실무 적용 포인트
+
+- 온체인 자산·키 관리 정책과 멀티시그/HSM 적용 현황 점검
+- 스마트 컨트랙트 감사 보고서와 알려진 취약 패턴(reentrancy 등) 대응 확인
+- 거래소·브리지 연동 시 출금 한도·이상거래 탐지 룰 재검증
+
+"""
+
+    text = f"{item.get('title', '')} {item.get('summary', '')}".lower()
+    template = "\n#### 실무 적용 포인트\n\n"
+
+    if any(
+        kw in text
+        for kw in ["smart contract", "스마트 컨트랙트", "defi", "reentrancy", "solidity"]
+    ):
+        template += _pick_variant(item, [
+            "- 스마트 컨트랙트 외부 감사(audit) 보고서와 reentrancy·정수 오버플로 대응 확인\n"
+            "- 업그레이드 가능 컨트랙트의 프록시 관리자 키를 멀티시그/타임락으로 보호\n"
+            "- DeFi 프로토콜 오라클 가격 조작(price manipulation) 방어 설계 점검\n",
+            "- 컨트랙트 배포 전 정적 분석(Slither)·퍼징(Echidna)을 CI 게이트에 연동\n"
+            "- 외부 호출(call) 후 상태 변경 순서(checks-effects-interactions) 패턴 검증\n"
+            "- DeFi 풀 유동성·청산 파라미터의 비정상 변경을 온체인 모니터링으로 탐지\n",
+        ])
+    elif any(
+        kw in text
+        for kw in ["exchange", "거래소", "bridge", "브리지", "cross-chain", "hack", "해킹"]
+    ):
+        template += _pick_variant(item, [
+            "- 사고 발표 후 공개된 IoC·악성 지갑 주소를 위협 인텔에 반영\n"
+            "- 브리지/거래소 핫월렛 출금 한도와 다중 승인(multisig) 정책 재검증\n"
+            "- 유사 공격 벡터(서명 검증 우회 등)에 대한 자사 연동 지점 점검\n",
+            "- 거래소 API 키 권한을 출금 비활성·읽기 전용으로 최소화하고 IP 화이트리스트 적용\n"
+            "- 크로스체인 브리지 검증자 집합·임계 서명(threshold signature) 구성 감사\n"
+            "- 이상거래 탐지 룰에 신규 사고 패턴을 추가하고 출금 지연(time-lock) 검토\n",
+        ])
+    elif any(
+        kw in text
+        for kw in ["regulation", "규제", "stablecoin", "스테이블코인", "cbdc", "etf", "법안"]
+    ):
+        template += _pick_variant(item, [
+            "- 신규 규제·가이드라인의 적용 범위와 자사 서비스 컴플라이언스 영향 분석\n"
+            "- 스테이블코인 준비금 증명(PoR)·감사 주기와 공시 요건 점검\n"
+            "- 자금세탁방지(AML)·여행규칙(Travel Rule) 대응 절차 최신화\n",
+            "- 규제 시행일 기준 내부 정책·약관 개정 일정과 책임자 승인 절차 수립\n"
+            "- 가상자산 사업자(VASP) 신고 요건과 지갑 주소 모니터링 보존 기간 검토\n"
+            "- 스테이블코인/ETF 관련 시장 변동성에 대비한 운영 리스크 시나리오 점검\n",
+        ])
+    elif any(kw in text for kw in ["wallet", "지갑", "custody", "수탁", "key", "키 관리"]):
+        template += _pick_variant(item, [
+            "- 개인키·시드 구문 저장 방식(HSM·하드웨어 지갑)과 백업 절차 점검\n"
+            "- 멀티시그 임계값(M-of-N) 구성과 서명자 권한 분리 현황 확인\n"
+            "- 수탁(custody) 출금 승인 워크플로우와 감사 로그 보존 검토\n",
+            "- 콜드/핫 월렛 자산 비율과 핫월렛 노출 한도를 리스크 기준으로 재산정\n"
+            "- 서명 단말 격리(air-gap)와 펌웨어 무결성 검증 주기 관리\n"
+            "- 키 분실·탈취 대비 사회공학 공격 대응 교육과 복구 절차 리허설\n",
+        ])
+    else:
+        template += _pick_variant(item, [
+            "- 온체인 트랜잭션 모니터링으로 자사 연관 주소의 이상 흐름 탐지\n"
+            "- 보유·연동 토큰의 스마트 컨트랙트 감사 이력과 알려진 위험 점검\n"
+            "- 블록체인 인프라(노드·RPC) 접근 제어와 키 관리 정책 재검증\n",
+            "- 블록체인 시장·정책 변화가 자사 자산 운용·리스크에 미치는 영향 분석\n"
+            "- 사용하는 프로토콜·체인의 거버넌스 변경·업그레이드 일정 추적\n"
+            "- 온체인 데이터를 위협 인텔에 연계해 악성 주소·믹서 사용 패턴 모니터링\n",
+        ])
+
+    return template
 
 
 def _generate_trend_analysis(news_items: List[Dict], section_num: int) -> str:

--- a/scripts/news/loader.py
+++ b/scripts/news/loader.py
@@ -252,6 +252,48 @@ def _filter_by_cutoff(items: List[Dict], cutoff: datetime) -> List[Dict]:
     return filtered
 
 
+# Topic diversity: primary-topic signals that mark an item as genuinely
+# ai/blockchain. When present, a BORDERLINE soft-security signal (exactly 2 soft
+# indicators) does NOT pull the item into the security bucket — only >=3 soft
+# indicators (or any STRONG indicator, below) does. Word-boundary anchored so
+# ambiguous substrings ("eth" in "method"/"ethics", "token" in "CSRF token",
+# "crypto" in "cryptography") do not raise a false primary signal.
+_AI_PRIMARY_RE = re.compile(
+    r"\b(?:anthropic|openai|claude|gpt|llm|gemini|deepmind|mistral|"
+    r"machine learning|neural network|hugging face)\b",
+    re.IGNORECASE,
+)
+_BLOCKCHAIN_PRIMARY_RE = re.compile(
+    r"\b(?:bitcoin|ethereum|defi|cryptocurrency|wallet|blockchain|"
+    r"stablecoin|nft|web3|solana)\b",
+    re.IGNORECASE,
+)
+
+# STRONG security indicators: a single one forces the security bucket — a CVE /
+# exploit / ransomware / malware story is a security story regardless of feed.
+_STRONG_SECURITY_INDICATORS = (
+    "cve-", "exploit", "malware", "악성코드", "ransomware", "랜섬웨어",
+)
+# SOFT indicators: only COUNT toward the >=2 (/ >=3 for on-topic ai/blockchain)
+# threshold — "attack"/"breach"/"vulnerability" appear in non-security topic
+# stories too, so a single soft mention must not reclassify.
+_SOFT_SECURITY_INDICATORS = (
+    "vulnerability", "취약점", "attack", "공격", "breach", "침해",
+)
+
+
+def _has_primary_topic_signal(text: str, category: str) -> bool:
+    """True iff ``text`` carries a strong primary-topic signal for ``category``
+    (ai / blockchain). Used to raise the soft-security-reclassification bar so a
+    single passing mention of "attack"/"breach" cannot erase an on-topic
+    ai/blockchain story."""
+    if category == "ai":
+        return bool(_AI_PRIMARY_RE.search(text))
+    if category == "blockchain":
+        return bool(_BLOCKCHAIN_PRIMARY_RE.search(text))
+    return False
+
+
 def categorize_news(items: List[Dict]) -> Dict[str, List[Dict]]:
     """Categorize news items with content-based reclassification."""
     categorized = defaultdict(list)
@@ -289,23 +331,25 @@ def categorize_news(items: List[Dict]) -> Dict[str, List[Dict]]:
                     category = "ai"
 
         if category not in ("security", "devsecops"):
-            security_indicators = [
-                "vulnerability",
-                "exploit",
-                "cve-",
-                "\ucde8\uc57d\uc810",
-                "malware",
-                "\uc545\uc131\ucf54\ub4dc",
-                "ransomware",
-                "\ub79c\uc12c\uc6e8\uc5b4",
-                "attack",
-                "\uacf5\uaca9",
-                "breach",
-                "\uce68\ud574",
-            ]
-            security_score = sum(1 for kw in security_indicators if kw in combined)
-            if security_score >= 2:
+            # A single STRONG indicator (CVE/exploit/malware/ransomware) forces
+            # security regardless of feed \u2014 a genuine incident is never diluted.
+            if any(kw in combined for kw in _STRONG_SECURITY_INDICATORS):
                 category = "security"
+            else:
+                # Soft indicators only count toward a threshold. On-topic
+                # ai/blockchain stories need a HIGHER bar (>=3) so a borderline
+                # pair of soft words does not drain them into the security
+                # bucket; cloud/devops/tech keep the >=2 bar.
+                soft_score = sum(
+                    1 for kw in _SOFT_SECURITY_INDICATORS if kw in combined
+                )
+                threshold = 2
+                if category in ("ai", "blockchain") and _has_primary_topic_signal(
+                    combined, category
+                ):
+                    threshold = 3
+                if soft_score >= threshold:
+                    category = "security"
 
         if category in ("security", "devsecops"):
             category = "security"

--- a/scripts/tests/test_news_templates.py
+++ b/scripts/tests/test_news_templates.py
@@ -20,6 +20,7 @@ from auto_publish_news import (
     _extract_trend_keyword,
     _filter_by_cutoff,
     _generate_ai_analysis_template,
+    _generate_blockchain_template,
     _generate_contextual_action_point,
     _generate_devops_template,
     _generate_executive_and_risk_sections,
@@ -36,6 +37,7 @@ from auto_publish_news import (
     extract_cve_id,
     filter_published_urls,
     generate_mitre_mapping,
+    generate_news_section,
     generate_risk_scorecard,
     select_top_news,
 )
@@ -1777,6 +1779,145 @@ class TestCategorizeNews:
         ]
         result = categorize_news(items)
         assert "security" in result
+
+    # --- Topic diversity (#2): keep on-topic ai/blockchain stories out of the
+    # security bucket when the security signal is only borderline (exactly 2
+    # indicators) AND the item has a strong primary-topic signal. A genuine
+    # security story (>=3 indicators) still reclassifies. cloud/devops/tech keep
+    # the >=2 bar. This preserves the security-digest identity while letting
+    # ai/blockchain content survive into the digest. ---
+    def test_blockchain_borderline_security_stays_blockchain(self):
+        # ethereum/defi primary signal + exactly 2 indicators (attack, breach)
+        items = [
+            self._item(
+                "Ethereum DeFi protocol attack analysis",
+                "cross-chain bridge breach review",
+                category="blockchain",
+            )
+        ]
+        result = categorize_news(items)
+        assert "blockchain" in result
+        assert "security" not in result
+
+    def test_ai_borderline_security_stays_ai(self):
+        # openai/claude primary signal + exactly 2 indicators (attack, breach)
+        items = [
+            self._item(
+                "OpenAI Claude model attack surface",
+                "agent breach mitigation",
+                category="ai",
+            )
+        ]
+        result = categorize_news(items)
+        assert "ai" in result
+        assert "security" not in result
+
+    def test_blockchain_three_indicators_still_security(self):
+        # 3+ indicators (vulnerability, exploit, malware) => genuine security
+        items = [
+            self._item(
+                "Ethereum wallet vulnerability exploit",
+                "malware drains funds",
+                category="blockchain",
+            )
+        ]
+        result = categorize_news(items)
+        assert "security" in result
+
+    def test_tech_borderline_security_still_reclassifies(self):
+        # non-ai/blockchain (tech) keeps the >=2 bar -> still security
+        items = [
+            self._item(
+                "Tech platform attack",
+                "data breach disclosed",
+                category="tech",
+            )
+        ]
+        result = categorize_news(items)
+        assert "security" in result
+
+    def test_blockchain_single_strong_indicator_forces_security(self):
+        # a STRONG indicator (exploit) forces security even at count 1, even on
+        # an on-topic blockchain story — genuine incidents are never diluted.
+        items = [
+            self._item(
+                "Ethereum wallet exploit drains funds",
+                "active in the wild",
+                category="blockchain",
+            )
+        ]
+        result = categorize_news(items)
+        assert "security" in result
+        assert "blockchain" not in result
+
+    def test_primary_signal_word_boundary_no_false_match(self):
+        # "method"/"together" contain "eth" but must NOT count as a blockchain
+        # primary signal -> a generic 2-soft-indicator item still reclassifies.
+        items = [
+            self._item(
+                "Network method attack",
+                "service breach disclosed together",
+                category="blockchain",
+            )
+        ]
+        result = categorize_news(items)
+        assert "security" in result  # no real primary signal -> >=2 bar applies
+
+
+# ===========================================================================
+# _generate_blockchain_template  (#3 — blockchain section template)
+# ===========================================================================
+
+
+class TestGenerateBlockchainTemplate:
+    """Tests for _generate_blockchain_template()."""
+
+    def _item(self, title, summary=""):
+        return {"title": title, "summary": summary, "url": f"https://x/{title}"}
+
+    def test_none_returns_template(self):
+        result = _generate_blockchain_template(None)
+        assert "#### 실무 적용 포인트" in result
+        assert ("멀티시그" in result or "스마트 컨트랙트" in result or "키 관리" in result)
+        _assert_no_banned(result, "blockchain None branch")
+
+    def test_smart_contract_branch(self):
+        result = _generate_blockchain_template(
+            self._item("DeFi smart contract reentrancy bug", "solidity audit")
+        )
+        assert "#### 실무 적용 포인트" in result
+        assert ("컨트랙트" in result or "DeFi" in result or "reentrancy" in result)
+
+    def test_exchange_hack_branch(self):
+        result = _generate_blockchain_template(
+            self._item("Crypto exchange bridge hack", "거래소 해킹 분석")
+        )
+        assert ("IoC" in result or "브리지" in result or "출금" in result)
+
+    def test_regulation_branch(self):
+        result = _generate_blockchain_template(
+            self._item("New stablecoin regulation", "CBDC 규제 법안")
+        )
+        assert ("규제" in result or "스테이블코인" in result or "AML" in result)
+
+    def test_generic_fallback_branch(self):
+        result = _generate_blockchain_template(
+            self._item("Bitcoin price rally", "시장 동향")
+        )
+        assert "#### 실무 적용 포인트" in result  # generic else still emits a block
+
+    def test_dispatched_for_blockchain_category(self):
+        # generate_news_section must route a blockchain item to the template.
+        section = generate_news_section(
+            {
+                "title": "Ethereum DeFi protocol smart contract audit",
+                "summary": "reentrancy 취약점 점검",
+                "category": "blockchain",
+                "url": "https://example.com/2026/eth",
+            },
+            "1",
+        )
+        assert "#### 실무 적용 포인트" in section
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

The weekly auto-digest was ~73% security-dominated because `categorize_news` drained ai/blockchain items into the security bucket and blockchain had no section template. This lets on-topic ai/blockchain/devops content survive into the digest **without** breaking the security-digest identity or surfacing stale content. (Architect-designed, TDD; first of the 3 workstreams — covers diversity + SEO content-freshness follow on.)

## Changes
- **`loader.py` — STRONG vs SOFT security indicators.** A STRONG indicator (`cve-`/`exploit`/`malware`/`ransomware`) forces `security` at any count — genuine incidents are never diluted. SOFT indicators (`vulnerability`/`attack`/`breach` + Korean) only count toward a threshold: on-topic ai/blockchain stories (with a **word-boundary-anchored** primary signal — no false `eth`-in-`method` matches) need ≥3; cloud/devops/tech keep ≥2. The blockchain→ai/security block, devsecops→security merge, and the **asymmetric stale filter are deliberately UNCHANGED** (stale filter kept so old ai/blockchain news is never surfaced — per the "no stale content" constraint).
- **`content_generator.py` — `_generate_blockchain_template`** (None fallback + specific-before-general keyword branches: smart-contract/DeFi, exchange/bridge hack, regulation/stablecoin, wallet/custody, generic), wired into `generate_news_section` after the cloud/devops branch (exact `==`, no over-match).
- **`auto_publish_news.py` / tests** — re-export + import.

## Impact (empirical)
`categorize_news` over real `_data/collected_news.json` now yields **balanced buckets** (ai=5, blockchain=5, cloud=5, devops=5, security=5, tech=5); blockchain was previously ~0. Body sections (`categorized[..][:3]`) now render ai/blockchain/devops alongside security — which also naturally diversifies the covers (workstream B) as topics vary.

## Tests
- `TestCategorizeNews`: borderline ai/blockchain stays; STRONG forces security; word-boundary no false match; tech keeps ≥2.
- `TestGenerateBlockchainTemplate`: None/smart-contract/exchange/regulation/generic/dispatch.
- Full suite **2221 passed**.

## Review
code-reviewer COMMENT (0 CRITICAL/HIGH). MEDIUM items addressed in this PR: STRONG/SOFT split (identity dilution), word-boundary primary signals (substring false matches). `select_top_news`/title generation untouched.

## Out of scope (follow-ups)
- Title/highlights still security-first (body floor is a separate change).
- Cover source-name-in-title escape (`Cloudflare Blog`); 5-column highlights table parsing.
- Pre-existing `package.json`/`package-lock.json` working-tree changes are **not** included in this PR.