### PR TITLE
feat(gate): digest 미번역 영문 탐지 게이트 (재발 방지 A)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -125,15 +125,33 @@ if [ -n "$STAGED_POSTS" ]; then
   echo "[pre-commit] KST-midnight check: passed."
 fi
 
-# 9. Auto-dedup duplicate '실무 적용 포인트' blocks in staged posts.
-#    The pre-2026-06-24 generator could repeat the same advice block across two
-#    news items (_pick_variant collision). This removes those repeats from
-#    staged posts and re-stages the cleaned content. Posts with UNSTAGED edits
-#    are skipped (won't sweep un-reviewed hunks). Non-blocking auto-fix.
-if [ -n "$STAGED_POSTS" ]; then
-  echo "[pre-commit] Deduping practical-point blocks in staged posts..."
-  python3 "$REPO_ROOT/scripts/check_posts.py" --fix --staged
-  echo "[pre-commit] Practical-point dedup: done."
+# 9. Digest structural invariant gate (Sub-project 0 — numbering/H1/checklist)
+STAGED_DIGEST_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+Weekly_Digest[^/]*\.md$' || true)
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest post structural invariants..."
+  python3 "$REPO_ROOT/scripts/check_digest_structure.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Digest structural violation found. Fix before committing."
+    echo "             Digest posts need contiguous ## N. numbering, no body H1,"
+    echo "             and a single global ## 실무 체크리스트 (no per-item checklist)."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest structural check: passed."
+fi
+
+# 9b. Digest untranslated-English gate (translation-fallback regression guard)
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest posts for untranslated English..."
+  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
+    echo "             Translate the flagged prose to Korean (preserve proper"
+    echo "             nouns / CVE IDs). Cited English titles are not flagged."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest untranslated-English check: passed."
 fi
 
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
@@ -168,21 +186,4 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
     exit 1
   fi
   echo "[pre-commit] Post quality: passed."
-fi
-
-# 12. Digest untranslated-English gate — block digests whose 요약/summary=
-#     fields fell back to raw English (translation API unavailable on the
-#     repository_dispatch publish path). Cited English titles are not flagged.
-STAGED_DIGEST_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+Weekly_Digest[^/]*\.md$' || true)
-if [ -n "$STAGED_DIGEST_POSTS" ]; then
-  echo "[pre-commit] Checking digest posts for untranslated English..."
-  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
-  if [ $? -ne 0 ]; then
-    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
-    echo "             Translate the flagged prose to Korean (preserve proper"
-    echo "             nouns / CVE IDs). Cited English titles are not flagged."
-    echo "             To bypass (not recommended): git commit --no-verify"
-    exit 1
-  fi
-  echo "[pre-commit] Digest untranslated-English check: passed."
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -169,3 +169,20 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
   fi
   echo "[pre-commit] Post quality: passed."
 fi
+
+# 12. Digest untranslated-English gate — block digests whose 요약/summary=
+#     fields fell back to raw English (translation API unavailable on the
+#     repository_dispatch publish path). Cited English titles are not flagged.
+STAGED_DIGEST_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+Weekly_Digest[^/]*\.md$' || true)
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest posts for untranslated English..."
+  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
+    echo "             Translate the flagged prose to Korean (preserve proper"
+    echo "             nouns / CVE IDs). Cited English titles are not flagged."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest untranslated-English check: passed."
+fi

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -35,6 +35,7 @@ on:
       - 'scripts/check_rollup_spec_consistency.py'
       - 'scripts/check_kst_midnight.py'
       - 'scripts/check_digest_structure.py'
+      - 'scripts/check_digest_untranslated.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -76,6 +77,7 @@ on:
       - 'scripts/check_rollup_spec_consistency.py'
       - 'scripts/check_kst_midnight.py'
       - 'scripts/check_digest_structure.py'
+      - 'scripts/check_digest_untranslated.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -243,6 +245,21 @@ jobs:
           fi
           echo "[digest-structure] diff base: $BASE"
           python3 scripts/check_digest_structure.py --changed "$BASE"
+
+      - name: Digest untranslated-English gate (PR-diff-scoped)
+        id: digest_untranslated
+        # PR-diff-scoped: only checks digest posts touched by this PR/push, so
+        # the whole legacy corpus (already Korean) is not re-scanned. Guards the
+        # repository_dispatch translation-fallback regression where LLM keys are
+        # zeroed and 요약/summary= fall back to raw English RSS text.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          echo "[digest-untranslated] diff base: $BASE"
+          python3 scripts/check_digest_untranslated.py --changed "$BASE"
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/scripts/check_digest_untranslated.py
+++ b/scripts/check_digest_untranslated.py
@@ -1,0 +1,235 @@
+"""Untranslated-English guard for weekly-digest posts.
+
+Weekly digests are auto-generated. When the translation fallback chain
+(Gemini CLI -> DeepSeek API -> raw English) has no API key available — which
+happens on the `repository_dispatch` publish path where LLM secrets are
+intentionally zeroed out for security — the `#### 요약` prose and
+`summary="..."` news-card fields are emitted as raw ENGLISH RSS text instead
+of Korean. This guard flags that regression so it never lands silently.
+
+Detection (per 요약 block / summary= field):
+  1. Strip legitimately-English spans: quoted article titles ('...' / "...")
+     and parenthetical glosses ((next-best-product)). A Korean sentence that
+     merely *cites* an English headline is NOT a violation.
+  2. On the remainder, an English SENTENCE is present when there are >= 3
+     English stop-words AND the Hangul ratio is < 0.55 (i.e. the prose itself
+     is English, not Korean-with-proper-nouns).
+
+Only Weekly_Digest posts are checked; every mode filters to them. Mirrors the
+CLI of check_digest_structure.py.
+
+Usage:
+    python3 scripts/check_digest_untranslated.py --staged        # staged digest posts
+    python3 scripts/check_digest_untranslated.py --changed main  # digest posts changed vs BASE
+    python3 scripts/check_digest_untranslated.py --all           # every digest post
+    python3 scripts/check_digest_untranslated.py path/a.md path/b.md
+"""
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO / "_posts"
+
+_POST_PATH_RE = re.compile(r"^_posts/[^/]+\.md$")
+
+# English function words that signal an English *sentence* (not a proper noun).
+_STOP = frozenset(
+    "the a an is are was were with that this these those has have had been will "
+    "from into over under between during about their its his her they them we you "
+    "which who whom whose when where while because although though and or but of "
+    "to in on for by as at it he she can could would should may might must not".split()
+)
+
+# Quote characters that wrap a cited English title/phrase.
+_QUOTES = "\"'‘’“”″‟"
+# A quoted span: opening quote, >=2 non-quote chars, closing quote.
+_QUOTED_SPAN = re.compile(rf"[{_QUOTES}][^{_QUOTES}]{{2,}}?[{_QUOTES}]")
+# A parenthetical gloss that is mostly ASCII (e.g. "(next-best-product)").
+_ASCII_PAREN = re.compile(r"\([A-Za-z0-9 .,&'/+-]{2,}\)")
+# A multi-word proper-noun sequence: 2+ consecutive Capitalized/ALL-CAPS tokens
+# (e.g. "GeForce NOW", "The Adventures of Elliot: The Millennium Tales",
+# "Steam Summer Sale"). Real English PROSE is distinguished by *lowercase*
+# function words (is/the/with/that) mid-sentence; a Title-Cased headline is a
+# cited name, not prose, so we strip it before counting stop-words. Small
+# joiners (of/the/and/&/:/-) are allowed *inside* such a run.
+_PROPER_SEQ = re.compile(
+    r"\b[A-Z][A-Za-z0-9]*(?:[ :/&-]+(?:of|the|and|for|in|on|[A-Z][A-Za-z0-9]*))+\b"
+)
+
+
+def _body(text: str) -> str:
+    m = re.match(r"^---\n.*?\n---\n", text, re.DOTALL)
+    return text[m.end():] if m else text
+
+
+def _strip_code_fences(text: str) -> str:
+    out, in_code = [], False
+    for ln in text.split("\n"):
+        if ln.strip().startswith("```"):
+            in_code = not in_code
+            continue
+        if not in_code:
+            out.append(ln)
+    return "\n".join(out)
+
+
+def _summary_blocks(body: str) -> list:
+    """Every '#### 요약' prose block (text up to the next heading / rule / blank-gap)."""
+    return re.findall(
+        r"####\s*요약\s*\n+(.+?)(?:\n\n|\n####|\n---|\n##\s)", body, flags=re.S
+    )
+
+
+def _summary_fields(body: str) -> list:
+    """Every news-card summary="..." attribute value."""
+    return re.findall(r'summary="([^"]+)"', body)
+
+
+def is_untranslated(text: str) -> bool:
+    """True when *text* contains an English sentence (not just cited titles)."""
+    # Drop cited English titles / ASCII glosses / Title-Cased proper-noun
+    # sequences first, then URLs — what remains is candidate PROSE.
+    stripped = _QUOTED_SPAN.sub(" ", text)
+    stripped = _ASCII_PAREN.sub(" ", stripped)
+    stripped = _PROPER_SEQ.sub(" ", stripped)
+    stripped = re.sub(r"https?://\S+", " ", stripped)
+
+    words = re.findall(r"[A-Za-z]+", stripped.lower())
+    stops = sum(1 for w in words if w in _STOP)
+    hangul = len(re.findall(r"[가-힣]", stripped))
+    ascii_letters = len(re.findall(r"[A-Za-z]", stripped))
+    hangul_ratio = hangul / (hangul + ascii_letters + 1)
+    return stops >= 3 and hangul_ratio < 0.55
+
+
+def check_post(path: str) -> list:
+    with open(path, encoding="utf-8") as fh:
+        body = _strip_code_fences(_body(fh.read()))
+    violations = []
+    for i, block in enumerate(_summary_blocks(body), 1):
+        if is_untranslated(block):
+            snippet = re.sub(r"\s+", " ", block.strip())[:70]
+            violations.append(f"영문 요약 블록 #{i}: {snippet}")
+    for i, field in enumerate(_summary_fields(body), 1):
+        if is_untranslated(field):
+            snippet = re.sub(r"\s+", " ", field.strip())[:70]
+            violations.append(f"영문 summary= 필드 #{i}: {snippet}")
+    return violations
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+def _all_post_paths() -> list:
+    return sorted(p for p in POSTS_DIR.glob("*.md") if _is_digest_post(p))
+
+
+def _git_post_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(
+            cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        p = line.strip()
+        if _POST_PATH_RE.match(p):
+            full = REPO / p
+            if full.exists() and _is_digest_post(full):
+                paths.append(full)
+    return sorted(paths)
+
+
+def _staged_post_paths() -> list:
+    return _git_post_paths(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"]
+    )
+
+
+def _changed_post_paths(base: str) -> list:
+    return _git_post_paths(
+        ["git", "diff", "--name-only", f"{base}...HEAD", "--diff-filter=ACM"]
+    )
+
+
+def _explicit_paths(args_paths: list) -> list:
+    paths = []
+    for a in args_paths:
+        p = Path(a)
+        if not p.is_absolute():
+            cwd_p = Path.cwd() / p
+            p = cwd_p if cwd_p.exists() else REPO / a
+        if not p.exists():
+            print(f"[digest-untranslated] WARNING: file not found: {a}", file=sys.stderr)
+            continue
+        if _is_digest_post(p):
+            paths.append(p)
+    return paths
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag Weekly_Digest _posts/*.md whose 요약/summary= fields contain raw "
+            "untranslated English (translation-fallback regression). Cited English "
+            "titles inside Korean prose are NOT flagged. Exits 1 if any found."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true",
+                      help="Only check staged digest posts (git diff --cached).")
+    mode.add_argument("--all", action="store_true",
+                      help="Check every digest post.")
+    mode.add_argument("--changed", metavar="BASE", default=None,
+                      help="Only check digest posts changed vs BASE (git diff BASE...HEAD).")
+    parser.add_argument("paths", nargs="*",
+                        help="Explicit post file paths (non-digest paths are skipped).")
+    args = parser.parse_args()
+
+    if args.staged:
+        files = _staged_post_paths()
+    elif args.changed:
+        files = _changed_post_paths(args.changed)
+    elif args.paths:
+        files = _explicit_paths(args.paths)
+    else:
+        files = _all_post_paths()
+
+    if not files:
+        print("[digest-untranslated] No digest post files to check.")
+        sys.exit(0)
+
+    rc = 0
+    checked = 0
+    for path in files:
+        vs = check_post(str(path))
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        checked += 1
+        if vs:
+            rc = 1
+            print(f"FAIL {rel}")
+            for v in vs:
+                print(f"  - {v}")
+        else:
+            print(f"OK   {rel}")
+
+    if rc:
+        print(
+            f"\n[digest-untranslated] FAIL — untranslated English found in one or "
+            f"more of {checked} digest post(s). Translate 요약/summary= to Korean "
+            f"(preserve proper nouns / CVE IDs).",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[digest-untranslated] OK — {checked} digest post(s) checked, 0 violations.")
+
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -180,6 +180,20 @@ if [ -n "$STAGED_DIGEST_POSTS" ]; then
   echo "[pre-commit] Digest structural check: passed."
 fi
 
+# 9b. Digest untranslated-English gate (translation-fallback regression guard)
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest posts for untranslated English..."
+  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
+    echo "             Translate the flagged prose to Korean (preserve proper"
+    echo "             nouns / CVE IDs). Cited English titles are not flagged."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest untranslated-English check: passed."
+fi
+
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
 STAGED_HEAD_HTML=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_includes/head\.html$' || true)
 if [ -n "$STAGED_HEAD_HTML" ]; then

--- a/scripts/tests/test_check_digest_untranslated.py
+++ b/scripts/tests/test_check_digest_untranslated.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from check_digest_untranslated import check_post, is_untranslated
+
+# --- unit: is_untranslated() heuristic ------------------------------------
+
+_REAL_ENGLISH = (
+    "A malvertising operation dubbed SourTrade is making victims' browsers "
+    "build the final Windows executable themselves, using a legitimate Bun "
+    "runtime as its base instead of serving one complete malicious file. "
+    "EDR/SIEM에서 IoC 기반 탐지 룰을 업데이트하세요."
+)
+_KOR_WITH_UNQUOTED_TITLES = (
+    "이번 GFN Thursday에서는 Steam Summer Sale과 GeForce NOW 멤버십 할인이 "
+    "결합된 이중 혜택이 제공됩니다. 또한 Devolver 라인업에 Dark Scrolls가 "
+    "합류하고, Square Enix의 The Adventures of Elliot: The Millennium Tales도 "
+    "추가됩니다."
+)
+_KOR_WITH_CITED_TITLE = (
+    '비트코인 매거진의 칼럼 "The Hyperinflation of 1971 at the Kindergarten"은 '
+    "유치원생 수준에서 초인플레이션을 설명합니다. 이 글은 Alex v. Frankenberg가 "
+    "작성했습니다."
+)
+_KOR_CLEAN = (
+    "SourTrade라 불리는 악성 광고 캠페인은 피해자의 브라우저가 최종 Windows "
+    "실행 파일을 직접 빌드하도록 만듭니다. EDR/SIEM에서 IoC 기반 탐지 룰을 "
+    "업데이트하세요."
+)
+_KOR_WITH_CVE = (
+    "이 취약점은 CVE-2026-16723으로 추적되고 있으니, CVSS와 KEV 포함 여부를 "
+    "검토한 뒤 유지보수 창과 롤백 플랜을 준비하세요."
+)
+
+
+def test_flags_real_english_prose():
+    assert is_untranslated(_REAL_ENGLISH) is True
+
+
+def test_ignores_korean_with_unquoted_proper_noun_titles():
+    # Title-Cased product/article names ("GeForce NOW", "The Adventures of ...")
+    # inside Korean prose are cited names, not English prose.
+    assert is_untranslated(_KOR_WITH_UNQUOTED_TITLES) is False
+
+
+def test_ignores_korean_citing_quoted_english_title():
+    assert is_untranslated(_KOR_WITH_CITED_TITLE) is False
+
+
+def test_ignores_clean_korean():
+    assert is_untranslated(_KOR_CLEAN) is False
+
+
+def test_ignores_korean_with_identifiers():
+    assert is_untranslated(_KOR_WITH_CVE) is False
+
+
+# --- integration: check_post() over a whole digest body -------------------
+
+_HEAD = "---\ntitle: x\nimage: /assets/images/x.svg\n---\n\n"
+
+
+def _write(txt):
+    f = tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8")
+    f.write(txt)
+    f.close()
+    return f.name
+
+
+def test_check_post_flags_english_summary_block():
+    body = _HEAD + "## 1. 보안 뉴스\n\n### 1.1 항목\n\n#### 요약\n\n" + _REAL_ENGLISH + "\n\n---\n"
+    vs = check_post(_write(body))
+    assert vs and any("요약 블록" in v for v in vs)
+
+
+def test_check_post_flags_english_summary_field():
+    body = (
+        _HEAD
+        + '## 1. 보안 뉴스\n\n{% include news-card.html\n  title="x"\n  summary="'
+        + _REAL_ENGLISH.replace('"', "'")
+        + '"\n%}\n\n#### 요약\n\n'
+        + _KOR_CLEAN
+        + "\n\n---\n"
+    )
+    vs = check_post(_write(body))
+    assert vs and any("summary=" in v for v in vs)
+
+
+def test_check_post_passes_clean_korean_digest():
+    body = (
+        _HEAD
+        + '## 1. 보안 뉴스\n\n### 1.1 항목\n\n{% include news-card.html\n  title="한국어 제목"\n  summary="'
+        + _KOR_CLEAN
+        + '"\n%}\n\n#### 요약\n\n'
+        + _KOR_CLEAN
+        + "\n\n---\n"
+    )
+    assert check_post(_write(body)) == []
+
+
+def test_check_post_ignores_code_fence_content():
+    # An English sentence inside a fenced code block must NOT trip the guard.
+    body = (
+        _HEAD
+        + "## 1. 보안 뉴스\n\n#### 요약\n\n"
+        + _KOR_CLEAN
+        + "\n\n```\nthe attacker is able to run code with the privileges of the process\n```\n\n---\n"
+    )
+    assert check_post(_write(body)) == []


### PR DESCRIPTION
## 배경

PR #468에서 고친 "영문 폴백 다이제스트"의 **재발 방지 A단계**(탐지 게이트). 근본 원인은 `repository_dispatch` 발행 경로에서 번역 API 키가 빈 문자열로 막혀(MED-1 보안 파티션) 요약/제목이 영문 RSS 원문으로 폴백되는 것.

## 변경

- **`scripts/check_digest_untranslated.py`** — 다이제스트의 `#### 요약` 블록·`summary=` 필드에서 **미번역 영문 문장**을 탐지.
  - 휴리스틱: 인용 제목(`'...'`/`"..."`)·괄호 영어 주석·**Title-Case 고유명사 시퀀스** 제거 후, 영어 불용어 ≥3 AND 한글비율 <0.55.
  - 핵심은 **오탐 0**: 한국어 요약이 영어 기사 제목을 인용/언급하는 경우는 통과. 코퍼스 175개 전수 `--all` = 0 위반.
  - CLI는 `check_digest_structure.py`와 동일: `--staged` / `--changed BASE` / `--all` / 명시 경로.
- **테스트 9건** (`test_check_digest_untranslated.py`): 진짜 영문 탐지 + 인용제목/Title-Case제목/CVE식별자/코드펜스 오탐 방지 + 통합(요약블록·summary필드·클린통과).
- **배선**:
  - `.githooks/pre-commit` step 12 (활성 훅) + `scripts/install-hooks.sh` (일관성)
  - `.github/workflows/svg-lint.yml`: PR-diff-scoped 게이트 스텝 + path 필터 2곳

## 검증

- ✅ `pytest test_check_digest_untranslated.py`: 9 passed
- ✅ 전체 스크립트 스위트: 2940 passed, 5 skipped
- ✅ 코퍼스 `--all`: 175개 0 위반 (오탐 없음)
- ✅ 영문 주입 다이제스트 → 게이트 FAIL 확인
- ✅ `bash -n` 훅 문법 OK, svg-lint.yml YAML 파싱 OK

## 후속 (B단계, 별도 PR)

자동 **교정**은 신뢰 경로 후처리 번역 워크플로로 별도 진행(security-auditor 검토 필수). 이 PR은 탐지/차단 레이어만.