### PR TITLE
feat(digest): 고유명사 영문 canonical 가드 (Phase 1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -154,6 +154,22 @@ if [ -n "$STAGED_DIGEST_POSTS" ]; then
   echo "[pre-commit] Digest untranslated-English check: passed."
 fi
 
+# 9c. Digest proper-noun canonicalization gate — enforce English-canonical
+#     proper nouns in digest bodies (deny-by-default allow-list). Prevents the
+#     intra-document 비트코인/Bitcoin mixing. Cited titles / code / CVE exempt.
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest proper-noun canonicalization..."
+  python3 "$REPO_ROOT/scripts/check_digest_proper_nouns.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Non-canonical (Hangul) proper noun found in a digest body."
+    echo "             Use English canonical spellings (e.g. 비트코인 -> Bitcoin),"
+    echo "             or auto-fix: python3 scripts/check_digest_proper_nouns.py --fix --staged"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest proper-noun check: passed."
+fi
+
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
 STAGED_HEAD_HTML=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_includes/head\.html$' || true)
 if [ -n "$STAGED_HEAD_HTML" ]; then
@@ -186,21 +202,4 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
     exit 1
   fi
   echo "[pre-commit] Post quality: passed."
-fi
-
-# 12. Digest untranslated-English gate — block digests whose 요약/summary=
-#     fields fell back to raw English (translation API unavailable on the
-#     repository_dispatch publish path). Cited English titles are not flagged.
-STAGED_DIGEST_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+Weekly_Digest[^/]*\.md$' || true)
-if [ -n "$STAGED_DIGEST_POSTS" ]; then
-  echo "[pre-commit] Checking digest posts for untranslated English..."
-  python3 "$REPO_ROOT/scripts/check_digest_untranslated.py" --staged
-  if [ $? -ne 0 ]; then
-    echo "[pre-commit] Untranslated English found in a digest 요약/summary= field."
-    echo "             Translate the flagged prose to Korean (preserve proper"
-    echo "             nouns / CVE IDs). Cited English titles are not flagged."
-    echo "             To bypass (not recommended): git commit --no-verify"
-    exit 1
-  fi
-  echo "[pre-commit] Digest untranslated-English check: passed."
 fi

--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -353,6 +353,16 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
           TODAY=$(date +%Y-%m-%d)
+
+          # Canonicalize proper nouns (비트코인 -> Bitcoin ...) in the new digest
+          # body BEFORE staging, so the committed digest is already compliant and
+          # the svg-lint proper-noun gate stays green on the direct-push path.
+          # Body-text only (front matter untouched); deny-by-default allow-list.
+          # Non-blocking: a failure must never stop the digest from publishing.
+          for f in "_posts/${TODAY}"*Weekly_Digest*.md; do
+            [ -f "$f" ] && python3 scripts/check_digest_proper_nouns.py --fix "$f" || true
+          done
+
           git add "_posts/${TODAY}"*.md 2>/dev/null || true
           git add "assets/images/${TODAY}"*.svg 2>/dev/null || true
           git add "assets/images/${TODAY}"*.png 2>/dev/null || true

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -36,6 +36,7 @@ on:
       - 'scripts/check_kst_midnight.py'
       - 'scripts/check_digest_structure.py'
       - 'scripts/check_digest_untranslated.py'
+      - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -78,6 +79,7 @@ on:
       - 'scripts/check_kst_midnight.py'
       - 'scripts/check_digest_structure.py'
       - 'scripts/check_digest_untranslated.py'
+      - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -260,6 +262,21 @@ jobs:
           fi
           echo "[digest-untranslated] diff base: $BASE"
           python3 scripts/check_digest_untranslated.py --changed "$BASE"
+
+      - name: Digest proper-noun canonicalization gate (PR-diff-scoped)
+        id: digest_proper_nouns
+        # PR-diff-scoped, NOT --all: 135 legacy digests still use Hangul proper
+        # nouns (Phase 2 backfill pending). --changed only checks digests touched
+        # by this PR/push. Enforces English-canonical proper nouns (deny-by-default
+        # allow-list) so new digests never reintroduce 비트코인/Bitcoin mixing.
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/${{ github.event.pull_request.base.ref }}"
+          else
+            BASE="HEAD~1"
+          fi
+          echo "[digest-proper-nouns] diff base: $BASE"
+          python3 scripts/check_digest_proper_nouns.py --changed "$BASE"
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/scripts/check_digest_proper_nouns.py
+++ b/scripts/check_digest_proper_nouns.py
@@ -1,0 +1,313 @@
+"""Proper-noun canonicalization guard for weekly-digest posts.
+
+Policy (decided 2026-07-28, owner call — see notes/digest-proper-noun-policy.md):
+digest BODY proper nouns use the **English canonical** spelling. Empirically the
+worst offender was intra-document mixing: 112 of 194 digests used *both*
+비트코인 and Bitcoin in the same file.
+
+This guard is **deny-by-default**: only the Hangul forms in ``ENTITIES`` are
+ever flagged or rewritten. An unlisted Hangul token is never touched (the entity
+over-matching lesson from the L20 topic-tag guard).
+
+Scope & masking:
+  * Only the post BODY is inspected — front matter (title:/excerpt:) is owned by
+    the re-translate workflow (재발 방지 B) and left untouched.
+  * These spans are masked out before detection AND skipped during --fix, so a
+    Hangul form inside them is preserved: fenced/inline code, cited quoted
+    titles ('...'/"..."), URLs, and CVE IDs.
+  * Replacement is **josa-aware**: 구글 → Google, 구글은 → Google은, 구글의 →
+    Google의 (particle preserved), but 구글링 (a derived verb) is left ALONE
+    because 링 is not a particle. This prevents mangling Korean derivations.
+
+Only Weekly_Digest posts are checked; every mode filters to them. Mirrors the
+CLI of check_digest_untranslated.py.
+
+Usage:
+    python3 scripts/check_digest_proper_nouns.py --staged        # staged digest posts
+    python3 scripts/check_digest_proper_nouns.py --changed main  # digest posts changed vs BASE
+    python3 scripts/check_digest_proper_nouns.py --all           # every digest post (report only)
+    python3 scripts/check_digest_proper_nouns.py --fix --staged  # rewrite Hangul forms -> canonical
+    python3 scripts/check_digest_proper_nouns.py path/a.md
+"""
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO / "_posts"
+
+_POST_PATH_RE = re.compile(r"^_posts/[^/]+\.md$")
+
+# --- Canonical map (deny-by-default allow-list): Hangul form -> English -------
+# Only these Hangul spellings are ever flagged/rewritten. Grow this list only
+# after measuring that an entity is genuinely mixed across digests.
+ENTITIES = {
+    "비트코인": "Bitcoin",
+    "이더리움": "Ethereum",
+    "쿠버네티스": "Kubernetes",
+    "리눅스": "Linux",
+    "도커": "Docker",
+    "구글": "Google",
+    "마이크로소프트": "Microsoft",
+    "아마존": "Amazon",
+    "깃허브": "GitHub",
+    "클라우드플레어": "Cloudflare",
+}
+
+# Common Korean particles (josa) that legitimately attach to a noun. When one of
+# these directly follows an entity it is preserved (구글은 -> Google은). Ordered
+# longest-first so the alternation is greedy where it matters.
+_JOSA = [
+    "으로서", "으로써", "에서는", "에게서", "이라는", "라는", "이라고", "라고",
+    "으로", "에서", "에게", "한테", "부터", "까지", "보다", "처럼", "같이",
+    "이나", "이란", "이든", "든지", "조차", "마저", "밖에", "만큼", "이랑",
+    "은", "는", "이", "가", "을", "를", "의", "와", "과", "도", "만", "로",
+    "에", "랑", "나", "뿐", "및",
+]
+_JOSA_ALT = "|".join(sorted(_JOSA, key=len, reverse=True))
+
+# Per-entity matcher: the Hangul form, NOT embedded in a larger Hangul/Latin
+# token, and followed by end-of-string, a non-Hangul char, or a known particle.
+# 구글링 fails all three lookahead branches (링 is Hangul and not a particle),
+# so a derived word is never rewritten.
+_ENTITY_RE = {
+    ko: re.compile(
+        rf"(?<![가-힣A-Za-z0-9]){re.escape(ko)}(?=$|[^가-힣]|(?:{_JOSA_ALT}))"
+    )
+    for ko in ENTITIES
+}
+
+# Spans preserved verbatim (masked for detection, skipped for --fix).
+_FENCED_CODE = re.compile(r"```.*?```", re.DOTALL)
+_INLINE_CODE = re.compile(r"`[^`\n]+`")
+_URL = re.compile(r"https?://\S+")
+_CVE = re.compile(r"CVE-\d{4}-\d{3,7}", re.IGNORECASE)
+_QUOTES = "\"'‘’“”"
+# A cited title inside prose ("...법의 미래"). The (?<!=) guard means a news-card
+# attribute value — title="...", summary="...", source="..." — is NOT treated as
+# a cited title: those are translated display copy and MUST be canonicalized too,
+# otherwise the prose says "Bitcoin" while the adjacent card says "비트코인" (the
+# very intra-document mixing this guard exists to kill). Empirically verified on
+# 2026-07-23 digest before shipping.
+_QUOTED_SPAN = re.compile(rf"(?<!=)[{_QUOTES}][^{_QUOTES}\n]{{2,}}?[{_QUOTES}]")
+
+_PROTECTED = [_FENCED_CODE, _INLINE_CODE, _URL, _CVE, _QUOTED_SPAN]
+
+
+def _split_front_matter(text: str) -> tuple:
+    """Return (front_matter_including_delimiters, body). Body is everything after
+    the closing '---'. Front matter is never modified by this guard."""
+    m = re.match(r"^(---\n.*?\n---\n)(.*)$", text, re.DOTALL)
+    if m:
+        return m.group(1), m.group(2)
+    return "", text
+
+
+def _protected_spans(body: str) -> list:
+    """Merged, sorted (start, end) intervals that must be preserved verbatim."""
+    spans = []
+    for rx in _PROTECTED:
+        for m in rx.finditer(body):
+            spans.append((m.start(), m.end()))
+    spans.sort()
+    merged = []
+    for s, e in spans:
+        if merged and s <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    return merged
+
+
+def _unprotected_segments(body: str) -> list:
+    """Yield (text, is_protected) segments covering the whole body in order."""
+    segs = []
+    pos = 0
+    for s, e in _protected_spans(body):
+        if s > pos:
+            segs.append((body[pos:s], False))
+        segs.append((body[s:e], True))
+        pos = e
+    if pos < len(body):
+        segs.append((body[pos:], False))
+    return segs
+
+
+def find_violations(body: str) -> list:
+    """Return [(hangul, canonical, count)] for entity Hangul forms present in the
+    UNPROTECTED body. Empty list == compliant."""
+    searchable = "".join(t for t, prot in _unprotected_segments(body) if not prot)
+    out = []
+    for ko, en in ENTITIES.items():
+        n = len(_ENTITY_RE[ko].findall(searchable))
+        if n:
+            out.append((ko, en, n))
+    return out
+
+
+def fix_body(body: str) -> tuple:
+    """Return (new_body, total_replacements). Only unprotected segments are
+    rewritten; particles are preserved by the lookahead (구글은 -> Google은)."""
+    total = 0
+    parts = []
+    for text, prot in _unprotected_segments(body):
+        if prot:
+            parts.append(text)
+            continue
+        for ko in ENTITIES:
+            text, n = _ENTITY_RE[ko].subn(ENTITIES[ko], text)
+            total += n
+        parts.append(text)
+    return "".join(parts), total
+
+
+def check_post(path: str) -> list:
+    """Return human-readable violation strings for one post (report mode)."""
+    with open(path, encoding="utf-8") as fh:
+        _, body = _split_front_matter(fh.read())
+    violations = []
+    for ko, en, n in find_violations(body):
+        violations.append(f"{ko} -> {en} ({n}회)")
+    return violations
+
+
+def fix_post(path: Path) -> int:
+    """Rewrite Hangul entity forms to canonical English in the body. Returns the
+    number of replacements (0 == file untouched)."""
+    original = path.read_text(encoding="utf-8")
+    fm, body = _split_front_matter(original)
+    new_body, n = fix_body(body)
+    if n:
+        path.write_text(fm + new_body, encoding="utf-8")
+    return n
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+def _all_post_paths() -> list:
+    return sorted(p for p in POSTS_DIR.glob("*.md") if _is_digest_post(p))
+
+
+def _git_post_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(
+            cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        p = line.strip()
+        if _POST_PATH_RE.match(p):
+            full = REPO / p
+            if full.exists() and _is_digest_post(full):
+                paths.append(full)
+    return sorted(paths)
+
+
+def _staged_post_paths() -> list:
+    return _git_post_paths(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"]
+    )
+
+
+def _changed_post_paths(base: str) -> list:
+    return _git_post_paths(
+        ["git", "diff", "--name-only", f"{base}...HEAD", "--diff-filter=ACM"]
+    )
+
+
+def _explicit_paths(args_paths: list) -> list:
+    paths = []
+    for a in args_paths:
+        p = Path(a)
+        if not p.is_absolute():
+            cwd_p = Path.cwd() / p
+            p = cwd_p if cwd_p.exists() else REPO / a
+        if not p.exists():
+            print(f"[digest-proper-nouns] WARNING: file not found: {a}", file=sys.stderr)
+            continue
+        if _is_digest_post(p):
+            paths.append(p)
+    return paths
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Enforce English-canonical proper nouns in Weekly_Digest _posts/*.md "
+            "bodies (deny-by-default allow-list). Cited titles / code / URLs / CVE "
+            "IDs and the front matter are preserved. Exits 1 if any Hangul form is "
+            "found; --fix rewrites them in place."
+        )
+    )
+    parser.add_argument("--fix", action="store_true",
+                        help="Rewrite Hangul entity forms to canonical English in place.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true",
+                      help="Only process staged digest posts (git diff --cached).")
+    mode.add_argument("--all", action="store_true",
+                      help="Process every digest post.")
+    mode.add_argument("--changed", metavar="BASE", default=None,
+                      help="Only process digest posts changed vs BASE (git diff BASE...HEAD).")
+    parser.add_argument("paths", nargs="*",
+                        help="Explicit post file paths (non-digest paths are skipped).")
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        files = _staged_post_paths()
+    elif args.changed:
+        files = _changed_post_paths(args.changed)
+    elif args.paths:
+        files = _explicit_paths(args.paths)
+    else:
+        files = _all_post_paths()
+
+    if not files:
+        print("[digest-proper-nouns] No digest post files to process.")
+        return 0
+
+    rc = 0
+    checked = fixed = 0
+    for path in files:
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        checked += 1
+        if args.fix:
+            n = fix_post(path)
+            if n:
+                fixed += 1
+                print(f"FIXED {rel}  ({n} replacement(s))")
+            else:
+                print(f"OK    {rel}")
+        else:
+            vs = check_post(str(path))
+            if vs:
+                rc = 1
+                print(f"FAIL {rel}")
+                for v in vs:
+                    print(f"  - {v}")
+            else:
+                print(f"OK   {rel}")
+
+    if args.fix:
+        print(f"\n[digest-proper-nouns] --fix done — {fixed}/{checked} post(s) rewritten.")
+        return 0
+    if rc:
+        print(
+            f"\n[digest-proper-nouns] FAIL — non-canonical (Hangul) proper nouns "
+            f"found in one or more of {checked} digest post(s). Use English "
+            f"canonical spellings (e.g. 비트코인 -> Bitcoin), or run with --fix. "
+            f"Cited titles / code / CVE IDs are exempt.",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[digest-proper-nouns] OK — {checked} digest post(s) checked, 0 violations.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -194,6 +194,22 @@ if [ -n "$STAGED_DIGEST_POSTS" ]; then
   echo "[pre-commit] Digest untranslated-English check: passed."
 fi
 
+# 9c. Digest proper-noun canonicalization gate — enforce English-canonical
+#     proper nouns in digest bodies (deny-by-default allow-list). Prevents the
+#     intra-document 비트코인/Bitcoin mixing. Cited titles / code / CVE exempt.
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest proper-noun canonicalization..."
+  python3 "$REPO_ROOT/scripts/check_digest_proper_nouns.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Non-canonical (Hangul) proper noun found in a digest body."
+    echo "             Use English canonical spellings (e.g. 비트코인 -> Bitcoin),"
+    echo "             or auto-fix: python3 scripts/check_digest_proper_nouns.py --fix --staged"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest proper-noun check: passed."
+fi
+
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
 STAGED_HEAD_HTML=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_includes/head\.html$' || true)
 if [ -n "$STAGED_HEAD_HTML" ]; then

--- a/scripts/tests/test_check_digest_proper_nouns.py
+++ b/scripts/tests/test_check_digest_proper_nouns.py
@@ -1,0 +1,192 @@
+"""Tests for scripts/check_digest_proper_nouns.py.
+
+Covers the policy contract (notes/digest-proper-noun-policy.md):
+  - deny-by-default allow-list: only listed Hangul forms are flagged/rewritten
+  - masking: cited quoted titles / code / URLs / CVE IDs are exempt
+  - josa-aware --fix: 구글은 -> Google은, but 구글링 (derived word) is untouched
+  - front matter is never modified
+  - --fix is idempotent
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from check_digest_proper_nouns import (  # noqa: E402
+    ENTITIES,
+    check_post,
+    find_violations,
+    fix_body,
+    fix_post,
+    main,
+    _is_digest_post,
+    _split_front_matter,
+)
+
+# --- find_violations() -----------------------------------------------------
+
+
+def test_flags_listed_hangul_form():
+    v = find_violations("비트코인 가격이 급등했습니다.")
+    assert v == [("비트코인", "Bitcoin", 1)]
+
+
+def test_counts_multiple_occurrences():
+    v = find_violations("구글은 발표했고 구글의 정책은 바뀌었다.")
+    assert v == [("구글", "Google", 2)]
+
+
+def test_ignores_unlisted_hangul_token():
+    # 네이버 / 카카오 are not in the allow-list -> never flagged (deny-by-default).
+    assert find_violations("네이버와 카카오가 발표했습니다.") == []
+
+
+def test_english_canonical_is_compliant():
+    assert find_violations("Bitcoin surged and Google announced a policy.") == []
+
+
+def test_detects_intra_document_mixing():
+    # Both 비트코인 and Bitcoin in one body -> the Hangul form is still a violation.
+    v = find_violations("비트코인 시세와 Bitcoin ETF 흐름을 함께 봅니다.")
+    assert v == [("비트코인", "Bitcoin", 1)]
+
+
+# --- masking (exempt spans) ------------------------------------------------
+
+
+def test_cited_quoted_title_is_exempt():
+    assert find_violations('칼럼 "구글 검색의 미래"를 인용합니다.') == []
+
+
+def test_news_card_attribute_value_is_fixable():
+    # title="..."/summary="..." are translated display copy, NOT cited titles.
+    # They MUST canonicalize so the card matches the prose (no intra-doc mixing).
+    body = '  title="스위스 은행이 비트코인 거래 시작"\n  source="Bitcoin Magazine"'
+    assert find_violations(body) == [("비트코인", "Bitcoin", 1)]
+    new, n = fix_body(body)
+    assert 'title="스위스 은행이 Bitcoin 거래 시작"' in new and n == 1
+
+
+def test_inline_code_is_exempt():
+    assert find_violations("`구글` 은 코드 안이라 예외입니다.") == []
+
+
+def test_fenced_code_is_exempt():
+    body = "설명\n```\n비트코인 sample\n```\n끝"
+    assert find_violations(body) == []
+
+
+def test_url_is_exempt():
+    assert find_violations("자세히는 https://example.com/비트코인 참고.") == []
+
+
+def test_cve_is_exempt_but_surrounding_entity_flagged():
+    v = find_violations("CVE-2026-12345 관련 구글 패치가 나왔다.")
+    assert v == [("구글", "Google", 1)]
+
+
+# --- fix_body(): josa-aware rewriting --------------------------------------
+
+
+def test_fix_bare_entity():
+    new, n = fix_body("비트코인 상승")
+    assert new == "Bitcoin 상승" and n == 1
+
+
+def test_fix_preserves_josa():
+    new, n = fix_body("구글은 발표했고 구글의 정책, 구글이 주도.")
+    assert new == "Google은 발표했고 Google의 정책, Google이 주도." and n == 3
+
+
+def test_fix_does_not_mangle_derived_word():
+    # 구글링 (to google, a Korean verb) must NOT become 'Google링'.
+    new, n = fix_body("사람들이 구글링을 했다.")
+    assert new == "사람들이 구글링을 했다." and n == 0
+
+
+def test_fix_skips_protected_spans():
+    body = '인용 "구글" 과 `비트코인` 및 https://x.io/구글 은 그대로, 구글은 변경.'
+    new, n = fix_body(body)
+    assert '"구글"' in new  # quoted title preserved
+    assert "`비트코인`" in new  # inline code preserved
+    assert "https://x.io/구글" in new  # url preserved
+    assert "Google은 변경" in new  # unprotected occurrence rewritten
+    assert n == 1
+
+
+def test_fix_is_idempotent():
+    body = "비트코인과 구글은 이더리움 위에서 동작한다."
+    once, _ = fix_body(body)
+    twice, n2 = fix_body(once)
+    assert once == twice and n2 == 0
+
+
+def test_all_entities_rewrite():
+    for ko, en in ENTITIES.items():
+        new, n = fix_body(f"{ko} 관련 소식")
+        assert new == f"{en} 관련 소식", f"{ko} should become {en}"
+        assert n == 1
+
+
+# --- front matter is never touched -----------------------------------------
+
+
+def test_front_matter_preserved():
+    doc = (
+        "---\n"
+        'title: "구글의 새 정책"\n'   # front matter Hangul must survive
+        "---\n"
+        "본문에서 구글은 canonical.\n"
+    )
+    fm, body = _split_front_matter(doc)
+    assert "구글의 새 정책" in fm
+    new_body, n = fix_body(body)
+    assert "Google은 canonical" in new_body and n == 1
+
+
+# --- integration: check_post / fix_post / main -----------------------------
+
+
+def _write_digest(tmp: Path, name: str, body: str) -> Path:
+    p = tmp / f"2026-01-01-{name}_Weekly_Digest.md"
+    p.write_text(f"---\ntitle: \"x\"\n---\n{body}", encoding="utf-8")
+    return p
+
+
+def test_check_post_reports_violation():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_digest(Path(d), "T", "비트코인과 구글 뉴스.")
+        vs = check_post(str(p))
+        assert any("비트코인 -> Bitcoin" in v for v in vs)
+        assert any("구글 -> Google" in v for v in vs)
+
+
+def test_fix_post_rewrites_and_preserves_front_matter():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_digest(Path(d), "T", "구글은 발표했다.")
+        n = fix_post(p)
+        out = p.read_text(encoding="utf-8")
+        assert n == 1
+        assert 'title: "x"' in out
+        assert "Google은 발표했다." in out
+
+
+def test_is_digest_post_scope():
+    assert _is_digest_post(Path("2026-01-01-X_Weekly_Digest.md")) is True
+    assert _is_digest_post(Path("2026-01-01-Regular_Post.md")) is False
+
+
+def test_main_check_exit_code_on_violation(capsys):
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_digest(Path(d), "T", "비트코인 뉴스.")
+        rc = main([str(p)])
+        assert rc == 1
+
+
+def test_main_fix_then_check_clean(capsys):
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_digest(Path(d), "T", "비트코인 뉴스.")
+        assert main(["--fix", str(p)]) == 0
+        capsys.readouterr()
+        assert main([str(p)]) == 0  # now compliant

--- a/scripts/tests/test_ci_digest_proper_nouns_wiring_guard.py
+++ b/scripts/tests/test_ci_digest_proper_nouns_wiring_guard.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""CI/pre-commit wiring guard for the digest proper-noun canonicalization gate.
+
+check_digest_proper_nouns.py enforces English-canonical proper nouns in digest
+bodies (deny-by-default). The enforcement only has teeth if it is actually
+wired into (a) the generated pre-commit hook and (b) the svg-lint CI workflow.
+Either wire can be dropped silently in an unrelated edit; this guard fails
+loudly if that happens.
+
+Direction: presence assertion. If the gate is intentionally moved/renamed,
+update this guard in the same PR and say why. See notes/digest-proper-noun-policy.md.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = "scripts/check_digest_proper_nouns.py"
+HOOK = REPO / ".githooks" / "pre-commit"
+INSTALL = REPO / "scripts" / "install-hooks.sh"
+CI = REPO / ".github" / "workflows" / "svg-lint.yml"
+BLOGWATCHER = REPO / ".github" / "workflows" / "ai-blogwatcher.yml"
+
+
+def _noncomment(text: str) -> str:
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def test_script_exists():
+    assert (REPO / SCRIPT).is_file(), f"{SCRIPT} missing (moved/renamed?)"
+
+
+# The hooks invoke it as: python3 "$REPO_ROOT/scripts/...py" --staged
+# so allow an optional closing quote between the path and the --staged flag.
+_STAGED_RE = re.compile(rf"{re.escape(SCRIPT)}\"?\s+--staged")
+
+
+def test_wired_into_active_pre_commit_hook():
+    body = _noncomment(HOOK.read_text(encoding="utf-8"))
+    assert _STAGED_RE.search(body), (
+        "The active .githooks/pre-commit no longer invokes "
+        f"'{SCRIPT} --staged'. Digest proper-noun canonicalization is no longer "
+        "enforced locally. Re-add the gate (regenerate via scripts/install-hooks.sh)."
+    )
+
+
+def test_wired_into_canonical_hook_source():
+    # install-hooks.sh is the canonical source that regenerates .githooks/pre-commit;
+    # if the gate is only in the generated file it will vanish on the next re-run.
+    body = _noncomment(INSTALL.read_text(encoding="utf-8"))
+    assert _STAGED_RE.search(body), (
+        "scripts/install-hooks.sh (the canonical hook source) does not invoke "
+        f"'{SCRIPT} --staged'. Running install-hooks.sh would drop the gate from "
+        "the generated hook. Add it to the heredoc in install-hooks.sh."
+    )
+
+
+def test_wired_into_svg_lint_ci():
+    body = _noncomment(CI.read_text(encoding="utf-8"))
+    assert re.search(rf"{re.escape(SCRIPT)}\s+--changed", body), (
+        "svg-lint.yml no longer runs the digest proper-noun gate "
+        f"('{SCRIPT} --changed'). New digests could reintroduce Hangul proper "
+        "nouns without CI catching it. Re-add the PR-diff-scoped step."
+    )
+
+
+def test_ci_path_filter_triggers_on_script_change():
+    body = CI.read_text(encoding="utf-8")
+    # The script must be in the push+PR path filters so edits to it re-run the gate.
+    assert body.count(f"'{SCRIPT}'") >= 2, (
+        f"'{SCRIPT}' is missing from the push and/or pull_request path filters in "
+        "svg-lint.yml; edits to the guard would not trigger the workflow."
+    )
+
+
+def test_blogwatcher_auto_fixes_new_digests():
+    # The trusted publish path pushes straight to main, where the svg-lint gate
+    # runs --changed. Without an auto --fix at publish time, every new digest
+    # with a Hangul proper noun would turn svg-lint red on main. Guard the
+    # self-heal so it is not silently dropped.
+    body = _noncomment(BLOGWATCHER.read_text(encoding="utf-8"))
+    assert re.search(rf"{re.escape(SCRIPT)}\s+--fix", body), (
+        "ai-blogwatcher.yml no longer auto-fixes proper nouns in new digests "
+        f"('{SCRIPT} --fix'). New digests could push non-canonical proper nouns "
+        "to main and turn the svg-lint gate red. Re-add the --fix step."
+    )


### PR DESCRIPTION
## 배경
194개 digest 실측 결과 동일 엔티티의 한/영 혼용이 만연 — 특히 **Bitcoin: 같은 파일에 비트코인+Bitcoin 공존 112건**(최대 defect). owner 결정: 고유명사 **전부 영문 canonical**. 설계: `notes/digest-proper-noun-policy.md`.

## 구현 (Phase 1 — 신규 강제)
- **`scripts/check_digest_proper_nouns.py`**: deny-by-default allow-list(비트코인→Bitcoin, 구글→Google 등 10종). `--check`/`--fix`, `--staged`/`--changed BASE`/`--all`, 명시 경로.
  - **josa-aware 치환**: 구글은→Google은, 구글의→Google의 (조사 보존), 그러나 **구글링(파생어)은 불변** — 오변환 방지.
  - **마스킹**: 코드(펜스/인라인)/URL/CVE/인용 제목 예외. 단 뉴스카드 `title=`/`summary=` 속성값은 번역 카피이므로 **수정 대상**(카드-산문 불일치 방지) — 실제 07-23 digest로 검증.
  - front matter 불변, Weekly_Digest만 대상.
- **Wiring**: pre-commit(step 9c, `--staged`) + svg-lint CI(`--changed`, PR-diff-scoped, NOT --all) + **blogwatcher 발행 `--fix` 자가치유**(신뢰 경로가 non-canonical을 main에 push해 CI red 되는 것 방지 — task 2 baseline과 동일 철학). `install-hooks.sh` 재생성으로 무해한 중복 step 12 정리.

## 테스트 (29건)
- 로직 23: allow-list/deny-by-default, 마스킹, josa, 구글링 불변, 멱등성, front matter 불변, 카드 필드 수정, 통합.
- wiring 가드 6: pre-commit·install-hooks·CI step·path filter·blogwatcher --fix 존재 강제.
- pre-commit 전체 2987 passed.

## 범위
Phase 1은 **신규 digest 강제**만. 레거시 135개 백필은 Phase 2(별도 PR).

관련: 재발 방지 A(#469)/B(#470), baseline 자가치유(#471).