### PR TITLE
ci(svg): check-svg 트리거를 스캔 범위에 맞춰 보강 + 은폐 회귀 가드

### DIFF
--- a/.github/workflows/check-svg.yml
+++ b/.github/workflows/check-svg.yml
@@ -1,5 +1,19 @@
 name: SVG Quality Check
 
+# Trigger scope must cover everything this workflow's steps depend on, because
+# the steps scan the WHOLE corpus (check_svg_quality.py over assets/images/), not
+# just the changed files. When the trigger is narrower than the scan, a regression
+# stays hidden until some unrelated change happens to touch a filtered path — and
+# that PR then inherits a failure it did not cause.
+#
+# Observed 2026-07-13 → 08-04: commit 6bbe71af restored 4 README architecture SVGs
+# without <title>, main went red, and because no filtered path changed for three
+# weeks the workflow never ran. PR #481 (touching scripts/check_posts.py) tripped
+# the trigger and inherited the 4 pre-existing FAILs. Fixed in #489.
+#
+# Two-part fix: (1) the daily `schedule:` scans main regardless of paths, so a
+# corpus regression surfaces within 24h; (2) `paths` lists every script the steps
+# invoke plus this workflow file, so editing the gate runs the gate.
 on:
   push:
     branches:
@@ -8,6 +22,9 @@ on:
       - 'assets/images/*.svg'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
+      - 'scripts/check_svg_quality.py'
+      - 'scripts/verify_images_unified.py'
+      - '.github/workflows/check-svg.yml'
   pull_request:
     branches:
       - main
@@ -15,6 +32,15 @@ on:
       - 'assets/images/*.svg'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
+      - 'scripts/check_svg_quality.py'
+      - 'scripts/verify_images_unified.py'
+      - '.github/workflows/check-svg.yml'
+  schedule:
+    # 03:15 UTC = 12:15 KST. Free slot: the blogwatcher digest (00:00), the Pages
+    # backup deploy (00:30), monitoring (01:00), translate-backfill (01:30),
+    # googlebot monitor (02:00) and the Sentry healthcheck (02:30) have all
+    # settled, and the ops-orchestrator lanes (*/6h, 04:00) do not collide.
+    - cron: '15 3 * * *'
   workflow_dispatch: {}
 
 permissions: {}

--- a/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
+++ b/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""CI regression guard: the SVG quality gate must not be able to conceal a red main.
+
+Why this guard exists
+---------------------
+``check-svg.yml`` scans the WHOLE corpus (``check_svg_quality.py --fix --ci
+assets/images/``) but is trigger-filtered by ``paths``. That asymmetry hid a real
+regression for three weeks:
+
+- 2026-07-13, commit ``6bbe71af`` restored 4 README architecture SVGs from
+  ``_unused_archive`` without a ``<title>`` element -> the gate's full-corpus scan
+  returned ``292 PASS / 4 FAIL`` and main was red.
+- No path in the filter changed afterwards, so the workflow never ran again. The
+  last main run stayed the 07-13 failure, invisible.
+- 2026-08-04, PR #481 touched ``scripts/check_posts.py`` (a filtered path), tripped
+  the trigger, and inherited 4 FAILs it did not cause — reading as "this PR broke
+  CI". Fixed in #489, trigger hardened here.
+
+Two invariants keep that from recurring:
+
+1. A ``schedule:`` cron runs the gate on main regardless of ``paths``, so a corpus
+   regression surfaces within 24h instead of waiting for an unrelated change.
+2. ``paths`` covers every script the steps actually invoke (self-consistency). A
+   step added for a new script whose path is not filtered re-opens the same hole,
+   just for a different file.
+
+Maps to OWASP CICD-SEC-1 (Insufficient Flow Control) and NIST SSDF PO.3.
+Direction: presence / superset assertions — narrowing the trigger or dropping the
+schedule trips this; widening it stays green. If the gate is intentionally reworked
+(e.g. the scan becomes diff-scoped so the narrow trigger is no longer a mismatch),
+update this guard in the same PR and say why.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "check-svg.yml"
+
+# Scripts whose changes must run the gate even though the guard derives the rest
+# dynamically: check_svg_quality.py owns the corpus-wide PASS/FAIL verdict, so a
+# change to it silently redefines what the gate means.
+CORE_SCRIPT = "scripts/check_svg_quality.py"
+
+
+def _noncomment_lines(text: str) -> str:
+    """Workflow text with comment-only lines dropped.
+
+    The rationale prose at the top of check-svg.yml names the very scripts and
+    triggers this guard asserts on. Matching that commentary would keep the guard
+    green after the real YAML was deleted, so comment-only lines are removed.
+    Inline trailing comments survive because those lines are not comment-only.
+    """
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _body() -> str:
+    return _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _invoked_scripts(body: str) -> set:
+    """Repo-relative script paths the workflow's run: steps execute."""
+    return set(re.findall(r"python3\s+(scripts/[\w./-]+\.py)", body))
+
+
+def _filtered_paths(body: str) -> set:
+    """Every quoted entry under a `paths:` list in the trigger block."""
+    return set(re.findall(r"^\s*-\s*['\"]([^'\"]+)['\"]\s*$", body, re.MULTILINE))
+
+
+def test_workflow_exists():
+    assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
+
+
+def test_schedule_trigger_present():
+    assert re.search(r"^\s*schedule:\s*$", _body(), re.MULTILINE), (
+        "check-svg.yml lost its 'schedule:' trigger. The gate scans the whole "
+        "corpus but is path-filtered, so without a scheduled run a regression on "
+        "main stays invisible until some unrelated change touches a filtered path "
+        "(observed 2026-07-13 -> 08-04, three weeks red). Re-add the cron, or make "
+        "the scan diff-scoped and update this guard."
+    )
+
+
+def test_schedule_has_cron():
+    crons = re.findall(r"-\s*cron:\s*[\"']([^\"']+)[\"']", _body())
+    assert crons, (
+        "the schedule: trigger has no 'cron:' entry, so the gate never runs on a "
+        "timer and a corpus regression can sit undetected. Re-add a cron (e.g. "
+        "'15 3 * * *'). If intentional, update this guard."
+    )
+
+
+def test_manual_dispatch_still_available():
+    """workflow_dispatch is the escape hatch used to confirm a fix without a push."""
+    assert re.search(r"^\s*workflow_dispatch:", _body(), re.MULTILINE), (
+        "check-svg.yml lost workflow_dispatch; there is no way to re-run the gate "
+        "on demand after fixing a corpus regression. If intentional, update this guard."
+    )
+
+
+def test_corpus_scan_still_covers_whole_directory():
+    """The gate's value is the full-corpus verdict; narrowing it hides regressions."""
+    body = _body()
+    # Anchored at end-of-line: 'assets/images/one.svg' must NOT satisfy this, or the
+    # assertion would pass while the scan had been narrowed to a single file.
+    assert re.search(
+        rf"{re.escape(CORE_SCRIPT)}\s+--fix\s+--ci\s+assets/images/\s*$",
+        body,
+        re.MULTILINE,
+    ), (
+        f"check-svg.yml no longer runs '{CORE_SCRIPT} --fix --ci assets/images/'. "
+        "If the scan was narrowed to changed files only, that is a legitimate "
+        "alternative fix for the trigger/scan mismatch — but then say so and update "
+        "this guard (and test_schedule_trigger_present) in the same PR."
+    )
+
+
+def test_every_invoked_script_is_in_the_trigger_paths():
+    """Self-consistency: a step's script must also be a filtered path.
+
+    This is the general form of the 2026-07-13 hole. A new step added for a script
+    outside `paths` means edits to that script never run the gate that depends on it.
+    """
+    body = _body()
+    invoked = _invoked_scripts(body)
+    assert invoked, "no 'python3 scripts/*.py' step found — did the steps move?"
+    filtered = _filtered_paths(body)
+    missing = sorted(s for s in invoked if s not in filtered)
+    assert not missing, (
+        "check-svg.yml runs these scripts but does not list them under 'paths', so "
+        f"changing them never runs the gate that depends on them: {missing}. Add each "
+        "to BOTH the push: and pull_request: paths lists."
+    )
+
+
+def test_workflow_file_itself_is_a_filtered_path():
+    """Editing the gate must run the gate, or a weakening ships unverified."""
+    filtered = _filtered_paths(_body())
+    assert ".github/workflows/check-svg.yml" in filtered, (
+        "check-svg.yml does not list itself under 'paths'. A change to the gate "
+        "(including one that breaks it) would then merge without the gate ever "
+        "running on the PR."
+    )
+
+
+def test_scripts_referenced_by_paths_exist():
+    """Canary: a renamed script leaves a dead path filter that silently matches nothing."""
+    filtered = _filtered_paths(_body())
+    dead = sorted(
+        p
+        for p in filtered
+        if p.startswith("scripts/") and not (REPO_ROOT / p).is_file()
+    )
+    assert not dead, (
+        f"these trigger paths point at files that no longer exist: {dead}. A dead "
+        "path filter matches nothing, so the gate stops running for that dependency."
+    )


### PR DESCRIPTION
#489의 후속 — 4종 SVG를 고친 것은 증상 수정이었고, 이 PR은 **은폐 메커니즘 자체**를 막습니다.

## 문제: 트리거는 좁고 스캔은 넓다

`check-svg.yml`은 코퍼스 전체를 스캔합니다(`check_svg_quality.py --fix --ci assets/images/`). 그런데 트리거는 `paths` 필터로 좁습니다. 이 비대칭이 실제 회귀를 3주간 은폐했습니다.

| 시점 | 사건 |
|------|------|
| 2026-07-13 | `6bbe71af`가 README SVG 4종을 `_unused_archive`에서 `<title>` 없이 복원 → 전체 스캔 `292 PASS / 4 FAIL`, main red |
| 07-13 ~ 08-04 | 필터 경로가 바뀌지 않아 **워크플로가 한 번도 실행되지 않음**. main의 마지막 실행이 07-13 failure로 고정 |
| 2026-08-04 | PR #481이 `scripts/check_posts.py`(필터 경로)를 건드려 트리거를 밟고, **자기가 유발하지 않은 FAIL 4건 상속** → "이 PR이 CI를 깼다"로 읽힘 |

## 변경 1 — `schedule:` cron

```yaml
schedule:
  - cron: '15 3 * * *'   # 12:15 KST
```

`paths`와 무관하게 main을 매일 스캔하므로, 코퍼스 회귀가 무관한 변경을 기다리지 않고 **24시간 내 표면화**합니다. `deploy-pages.yml`의 자가치유 cron과 같은 패턴입니다.

슬롯 선정: 기존 크론(blogwatcher 00:00, Pages 백업 00:30, monitoring 01:00, translate-backfill 01:30, googlebot 02:00, Sentry 02:30, ops-orchestrator `*/6h`·04:00)과 비충돌.

## 변경 2 — `paths` 자기 일관성

워크플로가 **실제로 실행하는** 스크립트가 필터에 빠져 있었습니다:

| 경로 | 이전 | 이후 |
|------|:----:|:----:|
| `scripts/check_posts.py` | ✅ | ✅ |
| `scripts/check_cover_qr_urls.py` | ✅ | ✅ |
| `scripts/check_svg_quality.py` | ❌ 실행하는데 필터에 없음 | ✅ |
| `scripts/verify_images_unified.py` | ❌ 실행하는데 필터에 없음 | ✅ |
| `.github/workflows/check-svg.yml` | ❌ 게이트를 고쳐도 게이트가 안 돔 | ✅ |

## 변경 3 — 회귀 가드 `test_ci_svg_gate_no_conceal_guard.py`

7방향 탐지 (OWASP CICD-SEC-1 / NIST SSDF PO.3):

1. `schedule:` 블록 제거
2. `cron:` 엔트리만 제거
3. `workflow_dispatch` 제거
4. 스캔 범위 축소 (`assets/images/` → 단일 파일)
5. **invoked script가 `paths`에 없음** ← 원래 구멍의 일반형. 스텝을 추가하면서 경로를 안 넣으면 같은 구멍이 다른 파일로 재발
6. 워크플로 self-path 제거
7. dead path filter (스크립트 rename 후 필터가 아무것도 매칭 안 함)

방향: presence / superset 어서션이라 **트리거를 넓히는 변경은 green**, 좁히면 trip. 스캔을 diff-scoped로 바꾸는 대안 수정도 정당하므로, 그 경우 같은 PR에서 가드를 갱신하라는 안내를 실패 메시지에 넣었습니다.

## 검증

```
가드 positive (실제 파일)        → 8 passed
가드 non-vacuous (변형 주입)      → 7/7 전부 AssertionError (은폐 없음)
  ※ 초기 4번 어서션이 vacuous였음 — 'assets/images/one.svg'가 접두사
    매칭으로 통과 → 정규식을 end-of-line 앵커로 수정 후 재검증
전체 스위트                      → 3030 passed, 5 skipped
YAML 파싱                        → triggers = [pull_request, push, schedule, workflow_dispatch]
```

comment-only 라인을 제거한 뒤 어서션하므로, 워크플로 상단의 근거 주석(같은 스크립트·트리거명을 언급)이 실제 YAML 삭제 후에도 가드를 green으로 유지하는 일은 없습니다.