### PR TITLE
refactor(build): restore inline sentry_dsn regex (guard FP fixed upstream)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,12 +129,12 @@ fi
 # Inject Sentry DSN from Vercel env var (if set, overrides _config.yml)
 if [ -n "$SENTRY_DSN" ]; then
     log "Injecting Sentry DSN from environment variable..."
-    SENTRY_DSN_RE='^sentry_dsn:.*$' python3 -c "
-import os, re, sys
+    python3 -c "
+import re, sys
 with open('_config.yml', 'r') as f:
     content = f.read()
 dsn = sys.argv[1].strip().strip('\"').strip(\"'\")
-content = re.sub(os.environ['SENTRY_DSN_RE'], 'sentry_dsn: \"' + dsn + '\"', content, flags=re.MULTILINE)
+content = re.sub(r'^sentry_dsn:.*$', 'sentry_dsn: \"' + dsn + '\"', content, flags=re.MULTILINE)
 with open('_config.yml', 'w') as f:
     f.write(content)
 print('DSN injected: ' + dsn[:30] + '...' + dsn[-15:])


### PR DESCRIPTION
## Summary

#454 routed `re.sub(r'^sentry_dsn:.*$', ...)` in `build.sh` through a `SENTRY_DSN_RE` env var **only** to satisfy the injection guard's then-overbroad "any unescaped `$`" rule — the regex end-anchor `$` (before `'`) is bash-**inert**, never a real interpolation. The guard was made precise in claudesec #352 and re-synced here in #455, so it now correctly permits the inline anchor. This restores the simpler original form and drops the now-unused `import os`.

## Verification
- Refined guard (`scripts/tests/test_ci_injection_guard.py`): **24 tests pass**, live scan 15 sites / **0 violations** — the inline `$` anchor is correctly not flagged (validates the #352/#455 precision fix).
- Substitution still rewrites `sentry_dsn:` correctly (spot-checked).
- `bash -n` clean; shellcheck unchanged (only pre-existing warnings).

Behaviour-preserving; purely removes an unnecessary contortion the upstream guard fix made obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)