### PR TITLE
feat(pre-commit): post quality-score gate (step 11) — local quality floor

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -150,3 +150,22 @@ if [ -n "$STAGED_HEAD_HTML" ]; then
   fi
   echo "[pre-commit] CSP inline-script hash check: passed."
 fi
+
+# 11. Post quality-score gate — block commits of posts below the quality floor.
+#     Mirrors scripts/pre-commit-quality-check.sh (validate_post_quality.py, 100-pt).
+#     Only staged _posts/*.md are scored; fail < 60, warn < 80.
+STAGED_QUALITY_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+\.md$' || true)
+if [ -n "$STAGED_QUALITY_POSTS" ]; then
+  echo "[pre-commit] Scoring staged post quality (fail < 60, warn < 80)..."
+  echo "$STAGED_QUALITY_POSTS" \
+    | tr '\n' '\0' \
+    | xargs -0 python3 "$REPO_ROOT/scripts/validate_post_quality.py" \
+        --fail-below 60 --warn-below 80 --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Post quality below floor (60). Fix before committing."
+    echo "             Inspect a file: python3 scripts/validate_post_quality.py <file>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Post quality: passed."
+fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -194,6 +194,25 @@ if [ -n "$STAGED_HEAD_HTML" ]; then
   fi
   echo "[pre-commit] CSP inline-script hash check: passed."
 fi
+
+# 11. Post quality-score gate — block commits of posts below the quality floor.
+#     Mirrors scripts/pre-commit-quality-check.sh (validate_post_quality.py, 100-pt).
+#     Only staged _posts/*.md are scored; fail < 60, warn < 80.
+STAGED_QUALITY_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+\.md$' || true)
+if [ -n "$STAGED_QUALITY_POSTS" ]; then
+  echo "[pre-commit] Scoring staged post quality (fail < 60, warn < 80)..."
+  echo "$STAGED_QUALITY_POSTS" \
+    | tr '\n' '\0' \
+    | xargs -0 python3 "$REPO_ROOT/scripts/validate_post_quality.py" \
+        --fail-below 60 --warn-below 80 --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Post quality below floor (60). Fix before committing."
+    echo "             Inspect a file: python3 scripts/validate_post_quality.py <file>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Post quality: passed."
+fi
 HOOK
 
 chmod +x "$HOOK_FILE"


### PR DESCRIPTION
## 요약
`validate_post_quality.py`(100점 만점) 품질 게이트를 활성 pre-commit 훅에 **step 11**로 추가. 저품질 `_posts/*.md`가 커밋 시점에 로컬에서 차단되어, 이미 CI/PR에 있는 품질 도구와 대칭을 이룸.

## 왜
`core.hooksPath=.githooks`로 설정돼 있어 `.git/hooks/pre-commit`는 무시됨. 따라서 `.git/hooks`에 심볼릭 링크하는 naive 방식은 (a) 실행조차 안 되고 (b) 실행돼도 기존 10단계 가드를 덮어씀. 정식 경로(`install-hooks.sh` 힙독 + `.githooks/pre-commit`) 양쪽에 additive로 추가.

## 변경
- `scripts/install-hooks.sh`: 힙독에 step 11 추가
- `.githooks/pre-commit`: 동일 step 11 추가(즉시 활성)
- staged `_posts/*.md`만 채점, fail < 60 / warn < 80
- 사전 존재하던 step-9 드리프트(dedup ↔ digest-structural)는 범위 밖이라 미터치

## 검증
- `sh -n` 문법 통과(양 파일)
- 저품질 포스트 스테이징 → `exit 1`(차단 + bypass 안내)
- 정상 포스트 스테이징 → `Post quality: passed.` `exit 0`
- 인덱스 클린