### PR TITLE
ci: remove circular self-approve from dependabot auto-merge + fix version comment

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,15 @@
 name: Dependabot Auto-Merge
 
-# Auto-approve and squash-merge low-risk Dependabot PRs once required
-# checks pass. Major-version bumps still need manual review.
+# Enable auto-merge (squash) for low-risk Dependabot PRs so they merge once
+# required checks pass. Major-version bumps still need manual review.
+#
+# We do NOT self-approve PRs here: the repo setting "Allow GitHub Actions to
+# create and approve pull requests" is disabled (by design — a bot approving
+# its own PR is a circular control with no independent review value), so a
+# `gh pr review --approve` step would fail with "GitHub Actions is not
+# permitted to approve pull requests". `gh pr merge --auto` does not require
+# that approval; it arms GitHub's auto-merge, which fires when required status
+# checks pass (and any required human review is satisfied).
 #
 # Triggers only when the PR author is dependabot[bot]. Uses the metadata
 # action to introspect update-type and refuses anything classified as
@@ -37,7 +45,7 @@ jobs:
 
       - name: Get Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v2.4.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,17 +63,6 @@ jobs:
           classification="$(python3 scripts/dependabot_classify_pr.py "$PR_TITLE")"
           echo "classification=$classification" >> "$GITHUB_OUTPUT"
           echo "Title-based classification: '$classification'"
-
-      - name: Approve PR (patch + minor only)
-        if: |
-          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
-          steps.meta.outputs.update-type == 'version-update:semver-minor' ||
-          steps.title_class.outputs.classification == 'version-update:semver-patch' ||
-          steps.title_class.outputs.classification == 'version-update:semver-minor'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge (patch + minor only)
         if: |

--- a/scripts/tests/test_dependabot_auto_merge_workflow.py
+++ b/scripts/tests/test_dependabot_auto_merge_workflow.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""CI config regression guards for .github/workflows/dependabot-auto-merge.yml.
+
+Concrete incident this protects against
+----------------------------------------
+The workflow once carried an ``Approve PR`` step running
+``gh pr review --approve``. Because the repo setting "Allow GitHub Actions to
+create and approve pull requests" is disabled by design, that step failed on
+EVERY Dependabot PR with::
+
+    failed to create review: GraphQL: GitHub Actions is not permitted to
+    approve pull requests. (addPullRequestReview)
+
+which blocked the entire auto-merge workflow (PRs #369/#368/#393/#370). The
+step was removed; ``gh pr merge --auto`` does not need it. These guards make a
+silent re-introduction of the self-approve anti-pattern — or an accidental
+removal of the real auto-merge mechanism — fail loudly and reviewably.
+
+Invariant directions
+---------------------
+* self-approve step : MUST be ABSENT  (presence => regression)
+* ``gh pr merge --auto`` : MUST be PRESENT (absence => merge mechanism lost)
+* fetch-metadata pin comment : the pinned SHA must be labelled with the tag it
+  actually resolves to (consistency; stale labels break supply-chain audits)
+
+Comments are stripped before scanning for the self-approve / auto-merge tokens,
+because the workflow header legitimately *mentions* ``gh pr review --approve``
+when explaining why it is not used. A naive substring scan would self-trip.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TARGET = REPO_ROOT / ".github" / "workflows" / "dependabot-auto-merge.yml"
+
+# fetch-metadata pin currently in use and the tag it resolves to. If you repin
+# fetch-metadata, update BOTH and confirm the SHA resolves to the new tag via
+#   gh api repos/dependabot/fetch-metadata/tags
+_FETCH_METADATA_SHA = "25dd0e34f4fe68f24cc83900b1fe3fe149efef98"
+_FETCH_METADATA_TAG = "v3.1.0"
+
+
+def _strip_yaml_comments(text: str) -> str:
+    """Remove YAML comments line-by-line.
+
+    A ``#`` starts a comment when it is the first non-space character or is
+    preceded by whitespace. ``run:`` shell lines in this workflow contain no
+    ``#`` inside quotes, so this conservative rule is sufficient and avoids
+    matching commentary that merely references a banned token.
+    """
+    out: list[str] = []
+    for line in text.splitlines():
+        cut = None
+        for i, ch in enumerate(line):
+            if ch == "#" and (i == 0 or line[i - 1] in " \t"):
+                cut = i
+                break
+        out.append(line if cut is None else line[:cut])
+    return "\n".join(out)
+
+
+@pytest.fixture(scope="module")
+def raw() -> str:
+    if not TARGET.is_file():
+        pytest.skip(f"{TARGET} not found")
+    return TARGET.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def code(raw: str) -> str:
+    """Workflow text with YAML comments stripped (real steps only)."""
+    return _strip_yaml_comments(raw)
+
+
+def test_target_exists() -> None:
+    """Canary: a moved/renamed workflow should fail clearly, not vacuously."""
+    assert TARGET.is_file(), f"{TARGET} not found — update this guard if moved."
+
+
+def test_no_self_approve_step(code: str) -> None:
+    """`gh pr review --approve` must NOT be re-introduced (presence=regression).
+
+    The self-approve step fails on every run ("GitHub Actions is not permitted
+    to approve pull requests") and is a circular control with no independent
+    review value. If you intentionally re-enable PR approval, do it via the
+    repo setting + a non-GITHUB_TOKEN identity, and update this guard with the
+    rationale.
+    """
+    assert "gh pr review --approve" not in code, (
+        "Self-approve step re-introduced in dependabot-auto-merge.yml. This "
+        "fails on every run because 'Allow GitHub Actions to approve PRs' is "
+        "disabled by design. Remove it; 'gh pr merge --auto' does not need it."
+    )
+
+
+def test_auto_merge_mechanism_present(code: str) -> None:
+    """The actual merge mechanism must remain (absence=broken automation)."""
+    assert "gh pr merge --auto" in code, (
+        "'gh pr merge --auto' is gone from dependabot-auto-merge.yml — the "
+        "workflow no longer auto-merges anything. Restore the auto-merge step."
+    )
+
+
+def test_fetch_metadata_pin_comment_accurate(raw: str) -> None:
+    """The fetch-metadata SHA pin must be labelled with the tag it resolves to.
+
+    Stale version comments (the pin said `# v2.4.0` while the SHA was v3.1.0)
+    undermine supply-chain audits. If you repin, update _FETCH_METADATA_SHA /
+    _FETCH_METADATA_TAG above after confirming the resolution via the API.
+    """
+    pin_lines = [
+        ln for ln in raw.splitlines()
+        if "dependabot/fetch-metadata@" in ln and "uses:" in ln
+    ]
+    assert pin_lines, "fetch-metadata `uses:` pin line not found."
+    line = pin_lines[0]
+    if _FETCH_METADATA_SHA in line:
+        assert _FETCH_METADATA_TAG in line, (
+            f"fetch-metadata pinned to {_FETCH_METADATA_SHA[:12]} but comment "
+            f"does not say {_FETCH_METADATA_TAG}. The SHA resolves to "
+            f"{_FETCH_METADATA_TAG}; fix the comment (or update this guard if "
+            f"you repinned)."
+        )
+        # The previously-wrong label must not linger.
+        assert "v2.4.0" not in line, (
+            "Stale '# v2.4.0' comment on the fetch-metadata pin — the SHA is "
+            f"{_FETCH_METADATA_TAG}."
+        )


### PR DESCRIPTION
## 배경

최근 dependabot PR 4건(#369/#368/#393/#370)이 모든 실제 CI를 통과했지만 `auto-merge` 워크플로우가 매번 다음 에러로 실패했습니다:

\`\`\`
failed to create review: GraphQL: GitHub Actions is not permitted to approve pull requests. (addPullRequestReview)
\`\`\`

원인: 리포 설정 `Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"`가 비활성(의도적)이라 워크플로우의 `gh pr review --approve` 단계가 항상 실패합니다.

## 변경

1. **`Approve PR` 단계 제거** — 봇이 자기 PR을 승인하는 순환 컨트롤로 독립 리뷰 가치가 없고, 매 실행 실패의 원인. `gh pr merge --auto`는 이 승인을 필요로 하지 않으므로 제거해도 자동병합 기능에 영향 없음(필수 상태 체크 + 필수 휴먼 리뷰 충족 시 발화).
2. **stale 코멘트 수정** — `fetch-metadata` 핀 `25dd0e34`는 실제로 **v3.1.0**(v2.4.0 아님). `repos/dependabot/fetch-metadata/tags`로 검증. SHA 자체는 유효·안전했고 코멘트 라벨만 부정확했음.

## 검증

- YAML 유효성: OK
- `scripts/check_workflow_action_pins.py --check-existence`: `All pins consistent. No floating tags.` (33 workflows, 100 pins, exit 0)
- 전체 워크플로우 SHA 핀 감사: 17개 고유 핀 중 fetch-metadata 코멘트만 부정확했고 이 PR에서 수정. 나머지 16개 정확.

## 참고

이 PR은 H-02(워크플로우 차단)와 L-01(코멘트 불일치)을 해소합니다. 별도로 H-01(main 브랜치 보호 규칙 부재)은 후속 작업으로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)