### PR TITLE
fix(posts): 클릭 불가한 맨 URL 102건 링크화 (8개 포스트)

### DIFF
--- a/_posts/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.md
+++ b/_posts/2025-04-30-Public_PCEven_in_Safely_Passkey_OTP_Strong_Password_Management_Usage.md
@@ -564,16 +564,16 @@ AI 피싱 공격 특징:
 ### 6.4 추가 읽을거리
 
 1. "Bypassing MFA: A Deep Dive" (2024) - SANS Institute
-   - https://www.sans.org/white-papers/bypassing-mfa/
+   - [sans.org/white-papers/bypassing-mfa](https://www.sans.org/white-papers/bypassing-mfa/)
 
 2. "The State of Passkeys 2025" - FIDO Alliance
-   - https://fidoalliance.org/state-of-passkeys-2025/
+   - [fidoalliance.org/state-of-passkeys-2025](https://fidoalliance.org/state-of-passkeys-2025/)
 
 3. "SIM Swapping: The $68M Problem" (2024) - Krebs on Security
-   - https://krebsonsecurity.com/2024/08/sim-swapping-the-68m-problem/
+   - [krebsonsecurity.com](https://krebsonsecurity.com/2024/08/sim-swapping-the-68m-problem/)
 
 4. "AI Phishing Attacks Surge 93%" (2025) - Verizon DBIR
-   - https://www.verizon.com/business/resources/reports/dbir/
+   - [verizon.com/business/resources/reports/dbir](https://www.verizon.com/business/resources/reports/dbir/)
 
 ## 결론
 

--- a/_posts/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding.md
+++ b/_posts/2025-05-30-Cloud_Security_Course_7Batch_-_7Week_Docker_And_Kubernetes_Understanding.md
@@ -439,9 +439,9 @@ cat /var/log/falco/events.txt | \
 - Pod 상태, Network Policy, ImagePullBackOff 이벤트를 순서대로 확인
 
 <!-- Full troubleshooting commands were intentionally omitted for readability. Reference:
-https://kubernetes.io/docs/tasks/debug/
-https://kubernetes.io/docs/concepts/services-networking/network-policies/
-https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+[kubernetes.io/docs/tasks/debug](https://kubernetes.io/docs/tasks/debug/)
+[kubernetes.io](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+[kubernetes.io](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
 -->
 
 
@@ -451,12 +451,12 @@ https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-regi
 
 | 리소스 | URL | 설명 |
 |--------|-----|------|
-| Kubernetes 공식 문서 | https://kubernetes.io/docs/ | K8s 전체 레퍼런스 |
-| Docker 공식 문서 | https://docs.docker.com/ | Docker 엔진 및 Compose |
-| CIS Kubernetes Benchmark | https://www.cisecurity.org/benchmark/kubernetes | 보안 베스트 프랙티스 |
-| OWASP Kubernetes Top 10 | https://owasp.org/www-project-kubernetes-top-ten/ | 주요 보안 위협 |
-| Falco 문서 | https://falco.org/docs/ | 런타임 보안 |
-| Trivy 문서 | https://aquasecurity.github.io/trivy/ | 이미지 스캔 |
+| Kubernetes 공식 문서 | [kubernetes.io/docs](https://kubernetes.io/docs/) | K8s 전체 레퍼런스 |
+| Docker 공식 문서 | [docs.docker.com](https://docs.docker.com/) | Docker 엔진 및 Compose |
+| CIS Kubernetes Benchmark | [cisecurity.org/benchmark/kubernetes](https://www.cisecurity.org/benchmark/kubernetes) | 보안 베스트 프랙티스 |
+| OWASP Kubernetes Top 10 | [owasp.org/www-project-kubernetes-top-ten](https://owasp.org/www-project-kubernetes-top-ten/) | 주요 보안 위협 |
+| Falco 문서 | [falco.org/docs](https://falco.org/docs/) | 런타임 보안 |
+| Trivy 문서 | [aquasecurity.github.io/trivy](https://aquasecurity.github.io/trivy/) | 이미지 스캔 |
 
 ### 4.2 보안 도구
 
@@ -489,9 +489,9 @@ https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-regi
 
 #### 커뮤니티
 
-- **Kubernetes Slack**: https://slack.k8s.io/
-- **CNCF Slack - #falco**: https://cloud-native.slack.com/
-- **Reddit - r/kubernetes**: https://www.reddit.com/r/kubernetes/
+- **Kubernetes Slack**: [slack.k8s.io](https://slack.k8s.io/)
+- **CNCF Slack - #falco**: [cloud-native.slack.com](https://cloud-native.slack.com/)
+- **Reddit - r/kubernetes**: [reddit.com/r/kubernetes](https://www.reddit.com/r/kubernetes/)
 
 ### 4.4 인증 자격증 가이드
 

--- a/_posts/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.md
+++ b/_posts/2025-06-05-Email_Delivery_Trust_Improve_SendGrid_SPF_DKIM_DMARC_Setup_Complete_Guide.md
@@ -338,8 +338,8 @@ TTL: 3600
 
 다음 도구들을 사용하여 설정을 검증할 수 있습니다:
 
-- MXToolbox: https://mxtoolbox.com/spf.aspx
-- DMARC Analyzer: https://www.dmarcanalyzer.com/
+- MXToolbox: [mxtoolbox.com/spf.aspx](https://mxtoolbox.com/spf.aspx)
+- DMARC Analyzer: [dmarcanalyzer.com](https://www.dmarcanalyzer.com/)
 - Google Postmaster Tools: Gmail 전달률 확인
 
 ### 7.2 명령줄 도구

--- a/_posts/2025-09-17-NPM_Shai-Hulud_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis.md
+++ b/_posts/2025-09-17-NPM_Shai-Hulud_Self_Replication_Worm_Attack_180_Above_Package_Breach_Large_scale_Supply_Chain_Attack_Complete_Analysis.md
@@ -337,88 +337,88 @@ npm token create --read-only --cidr=10.0.0.0/8
 
 1. CISA (Cybersecurity & Infrastructure Security Agency)
    - NPM Supply Chain Attack Advisory (2025-11)
-   - URL: https://www.cisa.gov/news-events/alerts/2025/11/15/npm-supply-chain-attack
+   - URL: [cisa.gov](https://www.cisa.gov/news-events/alerts/2025/11/15/npm-supply-chain-attack)
 
 2. NIST (National Institute of Standards and Technology)
    - NIST SP 800-161 Rev. 1: Cybersecurity Supply Chain Risk Management
-   - URL: https://csrc.nist.gov/publications/detail/sp/800-161/rev-1/final
+   - URL: [csrc.nist.gov](https://csrc.nist.gov/publications/detail/sp/800-161/rev-1/final)
 
 3. NPM Security Team
    - NPM Security Best Practices
-   - URL: https://docs.npmjs.com/security
+   - URL: [docs.npmjs.com/security](https://docs.npmjs.com/security)
 
 4. MITRE ATT&CK Framework
    - T1195: Supply Chain Compromise
-   - URL: https://attack.mitre.org/techniques/T1195/
+   - URL: [attack.mitre.org/techniques/T1195](https://attack.mitre.org/techniques/T1195/)
 
 ### 3.2 기술 분석 리포트
 
 5. GitLab Vulnerability Research Team
    - Shai-Hulud Technical Analysis (2025-09)
-   - URL: https://about.gitlab.com/blog/2025/09/17/npm-shai-hulud-analysis/
+   - URL: [about.gitlab.com](https://about.gitlab.com/blog/2025/09/17/npm-shai-hulud-analysis/)
 
 6. Socket.dev Research
    - NPM 자가 복제 웜의 부상 (The Rise of Self-Replicating Worms in NPM)
-   - URL: https://socket.dev/blog/shai-hulud-worm-analysis
+   - URL: [socket.dev/blog/shai-hulud-worm-analysis](https://socket.dev/blog/shai-hulud-worm-analysis)
 
 7. Snyk Research
    - NPM 생태계 보안 리포트 2025 (NPM Ecosystem Security Report 2025)
-   - URL: https://snyk.io/reports/npm-ecosystem-security-2025/
+   - URL: [snyk.io/reports/npm-ecosystem-security-2025](https://snyk.io/reports/npm-ecosystem-security-2025/)
 
 8. Aqua Security
    - 공급망 공격의 Dead Man's Switch (Dead Man's Switch in Supply Chain Attacks)
-   - URL: https://blog.aquasec.com/dead-mans-switch-supply-chain
+   - URL: [blog.aquasec.com/dead-mans-switch-supply-chain](https://blog.aquasec.com/dead-mans-switch-supply-chain)
 
 ### 3.3 오픈소스 도구
 
 9. Socket.dev CLI
-   - GitHub: https://socket.dev/
+   - GitHub: [socket.dev](https://socket.dev/)
    - 실시간 공급망 위협 탐지 도구
 
 10. Snyk
-    - GitHub: https://github.com/snyk/snyk
+    - GitHub: [github.com/snyk/snyk](https://github.com/snyk/snyk)
     - 종합 취약점 스캔 도구
 
 11. OSV Scanner (Google)
-    - GitHub: https://github.com/google/osv-scanner
+    - GitHub: [github.com/google/osv-scanner](https://github.com/google/osv-scanner)
     - OSV 데이터베이스 기반 취약점 스캔 도구
 
 12. Syft (Anchore)
-    - GitHub: https://github.com/anchore/syft
+    - GitHub: [github.com/anchore/syft](https://github.com/anchore/syft)
     - SBOM 생성 도구
 
 13. Grype (Anchore)
-    - GitHub: https://github.com/anchore/grype
+    - GitHub: [github.com/anchore/grype](https://github.com/anchore/grype)
     - 취약점 스캔 도구
 
 14. lockfile-lint
-    - GitHub: https://github.com/lirantal/lockfile-lint
+    - GitHub: [github.com/lirantal/lockfile-lint](https://github.com/lirantal/lockfile-lint)
     - lockfile 무결성 검증 도구
 
 ### 3.4 법규 및 컴플라이언스
 
 15. 개인정보보호법 (한국)
-    - 법제처: https://www.law.go.kr/법령/개인정보보호법
+    - 법제처: [law.go.kr/법령/개인정보보호법](https://www.law.go.kr/법령/개인정보보호법)
 
 16. 정보통신망법 (한국)
-    - 법제처: https://www.law.go.kr/법령/정보통신망이용촉진및정보보호등에관한법률
+    - 법제처: [law.go.kr/법령/정보통신망이용촉진및정보보호등에관한법률](https://www.law.go.kr/법령/정보통신망이용촉진및정보보호등에관한법률)
 
 17. 전자금융거래법 (한국)
-    - 법제처: https://www.law.go.kr/법령/전자금융거래법
+    - 법제처: [law.go.kr/법령/전자금융거래법](https://www.law.go.kr/법령/전자금융거래법)
 
 18. GDPR (EU)
-    - Official Text: https://gdpr.eu/
+    - Official Text: [gdpr.eu](https://gdpr.eu/)
 
 ### 3.5 사고 사례 연구
 
 19. Nx / s1ngularity 공격 포스트모템
-    - URL: https://nx.dev/blog/s1ngularity-postmortem
+    - URL: [nx.dev/blog/s1ngularity-postmortem](https://nx.dev/blog/s1ngularity-postmortem)
 
 20. SolarWinds 공급망 공격 (참고 사례)
-    - CISA 분석: https://www.cisa.gov/solarwinds
+    - CISA 분석: [cisa.gov/solarwinds](https://www.cisa.gov/solarwinds)
 
 21. Log4j 취약점 (참고 사례)
-    - NIST: https://nvd.nist.gov/vuln/detail/CVE-2021-44228
+    - NIST: [nvd.nist.gov/vuln/detail/CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228)
 
 ### 3.6 학술 논문 및 연구
 
@@ -432,21 +432,21 @@ npm token create --read-only --cidr=10.0.0.0/8
 
 24. "의존성 혼동: Apple, Microsoft 등 수십 개 기업을 해킹한 방법" (Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies)
     - 저자: Alex Birsan
-    - URL: https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610
+    - URL: [medium.com](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)
 
 ### 3.7 추가 학습 자료
 
 25. OWASP CI/CD 보안 위험 Top 10 (OWASP Top 10 CI/CD Security Risks)
-    - URL: https://owasp.org/www-project-top-10-ci-cd-security-risks/
+    - URL: [owasp.org/www-project-top-10-ci-cd-security-risks](https://owasp.org/www-project-top-10-ci-cd-security-risks/)
 
 26. SLSA 프레임워크 - 소프트웨어 아티팩트 공급망 레벨 (Supply-chain Levels for Software Artifacts)
-    - URL: https://slsa.dev/
+    - URL: [slsa.dev](https://slsa.dev/)
 
 27. Sigstore (코드 서명)
-    - URL: https://www.sigstore.dev/
+    - URL: [sigstore.dev](https://www.sigstore.dev/)
 
 28. CycloneDX (SBOM 표준)
-    - URL: https://cyclonedx.org/
+    - URL: [cyclonedx.org](https://cyclonedx.org/)
 
 ---
 

--- a/_posts/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence.md
+++ b/_posts/2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog_Preview_See_2025_AIAnd_Security_Coexistence.md
@@ -219,49 +219,49 @@ AWS re:Invent 2025에서 발표된 Security Agent, Security Hub GA, GuardDuty Ex
 #### AWS 공식 문서
 1. AWS re:Invent 2025 Security Sessions
    - Security Keynote: "The Future of Cloud Security in the AI Era"
-   - URL: https://reinvent.awsevents.com/learn/security/
+   - URL: [reinvent.awsevents.com/learn/security](https://reinvent.awsevents.com/learn/security/)
    - 핵심 내용: Security Agent, GuardDuty Extended, IAM Policy Autopilot 발표
 
 2. AWS Security Hub Documentation
-   - URL: https://docs.aws.amazon.com/securityhub/
+   - URL: [docs.aws.amazon.com/securityhub](https://docs.aws.amazon.com/securityhub/)
    - 활용: 멀티 어카운트 보안 통합 관리 가이드
 
 3. AWS GuardDuty Extended Threat Detection
-   - URL: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_extended.html
+   - URL: [docs.aws.amazon.com](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_extended.html)
    - 활용: EKS Runtime Monitoring 설정 방법
 
 4. AWS IAM Policy Autopilot
-   - URL: https://docs.aws.amazon.com/iam/latest/UserGuide/policy-autopilot.html
+   - URL: [docs.aws.amazon.com](https://docs.aws.amazon.com/iam/latest/UserGuide/policy-autopilot.html)
    - 활용: 최소 권한 정책 자동 생성 실습
 
 5. AWS Well-Architected Framework - Security Pillar
-   - URL: https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/
+   - URL: [docs.aws.amazon.com](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/)
    - 활용: 보안 아키텍처 설계 원칙 및 모범 사례
 
 #### OWASP 공식 자료
 6. OWASP Top 10 - 2025 Preview
-   - URL: https://owasp.org/www-project-top-ten/
+   - URL: [owasp.org/www-project-top-ten](https://owasp.org/www-project-top-ten/)
    - 핵심 내용: AI 기반 공격 포함 예정
 
 7. OWASP AI Security and Privacy Guide
-   - URL: https://owasp.org/www-project-ai-security-and-privacy-guide/
+   - URL: [owasp.org](https://owasp.org/www-project-ai-security-and-privacy-guide/)
    - 활용: LLM 공격 기법 및 방어 전략
 
 8. OWASP Software Component Verification Standard (SCVS)
-   - URL: https://owasp.org/www-project-software-component-verification-standard/
+   - URL: [owasp.org](https://owasp.org/www-project-software-component-verification-standard/)
    - 활용: SBOM 구축 및 Supply Chain 보안
 
 #### Datadog 공식 자료
 9. Datadog Security Monitoring Documentation
-   - URL: https://docs.datadoghq.com/security/
+   - URL: [docs.datadoghq.com/security](https://docs.datadoghq.com/security/)
    - 활용: SIEM, CSPM, ASM 통합 설정 가이드
 
 10. Datadog Cloud Security Posture Management (CSPM)
-    - URL: https://docs.datadoghq.com/security/cspm/
+    - URL: [docs.datadoghq.com/security/cspm](https://docs.datadoghq.com/security/cspm/)
     - 활용: 클라우드 설정 오류 자동 탐지
 
 11. Datadog Application Security Management (ASM)
-    - URL: https://docs.datadoghq.com/security/application_security/
+    - URL: [docs.datadoghq.com/security/application_security](https://docs.datadoghq.com/security/application_security/)
     - 활용: 런타임 애플리케이션 보호
 
 ### 4.2 컨퍼런스 세션 및 발표 자료
@@ -297,183 +297,183 @@ AWS re:Invent 2025에서 발표된 Security Agent, Security Hub GA, GuardDuty Ex
 ### 4.3 산업 리포트 및 통계
 
 18. Gartner Magic Quadrant for SIEM (2025)
-    - URL: https://www.gartner.com/en/documents/magic-quadrant-siem
+    - URL: [gartner.com/en/documents/magic-quadrant-siem](https://www.gartner.com/en/documents/magic-quadrant-siem)
     - 핵심 내용: SIEM 시장 동향, 주요 벤더 평가
 
 19. Forrester Wave: Cloud Security Posture Management (2025)
-    - URL: https://www.forrester.com/wave/cloud-security-posture-management
+    - URL: [forrester.com](https://www.forrester.com/wave/cloud-security-posture-management)
     - 핵심 내용: CSPM 시장 분석, 구매 가이드
 
 20. Cybersecurity Ventures: 2025 Cybercrime Report
-    - URL: https://cybersecurityventures.com/cybercrime-report/
+    - URL: [cybersecurityventures.com/cybercrime-report](https://cybersecurityventures.com/cybercrime-report/)
     - 핵심 통계: 93% 보안 리더가 AI 공격 예상
 
 21. Verizon Data Breach Investigations Report (DBIR) 2025
-    - URL: https://www.verizon.com/business/resources/reports/dbir/
+    - URL: [verizon.com/business/resources/reports/dbir](https://www.verizon.com/business/resources/reports/dbir/)
     - 핵심 내용: 데이터 침해 사고 분석, 공격 벡터 통계
 
 22. Cloudflare Post-Quantum Cryptography Report
-    - URL: https://blog.cloudflare.com/post-quantum-cryptography-report/
+    - URL: [blog.cloudflare.com](https://blog.cloudflare.com/post-quantum-cryptography-report/)
     - 핵심 통계: 전체 트래픽의 52% Post-quantum 암호화 적용
 
 ### 4.4 기술 표준 및 프레임워크
 
 23. NIST Cybersecurity Framework 2.0
-    - URL: https://www.nist.gov/cyberframework
+    - URL: [nist.gov/cyberframework](https://www.nist.gov/cyberframework)
     - 활용: 보안 프레임워크 구축 기준
 
 24. NIST Post-Quantum Cryptography Standardization
-    - URL: https://csrc.nist.gov/projects/post-quantum-cryptography
+    - URL: [csrc.nist.gov/projects/post-quantum-cryptography](https://csrc.nist.gov/projects/post-quantum-cryptography)
     - 활용: Post-quantum 알고리즘 선택 가이드
 
 25. Zero Trust Architecture - NIST SP 800-207
-    - URL: https://csrc.nist.gov/publications/detail/sp/800-207/final
+    - URL: [csrc.nist.gov/publications/detail/sp/800-207/final](https://csrc.nist.gov/publications/detail/sp/800-207/final)
     - 활용: Zero Trust 아키텍처 설계 원칙
 
 26. CIS AWS Foundations Benchmark
-    - URL: https://www.cisecurity.org/benchmark/amazon_web_services
+    - URL: [cisecurity.org/benchmark/amazon_web_services](https://www.cisecurity.org/benchmark/amazon_web_services)
     - 활용: AWS 보안 설정 체크리스트
 
 27. ISO/IEC 27001:2022 Information Security Management
-    - URL: https://www.iso.org/standard/27001
+    - URL: [iso.org/standard/27001](https://www.iso.org/standard/27001)
     - 활용: 정보보안 관리 체계 구축
 
 ### 4.5 오픈소스 도구 및 프로젝트
 
 28. Trivy - Container Vulnerability Scanner
-    - GitHub: https://github.com/aquasecurity/trivy
+    - GitHub: [github.com/aquasecurity/trivy](https://github.com/aquasecurity/trivy)
     - 활용: 컨테이너 이미지 취약점 스캔
 
 29. Syft - SBOM Generation Tool
-    - GitHub: https://github.com/anchore/syft
+    - GitHub: [github.com/anchore/syft](https://github.com/anchore/syft)
     - 활용: 소프트웨어 Bill of Materials 자동 생성
 
 30. TruffleHog - Secret Scanner
-    - GitHub: https://github.com/trufflesecurity/trufflehog
+    - GitHub: [github.com/trufflesecurity/trufflehog](https://github.com/trufflesecurity/trufflehog)
     - 활용: Git 히스토리에서 시크릿 탐지
 
 31. Checkov - IaC Security Scanner
-    - GitHub: https://github.com/bridgecrewio/checkov
+    - GitHub: [github.com/bridgecrewio/checkov](https://github.com/bridgecrewio/checkov)
     - 활용: Terraform, CloudFormation 보안 스캔
 
 32. OWASP ZAP - Web Application Security Scanner
-    - URL: https://www.zaproxy.org/
+    - URL: [zaproxy.org](https://www.zaproxy.org/)
     - 활용: DAST (동적 애플리케이션 보안 테스트)
 
 33. Falco - Cloud Native Runtime Security
-    - URL: https://falco.org/
+    - URL: [falco.org](https://falco.org/)
     - 활용: Kubernetes 런타임 위협 탐지
 
 ### 4.6 한국 보안 커뮤니티 및 자료
 
 34. KISA (한국인터넷진흥원) 보안공지
-    - URL: https://www.kisa.or.kr/
+    - URL: [kisa.or.kr](https://www.kisa.or.kr/)
     - 활용: 국내 보안 동향, 취약점 공지
 
 35. AWSKRUG (AWS Korea User Group)
-    - URL: https://www.facebook.com/groups/awskrug
+    - URL: [facebook.com/groups/awskrug](https://www.facebook.com/groups/awskrug)
     - 활용: AWS 한국 사용자 커뮤니티, 정기 세미나
 
 36. GDGKR (Google Developer Group Korea)
-    - URL: https://gdg.community.dev/
+    - URL: [gdg.community.dev](https://gdg.community.dev/)
     - 활용: 클라우드 및 보안 기술 공유
 
 37. 한국정보보호학회 (KIISC)
-    - URL: https://www.kiisc.or.kr/
+    - URL: [kiisc.or.kr](https://www.kiisc.or.kr/)
     - 활용: 학술 연구, 보안 컨퍼런스
 
 38. 개인정보보호위원회 - 개인정보보호법
-    - URL: https://www.pipc.go.kr/
+    - URL: [pipc.go.kr](https://www.pipc.go.kr/)
     - 활용: 개인정보보호 규정 및 가이드라인
 
 ### 4.7 교육 및 자격증
 
 39. AWS Certified Security - Specialty
-    - URL: https://aws.amazon.com/certification/certified-security-specialty/
+    - URL: [aws.amazon.com](https://aws.amazon.com/certification/certified-security-specialty/)
     - 활용: AWS 보안 전문가 자격증
 
 40. Certified Information Systems Security Professional (CISSP)
-    - URL: https://www.isc2.org/Certifications/CISSP
+    - URL: [isc2.org/Certifications/CISSP](https://www.isc2.org/Certifications/CISSP)
     - 활용: 국제 정보보안 전문가 자격증
 
 41. Certified Kubernetes Security Specialist (CKS)
-    - URL: https://www.cncf.io/certification/cks/
+    - URL: [cncf.io/certification/cks](https://www.cncf.io/certification/cks/)
     - 활용: Kubernetes 보안 전문가 자격증
 
 42. OWASP Top 10 Training
-    - URL: https://owasp.org/www-project-top-ten/
+    - URL: [owasp.org/www-project-top-ten](https://owasp.org/www-project-top-ten/)
     - 활용: 웹 애플리케이션 보안 교육
 
 ### 4.8 블로그 및 뉴스 사이트
 
 43. AWS Security Blog
-    - URL: https://aws.amazon.com/blogs/security/
+    - URL: [aws.amazon.com/blogs/security](https://aws.amazon.com/blogs/security/)
     - 활용: AWS 보안 최신 동향, 모범 사례
 
 44. Krebs on Security
-    - URL: https://krebsonsecurity.com/
+    - URL: [krebsonsecurity.com](https://krebsonsecurity.com/)
     - 활용: 보안 사고 분석, 뉴스
 
 45. The Hacker News
-    - URL: https://thehackernews.com/
+    - URL: [thehackernews.com](https://thehackernews.com/)
     - 활용: 최신 보안 뉴스, 취약점 공지
 
 46. Dark Reading
-    - URL: https://www.darkreading.com/
+    - URL: [darkreading.com](https://www.darkreading.com/)
     - 활용: 기업 보안 전략, 트렌드 분석
 
 47. SANS Internet Storm Center
-    - URL: https://isc.sans.edu/
+    - URL: [isc.sans.edu](https://isc.sans.edu/)
     - 활용: 위협 인텔리전스, 실시간 보안 동향
 
 ### 4.9 실습 환경 및 랩
 
 48. AWS Workshop Studio
-    - URL: https://workshops.aws/
+    - URL: [workshops.aws](https://workshops.aws/)
     - 활용: AWS 보안 서비스 실습 (무료)
 
 49. Datadog Learning Center
-    - URL: https://learn.datadoghq.com/
+    - URL: [learn.datadoghq.com](https://learn.datadoghq.com/)
     - 활용: Datadog 플랫폼 실습
 
 50. TryHackMe - Cloud Security Rooms
-    - URL: https://tryhackme.com/
+    - URL: [tryhackme.com](https://tryhackme.com/)
     - 활용: 클라우드 보안 실습 (게이미피케이션)
 
 51. OWASP WebGoat
-    - URL: https://owasp.org/www-project-webgoat/
+    - URL: [owasp.org/www-project-webgoat](https://owasp.org/www-project-webgoat/)
     - 활용: 웹 애플리케이션 보안 실습 환경
 
 ### 4.10 관련 GitHub 저장소
 
 52. AWS Security Reference Architecture
-    - GitHub: https://docs.aws.amazon.com//aws-security-reference-architecture-examples
+    - GitHub: [docs.aws.amazon.com](https://docs.aws.amazon.com//aws-security-reference-architecture-examples)
     - 활용: AWS 보안 아키텍처 참고 구현
 
 53. Awesome Cloud Security
-    - GitHub: https://github.com/4ndersonLin/awesome-cloud-security
+    - GitHub: [github.com/4ndersonLin/awesome-cloud-security](https://github.com/4ndersonLin/awesome-cloud-security)
     - 활용: 클라우드 보안 리소스 큐레이션
 
 54. Kubernetes Security - Best Practice Guide
-    - GitHub: https://github.com/kabachook/k8s-security
+    - GitHub: [github.com/kabachook/k8s-security](https://github.com/kabachook/k8s-security)
     - 활용: Kubernetes 보안 가이드
 
 55. SecLists - Security Tester's Companion
-    - GitHub: https://github.com/danielmiessler/SecLists
+    - GitHub: [github.com/danielmiessler/SecLists](https://github.com/danielmiessler/SecLists)
     - 활용: 보안 테스트 페이로드 모음
 
 ### 4.11 팟캐스트 및 비디오
 
 56. AWS re:Invent YouTube Channel
-    - URL: https://www.youtube.com/@AWSEventsChannel
+    - URL: [youtube.com/@AWSEventsChannel](https://www.youtube.com/@AWSEventsChannel)
     - 활용: re:Invent 세션 다시보기
 
 57. Darknet Diaries Podcast
-    - URL: https://darknetdiaries.com/
+    - URL: [darknetdiaries.com](https://darknetdiaries.com/)
     - 활용: 보안 사건 스토리텔링
 
 58. Kubernetes Security Podcast
-    - URL: https://kubernetessecuritypodcast.com/
+    - URL: [kubernetessecuritypodcast.com](https://kubernetessecuritypodcast.com/)
     - 활용: 컨테이너 보안 최신 동향
 
 ### 4.12 추가 참고 도구

--- a/_posts/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response.md
+++ b/_posts/2025-12-19-Cloud_Security_8Batch_4Week_Integration_Security_Vulnerability_Inspection_And_ISMS-P_Certification_Response.md
@@ -193,8 +193,8 @@ summary_card:
 - 모니터링 및 대응: `CloudTrail`, `GuardDuty`, `Security Hub`, `CloudWatch`
 
 <!-- Full ASCII diagram omitted for readability. Reference architecture sources:
-https://docs.aws.amazon.com/waf/latest/developerguide/
-https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html
+[docs.aws.amazon.com/waf/latest/developerguide](https://docs.aws.amazon.com/waf/latest/developerguide/)
+[docs.aws.amazon.com](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html)
 -->
 
 ## 2. ISMS-P 인증 대응 실무 가이드

--- a/_posts/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice.md
+++ b/_posts/2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide_DevSecOps_From_Perspective_View_GitHub_Security_Tools_And_Best_Practice.md
@@ -320,8 +320,8 @@ contract FailSafeVault is Pausable, Ownable {
 
 <!-- Full sample intentionally shortened for readability.
 Reference:
-https://docs.openzeppelin.com/contracts/4.x/api/security
-https://docs.openzeppelin.com/contracts/4.x/access-control
+[docs.openzeppelin.com/contracts/4.x/api/security](https://docs.openzeppelin.com/contracts/4.x/api/security)
+[docs.openzeppelin.com/contracts/4.x/access-control](https://docs.openzeppelin.com/contracts/4.x/access-control)
 -->
 
 ### 4.3 보안 체크리스트

--- a/_posts/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation.md
+++ b/_posts/2026-01-14-2025_ISMS-P_Certification_Complete_Guide_AWS_In_Environment_Management_System_Establishment_And_Protection_Measures_Implementation.md
@@ -130,8 +130,8 @@ summary_card:
 - 보안 운영: `CloudTrail`, `CloudWatch`, `Security Hub`, `GuardDuty`, `Config`, `Inspector`
 
 <!-- Full ASCII architecture omitted for readability. Reference:
-https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html
-https://docs.aws.amazon.com/whitepapers/latest/introduction-devsecops-aws/welcome.html
+[docs.aws.amazon.com](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/welcome.html)
+[docs.aws.amazon.com](https://docs.aws.amazon.com/whitepapers/latest/introduction-devsecops-aws/welcome.html)
 -->
 
 #### CloudTrail 로그 설정

--- a/scripts/linkify_bare_urls.py
+++ b/scripts/linkify_bare_urls.py
@@ -1,0 +1,135 @@
+"""Make bare URLs clickable, using the corpus' own anchor convention.
+
+Corpus audit 2026-08-06: 123 bare ``https://…`` occurrences across 19 posts are
+rendered as PLAIN TEXT. Verified on built output rather than inferred —
+``_site/posts/2025/05/30/…Docker…/index.html`` contains the URL with no ``href``
+around it. ``_config.yml`` sets ``markdown: kramdown`` without GFM input, and
+kramdown does not auto-link bare URLs, so a reader simply cannot follow them.
+
+The anchor text is NOT invented: it mirrors what the corpus already writes —
+``[cisa.gov/known-exploited-vulnerabilities-catalog]``, ``[first.org/epss]``,
+``[attack.mitre.org]`` — i.e. the host with a leading ``www.`` removed, plus the
+path, falling back to the host alone when that would get unwieldy.
+
+Explicitly OUT of scope: the 250 ``[바로가기]`` / ``[링크]`` anchors flagged by a
+context-blind scan. Every one of them sits in a table's link column whose
+neighbouring cell already carries the title, so replacing the anchor text would
+duplicate that cell. They are correct as written.
+
+Usage:
+    python3 scripts/linkify_bare_urls.py --posts-glob '_posts/*.md' --dry-run
+    python3 scripts/linkify_bare_urls.py _posts/2025-12-17-*.md
+"""
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO = Path(__file__).resolve().parent.parent
+
+LABEL_MAX = 50
+
+_FRONT_MATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
+# Not preceded by markdown-link / HTML-attribute / angle-bracket context.
+_BARE_URL_RE = re.compile(r'(?<![\(\[<"=])\bhttps?://[^\s\)\]<>"\']+')
+_TRAILING_PUNCT = ".,;:!?"
+_INLINE_CODE_RE = re.compile(r"`[^`]*`")
+
+
+def label_for(url: str) -> str:
+    """Corpus convention: host without www., plus path when it stays short."""
+    parts = urlparse(url)
+    host = parts.netloc[4:] if parts.netloc.startswith("www.") else parts.netloc
+    path = parts.path.rstrip("/")
+    candidate = f"{host}{path}"
+    return candidate if path and len(candidate) <= LABEL_MAX else host
+
+
+def _linkify_line(line: str) -> str:
+    # Protect inline code spans so their URLs are never rewritten.
+    spans = []
+
+    def _stash(m):
+        spans.append(m.group(0))
+        return f"\x00{len(spans) - 1}\x00"
+
+    protected = _INLINE_CODE_RE.sub(_stash, line)
+
+    def _replace(m):
+        url = m.group(0)
+        trailing = ""
+        while url and url[-1] in _TRAILING_PUNCT:
+            trailing = url[-1] + trailing
+            url = url[:-1]
+        if not url:
+            return m.group(0)
+        return f"[{label_for(url)}]({url}){trailing}"
+
+    out = _BARE_URL_RE.sub(_replace, protected)
+    return re.sub(r"\x00(\d+)\x00", lambda m: spans[int(m.group(1))], out)
+
+
+def transform(text: str) -> str:
+    m = _FRONT_MATTER_RE.match(text)
+    front, body = (text[: m.end()], text[m.end():]) if m else ("", text)
+
+    out, in_fence, in_liquid = [], False, False
+    for line in body.split("\n"):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence:
+            out.append(line)
+            continue
+        # A Liquid tag spans MULTIPLE lines ('{% include news-card.html' then
+        # the attributes then '%}'), so a per-line '{%' guard misses the
+        # attribute lines. It missed image="…/https://s3…" — a URL nested
+        # inside another URL, which the '="' lookbehind also cannot see — and
+        # rewrote it, corrupting the cover image on 3 digests.
+        if not in_liquid and "{%" in line and "%}" not in line:
+            in_liquid = True
+        if in_liquid or "{%" in line or "{{" in line:
+            out.append(line)
+            if in_liquid and "%}" in line:
+                in_liquid = False
+            continue
+        out.append(_linkify_line(line))
+    return front + "\n".join(out)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Wrap bare URLs in markdown links.")
+    ap.add_argument("paths", nargs="*")
+    ap.add_argument("--posts-glob")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    files = [Path(p) for p in (args.paths or [])]
+    if args.posts_glob:
+        files += [Path(p) for p in sorted(glob.glob(args.posts_glob))]
+    if not files:
+        print("[linkify-urls] no post files to process.")
+        return 0
+
+    changed = 0
+    for f in files:
+        original = f.read_text(encoding="utf-8")
+        new = transform(original)
+        if new == original:
+            continue
+        changed += 1
+        if args.dry_run:
+            print(f"DRY  {f}")
+        else:
+            f.write_text(new, encoding="utf-8")
+            print(f"FIXED {f}")
+    verb = "would rewrite" if args.dry_run else "rewrote"
+    print(f"[linkify-urls] {verb} {changed}/{len(files)} post(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_linkify_bare_urls.py
+++ b/scripts/tests/test_linkify_bare_urls.py
@@ -1,0 +1,174 @@
+"""Tests for scripts/linkify_bare_urls.py.
+
+Corpus audit 2026-08-06: 123 bare `https://…` occurrences across 19 posts render
+as PLAIN TEXT, not links — verified on built output
+(`_site/posts/2025/05/30/…Docker…/index.html` contains the URL with no `href`).
+kramdown is configured without GFM input, so it does not auto-link bare URLs.
+
+The fix uses the corpus' own anchor convention — `[cisa.gov/known-exploited-…]`,
+`[first.org/epss]`, `[attack.mitre.org]` — i.e. host (minus `www.`) plus path,
+never an invented description.
+
+NOT in scope, and deliberately so: the 250 `[바로가기]`/`[링크]` anchors are all
+inside a table's link column whose neighbouring cell already carries the title.
+Rewriting them would duplicate that cell, so they are correct as they stand.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import linkify_bare_urls as lb  # noqa: E402
+
+_FM = '---\nlayout: post\noriginal_url: https://twodragon.tistory.com/704\n---\n\n'
+
+
+def t(body):
+    return lb.transform(_FM + body)
+
+
+# --- the fix -----------------------------------------------------------------
+
+
+def test_bare_url_becomes_a_link():
+    assert "[kubernetes.io/docs/tasks/debug](https://kubernetes.io/docs/tasks/debug/)" in t(
+        "참고: https://kubernetes.io/docs/tasks/debug/\n"
+    )
+
+
+def test_www_is_dropped_from_the_label_only():
+    out = t("- https://www.sans.org/white-papers/bypassing-mfa/\n")
+    assert "[sans.org/white-papers/bypassing-mfa](https://www.sans.org/white-papers/bypassing-mfa/)" in out
+
+
+def test_host_only_label_when_path_is_long():
+    url = "https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/"
+    out = t(f"- {url}\n")
+    assert f"[docs.aws.amazon.com]({url})" in out
+
+
+def test_root_url_labels_with_the_host():
+    assert "[slack.k8s.io](https://slack.k8s.io/)" in t("- **Kubernetes Slack**: https://slack.k8s.io/\n")
+
+
+def test_existing_line_label_is_preserved():
+    out = t("- **Kubernetes Slack**: https://slack.k8s.io/\n")
+    assert "- **Kubernetes Slack**: [" in out
+
+
+def test_trailing_sentence_punctuation_stays_outside_the_link():
+    out = t("자세한 내용은 https://example.com/guide 를 참고하세요.\n")
+    assert "[example.com/guide](https://example.com/guide)" in out
+    out2 = t("참고: https://example.com/guide.\n")
+    assert "[example.com/guide](https://example.com/guide)." in out2
+
+
+# --- what must NOT be touched ------------------------------------------------
+
+
+def test_front_matter_is_untouched():
+    out = t("본문.\n")
+    assert "original_url: https://twodragon.tistory.com/704" in out
+
+
+def test_existing_markdown_link_is_untouched():
+    src = "[FIDO](https://fidoalliance.org/) 참고.\n"
+    assert t(src) == _FM + src
+
+
+def test_code_fence_is_untouched():
+    src = "```bash\ncurl https://example.com/api\n```\n"
+    assert t(src) == _FM + src
+
+
+def test_inline_code_is_untouched():
+    src = "`curl https://example.com/api` 를 실행합니다.\n"
+    assert t(src) == _FM + src
+
+
+def test_liquid_include_url_is_untouched():
+    src = '{% include news-card.html\n  url="https://example.com/a"\n%}\n'
+    assert t(src) == _FM + src
+
+
+def test_html_attribute_url_is_untouched():
+    src = '<a href="https://example.com/a">x</a>\n'
+    assert t(src) == _FM + src
+
+
+def test_table_link_column_anchor_is_untouched():
+    src = "| 출처 | [링크](https://example.com/a) |\n"
+    assert t(src) == _FM + src
+
+
+# --- safety ------------------------------------------------------------------
+
+
+def test_transform_is_idempotent():
+    once = t("참고: https://kubernetes.io/docs/tasks/debug/\n")
+    assert lb.transform(once) == once
+
+
+def test_url_text_survives_verbatim_inside_the_link_target():
+    url = "https://csrc.nist.gov/publications/detail/sp/800-161/rev-1/final"
+    out = t(f"- {url}\n")
+    assert f"]({url})" in out
+
+
+@pytest.mark.parametrize(
+    "url,label",
+    [
+        ("https://attack.mitre.org/", "attack.mitre.org"),
+        ("https://www.first.org/epss/", "first.org/epss"),
+        ("http://example.com/a/b", "example.com/a/b"),
+    ],
+)
+def test_label_matches_the_corpus_convention(url, label):
+    assert lb.label_for(url) == label
+
+
+def test_cli_dry_run_does_not_write(tmp_path):
+    p = tmp_path / "2026-08-06-X.md"
+    src = _FM + "참고: https://kubernetes.io/docs/tasks/debug/\n"
+    p.write_text(src, encoding="utf-8")
+    assert lb.main([str(p), "--dry-run"]) == 0
+    assert p.read_text(encoding="utf-8") == src
+
+
+# --- multi-line Liquid regions (the 2026-03-01 corruption) -------------------
+
+
+_MULTILINE_CARD = (
+    "{% include news-card.html\n"
+    '  title="t"\n'
+    '  url="https://example.com/a"\n'
+    '  image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,w=1200/'
+    'https://s3.cointelegraph.com/uploads/2026-03/x.jpg"\n'
+    '  source="Cointelegraph"\n'
+    "%}\n"
+)
+
+
+def test_multiline_liquid_include_is_untouched():
+    """`{%` and the attribute lines are on DIFFERENT lines.
+
+    A per-line `{%` guard misses the attribute lines, and the nested URL inside
+    `image="…/https://s3…"` is not preceded by `="`, so it slipped past the
+    lookbehind and the image URL was corrupted on 3 digests.
+    """
+    assert t(_MULTILINE_CARD) == _FM + _MULTILINE_CARD
+
+
+def test_prose_after_a_liquid_block_is_still_linkified():
+    out = t(_MULTILINE_CARD + "\n참고: https://kubernetes.io/docs/tasks/debug/\n")
+    assert _MULTILINE_CARD in out
+    assert "[kubernetes.io/docs/tasks/debug](https://kubernetes.io/docs/tasks/debug/)" in out
+
+
+def test_nested_url_inside_a_query_string_is_not_split():
+    src = "- https://r.example.com/redirect?to=https://target.example/page\n"
+    out = t(src)
+    assert out.count("](") == 1, out


### PR DESCRIPTION
## 착수 전 재측정에서 전제 절반이 반증됐습니다

### 반증 — 비서술 앵커 250건은 전부 오탐

`[바로가기]` / `[링크]` 250건은 **예외 없이 표의 링크 열** 안이고, 인접 셀이 이미 제목을 담고 있습니다:

```markdown
| 날짜 | 주제 | 링크 |
| 3월 1일 | AI 에이전트 보안 위협, Gentlemen 랜섬웨어, 운영 대응 전략 | [바로가기](/posts/2026/03/01/…) |

| 출처 | 제목 | URL |
| SK텔레콤 | USIM 정보 유출 관련 공지 및 대응 | [링크](https://www.sktelecom.com/notice/usim-security) |
```

앵커를 제목으로 바꾸면 인접 열과 **중복**됩니다. **산문 내 비서술 앵커는 0건**이므로 이 절반은 수정 대상이 아닙니다.

### 확인 — 맨 URL은 진짜 결함 (추론 아닌 렌더 실측)

`_site` 빌드 산출물에서 직접 확인했습니다:

```
https://kubernetes.io/docs/tasks/debug/   linked=False
https://slack.k8s.io/                     linked=False
   ctx=…<li><strong>Kubernetes Slack</strong>: https://slack.k8s.io/</li>
```

`_config.yml` 은 GFM 입력 없는 kramdown이라 오토링크가 없습니다 — **독자가 클릭할 수 없습니다.**

## 수정

코퍼스 관례 그대로 `[host/path](url)` 를 씁니다 (`[cisa.gov/known-exploited-…]`, `[first.org/epss]`, `[attack.mitre.org]`). `www.` 제거, path가 길면 host만. **설명을 창작하지 않습니다.** `<url>` 오토링크 선례는 코퍼스에 0건이라 채택하지 않았습니다.

## 적용 도중 잡은 손상 (커밋 전 되돌림)

첫 구현이 뉴스 카드의 **중첩 URL**을 재작성해 커버 이미지를 깨뜨렸습니다:

```diff
- image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,w=1200/https://s3.cointelegraph.com/…jpg"
+ image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,w=1200/[s3.cointelegraph.com](https://s3…jpg)"
```

원인이 두 겹이었습니다:

1. **Liquid include는 여러 줄**이라 줄 단위 `{%` 가드가 속성 줄을 보지 못함
2. 중첩 URL은 `="` 룩비하인드에도 걸리지 않음

코드펜스와 동일하게 Liquid 영역을 상태 추적으로 보호하고 회귀 테스트 3건을 추가했습니다. **대상 포스트가 14 → 8개로 줄어든 것이 이 손상의 규모**였습니다.

## 검증

| 검증 | 결과 |
|---|---|
| 변경 라인 | 102건 / 전부 링크화 |
| 링크 타깃이 원문에 없는 경우 | **0** |
| **완전 가역** — 링크 문법을 벗기면 원문 라인이 정확히 복원 | 복원 실패 **0** (창작·손실 0) |
| `fix_malformed_liquid_includes --check` | 257개 파일 / malformed **0** |
| 게이트 4종 (구조·고유명사·미번역·체크리스트제목) | 각 185개 / 위반 **0** |
| `pytest scripts/tests/` | **3159 passed, 5 skipped** (신규 22건) |