### PR TITLE
fix(digest): lossless 불변식에 마커-컨텍스트 검사 추가 — 펜스 손상·숫자 삭제 은폐 해소

### DIFF
--- a/scripts/restore_digest_structure.py
+++ b/scripts/restore_digest_structure.py
@@ -312,17 +312,71 @@ _MARKER_RE = re.compile(
     re.MULTILINE,
 )
 _NUMERIC_RE = re.compile(r"^\d+\.?$")
+_HEADING_LINE_RE = re.compile(r"^[ \t]*#{1,6}[ \t]+")
+
+
+def _audit_fence_flags(lines: list) -> list:
+    """Second opinion on R0's verbatim region, for the lossless audit ONLY.
+
+    Deliberately a separate definition from `_fence_flags`, not a call to it: if
+    the audit reused the rules' own detector, a regression in fence DETECTION
+    would move both sides together and the invariant would stay blind by
+    construction — exactly the blindness this audit exists to remove. Kept in
+    lockstep by test_audit_fence_flags_agree_with_rule_flags over the corpus.
+    """
+    flags, in_code = [], False
+    for line in lines:
+        if line.strip().startswith("```"):
+            in_code = not in_code
+            flags.append(True)
+            continue
+        flags.append(in_code)
+    return flags
 
 
 def lossless_tokens(text: str) -> collections.Counter:
-    """Whitespace-separated tokens with markdown markers stripped.
+    """Context-aware token multiset: what a transform must leave untouched.
 
-    Numeric-only tokens are excluded because R4/R5 change section numbers by
-    design. Everything else must survive a transform unchanged — that equality is
-    the lossless contract, and main() enforces it per file before writing.
+    A flat "strip every marker, count the rest" multiset is marker-BLIND, and
+    that blindness hid a real corruption: R1 rewrote '# 예시' to '#### 예시'
+    inside fenced bash/yaml examples (2026-03-11, 2026-03-27). Only the marker
+    changed, so the multiset matched and the invariant passed while the post was
+    damaged — the defect had to be found by hand (PR #500). The global numeric
+    exclusion had the same shape of hole: deleting a standalone number from a
+    table cell was invisible.
+
+    So markers and numbers are compared where they are ALLOWED to change, and
+    verbatim where they are not:
+
+    * front matter — no rule touches it: compared line-verbatim.
+    * fenced lines (R0's verbatim region) — compared line-verbatim, markers
+      included, so any marker mis-conversion inside a fence trips the abort.
+    * outside fences — markers are erased (R1/R2/R3/R6 change them by design),
+      and a numeric-only token is dropped ONLY when it is the leading 'N.' slot
+      of a heading, which is the one number R4/R5 own. Numbers anywhere else
+      (prose, tables, '### 9.1' item numbers) must survive.
+
+    main() enforces equality per file before writing.
     """
-    stripped = _MARKER_RE.sub(" ", text)
-    return collections.Counter(t for t in stripped.split() if not _NUMERIC_RE.match(t))
+    front, body = _split_front_matter(text)
+    counter: collections.Counter = collections.Counter()
+
+    for line in front.split("\n"):
+        if line.strip():
+            counter[f"\x00fm\x00{line}"] += 1
+
+    lines = body.split("\n")
+    fenced = _audit_fence_flags(lines)
+    for i, line in enumerate(lines):
+        if fenced[i]:
+            if line.strip():
+                counter[f"\x00fence\x00{line}"] += 1
+            continue
+        tokens = _MARKER_RE.sub(" ", line).split()
+        if tokens and _HEADING_LINE_RE.match(line) and _NUMERIC_RE.match(tokens[0]):
+            tokens = tokens[1:]
+        counter.update(tokens)
+    return counter
 
 
 def _is_digest_post(path: Path) -> bool:

--- a/scripts/tests/test_restore_digest_structure.py
+++ b/scripts/tests/test_restore_digest_structure.py
@@ -10,6 +10,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from restore_digest_structure import (  # noqa: E402
     TOP_SECTION_RE,
@@ -250,6 +252,127 @@ def test_transform_resolves_all_four_kinds():
 def test_transform_is_idempotent():
     once = transform(_FM + _DEFECTIVE)
     assert transform(once) == once
+
+
+# --- lossless_tokens: marker-context sensitivity -----------------------------
+#
+# The multiset alone is marker-blind: `_MARKER_RE` erases heading/bullet markers
+# everywhere, so a marker MIS-conversion inside a code fence ('# 예시' ->
+# '#### 예시', the R0 defect of PR #500) leaves the token multiset identical and
+# the invariant passes while the post is corrupted. And the numeric exclusion was
+# global, so deleting a standalone number from a table was invisible too.
+# Markers may legitimately change ONLY outside fences; numbers may legitimately
+# change ONLY in a heading's leading 'N.' slot (R4/R5).
+
+
+def test_fence_interior_heading_marker_change_is_caught():
+    orig = _FM + "```bash\n# 예시 주석\n```\n"
+    damaged = _FM + "```bash\n#### 예시 주석\n```\n"
+    assert lossless_tokens(orig) != lossless_tokens(damaged)
+
+
+def test_fence_interior_bullet_marker_change_is_caught():
+    orig = _FM + "```\n- item\n```\n"
+    damaged = _FM + "```\n- [ ] item\n```\n"
+    assert lossless_tokens(orig) != lossless_tokens(damaged)
+
+
+def test_fence_interior_text_change_is_still_caught():
+    orig = _FM + "```\n# 예시 주석\n```\n"
+    damaged = _FM + "```\n# 다른 주석\n```\n"
+    assert lossless_tokens(orig) != lossless_tokens(damaged)
+
+
+def test_standalone_number_deletion_outside_headings_is_caught():
+    orig = _FM + "| 항목 | 3 |\n"
+    damaged = _FM + "| 항목 | |\n"
+    assert lossless_tokens(orig) != lossless_tokens(damaged)
+
+
+@pytest.mark.parametrize(
+    "orig,new",
+    [
+        ("### 제목\n", "#### 제목\n"),                       # R1 demote
+        ("### 대응 체크리스트\n", "**대응 체크리스트**\n"),   # R2 boldify
+        ("- [ ] 조치\n", "- 조치\n"),                         # R3 unbox
+        ("- 조치\n", "- [ ] 조치\n"),                         # R6 checkbox
+        ("## 9. 보안\n", "## 3. 보안\n"),                     # R4 renumber
+        ("## 9. 실무 체크리스트\n", "## 실무 체크리스트\n"),  # R5 unnumber
+        ("## 9. 보안\n", "#### 9. 보안\n"),                   # R5-then-R1 demote
+    ],
+)
+def test_intended_rule_effects_do_not_trip_the_invariant(orig, new):
+    assert lossless_tokens(_FM + orig) == lossless_tokens(_FM + new)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "### 9.1 항목\n",       # item sub-number is not the heading number slot
+        "발행 2026 년\n",       # prose number
+        "| 건수 | 12 |\n",      # table number
+    ],
+)
+def test_unchanged_content_never_trips_the_invariant(line):
+    assert lossless_tokens(_FM + line) == lossless_tokens(_FM + line)
+
+
+def test_invariant_backstops_an_r0_regression(monkeypatch, tmp_path, capsys):
+    """If fence protection regresses, the invariant must ABORT — not write.
+
+    This is the PR #500 defect replayed: with R0 disabled, R1 demotes the bash
+    comment inside the fence. Before the tightening the multiset still matched
+    and the file was written corrupted.
+    """
+    import restore_digest_structure as mod
+
+    post = tmp_path / "2026-08-06-Tech_Blog_Weekly_Digest_x.md"
+    post.write_text(
+        _FM
+        + "## 1. 보안\n\n### 1.1 기사\n\n```bash\n# 예시 주석\necho hi\n```\n\n"
+        "## 실무 체크리스트\n\n- [ ] 조치\n",
+        encoding="utf-8",
+    )
+    original = post.read_text(encoding="utf-8")
+
+    monkeypatch.setattr(mod, "_fence_flags", lambda lines: [False] * len(lines))
+    rc = mod.main([str(post)])
+
+    assert rc == 1, "a fence-interior marker rewrite must abort"
+    assert "lossless invariant violated" in capsys.readouterr().err
+    assert post.read_text(encoding="utf-8") == original, "must not write on abort"
+
+
+def test_audit_fence_flags_agree_with_rule_flags():
+    """The two detectors are separate on purpose — they must not DRIFT.
+
+    Disagreement would abort real posts (false positive), so this pins them to
+    the corpus while keeping the audit independent of `_fence_flags` edits.
+    """
+    import pathlib
+
+    import restore_digest_structure as mod
+
+    repo = pathlib.Path(__file__).resolve().parent.parent.parent
+    disagreeing = []
+    for p in sorted((repo / "_posts").glob("*Weekly_Digest*.md")):
+        lines = p.read_text(encoding="utf-8").split("\n")
+        if mod._audit_fence_flags(lines) != mod._fence_flags(lines):
+            disagreeing.append(p.name)
+    assert disagreeing == [], disagreeing
+
+
+def test_corpus_transform_stays_lossless_under_the_tightened_invariant():
+    """Every digest must still pass — the tightening must not abort real posts."""
+    import pathlib
+
+    repo = pathlib.Path(__file__).resolve().parent.parent.parent
+    offenders = []
+    for p in sorted((repo / "_posts").glob("*Weekly_Digest*.md")):
+        t = p.read_text(encoding="utf-8")
+        if lossless_tokens(t) != lossless_tokens(transform(t)):
+            offenders.append(p.name)
+    assert offenders == [], offenders
 
 
 def test_r1_and_r2_are_order_independent():


### PR DESCRIPTION
## 문제

`restore_digest_structure.lossless_tokens` 는 "모든 마커를 지우고 남은 토큰을 센다"는 방식이라 **마커에 눈이 멀어** 있었습니다. 실측으로 재현된 false negative 3종:

| # | 케이스 | 변경 전 |
|---|---|---|
| FN1 | 펜스 내부 `# 예시` → `#### 예시` | **통과** (PR #500이 수작업으로 찾아낸 바로 그 손상) |
| FN2 | 펜스 내부 `- item` → `- [ ] item` | **통과** |
| FN3 | 표 셀의 단독 숫자 `3` 삭제 | **통과** (`_NUMERIC_RE` 가 전역 제외) |

R0 펜스 보호가 규칙 쪽을 막아주긴 했지만, **불변식 자체는 백스톱 역할을 전혀 못 하고 있었습니다.** 오탐(false positive)은 0건이었습니다.

## 변경

마커와 숫자를 "바뀌어도 되는 자리"와 "그러면 안 되는 자리"로 구분합니다:

- **front matter** — 어떤 규칙도 손대지 않음 → 라인 단위 verbatim 비교
- **펜스 내부** (R0 verbatim 영역) → 마커 포함 라인 verbatim 비교
- **펜스 외부** — 마커는 소거(R1/R2/R3/R6이 의도적으로 바꿈), 숫자 토큰은 **제목의 선두 `N.` 슬롯일 때만** 제외 (R4/R5가 소유한 유일한 숫자). 산문·표·`### 9.1` 항목 번호는 이제 모두 보존 대상.

### `_audit_fence_flags` 를 왜 따로 두는가

처음엔 `_fence_flags` 를 재사용했는데, R0 회귀 재현 테스트가 **통과하지 못했습니다** — 규칙과 감사가 같은 판정기를 공유하면 펜스 *탐지*가 회귀할 때 양쪽이 함께 움직여 불변식이 **구조적으로** 눈이 멉니다. 실제로 `_fence_flags` 를 무력화한 상태에서 기존 구현은 손상된 파일을 그대로 썼습니다.

그래서 감사용 판정기를 별도 정의하고, 두 판정기의 드리프트는 코퍼스 대조 테스트로 고정했습니다.

## 검증

```
FN1 fence # -> ####                      caught=True
FN2 fence - x -> - [ ] x                 caught=True
FN3 table number deleted                 caught=True

R1 demote                                caught=False   ← 의도된 효과
R4 renumber                              caught=False
R5 unnumber                              caught=False
R5+R1 demote                             caught=False
```

- **R0 회귀 백스톱 테스트** — `_fence_flags` 를 무력화하면 `rc=1` + `lossless invariant violated` + **파일 미기록** 확인
- **코퍼스** 184건 transform 무손실 유지, dry-run abort 0건
- `pytest scripts/tests/` — **3111 passed, 5 skipped** (신규 17건)

`transform()` 과 R0~R6 규칙 본문은 미변경 — diff는 `lossless_tokens` + 신규 감사 판정기 + 테스트로 한정됩니다.

## 검증 명령

```bash
python3 -m pytest scripts/tests/test_restore_digest_structure.py -q
python3 scripts/restore_digest_structure.py --posts-glob '_posts/*Weekly_Digest*.md' --dry-run
```