### PR TITLE
fix(news): 한국어 요약의 문장 종결 마침표 복원 — strip 탓 재발 차단

### DIFF
--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -2677,6 +2677,30 @@ def _korean_display_title(item: Dict, max_len: int = 72) -> str:
     return fallback
 
 
+_SENTENCE_ENDING_RE = re.compile(
+    r"(습니다|합니다|입니다|됩니다|있습니다|없습니다|했다|한다|된다|이다|"
+    r"았다|었다|였다|밝혔다|나타났다|보인다|요)$"
+)
+
+
+def _restore_sentence_period(text: str) -> str:
+    """Put back the sentence-final period that ellipsis cleanup stripped.
+
+    ``.strip(" .")`` exists to clear ellipsis residue, but it also eats a
+    legitimate final period, so every Korean-path summary reached the news card
+    unterminated. 14 corpus cards show it, and the rate is rising (2026-04 x3,
+    05 x2, 06 x2, 07 x7).
+
+    A period is restored ONLY after a Korean sentence-ending morpheme. Summaries
+    whose SOURCE is a headline end on a noun ("…취약점 탐지, 검증, 수정 제안");
+    bolting a period onto those would be wrong Korean, and rewriting them needs
+    the original article, so they are left exactly as they are.
+    """
+    if not text or text.endswith((".", "!", "?")):
+        return text
+    return f"{text}." if _SENTENCE_ENDING_RE.search(text) else text
+
+
 def _korean_brief_summary(item: Dict, max_sentences: int = 2) -> str:
     summary = (item.get("summary", "") or "").strip()
     content_text = (item.get("content", "") or "").strip()
@@ -2706,12 +2730,16 @@ def _korean_brief_summary(item: Dict, max_sentences: int = 2) -> str:
             generated = _gemini_call(prompt, timeout=15)
             if generated:
                 generated = re.sub(r"\s+", " ", generated)
-                generated = generated.replace("...", " ").replace("…", " ").strip(" .")
+                generated = _restore_sentence_period(
+                    generated.replace("...", " ").replace("…", " ").strip(" .")
+                )
                 if len(generated) >= 25:
                     KOREAN_SUMMARY_CACHE[cache_key] = generated
                     return generated
 
-        concise = " ".join(selected).replace("...", " ").replace("…", " ").strip(" .")
+        concise = _restore_sentence_period(
+            " ".join(selected).replace("...", " ").replace("…", " ").strip(" .")
+        )
         if len(concise) > 220:
             concise = _truncate_korean_sentence(concise, 220)
         KOREAN_SUMMARY_CACHE[cache_key] = concise

--- a/scripts/tests/test_korean_summary_period.py
+++ b/scripts/tests/test_korean_summary_period.py
@@ -1,0 +1,106 @@
+"""Regression tests: a Korean summary must keep its sentence-final period.
+
+Corpus audit 2026-08-06/07 traced the "headline-shaped fragment" summaries to
+TWO different causes, and only one of them is ours:
+
+* 14 cards end with a sentence-ending morpheme but NO period — caused by
+  ``_korean_brief_summary``'s ``.strip(" .")``, which exists to clean up
+  ellipsis residue but also eats a legitimate final period. Recurrence is live
+  and rising: 2026-04 x3, 05 x2, 06 x2, **07 x7**.
+* 11 cards end on a noun ("…취약점 탐지, 검증, 수정 제안") because the SOURCE
+  text is a headline. Nothing here can fix that without rewriting content, so
+  these tests pin that such text is left alone — a period must NOT be bolted
+  onto a noun-ended fragment.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from scripts.news import content_generator as cg  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_llm(monkeypatch):
+    monkeypatch.setattr(cg, "_GEMINI_AVAILABLE", False, raising=False)
+    monkeypatch.setattr(cg, "_GEMINI_CIRCUIT_OPEN", True, raising=False)
+    cg.KOREAN_SUMMARY_CACHE.clear()
+
+
+_seq = iter(range(10_000))
+
+
+def summarize(text):
+    return cg._korean_brief_summary(
+        {"summary": text, "title": "t", "url": f"https://e.example/{next(_seq)}", "content": ""}
+    )
+
+
+# --- period restored ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,tail",
+    [
+        ("공격자가 npm 패키지를 장악했습니다. 방어 측은 SBOM을 점검해야 합니다.", "합니다."),
+        ("공격자가 npm 패키지를 장악했습니다.", "습니다."),
+        ("보고서는 국내외 랜섬웨어 이슈를 요약한다.", "한다."),
+        ("공격이 확산되고 있습니다...", "있습니다."),
+    ],
+)
+def test_sentence_ending_keeps_its_period(text, tail):
+    assert summarize(text).endswith(tail)
+
+
+def test_ellipsis_is_still_removed():
+    assert "..." not in summarize("공격이 확산되고 있습니다...")
+    assert "…" not in summarize("공격이 확산되고 있습니다…")
+
+
+# --- what must NOT gain a period --------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "headline",
+    [
+        "OpenAI Codex Security - AI 기반 보안 에이전트로 취약점 탐지, 검증, 수정 제안",
+        "Mozilla 파트너십으로 Firefox에서 22개 보안 취약점 발견 (14개 High)",
+        "스테이블코인 월간 거래량 1.8조 달러 사상 최고치, USDC가 70% 차지",
+    ],
+)
+def test_noun_ended_headline_is_left_alone(headline):
+    """The source text is a headline; bolting on a period would be wrong Korean."""
+    out = summarize(headline)
+    assert not out.endswith(".")
+    assert out == headline
+
+
+# --- safety ------------------------------------------------------------------
+
+
+def test_no_double_period():
+    assert not summarize("공격자가 침투했습니다.").endswith("..")
+
+
+def test_empty_input_returns_empty():
+    assert summarize("") == ""
+
+
+def test_helper_is_idempotent():
+    once = cg._restore_sentence_period("공격자가 침투했습니다")
+    assert cg._restore_sentence_period(once) == once
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("공격자가 침투했습니다", "공격자가 침투했습니다."),
+        ("공격자가 침투했습니다.", "공격자가 침투했습니다."),
+        ("취약점 탐지, 검증, 수정 제안", "취약점 탐지, 검증, 수정 제안"),
+        ("", ""),
+    ],
+)
+def test_restore_sentence_period_unit(raw, expected):
+    assert cg._restore_sentence_period(raw) == expected


### PR DESCRIPTION
## 규명 결과: 원인이 둘로 갈립니다

"헤드라인형 단편 25건"을 종결어미 유무로 분류하니 **하나만 우리 코드 탓**이었습니다.

### 원인 1 — 우리 탓 (16건): `.strip(" .")`

`_korean_brief_summary` 의 `.strip(" .")` 는 말줄임표 잔여 정리용인데 **정당한 문장 마침표까지** 먹습니다. 함수 수준에서 재현했습니다:

```
입력  "공격자가 npm 패키지를 장악했습니다."
출력  "공격자가 npm 패키지를 장악했습니다"      ← 마침표 소실
```

**모든** 한국어 경로 요약이 종결부호 없이 뉴스 카드에 도달합니다. 재발은 **현재진행이며 증가 추세**입니다:

| 월 | 2026-04 | 05 | 06 | **07** |
|---|---|---|---|---|
| 건수 | 3 | 2 | 2 | **7** |

### 원인 2 — 우리 탓 아님 (9건): 원문이 헤드라인

```
"…AI 기반 보안 에이전트로 취약점 탐지, 검증, 수정 제안"
"Mozilla 파트너십으로 Firefox에서 22개 보안 취약점 발견 (14개 High)"
```

명사로 끝납니다. 여기에 마침표를 붙이면 **틀린 한국어**이고, 다시 쓰려면 원문 재수집이 필요하므로 손대지 않았습니다. 테스트로 "건드리지 않음"을 고정했습니다.

## 수정

`_restore_sentence_period` 헬퍼를 두 경로(LLM 생성분, `concise` 폴백)에 적용합니다. **한국어 종결어미 뒤에만** 마침표를 복원하고, 이미 종결부호가 있으면 무변경(멱등)입니다.

## 검증

```
2문장 정상       → …'악했습니다. 방어 측은 SBOM을 점검해야 합니다.'   복원
1문장            → …'공격자가 npm 패키지를 장악했습니다.'              복원
말줄임표         → …'공격이 확산되고 있습니다.'                        복원 + 말줄임표 제거
명사형 헤드라인   → …'반 보안 에이전트로 취약점 탐지, 검증, 수정 제안'  유지
```

| 검증 | 결과 |
|---|---|
| 말줄임표 제거 유지 (`...`·`…` 잔여) | 0 |
| 코퍼스 25건 분류 | 복원 대상 **16** / 유지 대상 **9** |
| `pytest scripts/tests/` | **3181 passed, 5 skipped** (신규 15건) |

> 앞선 탐침은 14/11로 셌는데, 종결어미 목록이 좁았기 때문입니다. 배포되는 분류기(`_SENTENCE_ENDING_RE`) 기준이 16/9이며 이 값이 정확합니다.

## 범위

**생성기만** 수정했습니다. 기존 16개 카드 백필은 별도 작업으로 남깁니다 — 이 PR은 재발 차단이 목적입니다.