### PR TITLE
feat(workflow): 신뢰 경로 digest 재번역 워크플로 (재발 방지 B)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -187,3 +187,20 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
   fi
   echo "[pre-commit] Post quality: passed."
 fi
+
+# 12. Digest untranslated-English gate — block digests whose 요약/summary=
+#     fields fell back to raw English (translation API unavailable on the
+#     repository_dispatch publish path). Cited English titles are not flagged.
+STAGED_DIGEST_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+Weekly_Digest[^/]*\.md$' || true)
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest posts for untranslated English..."
+  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
+    echo "             Translate the flagged prose to Korean (preserve proper"
+    echo "             nouns / CVE IDs). Cited English titles are not flagged."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest untranslated-English check: passed."
+fi

--- a/.github/workflows/digest-translate-backfill.yml
+++ b/.github/workflows/digest-translate-backfill.yml
@@ -1,0 +1,163 @@
+name: Digest Translate Backfill
+
+# 재발 방지 B단계 — TRUSTED post-processing translator.
+#
+# The untrusted `repository_dispatch` publish path in ai-blogwatcher.yml zeroes
+# out all LLM keys (MED-1 secret partition), so any digest it publishes with an
+# English-only translation fallback lands untranslated. This job runs in a
+# TRUSTED context (schedule / manual dispatch ONLY — never repository_dispatch)
+# WITH the keys available, translates those English 요약/summary=/title= spans
+# back to Korean (scripts/retranslate_digest.py), and opens a review PR.
+#
+# Why this is safe even though the post text originated from untrusted RSS:
+# the key is never exposed to a dispatch requester (this workflow cannot be
+# triggered by repository_dispatch, and the translate step is additionally
+# guarded on github.event_name); the LLM output can only become validated
+# Korean post text (no tool/network/eval surface); and retranslate_digest.py
+# validates every translation (Hangul present, bounded length) before writing.
+# See notes/digest-retranslate-security.md.
+
+on:
+  schedule:
+    # 01:30 UTC (10:30 KST) — ~90 min after the ai-blogwatcher publish cron
+    # (0 0 * * *) so a freshly-published digest is already committed.
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "Translate digests changed within this many recent commits"
+        required: false
+        default: "5"
+      dry_run:
+        description: "Dry run (no write, no PR)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions: {}
+
+concurrency:
+  group: digest-translate-backfill
+  cancel-in-progress: false
+
+env:
+  PYTHON_VERSION: "3.11"
+
+jobs:
+  translate-backfill:
+    # Belt-and-suspenders: this workflow has no repository_dispatch trigger, but
+    # pin the whole job to the trusted event types so a future edit that adds one
+    # can never run the secret-injecting steps below.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      SINCE: ${{ github.event.inputs.since || '5' }}
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          fetch-depth: 10
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+          cache-dependency-path: "requirements-blogwatcher.txt"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          # requests (DeepSeek/Gemini REST) comes from the reviewed, floor-pinned
+          # blogwatcher dep set.
+          pip install -r requirements-blogwatcher.txt
+
+      - name: Retranslate untranslated digests
+        id: translate
+        env:
+          # SECRET PARTITION (mirrors ai-blogwatcher.yml MED-1): inject the LLM
+          # keys ONLY on the trusted event types. Even though this workflow has no
+          # repository_dispatch trigger, the guard makes a future misconfiguration
+          # fail-closed (empty key -> retranslate_digest.py is a clean no-op).
+          GEMINI_API_KEY: ${{ github.event_name != 'repository_dispatch' && secrets.GEMINI_API_KEY || '' }}
+          DEEPSEEK_API_KEY: ${{ github.event_name != 'repository_dispatch' && secrets.DEEPSEEK_API_KEY || '' }}
+          # Force auto mode so both backends are eligible (config._AI_MODE).
+          AUTO_PUBLISH_USE_AI: "auto"
+        run: |
+          set -euo pipefail
+          # Only strictly-numeric SINCE is honored (no shell metacharacters).
+          if [[ "${SINCE}" =~ ^[0-9]+$ ]] && [ "${SINCE}" -gt 0 ]; then
+            BASE="HEAD~${SINCE}"
+          else
+            BASE="HEAD~5"
+          fi
+          echo "Scanning digests changed vs ${BASE} ..."
+
+          ARGS=(--changed "${BASE}")
+          if [ "${DRY_RUN}" = "true" ]; then
+            ARGS+=(--dry-run)
+          fi
+
+          # retranslate_digest.py masks nothing sensitive to stdout and is a
+          # clean no-op when no key is present.
+          python3 scripts/retranslate_digest.py "${ARGS[@]}"
+
+          if [ "${DRY_RUN}" != "true" ] && ! git diff --quiet -- _posts; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open review PR with translations
+        if: steps.translate.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          TODAY=$(date -u +%Y-%m-%d)
+          BRANCH="digest-retranslate/${TODAY}-${RUN_ID}"
+          git checkout -b "$BRANCH"
+          git add -u _posts/
+          git commit -m "fix: 미번역 영문 다이제스트 요약/제목 한국어 재번역 (${TODAY})"
+          git push origin "$BRANCH"
+
+          # Do NOT push to main — open a PR so CI (digest gates) runs first.
+          # Mirror the blogwatcher graceful-degrade: if the repo blocks Actions
+          # from opening PRs, leave the branch pushed and print how to open it.
+          if gh pr create --base main --head "$BRANCH" \
+            --title "fix: 미번역 다이제스트 한국어 재번역 (${TODAY})" \
+            --body "재발 방지 B단계 — trusted scheduled translator retranslated English-fallback 요약/summary=/title= spans back to Korean. Translations are output-validated (Hangul + bounded length). Review the diff and let CI go green before merging."; then
+            echo "Opened retranslate review PR from $BRANCH"
+          else
+            echo "::error::Could not auto-open the PR. Translations are on branch '${BRANCH}' (main NOT updated)."
+            echo "::error::Fix: enable Settings → Actions → General → 'Allow GitHub Actions to create and approve pull requests', or use a PAT/App token. Open manually:"
+            echo "::error::  ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/compare/main...${BRANCH}?expand=1"
+            exit 1
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Digest Translate Backfill"
+            echo ""
+            echo "- Event: ${{ github.event_name }}"
+            echo "- Since: ${SINCE} commit(s)"
+            echo "- Dry run: ${DRY_RUN}"
+            echo "- Changes: ${{ steps.translate.outputs.changed }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/notes/digest-retranslate-security.md
+++ b/notes/digest-retranslate-security.md
@@ -1,0 +1,90 @@
+# Digest retranslate backfill — security design (재발 방지 B단계)
+
+**Date**: 2026-07-28
+**Components**: `scripts/retranslate_digest.py`, `.github/workflows/digest-translate-backfill.yml`
+**Detection reused**: `scripts/check_digest_untranslated.py` (Part A)
+
+## Problem
+
+Weekly digests auto-publish. On the **untrusted `repository_dispatch`** path,
+`ai-blogwatcher.yml` intentionally zeroes `GEMINI_API_KEY` / `DEEPSEEK_API_KEY`
+(MED-1 secret partition, 2026-07-06 audit) so an externally-authored payload can
+never reach a live LLM key. With no key, the translation fallback in
+`scripts/news/content_generator.py` emits **raw English** RSS text into
+`#### 요약` blocks and `summary=` / `title=` fields. Part A detects this; Part B
+(this work) corrects it.
+
+## Trust model — why this is safe
+
+Part B runs the LLM over post text that ORIGINATED from untrusted RSS, which
+sounds like it re-opens the MED-1 concern. It does not, for four independent
+reasons:
+
+1. **The key is never exposed to the dispatch requester.** MED-1's actual worry
+   is *secret exfiltration* — a poisoned feed reaching a live key on a path an
+   external party can trigger. `digest-translate-backfill.yml` has **no
+   `repository_dispatch` trigger** (only `schedule` + `workflow_dispatch`), so an
+   external party cannot cause it to run at all. A defense-in-depth
+   `if: github.event_name != 'repository_dispatch'` guard on the secret-injecting
+   step makes a *future* trigger edit fail-closed (empty key → the script is a
+   clean no-op), and the job-level `if` pins the whole job to trusted events.
+
+2. **The content is already committed.** By the time Part B runs, the digest is
+   in git (published by the trusted schedule path, or landed via the reviewed PR
+   the untrusted path opens). We translate *repository text*, not a live
+   attacker-controlled HTTP payload. There is no SSRF/feed-fetch surface here —
+   `retranslate_digest.py` does zero network I/O of its own beyond the LLM call.
+
+3. **The LLM output is sanitized before it can become post text.** The model
+   result is written into Markdown/Liquid: `summary=`/`title=` attribute values
+   (re-escaped to a single quote-free line) and — for `#### 요약` blocks — inline
+   into the kramdown-rendered body (raw inline HTML is on) which Jekyll also
+   re-processes through Liquid. So the output is NOT structurally inert by
+   position; a prompt-injected response containing `<script>`, `{% … %}`, or
+   `{{ … }}` plus Hangul would otherwise land as active markup. `_is_valid_korean`
+   therefore REJECTS any candidate containing `<`, `{%`, `{{`, or `]]>` (in
+   addition to requiring Hangul and bounding length); a rejected candidate is
+   fail-safe-dropped and the original English is kept (Part A still flags it).
+   There is no tool-use, no shell, no `eval`. Prompt injection in the source can
+   at worst change *what validated Korean sentence* gets written — it cannot
+   inject active HTML/Liquid, nor escalate to code or network access.
+
+4. **Every translation is output-validated before it is written** (fail-safe):
+   - must contain Hangul (`[가-힣]`) — rejects "translation refused"/echoed English,
+   - must be ≤ `MAX_LEN_RATIO` (3×) the source length — rejects runaway / injected
+     bulk output,
+   - `summary=`/`title=` are re-escaped (`_html_escape_quotes`) and whitespace-
+     collapsed to a single physical line with no inner double-quote, so the value
+     cannot break out of the Liquid attribute or the YAML/Markdown structure.
+   If validation fails, the **original English is kept** — we never write suspect
+   output. Worst realistic case: the post stays untranslated (Part A's gate still
+   flags it) rather than shipping garbage.
+
+Contrast with MED-1: MED-1 protects *the secret* on an externally-triggerable
+path by withholding the key. Part B protects *the output* on a
+non-externally-triggerable path by validating what the key produces. Different
+threat (exfiltration vs. content integrity), different, appropriate control.
+
+## Residual risks + mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Prompt injection in RSS-derived source text steers the translation | Output is validated Korean text only; no tool/eval/network surface. Bounded blast radius = one wrong sentence, caught on human PR review. |
+| Model emits an over-long / padded response | Length-ratio cap (3×) rejects it, original kept. |
+| Model emits English / refuses | Hangul check rejects it, original kept. |
+| Broken structure (unescaped quote, newline in attribute) | Single-line + `_html_escape_quotes` on write; `check_posts` / digest gates run on the PR before merge. |
+| Future edit adds `repository_dispatch` and leaks a key | Job-level `if` (trusted events only) + step-level `github.event_name != 'repository_dispatch'` guard → empty key → no-op. |
+| Direct push to main bypassing review | Job never pushes to main; it opens a PR (graceful-degrade: pushes branch + prints manual-open URL if `gh pr create` is disabled). |
+
+## Non-goals / decisions
+
+- **Does not touch `ai-blogwatcher.yml`** or the digest generator's live
+  behavior — this is a separate, additive correction pass.
+- **Whole-block translation**: a fully-English 요약 block (English RSS summary +
+  short appended Korean advisory) is translated as one unit rather than splicing
+  out only the English lead. Simpler and honest; the appended advisory's meaning
+  is preserved and the result is validated Korean. Partially-Korean blocks are
+  never touched (`is_untranslated` returns False), so this only fires on the true
+  fallback regression.
+- **Least privilege**: `permissions: contents: write, pull-requests: write`
+  only; top-level `permissions: {}`.

--- a/scripts/retranslate_digest.py
+++ b/scripts/retranslate_digest.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Trusted post-processing translator for weekly-digest posts (재발 방지 B단계).
+
+Part A (`scripts/check_digest_untranslated.py`) DETECTS digest posts whose
+`#### 요약` prose or news-card `summary="..."` / `title="..."` fields fell back
+to raw ENGLISH — which happens whenever the auto-publish translation chain runs
+with no LLM key. On the untrusted `repository_dispatch` publish path the LLM
+secrets are intentionally zeroed out (ai-blogwatcher.yml, MED-1 partition), so
+the fallback emits English instead of Korean.
+
+Part B (this script) is the CORRECTION. It runs in a TRUSTED context (scheduled
+`digest-translate-backfill.yml`, never `repository_dispatch`) WITH the keys
+available, finds the untranslated spans using `is_untranslated()`, translates
+English -> Korean by REUSING the existing helpers in
+`scripts/news/content_generator.py` + `scripts/news/enhancer.py` (no new API
+plumbing), and writes the Korean back in place — preserving Jekyll `{% include %}`
+structure, frontmatter, tables, code blocks, and proper nouns / CVE / MITRE IDs.
+
+Safety properties:
+  * GRACEFUL NO-OP without keys — if neither Gemini nor DeepSeek is available it
+    changes nothing and exits 0 (never writes a partial/garbage translation).
+  * OUTPUT VALIDATED — a translation is only written if it contains Hangul and is
+    not more than MAX_LEN_RATIO x the source length; otherwise the original is
+    kept (fail-safe). This bounds prompt-injection in RSS content: the only thing
+    that can ever land in a post is short, validated Korean text.
+  * IDEMPOTENT — re-running on already-Korean text is a no-op.
+
+Usage (mirrors check_digest_untranslated.py, plus --dry-run):
+    python3 scripts/retranslate_digest.py --staged
+    python3 scripts/retranslate_digest.py --changed HEAD~5
+    python3 scripts/retranslate_digest.py --all --dry-run
+    python3 scripts/retranslate_digest.py _posts/2026-07-25-...Weekly_Digest...md
+"""
+import argparse
+import html
+import os
+import re
+import sys
+from pathlib import Path
+
+# --- Path setup so both `import check_digest_untranslated` (scripts/ dir) and
+# `from scripts.news import ...` (repo root) resolve regardless of whether we
+# are run as a script or imported as scripts.retranslate_digest in tests.
+# Mirrors backfill_digest_enrichment.py's established pattern. ---
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+for _p in (str(_REPO_ROOT), str(_SCRIPTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+# Reuse detection + path-selection from Part A (single source of truth).
+from check_digest_untranslated import (  # noqa: E402
+    _all_post_paths,
+    _changed_post_paths,
+    _explicit_paths,
+    _staged_post_paths,
+    is_untranslated,
+)
+
+# Reuse the existing translation backends — do NOT reimplement API calls.
+from scripts.news.content_generator import (  # noqa: E402
+    _html_escape_quotes,
+    _translate_to_korean_deepseek,
+)
+from scripts.news.enhancer import (  # noqa: E402
+    _allow_deepseek,
+    _gemini_call,
+    check_gemini_available,
+)
+
+# A translated span is only accepted if it is at most this many times the
+# source length. Korean renderings of English are usually shorter or comparable
+# in character count; anything much longer signals a runaway / injected model
+# response, which we reject and keep the original.
+MAX_LEN_RATIO = 3.0
+
+# One physical '<indent>key="value"' news-card attribute line. Values never
+# contain a raw inner double-quote (they are &quot;-escaped at generation), so
+# '.*' up to the closing quote at end-of-line is exact.
+_FIELD_RE = re.compile(r'^(?P<indent>\s*)(?P<key>title|summary)="(?P<val>.*)"\s*$')
+
+# A '#### 요약' prose block: heading, then prose up to the next blank-gap /
+# heading / rule. Matches check_digest_untranslated._summary_blocks so the
+# region we rewrite is exactly the region Part A flags.
+_SUMMARY_BLOCK_RE = re.compile(
+    r"(####\s*요약\s*\n+)(.+?)(\n\n|\n####|\n---|\n##\s)", re.S
+)
+
+
+def _postprocess(raw: str) -> str:
+    """Collapse whitespace to a single physical line and strip wrapping quotes."""
+    if not raw:
+        return ""
+    return re.sub(r"\s+", " ", raw).strip().strip("\"'")
+
+
+def _is_valid_korean(candidate: str, source: str) -> bool:
+    """Output-validation gate (security): accept only bounded, inert Korean text.
+
+    Fail-safe: any candidate that fails a check is rejected so the caller keeps
+    the original English (Part A still flags it) rather than shipping suspect
+    output. Besides Hangul + length bounds, we reject HTML/Liquid metacharacters
+    so a prompt-injected model response (e.g. ``<script>…</script> 안녕`` or a
+    ``{% … %}`` tag) can never land in a post body: the '#### 요약' block path
+    injects the string raw into kramdown-rendered markdown (raw inline HTML is
+    on) and Jekyll re-processes bodies through Liquid, so unescaped ``<``/``{%``/
+    ``{{`` would become active markup, not displayed prose.
+    """
+    if not candidate:
+        return False
+    if not re.search(r"[가-힣]", candidate):
+        return False
+    if len(candidate) > MAX_LEN_RATIO * max(len(source), 1):
+        return False
+    # Reject active HTML / Liquid / CDATA metacharacters (stored-XSS guard).
+    if re.search(r"<|{%|{{|\]\]>", candidate):
+        return False
+    return True
+
+
+def _build_prompt(text: str, mode: str, context: str) -> str:
+    """Gemini prompt mirroring content_generator's translation prompts, with
+    an explicit instruction to preserve proper nouns / CVE / MITRE IDs."""
+    if mode == "title":
+        return (
+            f"다음 {context} 제목을 한국어 한 줄로 자연스럽게 번역하세요. "
+            "고유명사(회사명/제품명/행위자명), CVE ID, MITRE ATT&CK ID는 원문 표기를 "
+            "그대로 유지하세요. 따옴표/번호/불릿/설명 없이 번역된 제목 한 줄만 출력하세요.\n"
+            f"원문: {text}\n번역:"
+        )
+    return (
+        f"다음 {context}를 한국어 2~3문장으로 자연스럽게 번역하세요. "
+        "기술 용어와 고유명사(회사명/제품명/행위자명), CVE ID, MITRE ATT&CK ID, "
+        "그리고 문장 끝의 한국어 조치 문구는 원문 표기를 그대로 유지하세요. "
+        "마크다운/불릿/번호 없이 순수 문장만 출력하세요.\n"
+        f"원문: {text[:1000]}\n번역:"
+    )
+
+
+def backend_available() -> bool:
+    """True iff at least one translation backend (Gemini CLI/API or DeepSeek)
+    is reachable. Used to short-circuit to a clean no-op when no key exists."""
+    if check_gemini_available():
+        return True
+    if _allow_deepseek() and os.getenv("DEEPSEEK_API_KEY", ""):
+        return True
+    return False
+
+
+def translate(text: str, mode: str, context: str = "기술 뉴스") -> str:
+    """Translate English *text* -> Korean, reusing Gemini then DeepSeek.
+
+    Returns "" if no backend is available OR the model output fails validation
+    (fail-safe: the caller then keeps the original text unchanged).
+    """
+    text = text.strip()
+    if not text:
+        return ""
+
+    # 1) Gemini (CLI free-tier first, API fallback — both inside _gemini_call).
+    if check_gemini_available():
+        candidate = _postprocess(_gemini_call(_build_prompt(text, mode, context), timeout=20))
+        if _is_valid_korean(candidate, text):
+            return candidate
+
+    # 2) DeepSeek API fallback (reads DEEPSEEK_API_KEY internally).
+    if _allow_deepseek() and os.getenv("DEEPSEEK_API_KEY", ""):
+        candidate = _postprocess(
+            _translate_to_korean_deepseek(text, context=context, mode=mode)
+        )
+        if _is_valid_korean(candidate, text):
+            return candidate
+
+    return ""
+
+
+def _field_line(line: str, stats: dict) -> str:
+    """Translate one news-card title="..." / summary="..." line if it is
+    untranslated English; otherwise return it unchanged."""
+    m = _FIELD_RE.match(line)
+    if not m:
+        return line
+    key = m.group("key")
+    raw_val = m.group("val")
+    plain = html.unescape(raw_val)
+    if not is_untranslated(plain):
+        return line
+    mode = "title" if key == "title" else "summary"
+    translated = translate(plain, mode=mode, context="보안 뉴스")
+    if not translated:
+        return line  # fail-safe: keep original
+    # Re-escape for safe single-line injection into the Liquid double-quoted
+    # attribute (no inner double-quotes, no newlines).
+    safe = _html_escape_quotes(re.sub(r"\s+", " ", translated).strip())
+    stats["fields"] += 1
+    return f'{m.group("indent")}{key}="{safe}"'
+
+
+def _block_repl(m: "re.Match", stats: dict) -> str:
+    """Replace a '#### 요약' prose block with its Korean translation if it is
+    untranslated English; otherwise leave the whole match unchanged."""
+    head, prose, tail = m.group(1), m.group(2), m.group(3)
+    if not is_untranslated(prose):
+        return m.group(0)
+    translated = translate(prose, mode="summary", context="보안 뉴스 요약")
+    if not translated:
+        return m.group(0)  # fail-safe: keep original
+    stats["blocks"] += 1
+    return f"{head}{translated}{tail}"
+
+
+def retranslate_text(text: str) -> tuple:
+    """Return (new_text, stats). Pure function — no I/O.
+
+    Order is irrelevant because 요약 blocks and title=/summary= attribute lines
+    occupy disjoint regions of the post.
+    """
+    stats = {"fields": 0, "blocks": 0}
+    text = _SUMMARY_BLOCK_RE.sub(lambda m: _block_repl(m, stats), text)
+    text = "\n".join(_field_line(ln, stats) for ln in text.split("\n"))
+    return text, stats
+
+
+def retranslate_post(path: Path, dry_run: bool) -> dict:
+    """Read, translate in place, (optionally) write. Returns a result dict."""
+    with open(path, encoding="utf-8") as fh:
+        original = fh.read()
+    new, stats = retranslate_text(original)
+    changed = new != original
+    if changed and not dry_run:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(new)
+    return {"changed": changed, **stats}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Translate untranslated-English 요약/summary=/title= spans in "
+            "Weekly_Digest posts back to Korean (재발 방지 B단계). Trusted job "
+            "only — never runs on repository_dispatch. Graceful no-op without keys."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true",
+                      help="Only fix staged digest posts (git diff --cached).")
+    mode.add_argument("--all", action="store_true",
+                      help="Fix every digest post.")
+    mode.add_argument("--changed", metavar="BASE", default=None,
+                      help="Only fix digest posts changed vs BASE (git diff BASE...HEAD).")
+    parser.add_argument("paths", nargs="*",
+                        help="Explicit post file paths (non-digest paths are skipped).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report what WOULD change without writing.")
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        files = _staged_post_paths()
+    elif args.changed:
+        files = _changed_post_paths(args.changed)
+    elif args.paths:
+        files = _explicit_paths(args.paths)
+    else:
+        files = _all_post_paths()
+
+    if not files:
+        print("[digest-retranslate] No digest post files to process.")
+        return 0
+
+    # GRACEFUL NO-OP: with no translation backend, do nothing rather than risk a
+    # partial write. (Also the common local case — corpus is already Korean.)
+    if not backend_available():
+        print(
+            "[digest-retranslate] No translation backend available "
+            "(no Gemini CLI/API and no DEEPSEEK_API_KEY) — nothing translated. "
+            f"{len(files)} digest post(s) left unchanged."
+        )
+        return 0
+
+    changed = 0
+    for path in files:
+        rel = path.relative_to(_REPO_ROOT) if path.is_relative_to(_REPO_ROOT) else path
+        result = retranslate_post(path, dry_run=args.dry_run)
+        if result["changed"]:
+            changed += 1
+            verb = "WOULD FIX" if args.dry_run else "FIXED"
+            print(
+                f"{verb} {rel} "
+                f"(요약 blocks={result['blocks']}, fields={result['fields']})"
+            )
+        else:
+            print(f"ok   {rel}")
+
+    tail = "would change" if args.dry_run else "changed"
+    print(f"[digest-retranslate] {changed}/{len(files)} digest post(s) {tail}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ci_digest_translate_partition_guard.py
+++ b/scripts/tests/test_ci_digest_translate_partition_guard.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""CI regression guard: the digest-translate-backfill workflow must stay trusted.
+
+Why this guard exists
+---------------------
+`digest-translate-backfill.yml` runs the LLM re-translation pass (재발 방지 B단계)
+WITH `GEMINI_API_KEY`/`DEEPSEEK_API_KEY` in scope. That is only safe because the
+workflow is un-triggerable by external parties: it has NO `repository_dispatch`
+trigger, and every key expression is additionally gated on the trusted path
+(`github.event_name != 'repository_dispatch'`, belt-and-suspenders with the
+job-level schedule/workflow_dispatch allowlist `if`).
+
+Either protection can disappear *silently* — a future edit adding a
+`repository_dispatch` trigger, or dropping the gate from a key line, would hand a
+live LLM key to an attacker-controlled `client_payload` (the exact MED-1
+secret-exposure failure mode the sibling blogwatcher guard was built to catch).
+This guard makes that regression fail loudly.
+
+Maps to OWASP CICD-SEC-1 / A02 (secret exposure to untrusted input). If the
+partition is intentionally reworked, update this guard in the same PR.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "digest-translate-backfill.yml"
+
+GATE = "github.event_name != 'repository_dispatch'"
+
+
+def _triggers(text: str) -> list:
+    """Return the workflow's `on:` trigger keys (YAML parses `on` as True)."""
+    doc = yaml.safe_load(text)
+    on = doc.get("on", doc.get(True))
+    if isinstance(on, dict):
+        return list(on.keys())
+    if isinstance(on, list):
+        return list(on)
+    return [on]
+
+
+def _key_lines(text: str) -> list:
+    """Non-comment lines assigning a ``*_API_KEY:`` from ``secrets.*``."""
+    out = []
+    for ln in text.splitlines():
+        s = ln.strip()
+        if s.startswith("#"):
+            continue
+        if re.match(r"[A-Z0-9_]*API_KEY:\s*", s) and "secrets." in s:
+            out.append(ln)
+    return out
+
+
+class TestDigestTranslatePartitionGuard:
+    def test_workflow_exists(self):
+        assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
+
+    def test_no_repository_dispatch_trigger(self):
+        triggers = _triggers(WORKFLOW.read_text(encoding="utf-8"))
+        assert "repository_dispatch" not in triggers, (
+            "digest-translate-backfill.yml must NOT be triggerable by "
+            "repository_dispatch — that path is externally controllable and this "
+            f"workflow runs with live LLM keys. Found triggers: {triggers}. "
+            "Remove the trigger, or if reworking the trust model, update this guard."
+        )
+
+    def test_every_key_gated_on_trusted_path(self):
+        lines = _key_lines(WORKFLOW.read_text(encoding="utf-8"))
+        assert lines, (
+            "no *_API_KEY secret assignments found — the workflow structure "
+            "changed; review the secret partition and update this guard."
+        )
+        ungated = [ln.strip() for ln in lines if GATE not in ln]
+        assert not ungated, (
+            "these digest-translate API-key expressions are NOT gated on the "
+            f"trusted path (missing `{GATE}`); a future repository_dispatch trigger "
+            "would then hand over a live LLM key (MED-1 secret-exposure "
+            "regression):\n  " + "\n  ".join(ungated)
+        )

--- a/scripts/tests/test_retranslate_digest.py
+++ b/scripts/tests/test_retranslate_digest.py
@@ -1,0 +1,241 @@
+"""Tests for scripts/retranslate_digest.py (재발 방지 B단계 correction pass).
+
+The translation backends are fully MOCKED — no network. We monkeypatch the
+Gemini entrypoint (`_gemini_call`) / `check_gemini_available` and the DeepSeek
+helper on the retranslate_digest module namespace, so we exercise the real
+detection -> translate -> write wiring without any API call.
+"""
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import retranslate_digest as rt  # noqa: E402
+
+# --- Fixtures -------------------------------------------------------------
+
+# An English (untranslated) news-card + 요약 block, alongside a second card that
+# is ALREADY Korean (must stay untouched). Includes a table and frontmatter to
+# assert structure preservation.
+_ENGLISH_TITLE = (
+    "Attackers are exploiting a flaw in the Active Directory to escalate privileges"
+)
+_ENGLISH_SUMMARY = (
+    "BlueNoroff, tracked as CVE-2026-1234, is operating an active phishing kit "
+    "that impersonates the video platforms to deliver malware and to profile wallets."
+)
+_ENGLISH_BLOCK = (
+    "BlueNoroff threat actors are running a phishing kit and are abusing "
+    "CVE-2026-1234 to deliver malware to the victims in a social engineering campaign."
+)
+_KOREAN_TITLE = "AWS에서 Claude Opus 5 소개"
+_KOREAN_SUMMARY = (
+    "북한 위협 행위자들이 화상회의 플랫폼을 사칭하는 활성 피싱 키트를 운영하는 것으로 "
+    "확인되었습니다."
+)
+
+_POST = f"""---
+layout: post
+title: "주간 다이제스트"
+category: [security]
+---
+## 1. 보안 뉴스
+
+### 1.1 English Item
+
+{{% include news-card.html
+  title="{_ENGLISH_TITLE}"
+  url="https://thehackernews.com/example.html"
+  summary="{_ENGLISH_SUMMARY}"
+  source="The Hacker News"
+  severity="High"
+%}}
+
+#### 요약
+
+{_ENGLISH_BLOCK}
+
+
+#### 위협 분석
+
+| 항목 | 내용 |
+|------|------|
+| **CVE ID** | CVE-2026-1234 |
+| **심각도** | High |
+
+---
+
+### 1.2 Korean Item
+
+{{% include news-card.html
+  title="{_KOREAN_TITLE}"
+  url="https://aws.amazon.com/example"
+  summary="{_KOREAN_SUMMARY}"
+  source="AWS Security Blog"
+  severity="Medium"
+%}}
+
+#### 요약
+
+{_KOREAN_SUMMARY} 보안 영향도를 평가하고 필요 시 대응 조치를 수행하세요.
+
+---
+"""
+
+
+def _fake_gemini(prompt, timeout=20):
+    """A canned 'translator': returns Korean-dominant text that PRESERVES the
+    CVE ID and the BlueNoroff proper noun found in the source, so we can assert
+    preservation while keeping the output Korean (idempotent on re-run)."""
+    m = re.search(r"원문:\s*(.*?)\n번역:", prompt, re.S)
+    src = m.group(1) if m else prompt
+    parts = ["이것은 한국어로 번역된 문장입니다."]
+    cve = re.search(r"CVE-\d{4}-\d+", src)
+    if cve:
+        parts.append(f"이 취약점은 {cve.group(0)}로 추적되고 있습니다.")
+    if "BlueNoroff" in src:
+        parts.append("BlueNoroff 위협 행위자가 관련되어 있습니다.")
+    return " ".join(parts)
+
+
+def _mock_gemini(monkeypatch, call=_fake_gemini):
+    monkeypatch.setattr(rt, "check_gemini_available", lambda: True)
+    monkeypatch.setattr(rt, "_gemini_call", call)
+
+
+# --- Detection -> translation wiring --------------------------------------
+
+def test_translates_english_spans_and_preserves_structure(monkeypatch):
+    _mock_gemini(monkeypatch)
+    out, stats = rt.retranslate_text(_POST)
+
+    # English title + summary field replaced; the English 요약 block replaced.
+    assert stats == {"fields": 2, "blocks": 1}
+    assert _ENGLISH_TITLE not in out
+    assert _ENGLISH_SUMMARY not in out
+    assert _ENGLISH_BLOCK not in out
+    assert "이것은 한국어로 번역된 문장입니다." in out
+
+    # Proper noun + CVE ID preserved through translation.
+    assert "BlueNoroff" in out
+    assert out.count("CVE-2026-1234") >= 2  # summary field + 요약 block (+ table)
+
+    # Structure intact: both include blocks, frontmatter, table pipes.
+    assert out.count("{% include news-card.html") == 2
+    assert out.startswith("---\nlayout: post\n")
+    assert "| **CVE ID** | CVE-2026-1234 |" in out
+
+    # The already-Korean card is untouched.
+    assert f'title="{_KOREAN_TITLE}"' in out
+    assert f'summary="{_KOREAN_SUMMARY}"' in out
+
+
+def test_summary_field_stays_single_line_without_inner_quotes(monkeypatch):
+    _mock_gemini(monkeypatch)
+    out, _ = rt.retranslate_text(_POST)
+    for line in out.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("summary=") or stripped.startswith("title="):
+            # opens and closes on one physical line, no raw inner double-quote.
+            assert stripped.endswith('"')
+            assert stripped[stripped.index('"') + 1: -1].count('"') == 0
+
+
+def test_idempotent_second_run_is_noop(monkeypatch):
+    _mock_gemini(monkeypatch)
+    once, _ = rt.retranslate_text(_POST)
+    twice, stats2 = rt.retranslate_text(once)
+    assert twice == once
+    assert stats2 == {"fields": 0, "blocks": 0}
+
+
+# --- Output validation (security) -----------------------------------------
+
+def test_output_validation_rejects_non_korean_and_keeps_original(monkeypatch):
+    # Model returns English (no Hangul) -> validation fails -> original kept.
+    _mock_gemini(monkeypatch, call=lambda prompt, timeout=20: "This is still English output")
+    monkeypatch.setattr(rt, "_allow_deepseek", lambda: False)
+    out, stats = rt.retranslate_text(_POST)
+    assert out == _POST
+    assert stats == {"fields": 0, "blocks": 0}
+
+
+def test_output_validation_rejects_runaway_length(monkeypatch):
+    # Korean but absurdly long (> MAX_LEN_RATIO x source) -> rejected.
+    _mock_gemini(monkeypatch, call=lambda prompt, timeout=20: "가" * 5000)
+    monkeypatch.setattr(rt, "_allow_deepseek", lambda: False)
+    out, stats = rt.retranslate_text(_POST)
+    assert out == _POST
+    assert stats == {"fields": 0, "blocks": 0}
+
+
+def test_output_validation_rejects_html_liquid_injection(monkeypatch):
+    # M-01: a prompt-injected model response that keeps Hangul but smuggles
+    # active HTML/Liquid must be rejected (fail-safe: original English kept),
+    # so it can never land in a kramdown+Liquid-rendered post body.
+    for payload in (
+        "<script>steal()</script> 공격자가 코드를 실행합니다.",
+        "{% raw %} 공격자가 코드를 실행합니다.",
+        "{{ site.secret }} 공격자가 코드를 실행합니다.",
+    ):
+        _mock_gemini(monkeypatch, call=lambda prompt, timeout=20, p=payload: p)
+        monkeypatch.setattr(rt, "_allow_deepseek", lambda: False)
+        out, stats = rt.retranslate_text(_POST)
+        assert out == _POST, f"payload leaked into output: {payload!r}"
+        assert stats == {"fields": 0, "blocks": 0}
+
+
+# --- DeepSeek fallback path ------------------------------------------------
+
+def test_falls_back_to_deepseek_when_gemini_unavailable(monkeypatch):
+    monkeypatch.setattr(rt, "check_gemini_available", lambda: False)
+    monkeypatch.setattr(rt, "_allow_deepseek", lambda: True)
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-not-real")
+
+    def _fake_deepseek(text, context="기술 뉴스", mode="summary"):
+        return "딥시크로 번역된 한국어 요약 문장입니다."
+
+    monkeypatch.setattr(rt, "_translate_to_korean_deepseek", _fake_deepseek)
+    out, stats = rt.retranslate_text(_POST)
+    assert "딥시크로 번역된 한국어 요약 문장입니다." in out
+    assert stats["fields"] == 2 and stats["blocks"] == 1
+
+
+# --- Graceful no-op without keys ------------------------------------------
+
+def test_no_backend_is_clean_noop(monkeypatch, tmp_path):
+    monkeypatch.setattr(rt, "check_gemini_available", lambda: False)
+    monkeypatch.setattr(rt, "_allow_deepseek", lambda: False)
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+
+    assert rt.backend_available() is False
+
+    post = tmp_path / "2026-07-25-Sample_Weekly_Digest_Test.md"
+    post.write_text(_POST, encoding="utf-8")
+    rc = rt.main([str(post)])
+    assert rc == 0
+    assert post.read_text(encoding="utf-8") == _POST  # unchanged
+
+
+def test_main_writes_translation_to_file(monkeypatch, tmp_path):
+    _mock_gemini(monkeypatch)
+    post = tmp_path / "2026-07-25-Sample_Weekly_Digest_Test.md"
+    post.write_text(_POST, encoding="utf-8")
+
+    rc = rt.main([str(post)])
+    assert rc == 0
+    written = post.read_text(encoding="utf-8")
+    assert _ENGLISH_TITLE not in written
+    assert "이것은 한국어로 번역된 문장입니다." in written
+
+
+def test_main_dry_run_does_not_write(monkeypatch, tmp_path):
+    _mock_gemini(monkeypatch)
+    post = tmp_path / "2026-07-25-Sample_Weekly_Digest_Test.md"
+    post.write_text(_POST, encoding="utf-8")
+
+    rc = rt.main([str(post), "--dry-run"])
+    assert rc == 0
+    assert post.read_text(encoding="utf-8") == _POST  # unchanged on dry-run


### PR DESCRIPTION
## 배경

"영문 폴백 다이제스트" 재발 방지의 **B단계(자동 교정)**. #468(수동 번역), #469(탐지 게이트 A)에 이은 근본 대응.

근본 원인: `repository_dispatch` 발행 경로에서 LLM 키가 빈 문자열로 막혀(MED-1 보안 파티션) 요약/제목이 영문 RSS 원문으로 폴백. 이 워크플로는 **신뢰 컨텍스트(schedule/manual)**에서 키를 갖고 재번역→리뷰 PR로 자동 교정합니다.

> **의존**: #469 — `check_digest_untranslated.is_untranslated()`를 재사용합니다. #469 병합 후 이 브랜치를 리베이스하세요.

## 변경

- **`scripts/retranslate_digest.py`** — 커밋된 다이제스트의 영문 `#### 요약`/`title=`/`summary=`를 기존 헬퍼(`_translate_to_korean_deepseek`, Gemini)로 재번역. 구조·frontmatter·include 보존, 멱등, **키 없으면 clean no-op**.
- **`.github/workflows/digest-translate-backfill.yml`** — `schedule`+`workflow_dispatch`만(**repository_dispatch 없음**), 시크릿 스텝 파티션 가드, `permissions: {}` 기본거부 + 잡별 최소권한(contents/PR write), **main 직push 금지**·리뷰 PR(graceful degrade).
- **`notes/digest-retranslate-security.md`** — 신뢰 모델 문서.

## 보안 (security-auditor 검토: CHANGES REQUESTED → 반영 완료)

| 항목 | 조치 |
|------|------|
| **M-01** 요약 블록 stored-XSS 방어 갭 | `_is_valid_korean`이 `<`·`{%`·`{{`·`]]>` 거부(fail-safe 원문 유지) + 노트 정정 + 회귀 테스트 |
| **M-02** 신규 워크플로 파티션 회귀 가드 누락 | `test_ci_digest_translate_partition_guard.py`: repository_dispatch 금지 + 모든 `*_API_KEY` 게이트 검증 |
| **L-02** git add 과범위 | `git add -u _posts/`로 한정 |

정상 판정 항목: 트리거 분리, 시크릿/토큰 분리(LLM키↔GH_TOKEN), 최소권한, no `pull_request_target`, 셸 인젝션 방어(입력 regex 검증), SHA 핀, 출력 검증(한글·길이·1줄 이스케이프).

## 검증

- ✅ `pytest` retranslate(10, XSS 거부 포함) + 파티션가드 2개: 통과
- ✅ 전체 스크립트 스위트: 통과(pre-commit)
- ✅ `ruff check` clean, workflow YAML 파싱 OK, `bash -n` OK
- ✅ `retranslate_digest.py --all --dry-run`: 0/175 (코퍼스 이미 한국어, no-op)
- ✅ 출력 검증 유닛: `<script>`/`{% %}`/`{{ }}`/`]]>`/비한글/과길이 전부 거부

## 참고

시크릿 주입 + 자동 PR 워크플로이므로 **프로덕션 병합은 사용자 최종 승인 필요**.