### PR TITLE
test(digest): 체크박스 배치 불변식 가드 — 스코어러 스코프 분리는 실측상 no-op

### DIFF
--- a/scripts/tests/test_check_digest_structure.py
+++ b/scripts/tests/test_check_digest_structure.py
@@ -1,4 +1,6 @@
+import re
 import sys, os, tempfile
+from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import pytest
 import check_digest_structure as cds
@@ -238,3 +240,83 @@ def test_ratchet_requires_a_diff_scoped_mode(monkeypatch, capsys):
 
 def test_check_text_and_check_post_agree():
     assert cds.check_text(_BAD_H1) == check_post(_write(_BAD_H1))
+
+
+# --- scorer/gate agreement invariant ----------------------------------------
+#
+# validate_post_quality.validate_checklists scores the DOCUMENT-WIDE '- [ ]'
+# count, while this gate wants per-item checkboxes gone and only the global
+# '## 실무 체크리스트' boxed (R3 removes, R6 restores). Those two only agree so
+# long as every checkbox in a digest lives under the global heading — which is
+# what R3+R6 converged the corpus on (measured 2026-08-06: doc-wide == section
+# count for all 185 digests, and no checkbox hides inside a code fence).
+#
+# Pinning that equality is what makes "scope the scorer to the global section"
+# unnecessary: scoping is a provable no-op while this holds, and it would zero
+# the 66 non-digest posts that legitimately checklist under other headings.
+# The day this fails, the scorer and the gate have started disagreeing again.
+
+
+def _fence_stripped(text: str) -> str:
+    out, in_fence = [], False
+    for line in text.split("\n"):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _global_checklist_section(clean_body: str) -> str:
+    m = re.search(r"^## 실무 체크리스트[ \t]*$", clean_body, re.MULTILINE)
+    if not m:
+        return ""
+    rest = clean_body[m.end():]
+    nxt = re.search(r"^## ", rest, re.MULTILINE)
+    return rest[: nxt.start()] if nxt else rest
+
+
+def test_every_digest_checkbox_lives_under_the_global_checklist():
+    repo = Path(__file__).resolve().parent.parent.parent
+    offenders = {}
+    for p in sorted((repo / "_posts").glob("*Weekly_Digest*.md")):
+        clean = _fence_stripped(p.read_text(encoding="utf-8"))
+        doc_wide = len(re.findall(r"- \[ \]", clean))
+        in_section = len(re.findall(r"- \[ \]", _global_checklist_section(clean)))
+        if doc_wide != in_section:
+            offenders[p.name] = f"doc-wide={doc_wide} in-section={in_section}"
+    assert offenders == {}, offenders
+
+
+def test_fenced_checkboxes_do_not_inflate_any_digest_score():
+    """A '- [ ]' inside a code fence would score but is not a real checklist."""
+    repo = Path(__file__).resolve().parent.parent.parent
+    offenders = {}
+    for p in sorted((repo / "_posts").glob("*Weekly_Digest*.md")):
+        raw = p.read_text(encoding="utf-8")
+        if len(re.findall(r"- \[ \]", raw)) != len(
+            re.findall(r"- \[ \]", _fence_stripped(raw))
+        ):
+            offenders[p.name] = "fenced checkbox inflates the document-wide count"
+    assert offenders == {}, offenders
+
+
+def test_placement_helpers_actually_detect_a_violation():
+    """Proof the two corpus guards above are not vacuously green."""
+    item_box = (
+        "## 1. 보안\n\n### 1.1 기사\n\n- [ ] 항목별 조치\n\n"
+        "## 실무 체크리스트\n\n- [ ] 전역 조치\n"
+    )
+    clean = _fence_stripped(item_box)
+    assert len(re.findall(r"- \[ \]", clean)) == 2
+    assert len(re.findall(r"- \[ \]", _global_checklist_section(clean))) == 1
+
+    trailing_box = "## 실무 체크리스트\n\n- [ ] 전역\n\n## 참고 자료\n\n- [ ] 나중 항목\n"
+    clean = _fence_stripped(trailing_box)
+    assert len(re.findall(r"- \[ \]", clean)) == 2
+    assert len(re.findall(r"- \[ \]", _global_checklist_section(clean))) == 1
+
+    fenced = "## 실무 체크리스트\n\n- [ ] 전역\n\n```markdown\n- [ ] 예시\n```\n"
+    assert len(re.findall(r"- \[ \]", fenced)) == 2
+    assert len(re.findall(r"- \[ \]", _fence_stripped(fenced))) == 1


### PR DESCRIPTION
## 요약: 착수 전제가 실측으로 반증됐습니다

계획은 *"`validate_checklists` 를 전역 `## 실무 체크리스트` 하위로 한정해 baseline 갱신 31건의 근본 원인을 제거한다"* 였습니다. 코드를 고치기 전에 측정한 결과 **두 가지 전제가 모두 틀렸습니다.**

### 반증 1 — 스코프 한정은 다이제스트에 대해 증명 가능한 no-op

`_posts` 전체 257개 측정 (2026-08-06):

| 대상 | n | 결과 |
|---|---|---|
| 다이제스트 | 185 | 문서 전역 `- [ ]` 개수 **== 전역 섹션 개수** (185/185, 예외 0) |
| 다이제스트 | 185 | 코드펜스에 숨은 체크박스 **0건** |
| 비-다이제스트 | 66 | 전역 `## 실무 체크리스트` 섹션 **없음** → 스코프 한정 시 `checklists` 10 → **0** |

즉 스코프를 한정해도 다이제스트 점수는 **한 건도 변하지 않고**, 대신 비-다이제스트 66개가 회귀합니다. (점수뿐 아니라 **원시 개수**까지 동일해서, 상한 10점에 가려진 동률이 아닙니다.)

### 반증 2 — baseline 31건은 회귀가 아니라 상승이었다

`21ddeea3` 의 baseline diff 실제 내용:

```
-      "checklists": 0,
+      "checklists": 10,
-    "total": 80,
+    "total": 90,
```

R6이 레거시 평문 불릿을 `- [ ]` 로 수렴시켜 점수가 **오른** 것입니다. 스코프 충돌이 아니라 정상적인 점수 상승이고, regen이 정답이었습니다.

## 그래서 무엇을 했나

스코어러는 **건드리지 않았습니다.** 대신 원래 의도(두 게이트가 어긋나지 않게)를 실행 가능한 불변식으로 고정했습니다:

- `test_every_digest_checkbox_lives_under_the_global_checklist` — 다이제스트의 모든 체크박스가 전역 섹션 안에 있음
- `test_fenced_checkboxes_do_not_inflate_any_digest_score` — 펜스 내부 `- [ ]` 가 점수를 부풀리지 않음
- `test_placement_helpers_actually_detect_a_violation` — 항목별 / 후행 섹션 / 펜스 3종 **합성 위반**으로 가드의 탐지력 증명 (항상 통과하는 무의미한 테스트가 아님을 보장)

이 등식이 유지되는 한 스코프 한정은 불필요하고, **깨지는 순간이 스코어러와 구조 게이트가 다시 어긋나기 시작한 시점**입니다.

## 검증

`pytest scripts/tests/` — **3115 passed, 5 skipped**

프로덕션 코드는 미변경 — diff는 테스트 파일 하나입니다.