### PR TITLE
fix(ci): blogwatcher 발행 시 quality baseline 자가치유

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -362,6 +362,18 @@ jobs:
           git add "_data/published_news_urls.json" 2>/dev/null || true
           git add "data/collected_news.json" 2>/dev/null || true
 
+          # Self-heal the post-quality baseline. A cron-added digest missing from
+          # scripts/tests/fixtures/quality_baseline.json leaves
+          # test_regen_quality_baseline red on main (and every rebased PR).
+          # Refresh it and stage it into THIS digest commit so both the trusted
+          # push-to-main and untrusted PR paths stay green. Non-blocking: a regen
+          # failure must never stop the digest from publishing.
+          if python3 scripts/regen_quality_baseline.py; then
+            git add "scripts/tests/fixtures/quality_baseline.json" 2>/dev/null || true
+          else
+            echo "::warning::regen_quality_baseline failed; digest will publish but the quality baseline may go stale (main CI may need a manual 'python3 scripts/regen_quality_baseline.py' refresh)."
+          fi
+
           if git diff --staged --quiet; then
             echo "No changes to commit"
             exit 0

--- a/scripts/tests/test_ci_blogwatcher_baseline_selfheal_guard.py
+++ b/scripts/tests/test_ci_blogwatcher_baseline_selfheal_guard.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""CI regression guard: the BlogWatcher publish step must self-heal the quality baseline.
+
+Why this guard exists
+---------------------
+The AI BlogWatcher publishes the daily digest by committing a new
+``_posts/YYYY-MM-DD-*.md`` (``ai-blogwatcher.yml``, "Commit and publish" step).
+That post is NOT scored into ``scripts/tests/fixtures/quality_baseline.json`` by
+the publish path, so ``test_regen_quality_baseline`` (which asserts
+``regen_quality_baseline.py --check`` exits 0) goes red on ``main`` the moment
+the digest lands — and that red ``build`` propagates to every branch rebased on
+top. Observed 2026-07-28: the 07-28 digest broke ``main``'s build and blocked
+PR #470 until the baseline was refreshed by hand.
+
+The fix is a self-healing step: the publish job runs
+``regen_quality_baseline.py`` and stages the refreshed baseline into the SAME
+digest commit, so both the trusted push-to-main and the untrusted
+``repository_dispatch`` PR path stay green. That property disappears *silently*
+if someone drops the regen call or the ``git add`` of the baseline. This guard
+makes that removal fail loudly.
+
+Direction: presence assertion — any removal of the regen-and-stage pair trips
+this. If the self-heal is intentionally reworked (e.g. moved to a post-publish
+job or a reusable workflow), update this guard in the same PR and say why.
+
+See also memory: regen-quality-baseline-stale-cron.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+BASELINE_JSON = "scripts/tests/fixtures/quality_baseline.json"
+REGEN_SCRIPT = "scripts/regen_quality_baseline.py"
+
+
+def _noncomment_lines(text: str) -> str:
+    """The workflow text with comment-only lines removed.
+
+    Asserting on real YAML (not surrounding ``#`` prose that also names the
+    baseline/regen script) keeps the guard honest: a stale comment must not keep
+    it green after the real step is deleted. Inline trailing comments on a real
+    key line are preserved because that line is not comment-only.
+    """
+    return "\n".join(
+        ln for ln in text.splitlines() if not ln.lstrip().startswith("#")
+    )
+
+
+class TestBlogwatcherBaselineSelfHealGuard:
+    def test_workflow_exists(self):
+        assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
+
+    def test_regen_baseline_invoked(self):
+        body = _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+        assert re.search(rf"python3?\s+{re.escape(REGEN_SCRIPT)}", body), (
+            "ai-blogwatcher.yml no longer runs regen_quality_baseline.py in the "
+            "publish step. A cron-added digest that is missing from the committed "
+            "quality baseline turns test_regen_quality_baseline red on main and "
+            "on every rebased PR. Re-add the regen call before the commit, or if "
+            "moved to another job update this guard."
+        )
+
+    def test_baseline_staged_into_commit(self):
+        body = _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+        assert re.search(rf"git add\s+[\"']?{re.escape(BASELINE_JSON)}", body), (
+            "ai-blogwatcher.yml runs the baseline regen but no longer stages "
+            f"{BASELINE_JSON} into the digest commit, so the self-heal never "
+            "reaches main/PR. Re-add the 'git add' of the baseline JSON."
+        )
+
+    def test_regen_precedes_commit(self):
+        """The regen + stage must run before 'git commit' so the refreshed
+        baseline is part of the digest commit, not a dangling working-tree edit.
+        """
+        body = _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+        regen = re.search(rf"python3?\s+{re.escape(REGEN_SCRIPT)}", body)
+        commit = re.search(r"git commit\b", body)
+        assert regen and commit, "expected both the regen call and a 'git commit'"
+        assert regen.start() < commit.start(), (
+            "regen_quality_baseline.py must run BEFORE 'git commit' so the "
+            "refreshed baseline is staged into the same digest commit. It is "
+            "currently ordered after the commit, which leaves the baseline "
+            "change uncommitted (main stays red)."
+        )


### PR DESCRIPTION
## 문제
BlogWatcher 발행 스텝은 새 digest 포스트를 커밋하지만 `scripts/tests/fixtures/quality_baseline.json`에 스코어링하지 않아, digest가 main에 올라오는 즉시 `test_regen_quality_baseline`가 red가 되고 그 `build` red가 리베이스된 모든 PR로 전파됩니다.

- **관측(2026-07-28)**: 07-28 digest가 main build를 깨뜨려 #470 병합을 차단 → 수동 baseline 갱신으로 해소.

## 수정
`ai-blogwatcher.yml`의 "Commit and publish" 스텝에서 `git commit` 직전에:
1. `python3 scripts/regen_quality_baseline.py` 실행
2. 갱신된 baseline JSON을 **같은 digest 커밋에 stage**

→ 신뢰 경로(schedule/dispatch, main 직push)와 비신뢰 경로(repository_dispatch → 리뷰 PR) 양쪽 모두 green 유지. regen 실패는 **non-blocking**(digest 발행 자체는 절대 막지 않음, `::warning::`만 출력).

## 재발 방지
`test_ci_blogwatcher_baseline_selfheal_guard.py` 추가 — regen 호출 또는 baseline `git add`가 제거되거나 커밋 이후로 순서가 밀리면 실패.

## 검증
- YAML 파싱 OK
- 가드 4건 통과 + 음성 검증(스텝 제거 시 실패 확인)
- pre-commit 전체 2958 passed / 5 skipped

관련: 재발 방지 A(#469) / B(#470), 메모리 `regen-quality-baseline-stale-cron`