### PR TITLE
docs: cover subheadline session notes (#417-419) + baselined-keep decision

### DIFF
--- a/notes/decisions.md
+++ b/notes/decisions.md
@@ -197,3 +197,30 @@ Michael Saylor")은 **결정론적으로 수정 불가**로 확정하고 영구 
 **관련**: 같은 감사에서 채택한 honest 수정은 Fix A(generic format noun "url"을
 `_GENERIC_TRAILING`에 추가 → "FBI URL" junk bigram 제거, TestUrlBigramReject).
 부제 content-descriptor + route_hint 디커플링은 PR #417 참조.
+
+---
+
+## 2026-06-18 — Legacy honesty-baseline 커버는 baselined 유지 (regen/마이그레이션 안 함)
+
+**결정**: `scripts/cover_honesty_baseline.txt`에 grandfathered된 30건(L20 16 + L22 14)의
+legacy 커버를 honesty FAIL 해소 목적으로 **재생성하거나 L22→L20 마이그레이션하지 않는다.**
+현재 baseline을 영구 floor로 받아들인다.
+
+**근거 (경험적)**:
+- 이 커버들은 일반 long-form 보안 포스트(가이드/코스/사고분석)용이며, honesty FAIL 사유는
+  rich attack-chain 비주얼(`hub_spoke` HUB/RELAY/VICTIM, `data_exfil`, `cve_chain`,
+  `code_injection` C2_URL/exfil_keys 등)이 본문 evidence 토큰 없이 위협을 'assert'하기 때문.
+- **그러나 이 rich 스타일은 사용자가 품질 reference로 명시한 커버**(2026-01-14 AWS Cloud
+  Security IAM→EKS, 2026-01-14 ISMS-P)와 **동일**하다. 즉 honesty를 통과시키려 regen하면
+  references가 보존하려는 바로 그 비주얼을 honest-neutral로 벗겨내 일관성이 깨진다.
+- baseline은 grandfathered라 CI를 **막지 않는다**(svg-lint honesty gate는 NEW 회귀만 FAIL).
+- 보안 아키텍처/사고분석 글에서 attack-chain 비주얼은 illustrative로 적절하다고 본다.
+
+**적용**:
+- baseline 30건 = 영구 floor. "baseline 0" 추구하지 말 것.
+- 신규 digest 커버는 honesty-safe(neutral/advisory/market) 유지(자동 생성, 무인 cron).
+- 향후 누군가 "baseline 줄이자"고 하면 이 결정을 먼저 참조. regen은 시각 품질 저하 +
+  references 불일치 trade-off가 있음을 상기.
+- L22 14건 마이그레이션도 동일 사유로 보류(ralplan 분석 결론: 비용 대비 시각 손실).
+
+**관련**: false-orphan 오판 정정(image: 필드 기준 매칭), empirical-first 원칙.

--- a/notes/per-pr/cover-subheadline-overhaul-2026-06.md
+++ b/notes/per-pr/cover-subheadline-overhaul-2026-06.md
@@ -1,0 +1,82 @@
+# Cover subheadline overhaul — 2026-06-18 session (PR #417, #418, #419)
+
+Digest cover cards displayed a bare **source name** ("The Hacker News") as the
+subheadline. This session made the displayed subheadline a **content summary**
+derived from the highlight title, across the whole 2026-01..06 corpus, while
+keeping visual routing / honesty byte-identical.
+
+## What shipped
+
+| PR | Scope | Key change |
+|----|-------|------------|
+| **#417** | June 17 digest covers + generator | `_content_descriptor()` + `route_hint` decoupling in `scripts/news/l20_dispatch.py`; CI guard `test_ci_honesty_gate_guard.py` |
+| **#418** | 06-15, 06-18 covers + Fix A | add `url` to `_GENERIC_TRAILING` (drops junk "FBI URL" bigram); regenerate 06-18 (cron-published with pre-#417 generator) |
+| **#419** | Jan–May digest covers (114) | backfill content-descriptor subheadlines across 2026-01..05 via the cron L20 path |
+
+## The core design (route_hint decoupling)
+
+The displayed subheadline is now **display-only**. Visual routing — and therefore
+the honest visual class — keys off a new panel field `route_hint` (the original
+source/CVE text), NOT the displayed subheadline:
+
+```
+_panel_from_source_title:
+  display subheadline = content descriptor (title's secondary ASCII entities)
+                        OR source/CVE fallback when none
+  route_hint          = source/CVE text  (UNCHANGED → routing & honesty identical)
+```
+
+Both `route_visual_id` call sites (`_apply_real_content`,
+`resolve_digest_band_visuals`) route from `route_hint`, so on-disk visuals and the
+honesty scorer's replay stay in lockstep. The honesty gate verdict is unchanged by
+construction. Tests: `TestContentDescriptorSubheadline`,
+`test_decoupling_is_load_bearing` in `scripts/tests/test_l20_realcontent.py`.
+
+## Examples (source name → content descriptor)
+
+- `Google Vertex` → **AI SDK Bucket** · `Rokarolla` → **Android PIN SMS**
+- `Malicious NGINX` → **Configurations React2Shell** · `Cisco Catalyst` → **SD-WAN Controller**
+- `Fortinet` → **FortiSandbox** · `Amazon Bedrock` → **Guardrails InvokeGuardrailChecks API**
+
+~21% of cards still fall back to source/CVE — their Korean title carries only one
+ASCII entity, the deterministic limit. A Gemini-summary design to close that gap is
+drafted at `.omc/plans/cover-subtitle-en-pipeline.md` (critic verdict:
+PROCEED-WITH-CHANGES, **recommend defer** — cosmetic gain vs new LLM dependency).
+
+## Verification (every PR)
+
+honesty `--all --strict` exit 0 (no new STALE_RENDER/overclaim) · drift 0
+(digest/rollup/l25 specs untouched) · `check_svg_quality` 0 FAIL (no Hangul) ·
+title-ascii 0 · size-gate `--strict` exit 0 · pytest 2295+ · live curl confirmed
+on tech.2twodragon.com. CI runs `score_cover_honesty.py --all --strict` over the
+whole 203-cover corpus on every `assets/images/**.svg` change.
+
+## Decisions / lessons (this session)
+
+- **Regen path gotcha**: `generate_post_images.py --svg-only` has L20 DISABLED
+  (`L20_HERO_ENABLED=False`) → L22 fallback. The real L20 generator is the cron
+  path `auto_publish_news._render_l20_svg_string`; regenerate via
+  `scripts/_regen_june_l20_covers.py`. (memory: `l20-regen-path-gotcha`)
+- **Spec safety**: never L20-regenerate spec/rollup covers. Rollup posts
+  (Week/Monthly_Index) don't match the `Weekly_Digest` glob; the 3 digest_covers
+  specs (04-26/27/28) are reverted after a glob run. Verified spec-leak = 0.
+- **Rollup detail is already content** — the small "source" line on rollup covers
+  is a deliberate attribution badge, not a source-only subheadline (corrected a
+  grep false-positive).
+- **Cover↔post matching uses the post `image:` field, not the filename stem** — a
+  filename-stem audit produced 9 false "orphans" (incl. the user's reference
+  covers); deleting them would have broken live posts. (memory:
+  `cover-post-match-by-image-field`)
+- **Legacy honesty-baseline covers stay baselined** — the 30 grandfathered FAILs
+  share the rich attack-chain style of the user's reference covers; regenerating
+  to chase baseline=0 would blander them. baseline is non-blocking. See
+  `notes/decisions.md` (2026-06-18 entry).
+- **Strategy Michael / Class D** — Korean possessive "의" headline split is
+  permanently deferred (marker byte-identical to good cases). See
+  `notes/decisions.md`.
+
+## Cron continuity
+
+The next auto-published digest inherits the fix: `_render_l20_svg_string` (the
+cron render function) now emits content descriptors — verified 3/3 content
+subheadlines rendering 2026-06-18 via the cron path.


### PR DESCRIPTION
이번 세션(커버 부제 개선)의 결정·요약을 repo 문서에 기록합니다. **문서만 변경**(코드/커버 변경 0).

## 변경
- **notes/decisions.md** — 2건 결정 기록:
  1. **Legacy honesty-baseline 커버(30건)는 baselined 유지**. rich attack-chain 스타일이 사용자 reference 커버와 동일 → honesty=0 추구 regen은 밋밋하게 만들고 references와 불일치. baseline은 CI 비차단(grandfathered).
  2. **Strategy Michael / Class D** 영구 deferred (한국어 소유격 `의`, 결정론적 수정 불가).
- **notes/per-pr/cover-subheadline-overhaul-2026-06.md** — PR #417~419 세션 요약: route_hint 디커플링 설계, 검증, 교훈(regen-path gotcha, spec 안전, false-orphan 정정, cron 연속성).

## 맥락 (이번 세션 성과)
2026-01~06 digest 커버 전체가 출처명 부제 → content-descriptor로 개선(머지+라이브):
- #417 06월 17개 + generator + CI 가드 · #418 06-15 Fix A + 06-18 · #419 pre-06 114개
- cron 경로(`_render_l20_svg_string`)도 content descriptor 생성 확인 → 다음 자동발행 연속성 보장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)