### PR TITLE
docs: add body-derived 사전 요구사항 to 2 course posts

### DIFF
--- a/_posts/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding.md
+++ b/_posts/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding.md
@@ -97,6 +97,17 @@ redirect_from:
 - 실전 사례 및 문제 해결 방법
 - 보안 모범 사례 및 권장 사항
 
+## 사전 요구사항
+
+이 주차는 클라우드 시큐리티 과정 7기의 연속 강의로, 아래를 갖추면 실습을 원활히 따라올 수 있습니다.
+
+- **리눅스 셸/CLI 기본**: 본문에서 `docker`(pull, run, ps, logs), `kubectl`(get, apply), `trivy image` 명령을 직접 실행하므로 터미널 사용에 익숙해야 합니다.
+- **YAML 문법 이해**: Pod, Deployment, Service, NetworkPolicy 등 Kubernetes 매니페스트를 YAML로 다룹니다.
+- **로컬 실습 환경**: 컨테이너 보안 실습은 Minikube와 K9s를 기준으로 진행합니다.
+- **선행 주차**: 같은 과정 7기 6주차 [Cloudflare와 GitHub 보안]({% post_url 2025-05-23-Cloud_Security_Course_7Batch_-_6Week_Cloudflare_And_github_Security %})까지의 흐름을 이어받습니다.
+
+> 대상 독자: 클라우드 보안 전문가, DevOps 엔지니어, 보안 담당자.
+
 ## 1. Docker 기초 이해
 
 ### 1.1 Docker란?

--- a/_posts/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.md
+++ b/_posts/2025-12-05-Cloud_Security_8Batch_2Week_AWS_Security_Architecture_Core_VPCFrom_GuardDutyTo_Complete_Conquer.md
@@ -73,6 +73,17 @@ AWS 보안 아키텍처의 4대 핵심 구성요소(VPC, IAM, S3, GuardDuty)를 
 <figcaption>AWS VPC 보안 아키텍처 다이어그램 - Python diagrams로 생성</figcaption>
 </figure>
 
+## 사전 요구사항
+
+이 주차는 클라우드 시큐리티 과정 8기의 연속 강의이며, 아래를 알고 있으면 내용을 수월하게 따라올 수 있습니다.
+
+- **AWS 계정과 CLI 기본**: 본문에서 `aws cloudtrail lookup-events`, `aws s3api list-objects-v2` 등 AWS CLI 명령을 직접 실행합니다.
+- **AWS 기초 개념**: 리전, 서브넷, 보안 그룹 등 VPC·IAM·S3의 기본 용어에 익숙하면 좋습니다.
+- **로그/쿼리 도구(선택)**: 본문에는 Splunk SPL, Azure Sentinel KQL 위협 헌팅 쿼리 예시가 포함됩니다.
+- **선행 주차**: 같은 과정 8기 1주차 [인프라의 본질부터 보안의 미래까지]({% post_url 2025-11-26-Cloud_Security_8Batch_1Week_Infrastructure_EssenceFrom_Security_FutureTo %})의 흐름을 이어받습니다.
+
+> 대상 독자: 클라우드 아키텍트, DevOps 엔지니어, 클라우드 관리자.
+
 ## MITRE ATT&CK 매핑
 
 ### AWS 보안 서비스별 MITRE ATT&CK 커버리지


### PR DESCRIPTION
## Summary
Adds a honesty-safe `## 사전 요구사항` (Prerequisites) section to two course posts, derived strictly from existing body content — no new claims, no other changes.

- **2025-05-30 7기 7주차 Docker/K8s**: 리눅스 CLI(docker/kubectl/trivy), YAML, Minikube/K9s 실습, 선행 6주차 링크
- **2025-12-05 8기 2주차 AWS VPC**: AWS CLI(cloudtrail/s3api), AWS 기초 개념, Splunk/KQL(선택), 선행 1주차 링크

Each item traces to commands/manifests/links already present in the post body. Reuses in-file `{% post_url %}` slugs (both targets verified to exist).

## Verification
- Quality score unchanged: **89/100** and **88/100** (additions are score-neutral, honesty-safe)
- Diff: 2 files, +22 lines, additions only
- pre-commit step-11 quality gate passed at commit time

## Test plan
- [x] Both `{% post_url %}` targets resolve to existing posts
- [x] Scores held ≥ floor (60) and unchanged vs. pre-edit
- [ ] CI green