### PR TITLE
feat(blogwatcher): 발행 시 lone-adjective 커버 프리플라이트 (warn)

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -341,6 +341,20 @@ jobs:
           # but will fail immediately if today's auto-generated post regresses.
           pytest scripts/tests/test_briefing_stats.py -x --tb=short -q
 
+      - name: Lone-adjective cover pre-flight (warn — vetting needed)
+        if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'
+        run: |
+          # Surface an unvetted lone-adjective+AI cover panel (e.g. "Claude AI" ->
+          # lone "Claude") at PUBLISH time. TestCorpusNoLoneAdjectiveAi would
+          # otherwise fail on main only AFTER this cron pushes (silent, delayed).
+          # WARN, do NOT block: vetting (join vs defer in l20_dispatch) is a human
+          # decision, and the digest must still publish. The maintainer gets the
+          # exact word + remediation here instead of a cryptic later CI failure.
+          POST_FILE="${{ steps.check_post.outputs.post_file }}"
+          if ! python3 scripts/check_digest_lone_adjective.py "$POST_FILE"; then
+            echo "::warning::Unvetted lone-adjective+AI cover panel in ${POST_FILE}. main's TestCorpusNoLoneAdjectiveAi will go red until you vet the word in scripts/news/l20_dispatch.py (_AI_COMPOUND_ADJECTIVES to join, or _DEFERRED_AI_ADJECTIVES if the lone lead is a correct brand)."
+          fi
+
       - name: Commit and publish
         if: steps.check_post.outputs.post_created == 'true' && env.DRY_RUN != 'true'
         env:

--- a/scripts/check_digest_lone_adjective.py
+++ b/scripts/check_digest_lone_adjective.py
@@ -1,0 +1,169 @@
+"""Lone-adjective+AI panel guard for weekly-digest posts (publish-time pre-flight).
+
+A digest's ``summary_card.highlights[].title`` feeds the L20 cover side-cards
+via ``build_lead_headline``. When a title reads "<Word> AI, …" and the lead
+resolves to a lone ``<Word>``, the cover shows a bare adjective panel. That is
+allowed ONLY when the word is vetted in ``_AI_COMPOUND_ADJECTIVES`` (join, e.g.
+"Agentic AI") or ``_DEFERRED_AI_ADJECTIVES`` (lone lead is correct, e.g. the
+"Claude" brand). Otherwise ``TestCorpusNoLoneAdjectiveAi`` fails on ``main``
+AFTER the cron pushes the digest — a silent, delayed break (observed 2026-07-29
+"Claude AI").
+
+This CLI runs the SAME check scoped to specific posts so the blogwatcher
+publish path surfaces the exact offending word + remediation at publish time,
+instead of a cryptic corpus-test failure discovered later. It is a DETECTION
+guard: a lone-adjective panel needs a human vetting decision (join vs defer), so
+it is never auto-fixed.
+
+Exit 1 if any unvetted lone-adjective+AI panel is found.
+
+Usage:
+    python3 scripts/check_digest_lone_adjective.py _posts/2026-07-29-*Weekly_Digest*.md
+    python3 scripts/check_digest_lone_adjective.py --staged
+    python3 scripts/check_digest_lone_adjective.py --all
+"""
+import argparse
+import glob
+import html as _html
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO / "_posts"
+sys.path.insert(0, str(REPO))
+
+from scripts.news.l20_dispatch import (  # noqa: E402
+    build_lead_headline,
+    _AI_COMPOUND_ADJECTIVES,
+    _DEFERRED_AI_ADJECTIVES,
+)
+
+_POST_PATH_RE = re.compile(r"^_posts/[^/]+\.md$")
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+def check_post(path: str) -> list:
+    """Return offender strings for one post (empty == clean)."""
+    with open(path, encoding="utf-8") as fh:
+        raw = fh.read()
+    m = re.match(r"^---\n(.*?)\n---\n", raw, re.DOTALL)
+    if not m:
+        return []
+    try:
+        fm = yaml.safe_load(m.group(1))
+    except yaml.YAMLError:
+        return []
+    if not isinstance(fm, dict):
+        return []
+    sc = fm.get("summary_card")
+    if not isinstance(sc, dict):
+        return []
+    offenders = []
+    for hl in sc.get("highlights", []) or []:
+        title = (hl.get("title", "") or "") if isinstance(hl, dict) else ""
+        lead = build_lead_headline(title)
+        if not lead or " " in lead:
+            continue
+        # literal "<lead> AI" adjacency (AI standalone, not "OpenAI")
+        if re.search(rf"\b{re.escape(lead)}\s+AI\b", _html.unescape(title)):
+            low = lead.lower()
+            if low in _AI_COMPOUND_ADJECTIVES or low in _DEFERRED_AI_ADJECTIVES:
+                continue
+            offenders.append(f"lone {lead!r} <- {title[:70]!r}")
+    return offenders
+
+
+def _all_paths() -> list:
+    return sorted(p for p in POSTS_DIR.glob("*.md") if _is_digest_post(p))
+
+
+def _git_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        p = line.strip()
+        if _POST_PATH_RE.match(p):
+            full = REPO / p
+            if full.exists() and _is_digest_post(full):
+                paths.append(full)
+    return sorted(paths)
+
+
+def _explicit(args_paths: list) -> list:
+    paths = []
+    for a in args_paths:
+        p = Path(a)
+        if not p.is_absolute():
+            cwd_p = Path.cwd() / p
+            p = cwd_p if cwd_p.exists() else REPO / a
+        if p.exists() and _is_digest_post(p):
+            paths.append(p)
+    return paths
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag Weekly_Digest posts whose summary_card highlights would render "
+            "an unvetted lone-adjective+AI cover panel (TestCorpusNoLoneAdjectiveAi "
+            "would fail on main). Detection only — vetting is a human decision."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true")
+    mode.add_argument("--all", action="store_true")
+    mode.add_argument("--changed", metavar="BASE", default=None)
+    parser.add_argument("paths", nargs="*")
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        files = _git_paths(["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"])
+    elif args.changed:
+        files = _git_paths(["git", "diff", "--name-only", f"{args.changed}...HEAD", "--diff-filter=ACM"])
+    elif args.paths:
+        files = _explicit(args.paths)
+    else:
+        files = _all_paths()
+
+    if not files:
+        print("[digest-lone-adjective] No digest post files to check.")
+        return 0
+
+    rc = 0
+    for path in files:
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        offenders = check_post(str(path))
+        if offenders:
+            rc = 1
+            print(f"FAIL {rel}")
+            for o in offenders:
+                print(f"  - {o}")
+        else:
+            print(f"OK   {rel}")
+
+    if rc:
+        print(
+            "\n[digest-lone-adjective] FAIL — unvetted lone-adjective+AI cover "
+            "panel(s). Vet each word in scripts/news/l20_dispatch.py: add to "
+            "_AI_COMPOUND_ADJECTIVES if the join fixes the cover (e.g. 'Agentic "
+            "AI'), or _DEFERRED_AI_ADJECTIVES if the lone lead is correct (e.g. a "
+            "brand like 'Claude'). This mirrors TestCorpusNoLoneAdjectiveAi.",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[digest-lone-adjective] OK — {len(files)} digest(s) checked, 0 offenders.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_digest_lone_adjective.py
+++ b/scripts/tests/test_check_digest_lone_adjective.py
@@ -1,0 +1,77 @@
+"""Tests for scripts/check_digest_lone_adjective.py + its blogwatcher wiring.
+
+The CLI mirrors TestCorpusNoLoneAdjectiveAi so the blogwatcher publish path can
+surface an unvetted lone-adjective+AI cover panel at publish time (warn), rather
+than letting main's corpus test go red silently after the cron pushes.
+"""
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from check_digest_lone_adjective import check_post, main  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+BLOGWATCHER = REPO / ".github" / "workflows" / "ai-blogwatcher.yml"
+
+
+def _write(tmp, body_fm):
+    p = Path(tmp) / "2026-01-01-X_Weekly_Digest.md"
+    p.write_text(f"---\n{body_fm}\n---\nbody\n", encoding="utf-8")
+    return str(p)
+
+
+def test_flags_unvetted_lone_adjective():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "Quantum AI, breaks RSA" }')
+        offenders = check_post(p)
+        assert offenders and "Quantum" in offenders[0]
+
+
+def test_vetted_brand_claude_is_clean():
+    # 'claude' is in _DEFERRED_AI_ADJECTIVES (real brand, lone lead correct).
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "Claude AI, breaks PQC tests" }')
+        assert check_post(p) == []
+
+
+def test_vetted_compound_agentic_is_clean():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "Agentic AI, new risks" }')
+        assert check_post(p) == []
+
+
+def test_no_summary_card_is_clean():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, 'title: "x"')
+        assert check_post(p) == []
+
+
+def test_non_lead_ai_not_flagged():
+    # multi-word lead (has space) is not a lone-adjective panel
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "새로운 위협 동향 정리" }')
+        assert check_post(p) == []
+
+
+def test_main_exit_codes():
+    with tempfile.TemporaryDirectory() as d:
+        bad = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "Quantum AI, breaks RSA" }')
+        assert main([bad]) == 1
+    with tempfile.TemporaryDirectory() as d:
+        good = _write(d, 'summary_card:\n  highlights:\n    - { source: "X", title: "Claude AI, breaks PQC" }')
+        assert main([good]) == 0
+
+
+def test_wired_into_blogwatcher_publish():
+    body = "\n".join(
+        ln for ln in BLOGWATCHER.read_text(encoding="utf-8").splitlines()
+        if not ln.lstrip().startswith("#")
+    )
+    assert re.search(r"check_digest_lone_adjective\.py", body), (
+        "ai-blogwatcher.yml no longer runs the lone-adjective pre-flight; an "
+        "unvetted 'X AI' cover panel would break main's corpus test silently "
+        "after the cron push. Re-add the warn step."
+    )


### PR DESCRIPTION
## 배경
크론이 세션 중 두 번 main을 red로 만든 패턴: baseline stale(#471 해소), lone-adjective 커버(#474 해소). 신규 digest는 구조·proper-noun이 이미 clean(생성기 정규화 + #472 --fix)이라, **잔여 main-breaker는 lone-adjective 커버 vetting 하나**뿐.

## 문제
digest의 `summary_card.highlights[].title`가 "<Word> AI, …"이고 lead가 lone `<Word>`로 풀리면(예: 07-29 "Claude AI"→lone "Claude") `TestCorpusNoLoneAdjectiveAi`가 **크론 push 이후에야** main에서 red — 침묵·지연 실패.

## 수정
- `scripts/check_digest_lone_adjective.py`: 코퍼스 테스트와 **동일 로직**(build_lead_headline + `_AI_COMPOUND_ADJECTIVES`/`_DEFERRED_AI_ADJECTIVES`)을 스코프드 CLI로. --staged/--changed/--all/명시 경로.
- blogwatcher 발행 경로에 **warn-only** 프리플라이트: vetting(join vs defer)은 사람 결정이라 발행은 막지 않되, 정확한 단어 + remediation(l20_dispatch의 어느 리스트에 넣을지)을 **발행 시점에 즉시** `::warning::`으로. 크립틱한 후행 CI 실패 대신 소스에서 알림.

## 검증
- CLI: 미vet 'Quantum AI' 탐지, vet된 'Claude'(_DEFERRED)/'Agentic'(_AI_COMPOUND) clean, summary_card 없음 clean
- 코퍼스 --all 0 offenders(TestCorpusNoLoneAdjectiveAi와 일치), 테스트 7건 + 발행 wiring 가드
- pre-commit 2995 passed

## 한계
lone-adjective는 auto-fix 불가(사람 vetting 필요)라 warn-only. 자동화된 나머지(baseline #471, proper-noun #472)와 함께 크론→main-red 침묵 패턴을 마감.