### PR TITLE
fix(news): 뉴스 카드 요약 맹목 절단 → 문장 경계 인식 절단

### DIFF
--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -2904,7 +2904,12 @@ def generate_news_section(
             clean_image = image.split("?")[0] if "?" in image else image
             card_parts.append('  image="%s"' % _sanitize_liquid_param(clean_image))
         if ko_summary:
-            card_summary = _sanitize_liquid_param(ko_summary[:200])
+            # Boundary-aware, NOT ko_summary[:200]: the raw slice cut readers off
+            # mid-word ("…지원하는 방식으로 확") on 128 of 1,756 corpus cards, whose
+            # lengths cluster exactly on the cap. _korean_brief_summary already
+            # boundary-cuts at 220, so a blind 200 re-cut undid that work; the
+            # excerpt and table-summary paths have always used this helper.
+            card_summary = _sanitize_liquid_param(_truncate_korean_sentence(ko_summary, 200))
             card_parts.append('  summary="%s"' % card_summary)
         card_parts.append('  source="%s"' % _sanitize_liquid_param(source))
         card_parts.append('  severity="%s"' % severity)

--- a/scripts/tests/test_content_generator_card_summary.py
+++ b/scripts/tests/test_content_generator_card_summary.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Regression tests for the news-card ``summary`` truncation contract.
+
+Background — corpus audit 2026-08-06:
+128 of 1,756 emitted news cards ended mid-sentence, and their lengths cluster
+exactly on the cap (``len == 200`` x93, ``199`` x24). Root cause:
+``generate_news_section`` sliced with a raw ``ko_summary[:200]`` while the very
+same module already owns a boundary-aware truncator
+(``_truncate_korean_sentence``) that the excerpt and table-summary paths use.
+The card was the one place cutting blind, so readers got fragments like
+"…지원하는 방식으로 확".
+
+These tests assert the contract at the *generation* boundary, so a future edit
+cannot reintroduce a blind slice.
+"""
+
+from __future__ import annotations
+
+import itertools
+import re
+
+from scripts.news.content_generator import generate_news_section
+
+_CAP = 200
+_SENTENCE_END = ("다.", "요.", ".", "!", "?")
+
+
+_seq = itertools.count()
+
+
+def _build_item(*, title: str = "x", summary: str = "y", **overrides):
+    # KOREAN_SUMMARY_CACHE is keyed by id/url/title, and it is module-global —
+    # a shared URL makes one test return another test's summary.
+    uniq = next(_seq)
+    item = {
+        "title_ko": title,
+        "title": title,
+        "summary_ko": summary,
+        "summary": summary,
+        "url": f"https://example.com/post-{uniq}",
+        "source_name": "Example",
+        "category": "tech",
+        "image": "https://example.com/post.jpg",
+        "content": "x" * 800,
+    }
+    item.update(overrides)
+    return item
+
+
+def _card_summary(section: str) -> str:
+    m = re.search(r'\n\s*summary="(.*?)"\n', section, re.DOTALL)
+    assert m, f"no summary attribute emitted; section was:\n{section[:400]}"
+    return m.group(1)
+
+
+# _korean_brief_summary keeps the FIRST TWO sentences and only boundary-cuts
+# above 220 chars, so the fixture must make those two sentences exceed the 200
+# cap — that is the shape that reaches the blind slice and produced the 128
+# corpus defects.
+_LONG = (
+    "상업용 PhaaS 툴킷인 Greatness가 OAuth 2.0 Device Authorization Grant를 "
+    "악용하는 device code phishing 기능을 추가하여 다단계 인증을 우회하고 사용자 "
+    "계정을 탈취하는 최신 범죄웨어로 부상했으며 여러 산업군에서 피해가 확인되고 "
+    "있습니다. 방어 측은 조건부 액세스 정책과 디바이스 준수 상태를 함께 점검해야 "
+    "합니다."
+)
+
+
+def test_long_summary_is_not_cut_mid_sentence():
+    assert len(_LONG) > _CAP, "fixture must exceed the cap to exercise truncation"
+    summary = _card_summary(generate_news_section(_build_item(summary=_LONG), "1.1"))
+    assert summary.endswith(_SENTENCE_END), (
+        f"card summary must end on a sentence boundary, got: …{summary[-40:]!r}. "
+        "Use _truncate_korean_sentence, not a raw slice."
+    )
+
+
+def test_long_summary_does_not_land_exactly_on_the_cap():
+    """A raw slice makes len == cap; a boundary-aware cut essentially never does."""
+    summary = _card_summary(generate_news_section(_build_item(summary=_LONG), "1.1"))
+    assert len(summary) != _CAP, (
+        "length identical to the cap is the fingerprint of a blind slice "
+        f"({_CAP} chars); expected a sentence-boundary cut."
+    )
+
+
+def test_short_summary_is_not_truncated():
+    """Below the cap, the text must reach the card intact.
+
+    `_korean_brief_summary` strips the trailing period of every Korean-path
+    summary (`.strip(" .")`), so the passthrough form is period-less. That is a
+    separate pre-existing behaviour and NOT what this fix changes — asserting
+    the substring keeps this test honest about the truncation contract only.
+    """
+    short = "짧은 요약입니다."
+    summary = _card_summary(generate_news_section(_build_item(summary=short), "1.1"))
+    assert summary.rstrip(".") == short.rstrip(".")
+    assert len(summary) < _CAP
+
+
+def test_truncated_summary_is_a_prefix_of_the_original():
+    """Truncation may only drop a tail — it must never rewrite earlier text."""
+    summary = _card_summary(generate_news_section(_build_item(summary=_LONG), "1.1"))
+    head = summary.rstrip("…")
+    # The boundary helper may append a closing clause when no sentence end is
+    # reachable; the leading run must still match the source verbatim.
+    common = 0
+    for a, b in zip(head, _LONG):
+        if a != b:
+            break
+        common += 1
+    assert common >= 100, (
+        f"only {common} leading chars match the source summary — truncation must "
+        "not paraphrase or reorder the original text."
+    )
+
+
+def test_summary_stays_within_a_sane_bound():
+    """Boundary-aware cutting may overshoot slightly, but not without limit."""
+    summary = _card_summary(generate_news_section(_build_item(summary=_LONG), "1.1"))
+    assert len(summary) <= _CAP + 20, f"summary grew to {len(summary)} chars"


### PR DESCRIPTION
## 문제

코퍼스 감사(2026-08-06) 결과, 다이제스트 185개의 뉴스 카드 **1,756개 중 128개가 문장 중간에서 끊깁니다.** 길이가 캡에 정확히 몰려 있어 하드 절단임이 분명합니다:

| summary 길이 | 건수 |
|---|---|
| 200 | 93 |
| 199 | 24 |
| 202~204 | 8 |

독자에게는 `…지원하는 방식으로 확` 같은 파편이 노출됩니다.

## 근본 원인

`generate_news_section` 이 `ko_summary[:200]` 으로 **맹목 슬라이스**합니다 (`scripts/news/content_generator.py:2907`).

같은 모듈에 이미 문장 경계 인식 절단기 `_truncate_korean_sentence` 가 있고 excerpt(`:637`)와 `_table_summary`(`:2984`) 경로는 그것을 씁니다. **뉴스 카드만 빠져 있었습니다.**

게다가 `_korean_brief_summary` 는 220자에서 경계 인식으로 자르므로, 뒤이은 200자 맹목 재절단이 그 작업을 되돌리고 있었습니다.

## 실측

실제 다이제스트 본문 문단 90개(240~900자) 대상:

```
[:200] 맹목 슬라이스        → 문장 종결  2/90 (2%)
_truncate_korean_sentence  → 문장 종결 90/90 (100%)
```

샘플:

```
BEFORE(200): … 캠페인에서는 **악성 페이로드를 메모리에서 직접 실행하는 파일리스(filele
AFTER (108): …n을 배포하는 전용 드로퍼(dropper)** 역할에 특화된 점이 특징적입니다.
```

## 회귀 테스트 5건 (생성 경계에서 검증)

- 문장 중간 절단 금지
- **길이가 캡과 정확히 일치하지 않을 것** — 맹목 슬라이스의 지문
- 캡 미만 요약은 무절단
- 절단 결과는 원문의 접두사여야 함 (패러프레이즈·재배열 금지)
- 상한 이탈 금지

### TDD 과정에서 드러난 함정 2가지 (픽스처에 반영)

1. `KOREAN_SUMMARY_CACHE` 는 url/title 키의 **모듈 전역 캐시**라, 테스트 간 URL을 공유하면 다른 테스트의 요약이 반환됩니다 → 항목별 고유 URL
2. `_korean_brief_summary` 는 **첫 2문장만** 취하고 220자 초과일 때만 자릅니다 → 픽스처는 "첫 2문장 합이 200자 초과"여야 절단 경로에 도달합니다 (첫 시도는 이걸 놓쳐 RED가 재현되지 않았습니다)

## 범위

생성기 **1곳만** 수정했습니다. 승인 범위 밖이라 손대지 않은 것:

- 기존 128건 백필 (잘린 뒷부분은 원문이 없어 복원 불가)
- 참고자료 표 맞춤화 (151개 다이제스트가 동일한 3행 표)
- 비서술 앵커·맨 URL 정리
- 제목 에코 30건 / 헤드라인형 단편 25건 재요약

### 부수 관찰 (미수정)

`_korean_brief_summary` 의 `.strip(" .")` 가 **모든** 한국어 경로 요약의 마침표를 떼어냅니다. 헤드라인형 단편 25건의 일부 원인으로 보이나 별개 결함이라 이번 범위에서 제외했습니다.

## 검증

`pytest scripts/tests/` — **3117 passed, 5 skipped**