### PR TITLE
quality tooling: index-scoring CI guard + golden-baseline regen script

### DIFF
--- a/scripts/regen_quality_baseline.py
+++ b/scripts/regen_quality_baseline.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Regenerate the quality-scoring golden baseline used by test_index_scoring.py.
+
+scripts/tests/test_index_scoring.py asserts that every non-index post's
+validate_post() score stays byte-identical to the snapshot committed at
+scripts/tests/fixtures/quality_baseline.json. Posts not present in that
+snapshot are silently SKIPPED by the isolation test (see
+test_non_index_scores_byte_identical), so posts added by the daily
+blogwatcher cron accumulate as untested coverage over time. This script
+refreshes the snapshot so cron-added posts are folded back into the
+isolation guarantee.
+
+Usage:
+    python3 scripts/regen_quality_baseline.py          # write/refresh the baseline
+    python3 scripts/regen_quality_baseline.py --check  # dry-run; exit 1 if posts are
+                                                        # missing from the current baseline
+
+Does NOT modify validate_post_quality.py, any post under _posts/, any cover
+asset, or the isolation test logic — it only reads scores and writes the
+fixture JSON.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from validate_post_quality import validate_post  # noqa: E402
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO_ROOT / "_posts"
+BASELINE_PATH = (
+    Path(__file__).resolve().parent / "tests" / "fixtures" / "quality_baseline.json"
+)
+
+
+def score_all_posts(posts_dir: Path = POSTS_DIR) -> dict[str, dict[str, object]]:
+    """Score every post under posts_dir and return {filename: {total, scores}}."""
+    result: dict[str, dict[str, object]] = {}
+    for post in sorted(posts_dir.glob("*.md")):
+        r = validate_post(post)
+        result[post.name] = {"total": r["total"], "scores": r["scores"]}
+    return result
+
+
+def render_baseline(scored: dict[str, dict[str, object]]) -> str:
+    """Render scored posts as deterministic, minimal-diff JSON text.
+
+    Top-level keys (filenames) are sorted for a stable diff order. Inner
+    dict order (total/scores and each score dimension) is left as produced
+    by validate_post(), which builds them in a fixed order every run — NOT
+    alphabetically re-sorted, to match the existing committed fixture's
+    key order and avoid a spurious full-file diff on regen.
+    """
+    ordered = {name: scored[name] for name in sorted(scored)}
+    return json.dumps(ordered, indent=2) + "\n"
+
+
+def load_current_baseline(baseline_path: Path = BASELINE_PATH) -> dict[str, dict]:
+    if not baseline_path.exists():
+        return {}
+    return json.loads(baseline_path.read_text(encoding="utf-8"))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate scripts/tests/fixtures/quality_baseline.json "
+            "(the isolation-test golden snapshot)."
+        )
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Dry-run: list posts missing from the current baseline and exit 1 "
+        "if any are found, without writing.",
+    )
+    args = parser.parse_args(argv)
+
+    # Reference the module globals explicitly (not via default args) so a
+    # monkeypatched POSTS_DIR / BASELINE_PATH (e.g. in tests) is honored.
+    scored = score_all_posts(POSTS_DIR)
+    current = load_current_baseline(BASELINE_PATH)
+
+    added = sorted(set(scored) - set(current))
+    removed = sorted(set(current) - set(scored))
+
+    if args.check:
+        if added:
+            print(
+                f"[regen_quality_baseline] {len(added)} post(s) missing from "
+                "baseline (added since last regen):",
+                file=sys.stderr,
+            )
+            for name in added:
+                print(f"  MISSING  {name}", file=sys.stderr)
+            print(
+                "\nRun `python3 scripts/regen_quality_baseline.py` to refresh.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            f"[regen_quality_baseline] baseline is up to date "
+            f"({len(scored)} posts scored, 0 missing)."
+        )
+        return 0
+
+    BASELINE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BASELINE_PATH.write_text(render_baseline(scored), encoding="utf-8")
+    print(
+        f"[regen_quality_baseline] scored {len(scored)} posts — "
+        f"{len(added)} newly added, {len(removed)} removed."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ci_index_scoring_guard.py
+++ b/scripts/tests/test_ci_index_scoring_guard.py
@@ -1,0 +1,112 @@
+"""CI config regression guard — monthly-index genre scoring vs the pre-commit floor.
+
+Invariant locked here (OWASP CICD-SEC-1 / NIST SSDF PW.4):
+
+  Every monthly-index aggregator post must score >= the pre-commit quality
+  gate's ``FAIL_BELOW`` value, so that editing/staging an index page never
+  hard-blocks a commit.
+
+Why this guard exists (concrete incident):
+  Before genre-aware scoring, monthly-index pages scored 49/53/53 under the
+  digest-only rubric. ``scripts/pre-commit-quality-check.sh`` runs
+  ``validate_post_quality.py --fail-below 60`` with ``set -e`` on every staged
+  ``_posts/*.md``, so any edit to an index page hard-FAILED the commit. The
+  ``is_index_post`` / ``_score_index`` genre branch in validate_post_quality.py
+  lifted them to 87/100/100. If that branch is silently removed or broken, the
+  index pages drop below 60 again and the pre-commit gate starts blocking edits
+  to them — a regression invisible until someone happens to touch an index page.
+
+This test ties the two together: it reads the ACTUAL ``FAIL_BELOW`` from the
+pre-commit script and asserts every real index post clears it under the current
+scorer. Removing the genre branch makes this fail loudly in CI.
+
+Direction:
+  * ``FAIL_BELOW`` is pinned (==) to its known value; an intentional change must
+    update ``EXPECTED_FAIL_BELOW`` here (forces a conscious review).
+  * index scores use ``>=`` the gate (ratchet-up stays green).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRECOMMIT = REPO_ROOT / "scripts" / "pre-commit-quality-check.sh"
+POSTS_DIR = REPO_ROOT / "_posts"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+# The pre-commit hard floor this guard is bound to. If the hook intentionally
+# changes its FAIL_BELOW, update this constant in the same PR (conscious review).
+EXPECTED_FAIL_BELOW = 60
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from validate_post_quality import is_index_post, validate_post  # noqa: E402
+
+
+def _read_fail_below() -> int:
+    """Extract the FAIL_BELOW= value from the pre-commit quality hook."""
+    text = PRECOMMIT.read_text(encoding="utf-8")
+    m = re.search(r"^\s*FAIL_BELOW=(\d+)", text, re.MULTILINE)
+    assert m, "FAIL_BELOW= not found in pre-commit-quality-check.sh"
+    return int(m.group(1))
+
+
+def _index_posts() -> list[Path]:
+    return [
+        p
+        for p in sorted(POSTS_DIR.glob("*.md"))
+        if is_index_post(p.read_text(encoding="utf-8"), p.name)
+    ]
+
+
+def test_precommit_hook_exists():
+    assert PRECOMMIT.is_file(), f"{PRECOMMIT} not found (moved/renamed?)"
+
+
+def test_fail_below_pinned():
+    """The pre-commit floor must stay at its reviewed value.
+
+    If you intentionally change FAIL_BELOW in the hook, update
+    EXPECTED_FAIL_BELOW here so the change is reviewed alongside the gate.
+    """
+    assert _read_fail_below() == EXPECTED_FAIL_BELOW, (
+        f"pre-commit FAIL_BELOW changed from {EXPECTED_FAIL_BELOW}; "
+        "if intentional, update EXPECTED_FAIL_BELOW in this guard."
+    )
+
+
+def test_index_posts_detected():
+    """Sanity: the genre detector still finds the monthly-index pages.
+
+    A vacuous pass (0 index posts → nothing to check) would hide a broken
+    detector, so require at least one and that each is a *Monthly_Index* file.
+    """
+    idx = _index_posts()
+    assert idx, "no monthly-index posts detected — is_index_post regressed?"
+    for p in idx:
+        assert "Monthly_Index" in p.name, f"unexpected index detection: {p.name}"
+
+
+@pytest.mark.parametrize(
+    "post", _index_posts(), ids=lambda p: p.name
+)
+def test_index_post_clears_precommit_floor(post):
+    """Each monthly-index post must score >= the pre-commit FAIL_BELOW.
+
+    Removing/breaking the genre branch drops these to 49/53 (<60) and trips
+    this — the whole point of the guard.
+    """
+    floor = _read_fail_below()
+    result = validate_post(post)
+    total = result["total"]
+    assert total >= floor, (
+        f"{post.name} scores {total} < pre-commit floor {floor}: the "
+        "monthly-index genre-scoring branch (is_index_post/_score_index) is "
+        "missing or broken, which would hard-block commits editing index pages."
+    )

--- a/scripts/tests/test_regen_quality_baseline.py
+++ b/scripts/tests/test_regen_quality_baseline.py
@@ -1,0 +1,97 @@
+"""Tests for scripts/regen_quality_baseline.py.
+
+Covers:
+  - `--check` exits 0 when the committed baseline has no missing posts.
+  - The writer produces deterministic, filename-sorted JSON.
+  - Round-trip: scoring a sample post via score_all_posts() matches a direct
+    validate_post() call on the same file.
+
+Hermetic: all writes go to tmp_path / a monkeypatched BASELINE_PATH. The real
+scripts/tests/fixtures/quality_baseline.json is never overwritten by these
+tests.
+"""
+
+import json
+import shutil
+from pathlib import Path
+
+import regen_quality_baseline as rqb
+from validate_post_quality import validate_post
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+POSTS_DIR = REPO_ROOT / "_posts"
+
+
+def test_check_passes_when_baseline_current(capsys):
+    """--check is read-only and must exit 0 while no cron-added posts are
+    missing from the committed baseline."""
+    exit_code = rqb.main(["--check"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "up to date" in out
+
+
+def test_render_baseline_is_deterministic():
+    scored = {
+        "2026-02-01-Zeta.md": {"total": 42, "scores": {"b": 1, "a": 2}},
+        "2026-01-01-Alpha.md": {"total": 99, "scores": {"a": 1}},
+    }
+    out1 = rqb.render_baseline(scored)
+    out2 = rqb.render_baseline(scored)
+    assert out1 == out2
+    assert out1.endswith("\n")
+
+    parsed = json.loads(out1)
+    assert list(parsed.keys()) == ["2026-01-01-Alpha.md", "2026-02-01-Zeta.md"]
+    # inner key order is preserved as given (not alphabetically re-sorted)
+    assert list(parsed["2026-02-01-Zeta.md"]["scores"].keys()) == ["b", "a"]
+
+
+def test_score_all_posts_round_trip(tmp_path):
+    """Copy a handful of real posts into a tmp dir, score them via
+    score_all_posts(), and confirm each entry matches a direct validate_post()
+    call on the original file — no divergence introduced by the wrapper."""
+    sample_posts = sorted(POSTS_DIR.glob("*.md"))[:3]
+    assert sample_posts, "expected at least one real post fixture to sample"
+
+    tmp_posts_dir = tmp_path / "_posts"
+    tmp_posts_dir.mkdir()
+    for post in sample_posts:
+        shutil.copy(post, tmp_posts_dir / post.name)
+
+    scored = rqb.score_all_posts(tmp_posts_dir)
+
+    assert set(scored) == {p.name for p in sample_posts}
+    for post in sample_posts:
+        expected = validate_post(post)
+        actual = scored[post.name]
+        assert actual["total"] == expected["total"]
+        assert actual["scores"] == expected["scores"]
+
+
+def test_main_write_mode_is_hermetic(tmp_path, monkeypatch):
+    """Default (write) mode must only touch the monkeypatched BASELINE_PATH
+    and read from the monkeypatched POSTS_DIR — never the real fixture or
+    the real _posts/ corpus."""
+    real_fixture = rqb.BASELINE_PATH
+    real_fixture_bytes_before = real_fixture.read_bytes()
+
+    sample_posts = sorted(POSTS_DIR.glob("*.md"))[:2]
+    tmp_posts_dir = tmp_path / "_posts"
+    tmp_posts_dir.mkdir()
+    for post in sample_posts:
+        shutil.copy(post, tmp_posts_dir / post.name)
+
+    tmp_baseline = tmp_path / "quality_baseline.json"
+    monkeypatch.setattr(rqb, "POSTS_DIR", tmp_posts_dir)
+    monkeypatch.setattr(rqb, "BASELINE_PATH", tmp_baseline)
+
+    exit_code = rqb.main([])
+
+    assert exit_code == 0
+    assert tmp_baseline.exists()
+    written = json.loads(tmp_baseline.read_text(encoding="utf-8"))
+    assert set(written) == {p.name for p in sample_posts}
+
+    # the real committed fixture must be untouched
+    assert real_fixture.read_bytes() == real_fixture_bytes_before


### PR DESCRIPTION
## 개요
품질 스코어러 유지보수 툴링 2건. 콘텐츠/스코어러 로직 변경 없음 — 회귀 가드 + baseline 유지보수 스크립트만 추가.

## 커밋 (2개)
1. **feat(quality)** — `scripts/regen_quality_baseline.py`: 전 포스트 재채점 후 골든 baseline 픽스처를 결정론적으로 재생성. `--check`는 마지막 스냅샷 이후 추가된 포스트(일일 blogwatcher 크론)를 나열하고 drift 시 exit 1 → 격리 테스트 커버리지가 skip으로 조용히 침식되는 걸 방지. +tests.
2. **test(quality)** — `scripts/tests/test_ci_index_scoring_guard.py`: CI 회귀 가드(OWASP CICD-SEC-1). pre-commit `FAIL_BELOW`(60에 핀) 값을 잠그고, 모든 monthly-index 포스트가 그 이상 득점함을 강제. 장르 분기(`is_index_post`/`_score_index`) 제거 시 인덱스가 49/53(<60)로 떨어져 **loud하게 실패** — 인덱스 페이지 편집 커밋이 조용히 다시 막히는 회귀를 방지.

## 정직성 / 검증
- CI 가드 **비-vacuous 확인**: 장르 스코어러 87 vs general 49(<60) — 제거 시 확실히 트립.
- regen `--check` → "up to date (243 posts, 0 missing)".
- `pytest scripts/tests/` → **2927 passed, 5 skipped** (신규 +10).
- ruff clean. baseline 픽스처·포스트·스코어러 로직·커버 전부 불변.