### PR TITLE
fix(ci): README 아키텍처 SVG 4종 title/치수 복구 — check-svg 게이트 red 해소

### DIFF
--- a/assets/images/readme-architecture.svg
+++ b/assets/images/readme-architecture.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 800" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 800" width="1100" height="800" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+  <title>Tech Blog Reference Architecture</title>
   <defs>
     <!-- Gradients -->
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">

--- a/assets/images/readme-ci-pipeline.svg
+++ b/assets/images/readme-ci-pipeline.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 480" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 480" width="1000" height="480" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+  <title>Tech Blog CI Pipeline</title>
   <defs>
     <linearGradient id="cpBg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0f1a"/>

--- a/assets/images/readme-deploy-flow.svg
+++ b/assets/images/readme-deploy-flow.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 450" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 450" width="1000" height="450" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+  <title>Tech Blog Deploy Flow</title>
   <defs>
     <linearGradient id="dfBg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0f1a"/>

--- a/assets/images/readme-overall-flow.svg
+++ b/assets/images/readme-overall-flow.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 520" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1100 520" width="1100" height="520" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif">
+  <title>Tech Blog Overall Content Flow</title>
   <defs>
     <linearGradient id="ofBg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" style="stop-color:#0a0f1a"/>


### PR DESCRIPTION
## 문제

`check-svg` 워크플로가 **2026-07-13부터 계속 실패**하고 있었으나, path 필터 때문에 워크플로가 거의 트리거되지 않아 은폐되었습니다.

```
Summary: 292 PASS, 0 WARNING, 4 FAIL / 296 files checked
  [FAIL] assets/images/readme-architecture.svg  → Missing <title> element
  [FAIL] assets/images/readme-ci-pipeline.svg   → Missing <title> element
  [FAIL] assets/images/readme-deploy-flow.svg   → Missing <title> element
  [FAIL] assets/images/readme-overall-flow.svg  → Missing <title> element
```

## 근본 원인

커밋 `6bbe71af` (2026-07-13, "fix: CI 셸인젝션·죽은코드·문서 정정")이 README 참조 아키텍처 SVG 4종을 `_unused_archive`에서 복원할 때 `<title>`과 `width`/`height`를 빠뜨렸습니다.

`.github/workflows/check-svg.yml`은 `assets/images/*.svg`, `scripts/check_posts.py`, `scripts/check_cover_qr_urls.py` path 필터로만 트리거됩니다. 07-13 이후 main에서 이 경로가 바뀌지 않아 워크플로가 돌지 않았고(마지막 main 실행 = 07-13 failure), `scripts/check_posts.py`를 건드린 PR #481이 이 기존 실패를 그대로 상속했습니다.

즉 **#481의 결함이 아니라 main의 미발견 회귀**입니다.

## 변경

4종 각각에 ASCII `<title>` + viewBox와 일치하는 `width`/`height` 추가 (기존 통과 파일 `section-*.svg`와 동일한 구조).

| 파일 | viewBox | title |
|------|---------|-------|
| readme-architecture.svg | 1100x800 | Tech Blog Reference Architecture |
| readme-ci-pipeline.svg | 1000x480 | Tech Blog CI Pipeline |
| readme-deploy-flow.svg | 1000x450 | Tech Blog Deploy Flow |
| readme-overall-flow.svg | 1100x520 | Tech Blog Overall Content Flow |

## 검증 (로컬, check-svg.yml 5개 스텝 전부 재현)

```
1. check_svg_quality.py --ci assets/images/   → 300 PASS, 0 WARNING, 0 FAIL / 300 files
2. check_svg_title_ascii.py (4 files)         → OK — 0 violations
3. verify_images_unified.py --svg-validate    → 유효하지 않은 파일 0
4. check_cover_qr_urls.py                     → Scanned 182 / OK 182 / Failures 0
5. check_posts.py SVG 경고                     → truncated=0 dense=0 total=0
```

pre-commit: 3004 passed, 5 skipped.

## 언블록 대상

머지 후 #481 브랜치를 main과 동기화하면 `check-svg`가 green으로 전환됩니다 (→ #482 스택도 언블록).

## 남은 갭 (별도 PR 대상)

`check-svg.yml`의 path 필터가 좁아 전체 코퍼스 회귀가 3주간 은폐됐습니다. 트리거 확대(또는 schedule 추가)는 영향 범위를 따로 검증해야 하므로 이 PR에 포함하지 않았습니다.