### PR TITLE
feat(digest): 체크리스트 제목 변형 재발 방지 게이트 — 크론 발행 시점 차단

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -173,6 +173,24 @@ if [ -n "$STAGED_DIGEST_POSTS" ]; then
   echo "[pre-commit] Digest proper-noun check: passed."
 fi
 
+# 9d. Canonical checklist heading gate — exactly one '## 실무 체크리스트' H2.
+#     Step 9 counts the raw substring, so '### 실무 체크리스트' (demoted) and
+#     '## 실무 체크리스트 (P0)' (suffixed) pass it. No ratchet: the corpus is
+#     at 0 violations (measured 2026-08-06, 184/184), so any hit is new drift.
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest canonical checklist heading..."
+  python3 "$REPO_ROOT/scripts/check_digest_checklist_heading.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Non-canonical global checklist heading in a digest."
+    echo "             Canonical form is exactly: ## 실무 체크리스트"
+    echo "             Numbered ('## N. …') forms auto-fix with:"
+    echo "               python3 scripts/restore_digest_structure.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest checklist heading check: passed."
+fi
+
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
 STAGED_HEAD_HTML=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_includes/head\.html$' || true)
 if [ -n "$STAGED_HEAD_HTML" ]; then

--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -355,6 +355,28 @@ jobs:
             echo "::warning::Unvetted lone-adjective+AI cover panel in ${POST_FILE}. main's TestCorpusNoLoneAdjectiveAi will go red until you vet the word in scripts/news/l20_dispatch.py (_AI_COMPOUND_ADJECTIVES to join, or _DEFERRED_AI_ADJECTIVES if the lone lead is a correct brand)."
           fi
 
+      - name: Canonical checklist heading pre-flight (self-heal, then block)
+        if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'
+        run: |
+          # Guard the 601 -> 0 structure campaign against cron re-drift. The
+          # pre-commit structural ratchet never sees this post: the Actions
+          # commit below runs with no local hooks. And check_digest_structure
+          # counts the raw substring "## 실무 체크리스트", so a demoted
+          # (### …) or suffixed (… (P0)) heading passes it silently.
+          #
+          # Self-heal first — the numbered tier-C form (## N. 실무 체크리스트)
+          # is deterministically fixable by restore_digest_structure R5, and
+          # that rule is lossless (it aborts rather than drop content). Then
+          # re-verify and BLOCK: unlike the lone-adjective warn above, this is
+          # not a judgement call, and a drifted surface silently rots the
+          # corpus until a manual campaign finds it weeks later.
+          POST_FILE="${{ steps.check_post.outputs.post_file }}"
+          if ! python3 scripts/check_digest_checklist_heading.py "$POST_FILE"; then
+            echo "::warning::Non-canonical checklist heading in ${POST_FILE} — attempting restore_digest_structure self-heal."
+            python3 scripts/restore_digest_structure.py "$POST_FILE" || true
+          fi
+          python3 scripts/check_digest_checklist_heading.py "$POST_FILE"
+
       - name: Commit and publish
         if: steps.check_post.outputs.post_created == 'true' && env.DRY_RUN != 'true'
         env:

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -37,6 +37,7 @@ on:
       - 'scripts/check_digest_structure.py'
       - 'scripts/check_digest_untranslated.py'
       - 'scripts/check_digest_proper_nouns.py'
+      - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -80,6 +81,7 @@ on:
       - 'scripts/check_digest_structure.py'
       - 'scripts/check_digest_untranslated.py'
       - 'scripts/check_digest_proper_nouns.py'
+      - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -280,6 +282,15 @@ jobs:
           fi
           echo "[digest-proper-nouns] diff base: $BASE"
           python3 scripts/check_digest_proper_nouns.py --changed "$BASE"
+
+      - name: Digest canonical checklist heading gate
+        id: digest_checklist_heading
+        # --all, unlike the three gates above: the 601 -> 0 structure campaign
+        # (#494-#502) left the corpus at 0 violations (184/184 measured
+        # 2026-08-06), so there is no legacy debt to scope around and any hit
+        # is fresh drift — including one arriving via a cron push that never
+        # ran the pre-commit hook.
+        run: python3 scripts/check_digest_checklist_heading.py --all
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,7 +523,7 @@ the 9 historical posts affected before the rule was introduced. The 7
 posts that still violated the rule were fixed in commit `b4ff35c4`
 (2026-05-28).
 
-### Active automation gates (8 enforcing)
+### Active automation gates (9 enforcing)
 
 | # | Script | Scope | Wired to |
 |---|--------|-------|----------|
@@ -535,6 +535,7 @@ posts that still violated the rule were fixed in commit `b4ff35c4`
 | 6 | `check_svg_precommit.sh` | NUL-delimited path-safety wrapper | pre-commit |
 | 7 | `check_kst_midnight.py` | KST 00-09 post URL drift | pre-commit + svg-lint CI |
 | 8 | blogwatcher raster auto-emit | cron-side raster generation | `.github/workflows/ai-blogwatcher.yml` |
+| 9 | `check_digest_checklist_heading.py` | exactly one canonical `## 실무 체크리스트` H2 | pre-commit (9d) + svg-lint CI (`--all`) + blogwatcher publish (self-heal, then block) |
 
 ### Code Blocks
 - **Always** include language tags: ```python, ```bash, ```yaml

--- a/scripts/check_digest_checklist_heading.py
+++ b/scripts/check_digest_checklist_heading.py
@@ -1,0 +1,200 @@
+"""Canonical `## 실무 체크리스트` heading guard for weekly digests.
+
+The 601 -> 0 structure campaign (PRs #494-#502) ended with every digest owning
+exactly one canonical global checklist surface. Nothing stops the cron from
+re-introducing a variant tomorrow: `check_digest_structure.py` counts the RAW
+SUBSTRING ``"## 실무 체크리스트"`` (unanchored, no heading level), so
+
+    ### 실무 체크리스트          -> contains the substring, counts as 1, PASSES
+    ## 실무 체크리스트 (P0/P1)   -> no `$` anchor, counts as 1, PASSES
+    ## 9. 실무 체크리스트        -> counts as 0, reported only as the generic
+                                    "expected exactly one …, found 0" (tier C)
+
+and the structure gate runs on ``--staged``/``--changed`` only, which the cron's
+GitHub-Actions commit never triggers. So a drifted heading lands in the corpus
+and is discovered weeks later, by hand.
+
+This gate anchors on the heading line (level + exact text) and runs at publish
+time on the freshly written post. Topical item checklists (`#### 마이그레이션
+체크리스트`) are NOT the global surface and are never flagged; only headings
+that carry the words "실무 체크리스트" without being canonical, or the absence
+of the canonical surface entirely.
+
+Exit 1 if any digest lacks exactly one canonical `## 실무 체크리스트`.
+
+Usage:
+    python3 scripts/check_digest_checklist_heading.py _posts/2026-08-06-*Weekly_Digest*.md
+    python3 scripts/check_digest_checklist_heading.py --staged
+    python3 scripts/check_digest_checklist_heading.py --all
+"""
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO / "_posts"
+
+CANONICAL = "## 실무 체크리스트"
+_CANONICAL_TEXT = "실무 체크리스트"
+
+_FRONT_MATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
+_HEADING_RE = re.compile(r"^(#{1,6})[ \t]+(.*?)[ \t]*$")
+_POST_PATH_RE = re.compile(r"^_posts/[^/]+\.md$")
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in Path(path).name
+
+
+def _body(text: str) -> str:
+    m = _FRONT_MATTER_RE.match(text)
+    return text[m.end():] if m else text
+
+
+def _strip_code_fences(text: str) -> str:
+    """Drop fenced blocks (delimiters and interior) — same contract as R0."""
+    out, in_fence = [], False
+    for line in text.split("\n"):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _headings(clean_body: str) -> list:
+    """Return (level, text, raw_line) for every heading outside code fences."""
+    found = []
+    for line in clean_body.split("\n"):
+        m = _HEADING_RE.match(line)
+        if m:
+            found.append((len(m.group(1)), m.group(2).strip(), line.strip()))
+    return found
+
+
+def check_text(text: str) -> list:
+    """Return violation strings for one digest body (empty == clean)."""
+    headings = _headings(_strip_code_fences(_body(text)))
+
+    canonical = [h for h in headings if h[0] == 2 and h[1] == _CANONICAL_TEXT]
+    # A heading that carries the canonical words but is not the canonical form.
+    variants = [
+        h for h in headings if _CANONICAL_TEXT in h[1] and not (h[0] == 2 and h[1] == _CANONICAL_TEXT)
+    ]
+
+    violations = []
+    for _level, _t, raw in variants:
+        violations.append(
+            f"variant checklist heading: {raw!r} (canonical is exactly {CANONICAL!r})"
+        )
+    if not canonical and not variants:
+        candidates = [h[2] for h in headings if "체크리스트" in h[1]]
+        hint = f" nearest: {candidates[0]!r}" if candidates else ""
+        violations.append(
+            f"missing canonical checklist heading {CANONICAL!r}.{hint}"
+        )
+    elif len(canonical) > 1:
+        violations.append(
+            f"expected exactly one canonical {CANONICAL!r}, found {len(canonical)}"
+        )
+    return violations
+
+
+def check_post(path) -> list:
+    path = Path(path)
+    if not _is_digest_post(path):
+        return []
+    return check_text(path.read_text(encoding="utf-8"))
+
+
+def _all_paths() -> list:
+    return sorted(p for p in POSTS_DIR.glob("*.md") if _is_digest_post(p))
+
+
+def _git_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        p = line.strip()
+        if _POST_PATH_RE.match(p):
+            full = REPO / p
+            if full.exists() and _is_digest_post(full):
+                paths.append(full)
+    return sorted(paths)
+
+
+def _explicit(args_paths: list) -> list:
+    paths = []
+    for a in args_paths:
+        p = Path(a)
+        if not p.is_absolute():
+            cwd_p = Path.cwd() / p
+            p = cwd_p if cwd_p.exists() else REPO / a
+        if p.exists() and _is_digest_post(p):
+            paths.append(p)
+    return paths
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag Weekly_Digest posts whose global checklist surface is not "
+            "exactly one canonical '## 실무 체크리스트' H2 heading."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true")
+    mode.add_argument("--all", action="store_true")
+    mode.add_argument("--changed", metavar="BASE", default=None)
+    parser.add_argument("paths", nargs="*")
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        files = _git_paths(["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"])
+    elif args.changed:
+        files = _git_paths(
+            ["git", "diff", "--name-only", f"{args.changed}...HEAD", "--diff-filter=ACM"]
+        )
+    elif args.paths:
+        files = _explicit(args.paths)
+    else:
+        files = _all_paths()
+
+    if not files:
+        print("[digest-checklist-heading] No digest post files to check.")
+        return 0
+
+    rc = 0
+    for path in files:
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        violations = check_post(path)
+        if violations:
+            rc = 1
+            print(f"FAIL {rel}")
+            for v in violations:
+                print(f"  - {v}")
+        else:
+            print(f"OK   {rel}")
+
+    if rc:
+        print(
+            "\n[digest-checklist-heading] FAIL — the global checklist surface "
+            "drifted. Numbered ('## N. 실무 체크리스트') forms are auto-fixable "
+            "with `python3 scripts/restore_digest_structure.py <post>` (rule R5); "
+            "renamed or re-levelled headings need a manual edit to exactly "
+            f"'{CANONICAL}'.",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[digest-checklist-heading] OK — {len(files)} digest(s), 0 violations.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -213,6 +213,24 @@ if [ -n "$STAGED_DIGEST_POSTS" ]; then
   echo "[pre-commit] Digest proper-noun check: passed."
 fi
 
+# 9d. Canonical checklist heading gate — exactly one '## 실무 체크리스트' H2.
+#     Step 9 counts the raw substring, so '### 실무 체크리스트' (demoted) and
+#     '## 실무 체크리스트 (P0)' (suffixed) pass it. No ratchet: the corpus is
+#     at 0 violations (measured 2026-08-06, 184/184), so any hit is new drift.
+if [ -n "$STAGED_DIGEST_POSTS" ]; then
+  echo "[pre-commit] Checking digest canonical checklist heading..."
+  python3 "$REPO_ROOT/scripts/check_digest_checklist_heading.py" --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Non-canonical global checklist heading in a digest."
+    echo "             Canonical form is exactly: ## 실무 체크리스트"
+    echo "             Numbered ('## N. …') forms auto-fix with:"
+    echo "               python3 scripts/restore_digest_structure.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Digest checklist heading check: passed."
+fi
+
 # 10. CSP inline-script sha256 regression gate (prep for CSP Path B)
 STAGED_HEAD_HTML=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_includes/head\.html$' || true)
 if [ -n "$STAGED_HEAD_HTML" ]; then

--- a/scripts/tests/test_check_digest_checklist_heading.py
+++ b/scripts/tests/test_check_digest_checklist_heading.py
@@ -1,0 +1,163 @@
+"""Tests for the publish-time canonical-checklist-heading gate.
+
+Covers the recurrence hole closed after the 601 -> 0 structure campaign:
+`check_digest_structure.py` counts the RAW SUBSTRING "## 실무 체크리스트", so a
+demoted (`### 실무 체크리스트`) or suffixed (`## 실무 체크리스트 (P0)`) heading
+still counts as 1 and passes silently, while the numbered tier-C form
+(`## 9. 실무 체크리스트`) is only reported as the generic "found 0".
+"""
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import check_digest_checklist_heading as gate  # noqa: E402
+
+_FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
+_ITEM = "## 1. 보안\n\n### 1.1 항목\n\n본문.\n\n"
+
+
+def _post(tmp_path, body, name="2026-08-06-Tech_Blog_Weekly_Digest_x.md"):
+    p = tmp_path / name
+    p.write_text(_FM + body, encoding="utf-8")
+    return p
+
+
+# --- canonical / clean -------------------------------------------------------
+
+
+def test_canonical_heading_is_clean(tmp_path):
+    p = _post(tmp_path, _ITEM + "## 실무 체크리스트\n\n- [ ] 조치\n")
+    assert gate.check_post(p) == []
+
+
+def test_topical_item_checklist_is_not_flagged(tmp_path):
+    """`#### 마이그레이션 체크리스트` etc. are legitimate item content."""
+    body = (
+        "## 1. 보안\n\n### 1.1 항목\n\n#### 마이그레이션 체크리스트\n\n- 항목\n\n"
+        "## 실무 체크리스트\n\n- [ ] 조치\n"
+    )
+    assert gate.check_post(_post(tmp_path, body)) == []
+
+
+def test_heading_inside_code_fence_is_ignored(tmp_path):
+    body = (
+        "## 실무 체크리스트\n\n- [ ] 조치\n\n"
+        "```markdown\n### 실무 체크리스트\n```\n"
+    )
+    assert gate.check_post(_post(tmp_path, body)) == []
+
+
+def test_non_digest_post_is_skipped(tmp_path):
+    p = _post(tmp_path, "## 9. 실무 체크리스트\n", name="2026-08-06-Some_Post.md")
+    assert gate.check_post(p) == []
+
+
+# --- variants (the regression this gate blocks) ------------------------------
+
+
+def test_numbered_tier_c_variant_is_flagged(tmp_path):
+    v = gate.check_post(_post(tmp_path, _ITEM + "## 9. 실무 체크리스트\n\n- [ ] 조치\n"))
+    assert len(v) == 1
+    assert "9. 실무 체크리스트" in v[0]
+
+
+def test_demoted_h3_variant_is_flagged(tmp_path):
+    """Passes check_digest_structure today (substring count == 1)."""
+    v = gate.check_post(_post(tmp_path, _ITEM + "### 실무 체크리스트\n\n- [ ] 조치\n"))
+    assert len(v) == 1
+    assert "### 실무 체크리스트" in v[0]
+
+
+def test_suffixed_variant_is_flagged(tmp_path):
+    """Also passes check_digest_structure today (no `$` anchor)."""
+    v = gate.check_post(_post(tmp_path, _ITEM + "## 실무 체크리스트 (P0/P1)\n\n- [ ] 조치\n"))
+    assert len(v) == 1
+    assert "(P0/P1)" in v[0]
+
+
+def test_stray_variant_alongside_canonical_is_flagged(tmp_path):
+    body = _ITEM + "## 실무 체크리스트\n\n- [ ] 조치\n\n### 실무 체크리스트\n\n- [ ] 또\n"
+    v = gate.check_post(_post(tmp_path, body))
+    assert len(v) == 1
+    assert "### 실무 체크리스트" in v[0]
+
+
+def test_renamed_checklist_surface_is_flagged_as_missing(tmp_path):
+    """No `실무 체크리스트` at all — report missing + the nearest candidate."""
+    v = gate.check_post(_post(tmp_path, _ITEM + "## 실행 체크리스트\n\n- [ ] 조치\n"))
+    assert len(v) == 1
+    assert "missing" in v[0]
+    assert "## 실행 체크리스트" in v[0]
+
+
+def test_no_checklist_surface_at_all_is_flagged(tmp_path):
+    v = gate.check_post(_post(tmp_path, _ITEM))
+    assert len(v) == 1
+    assert "missing" in v[0]
+
+
+def test_duplicate_canonical_is_flagged(tmp_path):
+    body = _ITEM + "## 실무 체크리스트\n\n- [ ] a\n\n## 실무 체크리스트\n\n- [ ] b\n"
+    v = gate.check_post(_post(tmp_path, body))
+    assert len(v) == 1
+    assert "2" in v[0]
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_exit_1_on_variant(tmp_path, capsys):
+    p = _post(tmp_path, _ITEM + "## 9. 실무 체크리스트\n")
+    assert gate.main([str(p)]) == 1
+    assert "FAIL" in capsys.readouterr().out
+
+
+def test_cli_exit_0_on_canonical(tmp_path, capsys):
+    p = _post(tmp_path, _ITEM + "## 실무 체크리스트\n\n- [ ] 조치\n")
+    assert gate.main([str(p)]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+# --- corpus + wiring ---------------------------------------------------------
+
+
+def test_corpus_is_clean():
+    """Measured 2026-08-06: 184/184 digests carry exactly one canonical H2."""
+    offenders = {}
+    for p in sorted((REPO / "_posts").glob("*Weekly_Digest*.md")):
+        v = gate.check_post(p)
+        if v:
+            offenders[p.name] = v
+    assert offenders == {}, offenders
+
+
+def _noncomment(text: str) -> str:
+    return "\n".join(ln for ln in text.splitlines() if not ln.strip().startswith("#"))
+
+
+def test_wired_into_blogwatcher_publish():
+    wf = (REPO / ".github/workflows/ai-blogwatcher.yml").read_text(encoding="utf-8")
+    assert "check_digest_checklist_heading.py" in _noncomment(wf)
+
+
+@pytest.mark.parametrize("rel", [".githooks/pre-commit", "scripts/install-hooks.sh"])
+def test_wired_into_precommit(rel):
+    text = (REPO / rel).read_text(encoding="utf-8")
+    assert re.search(
+        r'check_digest_checklist_heading\.py"?\s+--staged', _noncomment(text)
+    ), f"{rel} must run the gate on staged digests"
+
+
+def test_self_heal_runs_before_the_blocking_verify():
+    """restore_digest_structure must be attempted BEFORE the gate blocks."""
+    wf = (REPO / ".github/workflows/ai-blogwatcher.yml").read_text(encoding="utf-8")
+    step = wf.split("Canonical checklist heading pre-flight")[1].split("- name:")[0]
+    assert step.index("restore_digest_structure.py") < step.rindex(
+        "check_digest_checklist_heading.py"
+    )


### PR DESCRIPTION
## 배경

601 → 0 구조 복원 캠페인(#494~#502)으로 코퍼스는 canonical 상태가 되었지만, **크론이 내일 다시 변형 제목을 넣는 것을 막는 장치가 없었다.**

### 기존 게이트의 두 가지 구멍

**1. `check_digest_structure.py`는 raw substring을 센다** (`scripts/check_digest_structure.py:80`)

```python
if clean_body.count("## 실무 체크리스트") != 1:
```

앵커(`^`/`$`)도 헤딩 레벨 판정도 없어서:

| 변형 | 현재 게이트 |
|---|---|
| `### 실무 체크리스트` (강등, 티어 D) | substring 포함 → **1로 세어 통과** |
| `## 실무 체크리스트 (P0/P1)` (접미) | `$` 앵커 부재 → **1로 세어 통과** |
| `## 9. 실무 체크리스트` (번호형, 티어 C) | 0으로 세어 일반 메시지만 |

**2. 크론 커밋은 그 게이트를 아예 거치지 않는다** — 구조 게이트는 `--staged`/`--changed` 전용인데, blogwatcher의 Actions 커밋에는 로컬 훅이 없다. 드리프트가 수 주 뒤 수작업 캠페인으로 발견되는 이유.

## 변경

- **`scripts/check_digest_checklist_heading.py`** (신규) — 제목 라인(레벨 + 정확 텍스트)에 앵커. `실무 체크리스트` 문구를 가지면서 canonical이 아닌 제목, canonical 부재, 중복을 각각 구분해 보고.
  - 항목별 토픽 체크리스트(`#### 마이그레이션 체크리스트`)는 전역 표면이 아니므로 **미검출** — 코퍼스의 기존 7개 토픽 제목 모두 무영향
  - 코드펜스 내부 제목 무시 (R0와 동일 계약)
- **blogwatcher 발행 경로** — 발행 전 self-heal(`restore_digest_structure` R5가 번호형을 무손실 교정) 후 **재검증하여 차단**. lone-adjective(warn-only)와 달리 판단이 개입할 여지가 없는 결함이라 blocking.
- **pre-commit 9d** + `install-hooks.sh` 미러 (생성 소스 동기 검증 완료)
- **svg-lint CI `--all`** — 레거시 부채가 0이라 래칫 불요

## 실측 근거

**코퍼스 오탐 위험 0** — 184/184 다이제스트가 정확히 하나의 canonical H2 보유, 근접 변형 0건. 이 실측이 blocking 채택의 근거.

**실제 포스트 기반 E2E** (`2026-08-05-Tech_Security_Weekly_Digest_AI_Agent_Update.md` 복사본):

| 케이스 | gate 사전 | self-heal | gate 사후 |
|---|---|---|---|
| 티어 C `## 9. 실무 체크리스트` | FAIL (rc=1) | FIXED | **OK (rc=0)** |
| 티어 D `### 실무 체크리스트` | FAIL (rc=1) | 교정 불가 | **FAIL (rc=1)** ← 의도대로 차단 |
| 대조군 (미변형) | — | — | OK (rc=0) |

**테스트** — `scripts/tests/test_check_digest_checklist_heading.py` 18건 (변형 5종 + 오탐 방지 4종 + CLI 2건 + 코퍼스 1건 + 배선 4건). 전체 스위트 `3094 passed, 5 skipped`.

## 검증 명령

```bash
python3 -m pytest scripts/tests/ -q
python3 scripts/check_digest_checklist_heading.py --all
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/svg-lint.yml'))"
```