### PR TITLE
fix(cover): 07-29 digest lone 'Claude' AI 패널 vet — main 치유

### DIFF
--- a/scripts/news/l20_dispatch.py
+++ b/scripts/news/l20_dispatch.py
@@ -1358,14 +1358,23 @@ _GENERIC_HEADLINE_WORDS: frozenset = frozenset({"show", "option", "command"})
 # lead-position "<adj> AI" highlight titles in the corpus (Agentic ×4, Vertical ×3).
 _AI_COMPOUND_ADJECTIVES: frozenset = frozenset({"agentic", "vertical"})
 
-# FM2 deferred — lone-adjective+"AI" cases the join above CANNOT reach because the
-# adjective is NOT the lead token. e.g. "Shadow AI" titles lead with "AI"
-# ("2025년 AI 보안 위협 현황: Shadow AI …"), so "Shadow" is non_cve[1] and its lone
-# rendering comes from the fallthrough cap-scan, not the lead-join. Adding "shadow"
-# to _AI_COMPOUND_ADJECTIVES is a verified NO-OP (does not change the cover) — it
-# would only silence the TestCorpusNoLoneAdjectiveAi guard. This positional case
-# needs a separate future rule; the guard exempts these so committed CI stays green.
-_DEFERRED_AI_ADJECTIVES: frozenset = frozenset({"shadow"})
+# FM2 deferred — lone-"<word> AI" cases where the lone rendering is CORRECT and a
+# compound join would be WRONG, so the word must NOT go in _AI_COMPOUND_ADJECTIVES.
+# _DEFERRED is consumed ONLY by TestCorpusNoLoneAdjectiveAi (build_lead_headline
+# does not read it), so adding a word here is a guaranteed cover NO-OP — it vets
+# the lone lead as intended and keeps CI green without changing any render.
+# Two structurally-distinct reasons a word lands here:
+#   - "shadow": NOT the lead token. "Shadow AI" titles lead with "AI"
+#     ("2025년 AI 보안 위협 현황: Shadow AI …"), so "Shadow" is non_cve[1]; its lone
+#     rendering comes from the fallthrough cap-scan, not the lead-join.
+#     A separate positional rule is still owed.
+#   - "claude": a real-entity BRAND (Anthropic's Claude), not a generic type
+#     adjective like agentic/vertical. It IS the lead token in "Claude AI, …"
+#     (2026-07-29 digest), but lone "Claude" is an honest, recognizable hero —
+#     joining to "Claude AI" is exactly the proper-noun-fragment breakage the
+#     _AI_COMPOUND_ADJECTIVES comment warns against ("Claude Mythos AI" -> "Mythos
+#     AI"). So the lone lead is CORRECT; we vet it, not join it.
+_DEFERRED_AI_ADJECTIVES: frozenset = frozenset({"shadow", "claude"})
 
 # FM4 — curated multi-word vendor/product entities whose FIRST word, when it ends
 # up as a resolved-bigram token, truncates the full entity that is literally


### PR DESCRIPTION
## 문제
크론이 세션 중 발행한 07-29 digest(`32add2b2`)의 summary_card highlight `Claude AI, 포스트퀀텀...`가 `TestCorpusNoLoneAdjectiveAi`(lone-adjective+AI 가드)를 트리거 → **main build red** (그리고 merge-commit을 쓰는 모든 PR CI로 전파, 예: #473). task 2 baseline과 동일한 '크론이 main 코퍼스 테스트를 깨뜨림' 패턴.

## 수정
`_DEFERRED_AI_ADJECTIVES`에 `claude` 추가 (+ 근거 주석).

- Claude는 generic type-adjective(agentic/vertical)가 **아니라** real-entity 브랜드(Anthropic). lone 'Claude' 렌더가 정직하고, join('Claude AI')은 `_AI_COMPOUND_ADJECTIVES` 주석이 경고하는 proper-noun fragment breakage('Claude Mythos AI'->'Mythos AI')에 해당 → **join 금지**, vet만.
- `_DEFERRED`는 가드 테스트에서만 소비되고 `build_lead_headline`은 미참조 → **커버 렌더 NO-OP** (empirical: `build_lead_headline('Claude AI, ...')` = 'Claude' 불변).

## 검증
- `TestCorpusNoLoneAdjectiveAi` 통과, `test_l20_realcontent.py` 230건 통과
- `_DEFERRED` exact-match 단정 없음(다른 테스트 미파손), pre-commit 2988 passed
- 커버 NO-OP 증명

관련: cover-system 스킬, [[l20_weak_headline_fm1_deferred]] 계열 vetting 규율.