### PR TITLE
fix(digest): 구조 게이트 '대응 체크리스트' 검사를 헤딩 앵커로 한정 (오탐 2건)

### DIFF
--- a/scripts/check_digest_structure.py
+++ b/scripts/check_digest_structure.py
@@ -84,7 +84,12 @@ def check_text(text: str) -> list:
     head = clean_body.split("## 실무 체크리스트")[0]
     if re.search(r"^\s*-\s*\[[ xX]?\]", head, re.MULTILINE):
         violations.append("per-item checkbox checklist present in an item body (should be removed)")
-    if "대응 체크리스트" in clean_body:
+    # Heading-anchored, NOT a bare substring: the defect is a per-item
+    # "대응 체크리스트" HEADING (## / ### / ####). A bare substring also matched
+    # incidental prose like a reference-table cell "랜섬웨어 사고 대응 체크리스트"
+    # (false positive surfaced on 2026-02-08). Front-matter excerpts are already
+    # excluded by _body(); this narrows the remaining body-prose false positives.
+    if re.search(r"^#{2,4}\s+.*대응 체크리스트", clean_body, re.MULTILINE):
         violations.append("per-item 대응 체크리스트 heading present (should be removed)")
 
     return violations

--- a/scripts/tests/test_check_digest_structure.py
+++ b/scripts/tests/test_check_digest_structure.py
@@ -61,6 +61,23 @@ def test_does_not_flag_prose_advisory():
     assert check_post(_write(prose)) == []
 
 
+def test_does_not_flag_대응_체크리스트_in_prose():
+    # "대응 체크리스트" as incidental PROSE (e.g. a reference-table cell) is NOT
+    # a per-item checklist heading → must not be flagged. Only ##/###/#### headings
+    # are the defect. False positive surfaced on the 2026-02-08 digest.
+    prose = _GOOD.replace(
+        "## 2. AI/ML 뉴스",
+        "## 2. AI/ML 뉴스\n| CISA Guide | 랜섬웨어 사고 대응 체크리스트 |",
+    )
+    assert not any("대응 체크리스트" in v for v in check_post(_write(prose)))
+
+
+def test_flags_per_item_대응_체크리스트_heading():
+    # A real per-item '#### 대응 체크리스트' heading (no checkbox) is still caught.
+    bad = _GOOD.replace("## 2. AI/ML 뉴스", "#### 대응 체크리스트\n본문.\n## 2. AI/ML 뉴스")
+    assert any("대응 체크리스트" in v for v in check_post(_write(bad)))
+
+
 # A fenced code EXAMPLE block whose contents look like violations
 # ('## 5. ...' numbering, '- [ ]' checkbox, '대응 체크리스트' heading) must be
 # ignored by ALL checks, not just the H1 check. Outside the fence, the post


### PR DESCRIPTION
## 범위 변경 (2026-08-04)

원래 이 PR은 가드 FP 2건(메타 하이픈 proper-noun + 구조 헤딩앵커)을 함께 고쳤습니다. 그중 **메타 하이픈 수정은 PR #481이 병렬로 동일 결함을 고친 중복**이었으므로 이 PR에서 제거하고, 고유한 **구조 게이트 수정만** 남겼습니다.

#481의 구현을 채택한 이유:
- `_ENTITY_DENY` per-entity 맵이라 확장 가능 (이 PR의 `_COMPOUND_PREFIX_ENTITIES`는 전체 엔티티 집합 단위)
- `비트코인-REIT`(2026-06-18, 정당한 Bitcoin 치환)이 blanket 제외로 누락되지 않는다는 **양성 케이스까지 테스트**
- 이 PR은 중간점 `·`도 거부했으나, `메타·구글`처럼 나열 구분자로 쓰인 경우는 실제 회사명이라 치환해야 맞음 → #481의 좁은 deny(`-–—`)가 더 정확

## 문제

`check_digest_structure.py`가 잡으려는 결함은 per-item **"대응 체크리스트" 헤딩**(`##`/`###`/`####`)인데, 맨 substring 검사(`if "대응 체크리스트" in clean_body`)라 산문에 우연히 등장한 같은 문구까지 위반으로 잡았습니다.

## 실측 오탐 (디제스트 182개 전수 스캔)

| 포스트 | 문맥 |
|--------|------|
| 2026-01-27 | `> # ISMS-P 인증심사 대응 체크리스트` — 인용 블록 내 외부 문서 제목 |
| 2026-02-08 | 참고자료 표 셀 `\| 랜섬웨어 사고 대응 체크리스트 \|` |

둘 다 per-item 체크리스트 헤딩이 아니라 정상 본문입니다.

## 변경

```python
if re.search(r"^#{2,4}\s+.*대응 체크리스트", clean_body, re.MULTILINE):
```

## 검증

```
코퍼스 실측 (182 digest):  플래그 111 → 109
  FP 제거:        2건 (01-27, 02-08)
  신규 플래그:     0건  ← 순수 축소, 회귀 없음
pytest scripts/tests/  → 3006 passed, 5 skipped
```

회귀 테스트 2건 추가:
- `test_does_not_flag_대응_체크리스트_in_prose` — 표 셀 산문은 통과
- `test_flags_per_item_대응_체크리스트_heading` — 진짜 `#### 대응 체크리스트` 헤딩은 계속 검출

## 머지 순서 참고

#482(구조 래칫)가 `check_post` → `check_text` 리팩터링을 포함하므로, #482가 먼저 머지되면 이 PR은 리베이스가 필요합니다(같은 줄 영역). 두 변경은 상호보완적입니다 — 래칫은 기존 결함을 grandfather 처리, 이 PR은 애초에 결함이 아닌 것을 제거.