### PR TITLE
feat(digest): 참고자료 표에 용도 열 + 실제 인용 출처 추가 (파일럿 5개)

### DIFF
--- a/_posts/2026-08-02-Tech_Security_Weekly_Digest_Bitcoin_AI_Update_Malware.md
+++ b/_posts/2026-08-02-Tech_Security_Weekly_Digest_Bitcoin_AI_Update_Malware.md
@@ -288,11 +288,13 @@ mitre_attack:
 - [ ] 암호화폐/블록체인 관련 컴플라이언스 점검
 ## 참고 자료
 
-| 리소스 | 링크 |
-|--------|------|
-| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |
-| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |
-| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |
+| 리소스 | 링크 | 용도 |
+|--------|------|------|
+| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
+| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
+| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) | 취약점 악용 확률 점수 — CVSS 보완 |
+| The Hacker News | [thehackernews.com](https://thehackernews.com) | 본문 3건 인용 |
+| Cointelegraph | [cointelegraph.com](https://cointelegraph.com) | 본문 3건 인용 |
 
 ---
 

--- a/_posts/2026-08-03-Tech_Security_Weekly_Digest_AI_Bitcoin_Go_Agent.md
+++ b/_posts/2026-08-03-Tech_Security_Weekly_Digest_AI_Bitcoin_Go_Agent.md
@@ -253,11 +253,13 @@ Bitcoin 사용자들이 Coldcard 해킹 사태 속에서 39,600 BTC를 소액 �
 - [ ] 암호화폐/블록체인 관련 컴플라이언스 점검
 ## 참고 자료
 
-| 리소스 | 링크 |
-|--------|------|
-| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |
-| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |
-| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |
+| 리소스 | 링크 | 용도 |
+|--------|------|------|
+| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
+| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
+| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) | 취약점 악용 확률 점수 — CVSS 보완 |
+| BleepingComputer | [bleepingcomputer.com](https://www.bleepingcomputer.com) | 본문 3건 인용 |
+| Cointelegraph | [cointelegraph.com](https://cointelegraph.com) | 본문 3건 인용 |
 
 ---
 

--- a/_posts/2026-08-04-Tech_Security_Weekly_Digest_Malware_Go_AWS_Ransomware.md
+++ b/_posts/2026-08-04-Tech_Security_Weekly_Digest_Malware_Go_AWS_Ransomware.md
@@ -449,11 +449,18 @@ Bitcoin 재무 전략 기업의 CEO가 "우리는 이 약세장을 극복할 것
 - [ ] 클라우드 인프라 보안 설정 정기 감사
 ## 참고 자료
 
-| 리소스 | 링크 |
-|--------|------|
-| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |
-| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |
-| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |
+| 리소스 | 링크 | 용도 |
+|--------|------|------|
+| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
+| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
+| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) | 취약점 악용 확률 점수 — CVSS 보완 |
+| The Hacker News | [thehackernews.com](https://thehackernews.com) | 본문 3건 인용 |
+| Meta Engineering Blog | [engineering.fb.com](https://engineering.fb.com) | 본문 1건 인용 |
+| OpenAI Blog | [openai.com](https://openai.com) | 본문 1건 인용 |
+| AWS Machine Learning Blog | [aws.amazon.com](https://aws.amazon.com) | 본문 1건 인용 |
+| Google Cloud Blog | [cloud.google.com](https://cloud.google.com) | 본문 3건 인용 |
+| GitHub Changelog | [github.blog](https://github.blog) | 본문 3건 인용 |
+| Bitcoin Magazine | [bitcoinmagazine.com](https://bitcoinmagazine.com) | 본문 3건 인용 |
 
 ---
 

--- a/_posts/2026-08-05-Tech_Security_Weekly_Digest_AI_Agent_Update.md
+++ b/_posts/2026-08-05-Tech_Security_Weekly_Digest_AI_Agent_Update.md
@@ -440,11 +440,20 @@ SEC 위원 Hester ‘Crypto Mom’ Peirce가 오랫동안 기다려온 암호화
 - [ ] 클라우드 인프라 보안 설정 정기 감사
 ## 참고 자료
 
-| 리소스 | 링크 |
-|--------|------|
-| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |
-| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |
-| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |
+| 리소스 | 링크 | 용도 |
+|--------|------|------|
+| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
+| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
+| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) | 취약점 악용 확률 점수 — CVSS 보완 |
+| Microsoft Security Blog | [microsoft.com](https://www.microsoft.com) | 본문 1건 인용 |
+| The Hacker News | [thehackernews.com](https://thehackernews.com) | 본문 1건 인용 |
+| BleepingComputer | [bleepingcomputer.com](https://www.bleepingcomputer.com) | 본문 1건 인용 |
+| OpenAI Blog | [openai.com](https://openai.com) | 본문 1건 인용 |
+| NVIDIA AI Blog | [blogs.nvidia.com](https://blogs.nvidia.com) | 본문 2건 인용 |
+| Google Cloud Blog | [cloud.google.com](https://cloud.google.com) | 본문 3건 인용 |
+| GitHub Changelog | [github.blog](https://github.blog) | 본문 2건 인용 |
+| GitHub Engineering Blog | [github.blog](https://github.blog) | 본문 1건 인용 |
+| Bitcoin Magazine | [bitcoinmagazine.com](https://bitcoinmagazine.com) | 본문 3건 인용 |
 
 ---
 

--- a/_posts/2026-08-06-Tech_Security_Weekly_Digest_AI_Malware_GPT_AWS.md
+++ b/_posts/2026-08-06-Tech_Security_Weekly_Digest_AI_Malware_GPT_AWS.md
@@ -441,11 +441,19 @@ OpenCost 1.121.0이 Kubernetes 환경에서 GPU 기반 모델의 토큰 단위 �
 - [ ] 클라우드 인프라 보안 설정 정기 감사
 ## 참고 자료
 
-| 리소스 | 링크 |
-|--------|------|
-| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |
-| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |
-| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |
+| 리소스 | 링크 | 용도 |
+|--------|------|------|
+| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
+| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
+| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) | 취약점 악용 확률 점수 — CVSS 보완 |
+| The Hacker News | [thehackernews.com](https://thehackernews.com) | 본문 3건 인용 |
+| Meta Engineering Blog | [engineering.fb.com](https://engineering.fb.com) | 본문 1건 인용 |
+| NVIDIA AI Blog | [blogs.nvidia.com](https://blogs.nvidia.com) | 본문 1건 인용 |
+| Cointelegraph | [cointelegraph.com](https://cointelegraph.com) | 본문 1건 인용 |
+| Google Cloud Blog | [cloud.google.com](https://cloud.google.com) | 본문 3건 인용 |
+| Docker Blog | [docker.com](https://www.docker.com) | 본문 1건 인용 |
+| CNCF Blog | [cncf.io](https://www.cncf.io) | 본문 2건 인용 |
+| Bitcoin Magazine | [bitcoinmagazine.com](https://bitcoinmagazine.com) | 본문 3건 인용 |
 
 ---
 

--- a/scripts/enrich_digest_references.py
+++ b/scripts/enrich_digest_references.py
@@ -1,0 +1,207 @@
+"""Give each digest's 참고 자료 table per-post context — without inventing facts.
+
+Corpus audit 2026-08-06: 151 digests carry a byte-identical 3-row table
+(CISA KEV / MITRE ATT&CK / FIRST EPSS) and 174 have no description column, so
+the section says nothing about the post it sits in — while the post's own news
+cards already name every source it actually cited.
+
+This transformer uses only what the post already contains:
+
+* adds a 용도 column with CANONICAL descriptions for the standard resources
+  (4 corpus posts already show the 3-column precedent, header '용도'), and
+* appends the sources the post genuinely cited, with the citation count taken
+  from its own news cards and the link derived from the cited URL's origin.
+
+No LLM, no fetching, no generated prose. A table containing a resource outside
+``RESOURCE_PURPOSE`` keeps its 2-column shape rather than getting an invented
+description — the source rows are still appended.
+
+Usage:
+    python3 scripts/enrich_digest_references.py --posts-glob '_posts/*Weekly_Digest*.md' --dry-run
+    python3 scripts/enrich_digest_references.py _posts/2026-08-05-*.md
+"""
+import argparse
+import glob
+import re
+import sys
+from collections import OrderedDict
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO = Path(__file__).resolve().parent.parent
+
+REFERENCE_HEADING = "## 참고 자료"
+PURPOSE_COLUMN = "용도"
+
+# Canonical purposes. Deliberately deny-by-default: an unmapped resource never
+# receives a made-up description.
+RESOURCE_PURPOSE = {
+    "CISA KEV": "실제 악용 확인된 취약점 목록 — 패치 우선순위 기준",
+    "CISA KEV Catalog": "실제 악용 확인된 취약점 목록 — 패치 우선순위 기준",
+    "CISA KEV (Known Exploited Vulnerabilities)": "실제 악용 확인된 취약점 목록 — 패치 우선순위 기준",
+    "MITRE ATT&CK": "공격 전술·기법 매핑 — 탐지 룰 설계",
+    "FIRST EPSS": "취약점 악용 확률 점수 — CVSS 보완",
+    "OWASP Top 10 for LLM": "LLM 애플리케이션 상위 위험 — AI 서비스 위협 모델링",
+    "OWASP LLM Top 10": "LLM 애플리케이션 상위 위험 — AI 서비스 위협 모델링",
+    "NIST AI RMF": "AI 위험 관리 프레임워크 — 거버넌스 통제 설계",
+}
+
+_CARD_RE = re.compile(r"\{%\s*include\s+news-card\.html(.*?)%\}", re.DOTALL)
+_ROW_RE = re.compile(r"^\|(.*)\|[ \t]*$")
+_SEP_CELL_RE = re.compile(r"^[\s:-]+$")
+
+
+def _attr(card_body: str, key: str):
+    m = re.search(rf'\b{key}="(.*?)"(?=\s+\w+="|\s*$)', card_body, re.DOTALL)
+    return m.group(1) if m else None
+
+
+def origin_of(url: str) -> str:
+    """Scheme + host of a cited article URL (the source's own site)."""
+    parts = urlparse(url)
+    return f"{parts.scheme}://{parts.netloc}" if parts.scheme and parts.netloc else ""
+
+
+def cited_sources(text: str) -> "OrderedDict":
+    """{source name: (origin url, citation count)} in first-appearance order."""
+    found: OrderedDict = OrderedDict()
+    for body in _CARD_RE.findall(text):
+        name, url = _attr(body, "source"), _attr(body, "url")
+        if not name or not url:
+            continue
+        origin = origin_of(url)
+        if not origin:
+            continue
+        if name in found:
+            prev_origin, count = found[name]
+            found[name] = (prev_origin, count + 1)
+        else:
+            found[name] = (origin, 1)
+    return found
+
+
+def _cells(line: str):
+    m = _ROW_RE.match(line)
+    return [c.strip() for c in m.group(1).split("|")] if m else None
+
+
+def _split_reference_section(text: str):
+    """(before, section, after) around the 참고 자료 section, or None."""
+    m = re.search(rf"^{re.escape(REFERENCE_HEADING)}[ \t]*$", text, re.MULTILINE)
+    if not m:
+        return None
+    rest = text[m.end():]
+    nxt = re.search(r"^## ", rest, re.MULTILINE)
+    end = m.end() + (nxt.start() if nxt else len(rest))
+    return text[: m.start()], text[m.start(): end], text[end:]
+
+
+def _rewrite_section(section: str, sources: "OrderedDict") -> str:
+    lines = section.split("\n")
+    header_idx = next(
+        (i for i, ln in enumerate(lines) if _cells(ln) and not all(_SEP_CELL_RE.match(c) for c in _cells(ln))),
+        None,
+    )
+    if header_idx is None:
+        return section
+    header = _cells(lines[header_idx])
+    if len(lines) <= header_idx + 1 or not _cells(lines[header_idx + 1]):
+        return section
+    if not all(_SEP_CELL_RE.match(c) for c in _cells(lines[header_idx + 1])):
+        return section
+
+    body_end = header_idx + 2
+    while body_end < len(lines) and _cells(lines[body_end]):
+        body_end += 1
+    rows = [_cells(ln) for ln in lines[header_idx + 2: body_end]]
+    if not rows:
+        return section
+
+    has_purpose = len(header) >= 3
+    upgrade = not has_purpose and all(r[0] in RESOURCE_PURPOSE for r in rows)
+
+    existing_labels = {r[0] for r in rows}
+    existing_links = {r[1] for r in rows if len(r) > 1}
+    new_rows = []
+    for name, (origin, count) in sources.items():
+        # display label drops a leading www. (matches the corpus convention:
+        # "thehackernews.com", "cisa.gov/…"); the href keeps the real host.
+        host = urlparse(origin).netloc
+        label = host[4:] if host.startswith("www.") else host
+        link = f"[{label}]({origin})"
+        if name in existing_labels or any(link in cell for cell in existing_links):
+            continue
+        new_rows.append([name, link, f"본문 {count}건 인용"])
+
+    if not upgrade and not new_rows:
+        return section
+
+    width = 3 if (has_purpose or upgrade) else 2
+    out_header = header[:width] if len(header) >= width else header + [PURPOSE_COLUMN]
+    rendered = ["| " + " | ".join(out_header) + " |",
+                "|" + "|".join(["-" * 8 if i == 0 else "-" * 6 for i in range(width)]) + "|"]
+    for r in rows:
+        cells = list(r[:width])
+        while len(cells) < width:
+            cells.append(RESOURCE_PURPOSE.get(r[0], ""))
+        rendered.append("| " + " | ".join(cells) + " |")
+    for r in new_rows:
+        rendered.append("| " + " | ".join(r[:width]) + " |")
+
+    return "\n".join(lines[:header_idx] + rendered + lines[body_end:])
+
+
+def transform(text: str) -> str:
+    parts = _split_reference_section(text)
+    if not parts:
+        return text
+    before, section, after = parts
+    return before + _rewrite_section(section, cited_sources(text)) + after
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Add 용도 column + cited sources to 참고 자료.")
+    ap.add_argument("paths", nargs="*")
+    ap.add_argument("--posts-glob")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args(argv)
+
+    files = [Path(p) for p in (args.paths or [])]
+    if args.posts_glob:
+        files += [Path(p) for p in sorted(glob.glob(args.posts_glob))]
+    files = [f for f in files if _is_digest_post(f)]
+    if args.limit:
+        files = files[: args.limit]
+    if not files:
+        print("[enrich-references] no digest post files to process.")
+        return 0
+
+    changed = 0
+    for f in files:
+        original = f.read_text(encoding="utf-8")
+        new = transform(original)
+        if new == original:
+            print(f"OK   {f}")
+            continue
+        # Everything before the section must be byte-identical.
+        if new.split(REFERENCE_HEADING)[0] != original.split(REFERENCE_HEADING)[0]:
+            print(f"ABORT {f}: content outside 참고 자료 changed", file=sys.stderr)
+            return 1
+        changed += 1
+        if args.dry_run:
+            print(f"DRY  {f}")
+        else:
+            f.write_text(new, encoding="utf-8")
+            print(f"FIXED {f}")
+    verb = "would rewrite" if args.dry_run else "rewrote"
+    print(f"[enrich-references] {verb} {changed}/{len(files)} post(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_enrich_digest_references.py
+++ b/scripts/tests/test_enrich_digest_references.py
@@ -1,0 +1,159 @@
+"""Tests for scripts/enrich_digest_references.py.
+
+The 참고 자료 table is identical across 151 digests (CISA KEV / MITRE ATT&CK /
+FIRST EPSS), carrying zero per-post context, and it has no description column
+even though 4 posts already show a 3-column precedent. This transformer adds a
+용도 column with canonical descriptions and appends the sources the post
+ACTUALLY cited, taken from its own news cards — no LLM, no invented facts.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import enrich_digest_references as enr  # noqa: E402
+
+_FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
+
+_TABLE_2COL = (
+    "## 참고 자료\n\n"
+    "| 리소스 | 링크 |\n"
+    "|--------|------|\n"
+    "| CISA KEV | [cisa.gov](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) |\n"
+    "| MITRE ATT&CK | [attack.mitre.org](https://attack.mitre.org/) |\n"
+    "| FIRST EPSS | [first.org/epss](https://www.first.org/epss/) |\n"
+)
+
+
+def _card(source, url):
+    return (
+        "{% include news-card.html\n"
+        '  title="t"\n'
+        f'  url="{url}"\n'
+        '  summary="s"\n'
+        f'  source="{source}"\n'
+        '  severity="High"\n'
+        "%}\n\n"
+    )
+
+
+def _post(cards="", table=_TABLE_2COL, head="## 1. 보안\n\n### 1.1 기사\n\n"):
+    return _FM + head + cards + table
+
+
+# --- column upgrade ----------------------------------------------------------
+
+
+def test_mapped_table_gains_the_용도_column():
+    out = enr.transform(_post())
+    assert "| 리소스 | 링크 | 용도 |" in out
+    assert "|--------|------|------|" in out
+    assert "실제 악용 확인된 취약점 목록" in out
+    assert "공격 전술·기법 매핑" in out
+
+
+def test_unmapped_label_keeps_the_table_two_column():
+    table = _TABLE_2COL + "| Docker 3Cs Framework | [docs.docker.com](https://docs.docker.com/) |\n"
+    out = enr.transform(_post(cards=_card("The Hacker News", "https://thehackernews.com/a"), table=table))
+    assert "| 리소스 | 링크 | 용도 |" not in out
+    # source rows are still appended, in the 2-column shape
+    assert "| The Hacker News | [thehackernews.com](https://thehackernews.com) |\n" in out
+
+
+# --- source rows -------------------------------------------------------------
+
+
+def test_cited_sources_are_appended_with_citation_counts():
+    cards = (
+        _card("Google Cloud Blog", "https://cloud.google.com/blog/a")
+        + _card("The Hacker News", "https://thehackernews.com/x")
+        + _card("Google Cloud Blog", "https://cloud.google.com/blog/b")
+    )
+    out = enr.transform(_post(cards=cards))
+    assert "| Google Cloud Blog | [cloud.google.com](https://cloud.google.com) | 본문 2건 인용 |" in out
+    assert "| The Hacker News | [thehackernews.com](https://thehackernews.com) | 본문 1건 인용 |" in out
+
+
+def test_source_order_follows_first_appearance():
+    cards = _card("B Source", "https://b.example/1") + _card("A Source", "https://a.example/1")
+    out = enr.transform(_post(cards=cards))
+    assert out.index("| B Source |") < out.index("| A Source |")
+
+
+def test_source_already_present_is_not_duplicated():
+    table = _TABLE_2COL + "| The Hacker News | [thehackernews.com](https://thehackernews.com) |\n"
+    out = enr.transform(_post(cards=_card("The Hacker News", "https://thehackernews.com/a"), table=table))
+    # count inside the reference section only — the news card also names the source
+    section = out.split("## 참고 자료")[1]
+    assert section.count("The Hacker News") == 1
+
+
+def test_post_without_cards_is_unchanged_except_the_column():
+    out = enr.transform(_post())
+    assert "본문" not in out
+
+
+# --- safety ------------------------------------------------------------------
+
+
+def test_transform_is_idempotent():
+    once = enr.transform(_post(cards=_card("The Hacker News", "https://thehackernews.com/a")))
+    assert enr.transform(once) == once
+
+
+def test_only_the_reference_section_is_rewritten():
+    src = _post(cards=_card("The Hacker News", "https://thehackernews.com/a"))
+    out = enr.transform(src)
+    assert out.split("## 참고 자료")[0] == src.split("## 참고 자료")[0]
+
+
+def test_post_without_a_reference_section_is_untouched():
+    src = _FM + "## 1. 보안\n\n본문.\n"
+    assert enr.transform(src) == src
+
+
+def test_reference_section_without_a_table_is_untouched():
+    src = _FM + "## 참고 자료\n\n- [링크](https://example.com)\n"
+    assert enr.transform(src) == src
+
+
+def test_trailing_section_after_references_survives():
+    src = _post() + "\n## 🔗 관련 포스트\n\n- 다른 글\n"
+    out = enr.transform(src)
+    assert out.endswith("## 🔗 관련 포스트\n\n- 다른 글\n")
+    assert "| 리소스 | 링크 | 용도 |" in out
+
+
+def test_non_digest_post_is_skipped_by_the_cli(tmp_path, capsys):
+    p = tmp_path / "2026-08-06-Some_Guide.md"
+    p.write_text(_post(), encoding="utf-8")
+    assert enr.main([str(p)]) == 0
+    assert p.read_text(encoding="utf-8") == _post()
+
+
+def test_cli_dry_run_does_not_write(tmp_path):
+    p = tmp_path / "2026-08-06-Tech_Blog_Weekly_Digest_x.md"
+    src = _post(cards=_card("The Hacker News", "https://thehackernews.com/a"))
+    p.write_text(src, encoding="utf-8")
+    assert enr.main([str(p), "--dry-run"]) == 0
+    assert p.read_text(encoding="utf-8") == src
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://www.microsoft.com/en-us/security/blog/x/", "https://www.microsoft.com"),
+        ("https://thehackernews.com/2026/08/a.html", "https://thehackernews.com"),
+        ("http://blogs.nvidia.com/blog/x", "http://blogs.nvidia.com"),
+    ],
+)
+def test_origin_is_derived_from_the_cited_url(url, expected):
+    assert enr.origin_of(url) == expected
+
+
+def test_www_prefix_is_dropped_from_the_display_label_only():
+    out = enr.transform(_post(cards=_card("Docker Blog", "https://www.docker.com/blog/x")))
+    assert "| Docker Blog | [docker.com](https://www.docker.com) | 본문 1건 인용 |" in out


### PR DESCRIPTION
## 문제

코퍼스 감사(2026-08-06):

- **151개 다이제스트가 바이트 동일한 3행 표**를 갖고 있습니다 (CISA KEV / MITRE ATT&CK / FIRST EPSS)
- **174개는 설명 열이 없습니다** (`| 리소스 | 링크 |` 2열)

즉 참고자료 섹션이 자신이 실린 포스트에 대해 아무것도 말하지 않습니다 — 정작 그 포스트의 뉴스 카드에는 **실제 인용한 출처가 전부 적혀 있는데도.**

## 접근: 포스트에 이미 있는 근거만 사용

LLM·외부 호출·생성 산문 **전무**입니다.

1. 표준 리소스에 canonical **용도** 설명 부여 — 3열 선례가 이미 코퍼스에 4건(`용도` 2, `활용 목적` 2) 있습니다
2. 그 포스트가 **실제 인용한 출처**를 인용 건수와 함께 행으로 추가. 링크는 인용 URL의 origin에서 도출, 표시 라벨은 `www.` 제거(코퍼스 관례)

### deny-by-default

`RESOURCE_PURPOSE` 에 없는 리소스가 섞인 표는 **3열로 승격하지 않습니다** — 없는 설명을 지어내느니 2열을 유지하고 출처 행만 덧붙입니다.

- 전 행이 맵에 커버되는 표: **154**
- 미커버 라벨 포함(2열 유지 대상): **15**

## 결과 (2026-08-05 포스트)

```markdown
| 리소스 | 링크 | 용도 |
|--------|------|------|
| CISA KEV | [cisa.gov/known-exploited-vulnerabilities-catalog](...) | 실제 악용 확인된 취약점 목록 — 패치 우선순위 기준 |
| MITRE ATT&CK | [attack.mitre.org](...) | 공격 전술·기법 매핑 — 탐지 룰 설계 |
| FIRST EPSS | [first.org/epss](...) | 취약점 악용 확률 점수 — CVSS 보완 |
| Microsoft Security Blog | [microsoft.com](https://www.microsoft.com) | 본문 1건 인용 |
| Google Cloud Blog | [cloud.google.com](https://cloud.google.com) | 본문 3건 인용 |
| NVIDIA AI Blog | [blogs.nvidia.com](https://blogs.nvidia.com) | 본문 2건 인용 |
```

## 파일럿 5개 실측

| 검증 | 결과 |
|---|---|
| 출처 행 인용 건수 정확성 (셀 단위 교차검증) | 28행 / **불일치 0** |
| 출처 커버리지 누락 | **0건** |
| 구조 게이트 (`check_digest_structure --ratchet`) | 통과 |
| 체크리스트 제목 게이트 | 통과 |
| 고유명사 게이트 | 통과 |
| 미번역 게이트 | 통과 |
| `pytest scripts/tests/` | **3137 passed, 5 skipped** (신규 17건) |

## 안전장치

- 참고자료 섹션 **앞의 본문은 바이트 동일**해야 하며, 아니면 CLI가 `ABORT`
- `transform` 은 **멱등** (재실행 시 행 중복 없음)
- 이미 표에 있는 출처는 라벨/링크 기준으로 중복 추가하지 않음

### 검증 스크립트 자체의 함정 (기록)

표 행을 정규식으로 파싱할 때 non-greedy가 **셀 경계를 넘어** 매칭해 "인용 건수 불일치 5건" 오탐이 났습니다. 셀 분해 후 재검증하니 0건 — 데이터 결함이 아니라 검증기 결함이었습니다.

## 범위

이 PR은 **파일럿 5개**입니다. 나머지 153개(`--dry-run` 기준 158/185가 대상)는 승인 후 별도 PR로 확산합니다.