### PR TITLE
fix(cover): reject generic-word digest headlines (Show/Option); share lead-headline helper with rollup

### DIFF
--- a/scripts/draft_rollup_spec.py
+++ b/scripts/draft_rollup_spec.py
@@ -60,7 +60,11 @@ REPO = Path(__file__).resolve().parent.parent
 # scripts/news/__init__.py imports via the ``scripts.`` package, so the repo
 # root (parent of scripts/) must be on sys.path.
 sys.path.insert(0, str(REPO))
-from scripts.news.l20_dispatch import _CVE_RE, _entity_tokens  # noqa: E402
+from scripts.news.l20_dispatch import (  # noqa: E402
+    _CVE_RE,
+    _entity_tokens,
+    build_lead_headline,
+)
 
 ROLLUP_COVERS_DIR = REPO / "_data" / "rollup_covers"
 POSTS_DIR = REPO / "_posts"
@@ -203,12 +207,14 @@ def lead_entity(title: str) -> str:
     toks = _entity_tokens(title)
     if not toks:
         return ""
-    non_cve = [t for t in toks if not _CVE_RE.match(t)]
-    if non_cve:
-        lead = non_cve[0]
-        if len(non_cve) > 1 and len(f"{non_cve[0]} {non_cve[1]}") <= _HEADLINE_MAX_CHARS:
-            lead = f"{non_cve[0]} {non_cve[1]}"
-    else:
+    # Shared cover-grade headline logic (clause guard, generic-word reject,
+    # acronym-product join). Returns "" on the non-CVE path when nothing
+    # resolves; fall back to a leading CVE id as the tag in that case.
+    lead = build_lead_headline(title)
+    if not lead:
+        non_cve = [t for t in toks if not _CVE_RE.match(t)]
+        if non_cve:
+            return ""
         lead = toks[0]
     return _shorten(lead, _HEADLINE_MAX_CHARS)
 

--- a/scripts/news/l20_dispatch.py
+++ b/scripts/news/l20_dispatch.py
@@ -912,6 +912,13 @@ _SEVERITY_WORDS: frozenset = frozenset({"critical", "high", "medium", "low"})
 # detection is intentionally NOT attempted (false-positive risk on real actors).
 _WEAK_TRAILING: frozenset = frozenset({"factories"}) | _SEVERITY_WORDS
 
+# Generic capitalized English common words that read as filler bigrams on a
+# cover ("Show Option") and as useless lone headlines ("Show"). Consulted ONLY
+# in the single-token reject path of _is_good_headline (W3) and in the bigram
+# both-generic reject — NEVER for real story subjects. Deliberately EXCLUDES
+# real subjects like "strategy" (the MSTR-rebrand entity, a legit lone lead).
+_GENERIC_HEADLINE_WORDS: frozenset = frozenset({"show", "option"})
+
 
 def _common_prefix_len(a: str, b: str) -> int:
     """Length of the case-insensitive common leading run of ``a`` and ``b``."""
@@ -940,7 +947,13 @@ def _is_good_headline(h: str) -> bool:
         return False
     if not has_space:
         tl = h.lower()
-        if tl in (_ENTITY_ACRONYMS | _GENERIC_TRAILING | _WEAK_HEADLINE_WORDS | _WEAK_TRAILING):
+        if tl in (
+            _ENTITY_ACRONYMS
+            | _GENERIC_TRAILING
+            | _WEAK_HEADLINE_WORDS
+            | _WEAK_TRAILING
+            | _GENERIC_HEADLINE_WORDS
+        ):
             return False
     elif all(t.lower() in _SEVERITY_WORDS for t in h.split()):
         # W4: a multi-word headline made entirely of severity words
@@ -1000,6 +1013,89 @@ def _severity_from_marker(cell: str) -> str:
     return ""
 
 
+def build_lead_headline(title: str) -> str:
+    """Lead 1-2 entity-token headline for a (possibly Korean) ``title``.
+
+    Encapsulates the shared headline-resolution logic used by both the L20
+    digest panel builder and ``draft_rollup_spec.lead_entity``. Operates on the
+    NON-CVE entity tokens of ``title`` and returns ``""`` when nothing resolves
+    (the caller then applies its own CVE / source fallback). Carries every
+    existing guard verbatim: generic-trailing block, near-dup prefix, length
+    cap, the load-bearing ``acronym_product_join`` exception (keeps "AWS KY3P" /
+    "npm Worm"), and the ``_is_good_headline`` single-token fallthrough — PLUS a
+    both-generic bigram reject so two filler words never form a headline
+    ("Show Option"). Combined with the generic-word reject in ``_is_good_headline``
+    this keeps lone/paired filler words ("Show", "Option") off the cover.
+
+    Known limitation (deferred): a possessive lead like "Strategy의 Michael
+    Saylor" still yields "Strategy Michael" — recovering the person bigram
+    "Michael Saylor" would need surname detection, which this module
+    deliberately avoids (false-positive risk on real actors; see the wordlist
+    comments above).
+    """
+    toks = _entity_tokens(title)
+    non_cve = [t for t in toks if not _CVE_RE.match(t)]
+    if not non_cve:
+        return ""
+    # Lead candidate: first entity, optionally joined with the second token
+    # — but never glue a generic platform/region trailing word ("Showboat
+    # Linux" -> "Showboat", "Foo MENA" -> "Foo").
+    candidate = non_cve[0]
+    if (
+        len(non_cve) > 1
+        and non_cve[1].lower() not in _GENERIC_TRAILING
+        # Skip a near-duplicate brand restatement ("ChatGPhish ChatGPT"):
+        # a long shared prefix means token 2 just echoes token 1.
+        and _common_prefix_len(non_cve[0], non_cve[1]) < 4
+        and len(f"{non_cve[0]} {non_cve[1]}") <= _HEADLINE_MAX_CHARS
+        # Never join two generic filler words into a useless bigram
+        # ("Show Option") — see _GENERIC_HEADLINE_WORDS.
+        and not (
+            non_cve[0].lower() in _GENERIC_HEADLINE_WORDS
+            and non_cve[1].lower() in _GENERIC_HEADLINE_WORDS
+        )
+    ):
+        candidate = f"{non_cve[0]} {non_cve[1]}"
+    # Trust the lead candidate only when it is good AND the LEAD token is
+    # not itself a generic/weak/acronym word — otherwise a phrase like
+    # "Linux Defender" would slip through on the strength of its space.
+    #
+    # Exception: a known cloud/product ACRONYM (aws, gcp, npm, …) IS a
+    # meaningful lead when the second token is a real entity — e.g.
+    # "AWS KY3P" is a recognisable vendor+product phrase. In that case
+    # keep the joined candidate even though the lead token alone would be
+    # flagged as "bad". Only reject the join when the lead is a *generic
+    # trailing* or *weak* word (linux, cloud, sorry, etc.).
+    lead_token_lower = non_cve[0].lower()
+    lead_is_acronym = lead_token_lower in _ENTITY_ACRONYMS
+    lead_is_generic = lead_token_lower in (_GENERIC_TRAILING | _WEAK_HEADLINE_WORDS)
+    lead_bad = lead_token_lower in (
+        _ENTITY_ACRONYMS | _GENERIC_TRAILING | _WEAK_HEADLINE_WORDS
+    )
+    # Allow "ACRONYM Product" joins (e.g. "AWS KY3P", "npm worm", "GCP
+    # IAM") when the second token itself passes _is_good_headline.
+    two_token_candidate = " " in candidate
+    acronym_product_join = (
+        two_token_candidate
+        and lead_is_acronym
+        and not lead_is_generic  # ios, ai, ml are in BOTH sets → still bad
+        and len(non_cve) > 1
+        and _is_good_headline(non_cve[1])
+    )
+    if _is_good_headline(candidate) and (not lead_bad or acronym_product_join):
+        return candidate
+    # The lead entity is a bare acronym / generic / weak word (e.g.
+    # "AI", "Sorry", "Linux"). Scan for the first token that passes,
+    # preferring a Capitalized non-acronym over a lone acronym.
+    cap = next(
+        (t for t in non_cve
+         if _is_good_headline(t) and t.lower() not in _ENTITY_ACRONYMS),
+        "",
+    )
+    acro = next((t for t in non_cve if _is_good_headline(t)), "")
+    return cap or acro
+
+
 def _panel_from_source_title(
     src: str, ttl: str, severity: str = ""
 ) -> Optional[Dict]:
@@ -1018,64 +1114,10 @@ def _panel_from_source_title(
     toks = _entity_tokens(ttl)
     if not toks:
         return None
-    non_cve = [t for t in toks if not _CVE_RE.match(t)]
     cve = _CVE_RE.search(_html.unescape(ttl))
     cve_str = cve.group(0).upper() if cve else ""
 
-    headline: str = ""
-    if non_cve:
-        # Lead candidate: first entity, optionally joined with the second token
-        # — but never glue a generic platform/region trailing word ("Showboat
-        # Linux" -> "Showboat", "Foo MENA" -> "Foo").
-        candidate = non_cve[0]
-        if (
-            len(non_cve) > 1
-            and non_cve[1].lower() not in _GENERIC_TRAILING
-            # Skip a near-duplicate brand restatement ("ChatGPhish ChatGPT"):
-            # a long shared prefix means token 2 just echoes token 1.
-            and _common_prefix_len(non_cve[0], non_cve[1]) < 4
-            and len(f"{non_cve[0]} {non_cve[1]}") <= _HEADLINE_MAX_CHARS
-        ):
-            candidate = f"{non_cve[0]} {non_cve[1]}"
-        # Trust the lead candidate only when it is good AND the LEAD token is
-        # not itself a generic/weak/acronym word — otherwise a phrase like
-        # "Linux Defender" would slip through on the strength of its space.
-        #
-        # Exception: a known cloud/product ACRONYM (aws, gcp, npm, …) IS a
-        # meaningful lead when the second token is a real entity — e.g.
-        # "AWS KY3P" is a recognisable vendor+product phrase. In that case
-        # keep the joined candidate even though the lead token alone would be
-        # flagged as "bad". Only reject the join when the lead is a *generic
-        # trailing* or *weak* word (linux, cloud, sorry, etc.).
-        lead_token_lower = non_cve[0].lower()
-        lead_is_acronym = lead_token_lower in _ENTITY_ACRONYMS
-        lead_is_generic = lead_token_lower in (_GENERIC_TRAILING | _WEAK_HEADLINE_WORDS)
-        lead_bad = lead_token_lower in (
-            _ENTITY_ACRONYMS | _GENERIC_TRAILING | _WEAK_HEADLINE_WORDS
-        )
-        # Allow "ACRONYM Product" joins (e.g. "AWS KY3P", "npm worm", "GCP
-        # IAM") when the second token itself passes _is_good_headline.
-        two_token_candidate = " " in candidate
-        acronym_product_join = (
-            two_token_candidate
-            and lead_is_acronym
-            and not lead_is_generic  # ios, ai, ml are in BOTH sets → still bad
-            and len(non_cve) > 1
-            and _is_good_headline(non_cve[1])
-        )
-        if _is_good_headline(candidate) and (not lead_bad or acronym_product_join):
-            headline = candidate
-        else:
-            # The lead entity is a bare acronym / generic / weak word (e.g.
-            # "AI", "Sorry", "Linux"). Scan for the first token that passes,
-            # preferring a Capitalized non-acronym over a lone acronym.
-            cap = next(
-                (t for t in non_cve
-                 if _is_good_headline(t) and t.lower() not in _ENTITY_ACRONYMS),
-                "",
-            )
-            acro = next((t for t in non_cve if _is_good_headline(t)), "")
-            headline = cap or acro
+    headline: str = build_lead_headline(ttl)
 
     if not headline:
         # No non-CVE entity passed. Prefer a CVE id, then an ASCII source as a

--- a/scripts/tests/test_draft_rollup_spec.py
+++ b/scripts/tests/test_draft_rollup_spec.py
@@ -74,6 +74,21 @@ def test_lead_entity_prefers_proper_noun_over_cve():
     assert lead_entity("순수 한글 제목") == ""
 
 
+def test_lead_entity_inherits_cover_grade_honesty_filtering():
+    """Intentional decision: rollup day-cell tags share the L20 cover headline
+    quality guards (generic-word reject, severity-join reject) via the shared
+    ``build_lead_headline`` helper — no weak "Show Option"/"Critical High" tags
+    leak onto rollup covers."""
+    # A generic platform lead falls through to the real following entity.
+    assert lead_entity("Linux Defender 우회") == "Defender"
+    # An all-severity-word join is rejected -> empty tag (omit, don't fabricate).
+    assert lead_entity("Critical High 경보") == ""
+    # Both tokens generic filler ("Show Option") -> empty tag.
+    assert lead_entity("Show Option 기능") == ""
+    # Positive control: a real vendor+product bigram is preserved.
+    assert lead_entity("Ivanti EPMM 취약점") == "Ivanti EPMM"
+
+
 def test_daily_urls_from_redirects_picks_only_daily_paths():
     redirects = [
         "/posts/2026/04/01/Tech_Security_Weekly_Digest_Zero-Day/",

--- a/scripts/tests/test_l20_realcontent.py
+++ b/scripts/tests/test_l20_realcontent.py
@@ -29,11 +29,13 @@ from scripts.news.l20_dispatch import (
     _digest_stats,
     _digest_table_panels,
     _entity_tokens,
+    _GENERIC_HEADLINE_WORDS,
     _honest_content_visual,
     _is_good_headline,
     _panel_from_source_title,
     _rescue_hero,
     _severity_from_marker,
+    build_lead_headline,
     resolve_digest_band_visuals,
     route_visual_id,
     _HEADLINE_MAX_CHARS,
@@ -1170,3 +1172,115 @@ class TestW2TableCategoryRanking:
         )
         panels = _digest_panels(sc, content)
         assert panels[0]["headline"].startswith("JDownloader"), [p["headline"] for p in panels]
+
+
+# ---------------------------------------------------------------------------
+# Weak two-token headline quality (plan
+# .omc/plans/weak-two-token-headline-quality.md): FM1 clause-crossing join,
+# FM2 generic-word bigram, Hangul-glue safety, and the shared-helper clause
+# guard. DISPLAYED text only — visual routing + honesty scorer untouched.
+# ---------------------------------------------------------------------------
+class TestWeakBigramAndClause:
+    def test_generic_word_rejected_as_lone_headline(self):
+        # FM2 root: a lone generic capitalized English word reads as filler.
+        assert _is_good_headline("Show") is False
+        assert _is_good_headline("Option") is False
+
+    def test_real_subjects_still_pass(self):
+        # "Strategy" is the MSTR-rebrand entity and "Michael" is a real actor —
+        # neither is generic, so both remain valid headline tokens.
+        assert _is_good_headline("Strategy") is True
+        assert _is_good_headline("Michael") is True
+
+    def test_fm2_generic_bigram_not_emitted(self):
+        # "Show Option" (both generic) must never surface as the headline, nor
+        # may either lone generic word.
+        panel = _panel_from_source_title("Cointelegraph", "Show Option 기능 노출", "")
+        assert panel["headline"] not in {"Show Option", "Show", "Option"}
+
+    def test_legit_bigram_preserved(self):
+        # "Michael Saylor가 발언": the Hangul "가" abuts "Saylor"; the legit
+        # person bigram must survive (no false split on the glued particle).
+        panel = _panel_from_source_title("Src", "Michael Saylor가 발언", "")
+        assert panel["headline"] == "Michael Saylor"
+
+    def test_possessive_bigram_preserved_not_overfiltered(self):
+        # "X의 Y" possessive joins are usually real entity bigrams and MUST be
+        # kept (the generic-word reject must not over-filter these).
+        assert build_lead_headline("Anthropic의 Claude Mythos 제로데이") == "Anthropic Claude"
+        assert build_lead_headline("Broadcom의 VMware 인수 이후") == "Broadcom VMware"
+
+
+class TestRollupLeadParity:
+    """draft_rollup_spec.lead_entity must produce the same headline as the L20
+    panel path for the same title (one shared join helper, no drift)."""
+
+    PARITY_TITLES = [
+        "Strategy의 Michael Saylor, BTC 매수",
+        "Show Option 기능 노출",
+        "Michael Saylor가 발언",
+        "Arthur Hayes 발언",
+        "Ivanti EPMM 취약점",
+        "Cisco Catalyst 결함",
+        "Mirai ADB 봇넷",
+        "Hugging Face 모델",
+        "AWS KY3P 발표",
+        "npm Worm 공격",
+        "Maps Pro 출시",
+        "Cisco Unified 패치",
+    ]
+
+    def test_lead_entity_matches_shared_helper(self):
+        # Both the L20 panel join and the rollup tag delegate to the SHARED
+        # build_lead_headline, so they agree on the non-CVE path by design.
+        from scripts.draft_rollup_spec import lead_entity
+
+        for title in self.PARITY_TITLES:
+            shared = build_lead_headline(title)
+            assert lead_entity(title) == shared, title
+
+    def test_cve_only_title_diverges_as_designed(self):
+        # The one intentional divergence: a CVE-only title has no non-CVE entity,
+        # so the shared helper returns "" and each caller applies its own CVE
+        # fallback — the rollup tag uses the CVE id (toks[0]).
+        from scripts.draft_rollup_spec import lead_entity
+
+        cve_only = "CVE-2026-1234 단독 권고"
+        assert build_lead_headline(cve_only) == ""
+        assert lead_entity(cve_only) == "CVE-2026-1234"
+
+
+class TestCorpusNoGenericHero:
+    """Output-level corpus guard: no live digest hero/side-card headline is a
+    lone _GENERIC_HEADLINE_WORDS member. Asserts on dict outputs, NOT SVG."""
+
+    def _load_posts(self, *globs):
+        import glob
+        import re
+        import yaml
+
+        posts = []
+        for g in globs:
+            for fn in sorted(glob.glob(g)):
+                with open(fn) as f:
+                    raw = f.read()
+                m = re.match(r"^---\n(.*?)\n---\n", raw, re.DOTALL)
+                if not m:
+                    continue
+                fm = yaml.safe_load(m.group(1))
+                posts.append(
+                    (fn.split("/")[-1][:10], fm.get("summary_card"), raw[m.end():])
+                )
+        return posts
+
+    def test_no_generic_word_hero_or_side_card(self):
+        posts = self._load_posts("_posts/2026-05-*.md", "_posts/2026-06-*.md")
+        assert len(posts) >= 30, f"expected the May+June digest corpus, got {len(posts)}"
+        failures = []
+        for datestr, summary_card, content in posts:
+            for p in _digest_panels(summary_card, content):
+                if p["headline"].lower() in _GENERIC_HEADLINE_WORDS:
+                    failures.append(
+                        f"{datestr}: generic-word headline {p['headline']!r}"
+                    )
+        assert not failures, "Generic-word covers:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary
Eliminates weak generic-word headlines on L20 digest covers and shares the
lead-headline logic with the rollup tag path.

- Adds `_GENERIC_HEADLINE_WORDS = {show, option}` to the single-token reject
  union in `_is_good_headline`, plus a both-generic bigram block — lone/paired
  filler words ("Show", "Show Option") no longer surface as headlines.
- Extracts `build_lead_headline(title)` from `_panel_from_source_title` (the
  join + single-token fallthrough), preserving the load-bearing
  `acronym_product_join` exception (keeps "AWS KY3P" / "npm Worm"). The
  CVE/source-fallback, `_src_fallback`, and source-name-echo logic stay in the
  caller, unchanged.
- `draft_rollup_spec.lead_entity` now shares the same helper, so rollup day-cell
  tags inherit the cover-grade quality filtering (no "Show Option" / "Critical
  High" tags). CVE-only titles keep their caller-side `toks[0]` fallback.

## Scope note (empirical-first)
The originally-planned punctuation clause guard + all-caps rescue were **dropped**:
the real defect title uses the Korean possessive "의" ("Strategy의 Michael
Saylor"), not a comma, so the clause guard had no real-corpus benefit and churned
a good headline ("CISA SolarWinds" → "SolarWinds"). The "Strategy Michael" case is
a **documented known limitation** — recovering the person bigram needs surname
detection, which `l20_dispatch.py` deliberately bans (false-positive risk).

## Blast radius
2 digest covers (2026-03-16, 2026-06-01) lose a generic-word filler headline.
On-disk covers are already stale vs the generator, so they are NOT regenerated
here — the blogwatcher cron re-renders them.

## Test plan
- [x] Full suite **2258 passed**
- [x] Drift: digest 33 OK / rollup 6 OK
- [x] Honesty gate `--strict` exit 0
- [x] SVG quality 244 PASS / 0 FAIL
- [x] code-reviewer APPROVE (0 critical/major)
- [x] All acceptance criteria + 10 counter-examples re-confirmed on both panel and rollup paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)