### PR TITLE
feat(posts): 맨 URL 탐지 게이트 — pre-commit + CI 배선 (크론 제외)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -224,3 +224,20 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
   fi
   echo "[pre-commit] Post quality: passed."
 fi
+
+# 12. Bare-URL gate — a plain https:// in prose renders as TEXT, not a link.
+#     This site's kramdown has no GFM input, so it does not auto-link. All 8
+#     posts fixed in PR #509 were hand-written guides, never cron digests, so
+#     the recurrence path is human authoring — hence pre-commit + CI, no cron.
+STAGED_ANY_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+\.md$' || true)
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for bare (unlinked) URLs..."
+  python3 "$REPO_ROOT/scripts/linkify_bare_urls.py" --check --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Bare URL found — readers cannot click it."
+    echo "             Auto-fix: python3 scripts/linkify_bare_urls.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Bare-URL check: passed."
+fi

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -38,6 +38,7 @@ on:
       - 'scripts/check_digest_untranslated.py'
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
+      - 'scripts/linkify_bare_urls.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -82,6 +83,7 @@ on:
       - 'scripts/check_digest_untranslated.py'
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
+      - 'scripts/linkify_bare_urls.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -291,6 +293,14 @@ jobs:
         # is fresh drift — including one arriving via a cron push that never
         # ran the pre-commit hook.
         run: python3 scripts/check_digest_checklist_heading.py --all
+
+      - name: Bare-URL gate (unlinked https:// in post prose)
+        id: bare_url_gate
+        # kramdown here has no GFM input, so a plain https:// renders as TEXT —
+        # verified on built output, not inferred. --all: the corpus is at 0
+        # after PR #509, so any hit is fresh. Guides, not cron digests, are the
+        # recurrence path, so there is deliberately no blogwatcher step.
+        run: python3 scripts/linkify_bare_urls.py --check --all
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -264,6 +264,23 @@ if [ -n "$STAGED_QUALITY_POSTS" ]; then
   fi
   echo "[pre-commit] Post quality: passed."
 fi
+
+# 12. Bare-URL gate — a plain https:// in prose renders as TEXT, not a link.
+#     This site's kramdown has no GFM input, so it does not auto-link. All 8
+#     posts fixed in PR #509 were hand-written guides, never cron digests, so
+#     the recurrence path is human authoring — hence pre-commit + CI, no cron.
+STAGED_ANY_POSTS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_posts/[^/]+\.md$' || true)
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for bare (unlinked) URLs..."
+  python3 "$REPO_ROOT/scripts/linkify_bare_urls.py" --check --staged
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Bare URL found — readers cannot click it."
+    echo "             Auto-fix: python3 scripts/linkify_bare_urls.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Bare-URL check: passed."
+fi
 HOOK
 
 chmod +x "$HOOK_FILE"

--- a/scripts/linkify_bare_urls.py
+++ b/scripts/linkify_bare_urls.py
@@ -23,6 +23,7 @@ Usage:
 import argparse
 import glob
 import re
+import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
@@ -100,32 +101,88 @@ def transform(text: str) -> str:
     return front + "\n".join(out)
 
 
+_POST_PATH_RE = re.compile(r"^_posts/[^/]+\.md$")
+
+
+def bare_urls(text: str) -> list:
+    """URLs the transform would linkify — the gate's offender list."""
+    found = []
+    for original, rewritten in zip(text.split("\n"), transform(text).split("\n")):
+        if original == rewritten:
+            continue
+        found.extend(re.findall(r"\]\((https?://[^)]+)\)", rewritten))
+    return found
+
+
+def _git_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        p = line.strip()
+        if _POST_PATH_RE.match(p) and (REPO / p).exists():
+            paths.append(REPO / p)
+    return sorted(paths)
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description="Wrap bare URLs in markdown links.")
     ap.add_argument("paths", nargs="*")
     ap.add_argument("--posts-glob")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="report bare URLs and exit 1 without writing (gate mode)",
+    )
+    ap.add_argument("--staged", action="store_true")
+    ap.add_argument("--all", action="store_true")
     args = ap.parse_args(argv)
 
     files = [Path(p) for p in (args.paths or [])]
     if args.posts_glob:
         files += [Path(p) for p in sorted(glob.glob(args.posts_glob))]
+    if args.staged:
+        files += _git_paths(["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"])
+    if args.all:
+        files += sorted((REPO / "_posts").glob("*.md"))
     if not files:
         print("[linkify-urls] no post files to process.")
         return 0
 
-    changed = 0
+    changed, rc = 0, 0
     for f in files:
         original = f.read_text(encoding="utf-8")
         new = transform(original)
         if new == original:
             continue
         changed += 1
-        if args.dry_run:
+        if args.check:
+            rc = 1
+            print(f"FAIL {f}")
+            for url in bare_urls(original):
+                print(f"  - bare URL: {url}")
+        elif args.dry_run:
             print(f"DRY  {f}")
         else:
             f.write_text(new, encoding="utf-8")
             print(f"FIXED {f}")
+
+    if args.check:
+        if rc:
+            print(
+                "\n[linkify-urls] FAIL — bare URLs render as PLAIN TEXT: this site's "
+                "kramdown is configured without GFM input, so they are not "
+                "auto-linked and a reader cannot follow them. Fix with:\n"
+                "  python3 scripts/linkify_bare_urls.py <post>",
+                file=sys.stderr,
+            )
+        else:
+            print(f"[linkify-urls] OK — {len(files)} post(s), 0 bare URLs.")
+        return rc
+
     verb = "would rewrite" if args.dry_run else "rewrote"
     print(f"[linkify-urls] {verb} {changed}/{len(files)} post(s).")
     return 0

--- a/scripts/tests/test_linkify_bare_urls.py
+++ b/scripts/tests/test_linkify_bare_urls.py
@@ -178,11 +178,16 @@ def test_nested_url_inside_a_query_string_is_not_split():
 
 
 def test_check_reports_offender_and_exits_1(tmp_path, capsys):
+    url = "https://kubernetes.io/docs/tasks/debug/"
     p = tmp_path / "2026-08-06-X.md"
-    p.write_text(_FM + "참고: https://kubernetes.io/docs/tasks/debug/\n", encoding="utf-8")
+    p.write_text(_FM + f"참고: {url}\n", encoding="utf-8")
     assert lb.main([str(p), "--check"]) == 1
     out = capsys.readouterr().out
-    assert "FAIL" in out and "kubernetes.io" in out
+    # Assert the whole reported line, not a host substring: a bare
+    # `"kubernetes.io" in out` reads as URL-substring validation (CodeQL
+    # py/incomplete-url-substring-sanitization) and is a weaker assertion.
+    assert "FAIL" in out
+    assert f"  - bare URL: {url}" in out
 
 
 def test_check_exits_0_when_clean(tmp_path, capsys):

--- a/scripts/tests/test_linkify_bare_urls.py
+++ b/scripts/tests/test_linkify_bare_urls.py
@@ -172,3 +172,55 @@ def test_nested_url_inside_a_query_string_is_not_split():
     src = "- https://r.example.com/redirect?to=https://target.example/page\n"
     out = t(src)
     assert out.count("](") == 1, out
+
+
+# --- --check gate mode -------------------------------------------------------
+
+
+def test_check_reports_offender_and_exits_1(tmp_path, capsys):
+    p = tmp_path / "2026-08-06-X.md"
+    p.write_text(_FM + "참고: https://kubernetes.io/docs/tasks/debug/\n", encoding="utf-8")
+    assert lb.main([str(p), "--check"]) == 1
+    out = capsys.readouterr().out
+    assert "FAIL" in out and "kubernetes.io" in out
+
+
+def test_check_exits_0_when_clean(tmp_path, capsys):
+    p = tmp_path / "2026-08-06-X.md"
+    p.write_text(_FM + "참고: [k8s](https://kubernetes.io/docs/)\n", encoding="utf-8")
+    assert lb.main([str(p), "--check"]) == 0
+
+
+def test_check_does_not_write(tmp_path):
+    p = tmp_path / "2026-08-06-X.md"
+    src = _FM + "참고: https://kubernetes.io/docs/tasks/debug/\n"
+    p.write_text(src, encoding="utf-8")
+    lb.main([str(p), "--check"])
+    assert p.read_text(encoding="utf-8") == src
+
+
+def test_corpus_is_clean_under_the_gate():
+    """Measured 2026-08-06 after PR #509: 0 bare URLs corpus-wide."""
+    offenders = [
+        p.name
+        for p in sorted((REPO / "_posts").glob("*.md"))
+        if lb.transform(p.read_text(encoding="utf-8")) != p.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], offenders
+
+
+def _noncomment(text: str) -> str:
+    return "\n".join(ln for ln in text.splitlines() if not ln.strip().startswith("#"))
+
+
+@pytest.mark.parametrize("rel", [".githooks/pre-commit", "scripts/install-hooks.sh"])
+def test_wired_into_precommit(rel):
+    import re as _re
+
+    text = (REPO / rel).read_text(encoding="utf-8")
+    assert _re.search(r'linkify_bare_urls\.py"?\s+--check', _noncomment(text)), rel
+
+
+def test_wired_into_ci():
+    wf = (REPO / ".github/workflows/svg-lint.yml").read_text(encoding="utf-8")
+    assert "linkify_bare_urls.py --check" in _noncomment(wf)


### PR DESCRIPTION
#509는 기존 102건을 고쳤을 뿐 **재발 방지가 없었습니다.** 이번에 게이트로 승격합니다.

## 배선 대상을 실측으로 결정했습니다

#509에서 고친 8개 포스트를 분류한 결과:

```
[가이드]   2025-04-30-Public_PC…Passkey_OTP…
[가이드]   2025-05-30-Cloud_Security_Course_7Batch…Docker_And_Kubernetes…
[가이드]   2025-06-05-Email_Delivery…SPF_DKIM_DMARC…
[가이드]   2025-09-17-NPM_Shai-Hulud…Supply_Chain_Attack…
[가이드]   2025-12-17-12_Conference_Review_AWSKRUG_OWASP_Datadog…
[가이드]   2025-12-19-Cloud_Security_8Batch_4Week…
[가이드]   2026-01-08-Blockchain_Cryptocurrency_Security_Complete_Guide…
[가이드]   2026-01-14-2025_ISMS-P_Certification_Complete_Guide…
```

**전부 수작업 가이드/강의/컨퍼런스 리뷰, 크론 발행 디제스트는 0건**입니다. 즉 생성기는 맨 URL을 만들지 않으므로 blogwatcher 스텝은 이득이 없습니다. 재발 경로는 **사람이 쓰는 포스트**이므로 pre-commit(작성 경로) + svg-lint CI(훅 미설치 push 경로)에만 배선했습니다.

> 제안에는 "크론" 배선도 포함돼 있었지만, 위 근거로 제외했습니다.

## 변경

- `linkify_bare_urls.py` 에 `--check`(비파괴 탐지, exit 1) + `--staged` / `--all` 추가
- **pre-commit 12단계** — 스테이징된 `_posts/*.md` **전체** 대상 (디제스트 한정이 아닙니다. 위험군이 가이드입니다). `install-hooks.sh` 미러 + 생성 소스 동일성 확인
- **svg-lint CI** — `--all` (코퍼스가 #509 이후 0건이라 래칫 불요) + path 필터 등록

## 검증

**게이트 실동작** (위반 주입):

```
FAIL /tmp/g.md
  - bare URL: https://example.com/some/page
rc=1
```

| 검증 | 결과 |
|---|---|
| 위반 주입 시 exit 1 + 위반 URL 출력, 파일 미기록 | 확인 |
| 코퍼스 257개 / 맨 URL | **0건** (rc=0) |
| `install-hooks.sh` 생성 소스 ↔ `.githooks/pre-commit` 동일 | True |
| `pytest scripts/tests/` | **3166 passed, 5 skipped** (신규 7건: `--check` 3, 코퍼스 1, 배선 3) |