### PR TITLE
feat(digest): allow-list에 메타→Meta, 시스코→Cisco 추가 (DEFER 재측정)

### DIFF
--- a/notes/digest-proper-noun-policy.md
+++ b/notes/digest-proper-noun-policy.md
@@ -50,6 +50,8 @@
 | 클라우드플레어 | Cloudflare |
 | 안드로이드 | Android |
 | 텔레그램 | Telegram |
+| 메타 | Meta |
+| 시스코 | Cisco |
 
 > allow-list는 **deny-by-default**: 목록에 없는 한글 토큰은 절대 자동 치환/플래그하지 않는다 (`l20_topic_tag_entity_guard`의 entity 오매칭 교훈). 신규 엔티티는 데이터로 혼용 ≥ 임계치 확인 + **substring 트랩 검증** 후 목록에 추가.
 
@@ -65,10 +67,32 @@ count를 부풀리므로 반드시 word-boundary 실측 필요** (naive grep 금
 | 리플→Ripple | **REJECT** | 100% 리플래시(reflash)/리플리카(replica) 노이즈, genuine 0 |
 | 네이버, 카카오 | **REJECT** | 국내 브랜드, 영문 표기 자체가 corpus에 없음(혼용 없음) |
 | OpenAI·Nvidia·TensorFlow·Ubuntu·RedHat·Discord | **REJECT** | 이미 100% 영문 canonical, 고칠 결함 없음 |
-| 메타→Meta | **DEFER** | 실 신호 있으나 메타데이터/메타버스/메타문자에 묻힘 → 전용 제외 규칙 필요 |
-| 윈도우→Windows | **DEFER** | "컨텍스트/안정화 윈도우"(window) **동음이의어** — regex로 못 고침 |
-| 시스코→Cisco | **DEFER** | 샌프란시스코 tail-substring 제외 필요, 볼륨 극소 |
+| 메타→Meta | ~~DEFER~~ → **ADD (2026-07-30)** | 아래 재측정 참조 — 예외 불요 |
+| 윈도우→Windows | **DEFER (확정)** | "컨텍스트/안정화 윈도우"(window) **동음이의어** — 아래 재측정 참조 |
+| 시스코→Cisco | ~~DEFER~~ → **ADD (2026-07-30)** | 아래 재측정 참조 — 예외 불요 |
 | 솔라나·크롬·삼성·파이어폭스 | **DEFER** | 혼용 0~1, 신호 부족 |
+
+### DEFER 재측정 (2026-07-30, 실제 가드 매처로 검증) — 메타·시스코 ADD, 윈도우 확정 DEFER
+
+**결정적 발견:** 위 DEFER 근거는 **naive substring count** 기반이었으나, 가드의 실제
+매처 `_ENTITY_RE` = `(?<![가-힣A-Za-z0-9]){ko}(?=$|[^가-힣]|josa)` 는 word-boundary +
+josa 룩어헤드라 **접미 복합어·임베디드 substring을 이미 제외**한다. 디제스트 코퍼스에서
+매처를 시뮬레이션한 결과:
+
+| 후보 | 매처 hits | genuine | 노이즈 누출 | 결정 |
+|------|----------:|--------:|-----------:|------|
+| 메타→Meta | 21 | 21 (메타의 광고·메타가 크리에이터·메타의 파이썬) | 0 (메타데이터/버스/분석/문자 = 메타+Hangul-non-josa → 룩어헤드가 이미 제외) | **ADD, 예외 불요** |
+| 시스코→Cisco | 2 | 2 (시스코가 분기·Unified) | 0 (샌프란시스코 = 임베디드 → 룩비하인드가 이미 제외) | **ADD, 예외 불요** |
+| 윈도우→Windows | 29 | ~10 (Parallels/Defender/사내) | ~19 (컨텍스트 윈도우 등) | **DEFER 확정** |
+
+**윈도우 확정 DEFER 근거:** window 어의(뜻)는 **선행 수식어**(컨텍스트/안정화/슬라이딩/
+익스플로잇/유지보수 기간/블록 N)에 실리므로 룩어헤드로 못 잡는다. deny-prefix
+negative-lookbehind를 설계·실측했으나 개재 토큰(숫자·괄호: "블록 961632 윈도우",
+"유지보수 기간(윈도우)")이 prefix 앵커를 무력화해 **KEPT 12건 중 3건(~25%) FP** 잔존.
+deny-by-default·no-FP 원칙상 자동 canonical화 불가 → genuine Windows 혼용은 per-post 수동.
+
+구현: `ENTITIES`에 `메타/시스코` 추가 + 회귀 테스트 4건(josa canonical·복합어 불변·
+샌프란시스코 불변·윈도우 미포함). 예외 코드는 추가하지 않음(기존 매처로 충분).
 
 ---
 

--- a/scripts/check_digest_proper_nouns.py
+++ b/scripts/check_digest_proper_nouns.py
@@ -57,12 +57,26 @@ ENTITIES = {
     # 2026-07-29 corpus-vetted additions (post-researcher measurement): genuine
     # Hangul/English mixing with NO substring-collision trap. Deliberately EXCLUDES
     # 애플 (→애플리케이션/application collision, ~0 genuine), 리플 (→리플래시/리플리카),
-    # 메타 (→메타데이터/메타버스), 윈도우 (→컨텍스트 윈도우 homonym), 시스코
-    # (→샌프란시스코) — each needs a bespoke exclusion, tracked in
-    # notes/digest-proper-noun-policy.md; and domestic-only 네이버/카카오 (never
-    # written in English) + already-English-canonical OpenAI/Nvidia/Ubuntu/…
+    # and domestic-only 네이버/카카오 (never written in English) +
+    # already-English-canonical OpenAI/Nvidia/Ubuntu/… — tracked in
+    # notes/digest-proper-noun-policy.md.
     "안드로이드": "Android",   # 6 files mixed; always standalone ("안드로이드 악성/펌웨어")
     "텔레그램": "Telegram",     # mixed; always standalone ("텔레그램 봇/기반/지갑")
+    # 2026-07-30 additions: previously DEFERRED on a naive-substring premise, but
+    # the josa+word-boundary matcher (_ENTITY_RE) already resolves their compound
+    # noise, so NO bespoke exclusion is needed. Verified with the real matcher on
+    # the digest corpus (see notes/digest-proper-noun-policy.md §2 re-measurement).
+    "메타": "Meta",       # 21/21 genuine (메타의 광고, 메타가 크리에이터, 메타의 파이썬).
+                          # 메타데이터/메타버스/메타분석/메타문자 = 메타+Hangul-non-josa →
+                          # already excluded by the lookahead (0 leaks).
+    "시스코": "Cisco",     # 2/2 genuine (시스코가 분기 실적, 시스코 Unified). 샌프란시스코 =
+                          # 시스코 embedded in a larger Hangul token → already excluded by the
+                          # (?<![가-힣…]) lookbehind (0 leaks).
+    # 윈도우 (→Windows) STAYS DEFERRED: genuine homonym. The "window" sense
+    # (컨텍스트/안정화/슬라이딩/익스플로잇 윈도우, "블록 N 윈도우", "유지보수 기간(윈도우)")
+    # cannot be regex-separated from the OS sense — a deny-prefix still leaves ~25%
+    # false positives (intervening numbers/parens defeat the prefix anchor). Any
+    # genuine Windows mixing must be fixed per-post by hand, not auto-canonicalized.
 }
 
 # Common Korean particles (josa) that legitimately attach to a noun. When one of

--- a/scripts/tests/test_check_digest_proper_nouns.py
+++ b/scripts/tests/test_check_digest_proper_nouns.py
@@ -129,6 +129,40 @@ def test_all_entities_rewrite():
         assert n == 1
 
 
+# --- 2026-07-30 additions: 메타/시스코 canonical + substring-trap guards --------
+
+
+def test_meta_company_is_canonicalized_with_josa():
+    # 메타의/메타가/메타 (standalone) are the company Meta.
+    new, n = fix_body("메타의 광고 랭킹과 메타가 발표한 정책, 그리고 메타 광고.")
+    assert new == "Meta의 광고 랭킹과 Meta가 발표한 정책, 그리고 Meta 광고."
+    assert n == 3
+
+
+def test_meta_compound_words_are_not_touched():
+    # 메타 + Hangul-non-josa (데/버/분/문) is a compound noun, never Meta.
+    body = "메타데이터를 메타버스에서 메타분석하고 메타문자를 처리."
+    assert find_violations(body) == []
+    new, n = fix_body(body)
+    assert new == body and n == 0
+
+
+def test_cisco_is_canonicalized_but_san_francisco_is_not():
+    body = "시스코가 분기 실적을 발표했고 샌프란시스코 지사도 언급했다."
+    v = find_violations(body)
+    assert v == [("시스코", "Cisco", 1)]  # 샌프란시스코 embedded → not flagged
+    new, n = fix_body(body)
+    assert new == "Cisco가 분기 실적을 발표했고 샌프란시스코 지사도 언급했다."
+    assert n == 1
+
+
+def test_window_homonym_stays_deferred():
+    # 윈도우 is intentionally NOT in ENTITIES (context/exploit window homonym).
+    assert "윈도우" not in ENTITIES
+    body = "1M 토큰 컨텍스트 윈도우를 갖춘 모델과 윈도우 Defender."
+    assert find_violations(body) == []
+
+
 # --- front matter is never touched -----------------------------------------
 
 


### PR DESCRIPTION
## 배경
`notes/digest-proper-noun-policy.md`에서 메타·윈도우·시스코는 DEFER 상태였음. 이번에 **가드의 실제 매처로 재측정**하여 DEFER 근거를 검증.

## 결정적 발견
DEFER 근거는 **naive-substring count** 기반이었으나, 가드의 실제 매처 `_ENTITY_RE` = `(?<![가-힣A-Za-z0-9]){ko}(?=$|[^가-힣]|josa)` 는 word-boundary + josa 룩어헤드라 **접미 복합어·임베디드 substring을 이미 제외**한다.

디제스트 코퍼스에서 실제 매처를 시뮬레이션:

| 후보 | 매처 hits | genuine | 노이즈 누출 | 결정 |
|------|----------:|--------:|-----------:|------|
| 메타→Meta | 21 | 21 (메타의 광고·메타가 크리에이터) | 0 (메타데이터/버스/분석/문자 이미 제외) | **ADD, 예외 불요** |
| 시스코→Cisco | 2 | 2 (시스코가 분기·Unified) | 0 (샌프란시스코 이미 제외) | **ADD, 예외 불요** |
| 윈도우→Windows | 29 | ~10 | ~19 (컨텍스트 윈도우 등) | **DEFER 확정** |

**윈도우 확정 DEFER**: window 동음이의어가 *선행 수식어*(컨텍스트/블록 N/유지보수 기간)에 실려 룩어헤드로 못 잡고, deny-prefix negative-lookbehind도 개재 토큰(숫자·괄호: "블록 961632 윈도우", "유지보수 기간(윈도우)")이 앵커를 무력화해 **KEPT 12건 중 3건(~25%) FP** 잔존. deny-by-default·no-FP 원칙상 자동 canonical화 불가.

## 변경
- `ENTITIES`에 `메타→Meta`, `시스코→Cisco` 추가 (예외 코드 없음 — 기존 매처로 충분)
- 회귀 테스트 4건: josa canonical·복합어 불변(메타데이터)·샌프란시스코 불변·윈도우 미포함
- `notes/digest-proper-noun-policy.md` §2 재측정 기록

## 검증
- 전체 pytest 2999 passed / 5 skipped, pre-commit 통과
- 스코프: 가드는 `--staged`/`--changed`만 (레거시 일괄 미변경). blogwatcher `--fix`·신규 digest에만 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)