### PR TITLE
test(js): vitest 누수 타이머 flake 수정 (scrollIntoView 전역 스텁)

### DIFF
--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,29 @@
+// Global vitest setup for the JS regression suite (tests/js).
+//
+// jsdom does not implement Element.prototype.scrollIntoView. Several source
+// files call it from inside setTimeout callbacks (tags-page.js, archive-filter.js,
+// giscus-init.js, the quizzes). When such a timer fires AFTER its test has
+// finished, the missing method throws an unhandled `TypeError:
+// target.scrollIntoView is not a function`, which vitest promotes to a whole-run
+// failure (exit 1) even though every test "passed" -- a timing-dependent flake.
+//
+// The per-test suites that ASSERT scrollIntoView was called (aws-saa-quiz,
+// main-search, tags-page, archive-filter) save the current value in beforeEach
+// and reinstall their own vi.fn(); installing this no-op at load time means the
+// value they capture is a harmless function instead of `undefined`, so their
+// restore keeps leaked timers safe. The afterEach below re-establishes the stub
+// for any suite that `delete`s it (main-search), guaranteeing the method is
+// always callable between tests regardless of hook ordering.
+import { afterEach } from 'vitest';
+
+function installScrollIntoViewStub() {
+  if (typeof Element !== 'undefined' && typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = function () {};
+  }
+}
+
+installScrollIntoViewStub();
+
+afterEach(() => {
+  installScrollIntoViewStub();
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,6 +8,10 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     include: ['tests/js/**/*.test.js'],
+    // Installs a no-op Element.prototype.scrollIntoView so leaked setTimeout
+    // callbacks (which jsdom cannot satisfy) never throw an unhandled error
+    // that flakes the whole run to exit 1. See tests/js/setup.js.
+    setupFiles: ['tests/js/setup.js'],
     globals: false,
     coverage: {
       // The source under test is executed via `new Function(source)` inside each


### PR DESCRIPTION
## 문제
`vitest` CI 체크가 모든 테스트가 통과하는데도 비결정적으로 exit 1(flake). 최근 PR들에서 반복 관측됨.

## 근본 원인
jsdom은 `Element.prototype.scrollIntoView`를 구현하지 않는다. 여러 소스(`tags-page.js`, `archive-filter.js`, `giscus-init.js`, 퀴즈)가 `setTimeout` 콜백에서 이를 호출 → 타이머가 테스트 종료 후 발화하면 **unhandled TypeError** → vitest가 전체 실행을 실패 처리. `archive-filter.test.js:129`/`tags-page.test.js:236`이 `beforeEach`에서 캡처한 원본값(stock jsdom에선 `undefined`)을 복원해 누수 타이머가 throw.

## 수정 (테스트 인프라 전용, 프로덕션 무변경)
- **신규** `tests/js/setup.js`: 로드 시 no-op `scrollIntoView` 스텁 설치 + `afterEach` 재설치. 퍼-테스트 `vi.fn()` 오버라이드(호출 assert)는 그대로 보존.
- `vitest.config.js`: `setupFiles: ['tests/js/setup.js']`.
- 커버리지 임계값(branches 62 / functions 82 / lines 80 / statements 80) **불변**.

## 검증
전체 커버리지 스위트 **11회 반복(에이전트 6 + 독립 5) 전부 exit 0**, 28 파일 / 675 테스트 통과, `scrollIntoView is not a function` 0건. 커버리지 임계값 상회 유지.

관련: PR #449(mermaid CSP 가드) 병합 시 이 flake로 vitest가 red였음 — 이 PR로 근본 해소.