### PR TITLE
fix(news): 절단된 카드 요약 126건을 마지막 완성 문장으로 되감기

### DIFF
--- a/_posts/2026-03-19-Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch.md
+++ b/_posts/2026-03-19-Tech_Security_Weekly_Digest_Zero-Day_CVE_Ransomware_Patch.md
@@ -124,7 +124,7 @@ DevSecOps 실무자에게 이 사건은 **공급망 보안(Software Supply Chain
   title="Interlock 랜섬웨어, Cisco FMC 제로데이 CVE-2026-20131 악용해 루트 접근 획득"
   url="https://thehackernews.com/2026/03/interlock-ransomware-exploits-cisco-fmc.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjIlKuha7SKiNtcZ_rk3dVV2Mt4tDfyfAir2TYksjgJhuuBlUNRqZu0Zeh8xwCMU7XCedi9khw6ywY0sqBRY8BrY-8jLzGOdSU7YRit5m4ew711QN8qK-aG224wOrcXc7k3_8QDy1zfXZ1UWVaR3C_J3WzNuvCkApYqhmICJI62mVMO2R1OoiJ17ySmxQm6/s1600/cc.jpg"
-  summary="Amazon Threat Intelligence는 Cisco Secure Firewall Management Center(FMC) 소프트웨어의 치명적 결함 CVE-2026-20131을 악용한 Interlock 랜섬웨어 캠페인이 활발하다고 경고합니다. 이 취약점은 인증되지 않은 공격자가 원격으로 루트 접근 권한을 얻을 수 있게 하는 Java 바이트 스트림 역"
+  summary="Amazon Threat Intelligence는 Cisco Secure Firewall Management Center(FMC) 소프트웨어의 치명적 결함 CVE-2026-20131을 악용한 Interlock 랜섬웨어 캠페인이 활발하다고 경고합니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -278,7 +278,7 @@ Google Cloud는 완전 관리형 서비스인 Memorystore for Valkey의 9.0 버�
   title="Cloud SQL 자동 확장 읽기 풀로 읽기 확장성 간소화"
   url="https://cloud.google.com/blog/products/databases/cloudsql-read-pools-support-autoscaling/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/1_dN3AmBF.max-1000x1000.jpg"
-  summary="Cloud SQL autoscaling read pools는 데이터베이스의 읽기 중심 워크로드를 확장하기 위한 솔루션입니다. 이 기능은 단일 읽기 복제본의 용량 한계를 넘어서는 부하를 처리하며, 개발자가 로드 밸런서 뒤에 여러 복제본을 수동으로 구성하고 관리하는 복잡성을 해소합니다. 이를 통해 애플리케이션은 기본 인스턴스의 쓰기 작업에 영향을 주지 않고 읽"
+  summary="Cloud SQL autoscaling read pools는 데이터베이스의 읽기 중심 워크로드를 확장하기 위한 솔루션입니다. 이 기능은 단일 읽기 복제본의 용량 한계를 넘어서는 부하를 처리하며, 개발자가 로드 밸런서 뒤에 여러 복제본을 수동으로 구성하고 관리하는 복잡성을 해소합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE_AI_Malware.md
+++ b/_posts/2026-03-21-Tech_Security_Weekly_Digest_Security_CVE_AI_Malware.md
@@ -97,7 +97,7 @@ summary_card:
   title="Trivy Security Scanner GitHub Actions 침해로 75개 태그 탈취되어 CI/CD 비밀번호 유출"
   url="https://thehackernews.com/2026/03/trivy-security-scanner-github-actions.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgNf7vYlImTCJ7BCjYYEhoFZXTawhHcJJad9cFjQn98oQjaPY9HY6Qgpp6pAyqkq7CNHyVXI9fR8hcyVNlW_knYia3f0BhAlK7fZb2gplznk9v9QCFGKtIbMLTSu-erTslOxZCHd8jkJKXIcCYhK8QkKLuWjG8yxjhPBaEWUDzwY0sUkX5JvhBtzFxyfp_q/s1600/scan.jpg"
-  summary="Aqua Security가 유지 관리하는 오픈소스 취약점 스캐너 Trivy가 한 달 만에 두 번째로 침해되어 CI/CD 비밀을 탈취하는 악성코드를 유포했습니다. 이번 사고는 GitHub Actions의 \”aquasecurity/trivy-action\” 및 \”aquasecurity/setup-trivy\” 리포지토리를 타겟으로 했으며, 총 75개의 태그가 탈취"
+  summary="Aqua Security가 유지 관리하는 오픈소스 취약점 스캐너 Trivy가 한 달 만에 두 번째로 침해되어 CI/CD 비밀을 탈취하는 악성코드를 유포했습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-04-04-Tech_Security_Weekly_Digest_Go_AI_Data_Security.md
+++ b/_posts/2026-04-04-Tech_Security_Weekly_Digest_Go_AI_Data_Security.md
@@ -125,7 +125,7 @@ DevSecOps 실무자에게 이 공격은 **소프트웨어 공급망과 클라우
   title="Microsoft, Linux 서버에서 Cron을 통해 지속되는 쿠키 제어 PHP 웹 셸 상세 공개"
   url="https://thehackernews.com/2026/04/microsoft-details-cookie-controlled-php.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg_2zEf8l08MTElI1sGlJPVVWtscud2RAXdsivOvcby3pO4NUWMBioT3FNaFL7Bw0GeEqnX_WqY10FVqXhVNBTOrl0UMPoyun7AvshwpvfJIdfdJ0yJ1V2mz7ZHQDE9motXuuW6urvTJYu0kLGvpZf10Qx1hNeobD4YV25tJY9nvNoW9Sqd8nSsWK7NWQP0/s1600/php-linux.jpg"
-  summary="Microsoft Defender Security Research Team에 따르면 위협 행위자들이 Linux 서버에서 PHP 기반 웹 셸의 제어 채널로 HTTP cookie를 활용하고 원격 코드 실행을 달성하는 사례가 증가하고 있습니다. 이러한 웹 셸은 URL 매개변수가 아닌 공격자가 제공한 cookie 값을 통해 실행을 제어하며, Cron을 이용해 지속"
+  summary="Microsoft Defender Security Research Team에 따르면 위협 행위자들이 Linux 서버에서 PHP 기반 웹 셸의 제어 채널로 HTTP cookie를 활용하고 원격 코드 실행을 달성하는 사례가 증가하고 있습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-04-08-Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet.md
+++ b/_posts/2026-04-08-Tech_Security_Weekly_Digest_AI_CVE_Docker_Botnet.md
@@ -241,7 +241,7 @@ Amazon Nova 2 Sonic의 스트리밍 기능을 활용해 주제에 따라 두 AI 
 {% include news-card.html
   title="Claude Mythos 프리뷰: Vertex AI에서 프라이빗 프리뷰로 이용 가능"
   url="https://cloud.google.com/blog/products/ai-machine-learning/claude-mythos-preview-on-vertex-ai/"
-  summary="Anthropic의 최신 최강 모델인 Claude Mythos Preview가 Project Glasswing의 일환으로 선별된 Google Cloud 고객을 대상으로 Vertex AI에서 Private Preview로 제공됩니다. Vertex AI를 통한 Claude Mythos Preview 제공은 Google Cloud가 선도적인 AI 연구소의 모델에"
+  summary="Anthropic의 최신 최강 모델인 Claude Mythos Preview가 Project Glasswing의 일환으로 선별된 Google Cloud 고객을 대상으로 Vertex AI에서 Private Preview로 제공됩니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-10-Tech_Security_Weekly_Digest_AI_Malware_Go_Agent.md
+++ b/_posts/2026-04-10-Tech_Security_Weekly_Digest_AI_Malware_Go_Agent.md
@@ -271,7 +271,7 @@ Google Cloud가 대규모 GPU AI/ML 인프라의 신뢰성을 확보하기 위�
   title="Estée Lauder Companies가 풀 기반 에이전트 워크로드에 Cloud Run 작업자 풀을 활용하는 방법"
   url="https://cloud.google.com/blog/products/serverless/cloud-run-worker-pools-at-estee-lauder-companies/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/1_bo5uUuL.max-1000x1000.png"
-  summary="Estée Lauder Companies는 지속적인 데이터 스트림 처리 파이프라인과 같은 복잡한 애플리케이션을 위해 Cloud Run worker pools를 활용합니다. 이를 통해 pull-based agentic workloads에 적합한 지속적 백그라운드 실행 환경을 구축했습니다. Cloud Run은 기존 요청 기반 웹 애플리케이션과 배치 작업 실행을"
+  summary="Estée Lauder Companies는 지속적인 데이터 스트림 처리 파이프라인과 같은 복잡한 애플리케이션을 위해 Cloud Run worker pools를 활용합니다. 이를 통해 pull-based agentic workloads에 적합한 지속적 백그라운드 실행 환경을 구축했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-12-Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI.md
+++ b/_posts/2026-04-12-Tech_Security_Weekly_Digest_Data_GPT_Cloud_AI.md
@@ -99,7 +99,7 @@ summary_card:
   title="Citizen Lab: 법 집행 기관이 광고 데이터를 통해 5억 대 기기를 Webloc으로 추적"
   url="https://thehackernews.com/2026/04/citizen-lab-law-enforcement-used-webloc.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgJjyKn2cWWKQvAjaegOP6UqdtgG4Cr6nQdwobWhvYvaSKO-VGcFFSSAvT6ngpo8T9n0BitFhLNKPv669Qp3I_2ZajEs3DbveUT5qhc4zVWHRbjJH4fv0_84_FNhPFnN7EPFa9szLDP6B5G-1owBpAGGFILLSX4q8ZobwLXjI9CPn0DfExp6y0_33OdtmkV/s1600/location-data.jpg"
-  summary="Citizen Lab 보고서에 따르면 Hungarian domestic intelligence와 El Salvador 국가경찰, 다수의 미국 법 집행 기관이 Cobwebs Technologies가 개발한 Webloc 감시 시스템을 사용해 약 5억 대의 기기를 추적한 것으로 나타났습니다. Webloc은 광고 데이터를 활용한 지리적 위치 감시 시스템으로, 현재"
+  summary="Citizen Lab 보고서에 따르면 Hungarian domestic intelligence와 El Salvador 국가경찰, 다수의 미국 법 집행 기관이 Cobwebs Technologies가 개발한 Webloc 감시 시스템을 사용해 약 5억 대의 기기를 추적한 것으로 나타났습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-04-13-Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust.md
+++ b/_posts/2026-04-13-Tech_Security_Weekly_Digest_CVE_Patch_Zero-Day_Rust.md
@@ -194,7 +194,7 @@ mitre_attack:
   title="혁명의 유물, 2부: 허위 이익과 자유"
   url="https://bitcoinmagazine.com/culture/relics-of-a-revolution-part-ii-false-profits-and-freedom"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/04/Relics-of-a-Revolution-Part-II.png"
-  summary="Bitcoin Magazine의 'Relics of a Revolution, Part II: False Profits and Freedom' 기사는 Mear One의 예술을 통해 가짜 수익과 자유를 주제로, 그래피티 벽에서 Bitcoin의 Genesis Block에 이르기까지 부서진 금융 시스템에 맞선 투쟁을 추적합니다. 이 글은 Dennis Koch가 집"
+  summary="Bitcoin Magazine의 'Relics of a Revolution, Part II: False Profits and Freedom' 기사는 Mear One의 예술을 통해 가짜 수익과 자유를 주제로, 그래피티 벽에서 Bitcoin의 Genesis Block에 이르기까지 부서진 금융 시스템에 맞선 투쟁을 추적합니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-04-14-Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data.md
+++ b/_posts/2026-04-14-Tech_Security_Weekly_Digest_Malware_Vulnerability_AI_Data.md
@@ -197,7 +197,7 @@ Cloudflare가 OpenAI의 GPT-5.4와 Codex를 Agent Cloud에 도입했습니다. �
 {% include news-card.html
   title="Amazon Nova 모델 맞춤화를 위한 AWS Lambda 효과적 보상 함수 구축 방법"
   url="https://aws.amazon.com/blogs/machine-learning/how-to-build-effective-reward-functions-with-aws-lambda-for-amazon-nova-model-customization/"
-  summary="AWS Lambda를 활용해 Amazon Nova 모델 맞춤화를 위한 효과적이고 확장 가능한 보상 함수를 구축하는 방법을 소개합니다. RLVR와 RLAIF 중 작업 성격에 맞는 방법을 선택하고, 보상 해킹을 방지하는 다차원 보상 시스템을 설계할 수 있습니다. 또한 Lambda 함수를 학습 규모에 맞게 최적화하고 Amazon CloudWatch로 보상 분포를"
+  summary="AWS Lambda를 활용해 Amazon Nova 모델 맞춤화를 위한 효과적이고 확장 가능한 보상 함수를 구축하는 방법을 소개합니다. RLVR와 RLAIF 중 작업 성격에 맞는 방법을 선택하고, 보상 해킹을 방지하는 다차원 보상 시스템을 설계할 수 있습니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}

--- a/_posts/2026-04-15-Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch.md
+++ b/_posts/2026-04-15-Tech_Security_Weekly_Digest_AI_AWS_Agent_Patch.md
@@ -279,7 +279,7 @@ Google이 BigQuery Graph를 프리뷰로 출시했다. BigQuery Graph는 대규�
   title="BigQuery Graph와 Kineviz GraphXR로 비정형 기업 지식 확장하기"
   url="https://cloud.google.com/blog/products/data-analytics/using-bigquery-graph-with-kineviz-graphxr/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/1_O1oo2li.max-1000x1000.png"
-  summary="기업 데이터의 80% 이상을 차지하는 PDF, 이메일, 보고서 등의 비정형 데이터를 분석하기 위해 BigQuery Graph와 Kineviz GraphXR이 통합되었습니다. 이 두 기술은 단일화된 워크플로우를 제공하여 대규모 비정형 데이터에 숨겨진 비즈니스 인사이트를 발견하는 과정을 간소화합니다. 이를 통해 의사 결정자들이 기업의 비정형 지식에 효과적으로 "
+  summary="기업 데이터의 80% 이상을 차지하는 PDF, 이메일, 보고서 등의 비정형 데이터를 분석하기 위해 BigQuery Graph와 Kineviz GraphXR이 통합되었습니다. 이 두 기술은 단일화된 워크플로우를 제공하여 대규모 비정형 데이터에 숨겨진 비즈니스 인사이트를 발견하는 과정을 간소화합니다."
   source="Google Cloud Blog"
   severity="High"
 %}

--- a/_posts/2026-04-16-Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch.md
+++ b/_posts/2026-04-16-Tech_Security_Weekly_Digest_AI_Malware_CVE_Patch.md
@@ -255,7 +255,7 @@ AI 인프라 경제성 평가에서 전통적인 데이터 센터 비용 지표 
   title="Cloud CISO Perspectives: CISO가 기술적, 문화적 회복력을 추구하는 방법 (Q&A)"
   url="https://cloud.google.com/blog/products/identity-security/cloud-ciso-perspectives-how-cisos-can-pursue-technical-and-cultural-resilience-q-a/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/Thiebaut_Meyer_2025.max-1000x1000.jpg"
-  summary="Google Cloud의 CISO 오피스 담당자가 2026년 4월 첫 Cloud CISO Perspectives를 통해 Lloyds Banking Group의 CSO와의 대화를 공유했습니다. 이 대화에서는 보안 리더들이 기술적 회복탄력성과 문화적 회복탄력성을 동시에 추구하는 방법을 논의했습니다. 이 뉴스레터 내용은 Google Cloud 블로그에도 게시됩니"
+  summary="Google Cloud의 CISO 오피스 담당자가 2026년 4월 첫 Cloud CISO Perspectives를 통해 Lloyds Banking Group의 CSO와의 대화를 공유했습니다. 이 대화에서는 보안 리더들이 기술적 회복탄력성과 문화적 회복탄력성을 동시에 추구하는 방법을 논의했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-17-Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware.md
+++ b/_posts/2026-04-17-Tech_Security_Weekly_Digest_Botnet_Threat_AI_Malware.md
@@ -235,7 +235,7 @@ Gemini 앱에서 Personal Intelligence를 활용해 개인화된 이미지를 �
 {% include news-card.html
   title="Google Data Cloud의 새로운 소식"
   url="https://cloud.google.com/blog/products/data-analytics/whats-new-with-google-data-cloud/"
-  summary="Google은 AI 시대에 중요한 역할을 위해 Data Studio를 재도입하여 데이터 시각화와 보고를 넘어 BigQuery 대화형 에이전트와 Colab 노트북으로 구축된 데이터 앱을 호스팅할 것이라고 발표했습니다. 또한 미리보기로 제공되는 BigQuery Graph는 사용하기 쉬운 고확장성 그래프 분석 솔루션으로, 방대한 규모의 관계를 새로운 방식으로 모"
+  summary="Google은 AI 시대에 중요한 역할을 위해 Data Studio를 재도입하여 데이터 시각화와 보고를 넘어 BigQuery 대화형 에이전트와 Colab 노트북으로 구축된 데이터 앱을 호스팅할 것이라고 발표했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-19-Tech_Security_Weekly_Digest_AI_Data_CVE_Botnet.md
+++ b/_posts/2026-04-19-Tech_Security_Weekly_Digest_AI_Data_CVE_Botnet.md
@@ -127,7 +127,7 @@ redirect_from:
   title="크로스 테넌트 헬프데스크 사칭에서 데이터 유출까지: 인간 운영 침입 플레이북"
   url="https://www.microsoft.com/en-us/security/blog/2026/04/18/crosstenant-helpdesk-impersonation-data-exfiltration-human-operated-intrusion-playbook/"
   image="https://www.microsoft.com/en-us/security/blog/wp-content/uploads/2026/04/MS_Actional-Insights_Rapid-response.jpg"
-  summary="위협 행위자들이 Microsoft Teams 외부 협업 기능을 악용해 IT helpdesk 직원을 사칭하고 사용자들을 속여 원격 접근 권한을 얻고 있습니다. 침입 후 공격자들은 합법적 도구와 표준 관리 프로토콜을 남용해 측면 이동과 데이터 유출을 수행하며, Microsoft Defender는 Teams, 엔드포인트, ID 원격 분석을 통해 이러한 활동을 탐"
+  summary="위협 행위자들이 Microsoft Teams 외부 협업 기능을 악용해 IT helpdesk 직원을 사칭하고 사용자들을 속여 원격 접근 권한을 얻고 있습니다."
   source="Microsoft Security Blog"
   severity="High"
 %}
@@ -179,7 +179,7 @@ DevSecOps 관점에서 이 공격은 **CI/CD 파이프라인과 운영 환경 �
   title="Mirai 변종 Nexcorium, CVE-2024-3721 취약점으로 TBK DVR 장악해 DDoS 봇넷 구축"
   url="https://thehackernews.com/2026/04/mirai-variant-nexcorium-exploits-cve.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh6cxZZMfiWctk3Me9QO6UlzVRFab0SPGMTzThjpcPHCXm49bQ0rRvtG2W6gicJw4Mi1QUuv-yTDMK5GKJju3QicyjYJwdbA86Ok8w2oU5Vg28l4s0HAVv7_c03dStaM7OPd4Yq0khmm9MeQVUYnCYThMx4JvkCnZZ5PEtCXAA90vKfsAumsMAIw085JIsz/s1600/botnet-ddos.jpg"
-  summary="Fortinet FortiGuard Labs와 Palo Alto Networks Unit 42에 따르면 위협 행위자들이 TBK DVR과 EoL TP-Link Wi-Fi 라우터의 보안 결함을 악용해 Mirai 봇넷 변종을 배포하고 있습니다. TBK DVR을 대상으로 한 공격은 중간 심각도 명령어 삽입 취약점인 CVE-2024-3721을 악용하는 것으로 확인되"
+  summary="Fortinet FortiGuard Labs와 Palo Alto Networks Unit 42에 따르면 위협 행위자들이 TBK DVR과 EoL TP-Link Wi-Fi 라우터의 보안 결함을 악용해 Mirai 봇넷 변종을 배포하고 있습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.md
+++ b/_posts/2026-04-21-Tech_Security_Weekly_Digest_CVE_Apple_AI_Agent.md
@@ -144,7 +144,7 @@ index=security sourcetype=syslog ("exploit" OR "remote code execution" OR "shell
   title="주간 보안 뉴스 요약: Vercel 해킹, Push 사기, QEMU 악용, 신종 Android RAT 등장 및 기타 소식"
   url="https://thehackernews.com/2026/04/weekly-recap-vercel-hack-push-fraud.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEirkQSoHlNZvcdjrevc7r-D8mPj49i3XRimQjk-HtEVDYVX4vKEcW4JLiTblV5oI8MtUib2Q5iFerdt0x4_mGDvMJqsDd2wX6QNQxM25Wnrq-MRYADw1YuJly5yoSTIz_ToqlWsAKA2hLwru4Crx8aSguTETpDl4mjRfrCg0G8Cca5Rk0Am6FCwRCNPIqBy/s1600/recap-april.jpg"
-  summary="Vercel 해킹, Push Fraud, QEMU 악용, 새로운 Android RAT 등장 등 다양한 보안 사건이 발생했습니다. 공격자들은 타사 도구, 신뢰받는 다운로드 경로, 브라우저 확장 프로그램, 업데이트 채널과 같은 정상적인 요소를 악용하여 접근 권한을 얻고 있습니다. 이는 시스템을 파괴하기보다 신뢰를 왜곡시키는 방식으로 공격 패러다임이 변화하고 있"
+  summary="Vercel 해킹, Push Fraud, QEMU 악용, 새로운 Android RAT 등장 등 다양한 보안 사건이 발생했습니다. 공격자들은 타사 도구, 신뢰받는 다운로드 경로, 브라우저 확장 프로그램, 업데이트 채널과 같은 정상적인 요소를 악용하여 접근 권한을 얻고 있습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -275,7 +275,7 @@ Amazon SageMaker AI에서 NVIDIA RTX PRO 6000 Blackwell Server Edition GPU로 �
 {% include news-card.html
   title="AWS 위클리 라운드업: Amazon Bedrock의 Claude Opus 4.7, AWS Interconnect GA 등 (2026년 4월 20일)"
   url="https://aws.amazon.com/blogs/aws/aws-weekly-roundup-claude-opus-4-7-in-amazon-bedrock-aws-interconnect-ga-and-more-april-20-2026/"
-  summary="Amazon Bedrock에 향상된 에이전트 코딩 기능과 1M 토큰 컨텍스트 윈도우를 갖춘 Claude Opus 4.7이 출시되었습니다. 또한 AWS Interconnect가 멀티클라우드 프라이빗 연결성과 새로운 라스트 마일 옵션으로 정식 출시되었으며, Secrets Manager의 포스트-퀀텀 TLS와 새로운 C8in/C8ib EC2 인스턴스 등이 소개되"
+  summary="Amazon Bedrock에 향상된 에이전트 코딩 기능과 1M 토큰 컨텍스트 윈도우를 갖춘 Claude Opus 4.7이 출시되었습니다."
   source="AWS Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-22-Tech_Security_Weekly_Digest_AI_Ransomware_AWS_Go.md
+++ b/_posts/2026-04-22-Tech_Security_Weekly_Digest_AI_Ransomware_AWS_Go.md
@@ -193,7 +193,7 @@ Forescout Research Vedere Labs는 Lantronix와 Silex의 Serial-to-IP 컨버터�
 {% include news-card.html
   title="Facebook Groups 검색 현대화로 커뮤니티 지식의 힘을 발휘하다"
   url="https://engineering.fb.com/2026/04/21/ml-applications/modernizing-the-facebook-groups-search-to-unlock-the-power-of-community-knowledge/"
-  summary="Facebook은 커뮤니티 콘텐츠 검색의 주요 문제점을 해결하기 위해 새로운 hybrid retrieval architecture를 도입하고 automated model-based evaluation을 구현했습니다. 이를 통해 Facebook Groups Search를 근본적으로 변환하여 사용자가 관련성 높은 커뮤니티 지식을 더욱 신뢰성 있게 발견하고 검증"
+  summary="Facebook은 커뮤니티 콘텐츠 검색의 주요 문제점을 해결하기 위해 새로운 hybrid retrieval architecture를 도입하고 automated model-based evaluation을 구현했습니다."
   source="Meta Engineering Blog"
   severity="Medium"
 %}

--- a/_posts/2026-04-23-Tech_Security_Weekly_Digest_AI_Docker_Go_API.md
+++ b/_posts/2026-04-23-Tech_Security_Weekly_Digest_AI_Docker_Go_API.md
@@ -292,7 +292,7 @@ Google Cloud Next '26에서는 AI의 실용적 발전을 심층적으로 살펴�
 {% include news-card.html
   title="컴퓨트의 새로운 소식: 코어 및 에이전트 워크로드 확장"
   url="https://cloud.google.com/blog/products/compute/whats-new-in-compute-at-next26/"
-  summary="Google Cloud Next에서 발표한 새로운 컴퓨팅 기능은 코어 범용 및 AI 워크로드를 에이전트 세계에 맞춰 더 높은 성능과 낮은 비용으로 지원합니다. 이는 IT 리더와 개발자들이 에이전트 AI와 웹 서버, 데이터베이스, 기업 애플리케이션 같은 일상적인 고객 경험을 주도하는 범용 사용 사례 간 컴퓨팅 투자와 자원 균형을 맞추는 데 중요한 도움이 될 "
+  summary="Google Cloud Next에서 발표한 새로운 컴퓨팅 기능은 코어 범용 및 AI 워크로드를 에이전트 세계에 맞춰 더 높은 성능과 낮은 비용으로 지원합니다."
   source="Google Cloud Blog"
   severity="High"
 %}

--- a/_posts/2026-04-25-Tech_Security_Weekly_Digest_Patch_Security_Threat_Data.md
+++ b/_posts/2026-04-25-Tech_Security_Weekly_Digest_Patch_Security_Threat_Data.md
@@ -246,7 +246,7 @@ Google의 AI 비서 Gemini가 공간과 생활을 정리하는 데 도움을 주
 {% include news-card.html
   title="Visier와 Amazon Quick으로 워크포스 AI 에이전트 구축하기"
   url="https://aws.amazon.com/blogs/machine-learning/building-workforce-ai-agents-with-visier-and-amazon-quick/"
-  summary="Visier Workforce AI 플랫폼과 Amazon Quick를 Model Context Protocol (MCP)로 연결하여 모든 지식 근로자에게 통합된 에이전트 작업 공간을 제공하는 방법을 보여줍니다. Visier는 실시간 인력 데이터와 조직적 맥락을 기반으로 작업 공간을 구성하며, 사용자는 도구 전환 없이 대화형 결과에 대해 조치를 취할 수 있습"
+  summary="Visier Workforce AI 플랫폼과 Amazon Quick를 Model Context Protocol (MCP)로 연결하여 모든 지식 근로자에게 통합된 에이전트 작업 공간을 제공하는 방법을 보여줍니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}

--- a/_posts/2026-04-29-Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update.md
+++ b/_posts/2026-04-29-Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update.md
@@ -100,7 +100,7 @@ redirect_from:
   title="연구진, 단일 Git Push로 악용 가능한 GitHub CVE-2026-3854 원격 코드 실행 취약점 발견"
   url="https://thehackernews.com/2026/04/researchers-discover-critical-github.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgztlzahKA2HwUQiNDerhbX2l415JinNIW5jaU5tgskPVHqpMhba_NorYL9SSWRzLdSPjSnsxZKQic97f8H2Bx2G0Dsjb58dcdFuZoL0c5Gno3BVvYa4vi62_PNr1Qh-kBYED7YbTPw3fqQklMmnoPV0b1KYaienKHzIAtBuktMqyVCxGU0u8Hkd-zzYeNU/s1600/github.jpg"
-  summary="보안 연구자들이 GitHub.com과 GitHub Enterprise Server에 영향을 미치는 심각도 '높음(High)' 등급의 취약점 CVE-2026-3854(CVSS 점수 8.7)의 세부 내용을 공개했습니다. 이 결함은 명령 인젝션(Command Injection)으로, 저장소에 푸시 접근 권한이 있는 인증된 사용자가 단 한 번의 \”git push\” 명령으로 원격 코드 실행"
+  summary="보안 연구자들이 GitHub.com과 GitHub Enterprise Server에 영향을 미치는 심각도 '높음(High)' 등급의 취약점 CVE-2026-3854(CVSS 점수 8.7)의 세부 내용을 공개했습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-04-30-Tech_Security_Weekly_Digest_AI_Malware_Rust.md
+++ b/_posts/2026-04-30-Tech_Security_Weekly_Digest_AI_Malware_Rust.md
@@ -98,7 +98,7 @@ redirect_from:
   title="SAP 관련 npm 패키지, 자격 증명 탈취 공급망 공격으로 손상"
   url="https://thehackernews.com/2026/04/sap-npm-packages-compromised-by-mini.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh7ILiV-4oJHtNRt3-K52GIsgOaNUuN9owB5ky-Mk8FvRE3QmcqDg33oV3sCrzjgWEyIUfwTtn110bcMYVU3Lp61ArknIlPAcmMvbgJJ5-WheKYivyblon2tp79ux9pJmnYNv_ShhIAA5of3Wx7QzQRZs2mNuSQs6lLG23LKMVonvElcNMy6MXp6yVZO73F/s1600/sap-npm-hacks.jpg"
-  summary="보안 연구진이 SAP 관련 npm 패키지를 대상으로 자격 증명을 탈취하는 공급망 공격 캠페인을 경고하고 있습니다. mini Shai-Hulud라고 불리는 이 캠페인은 Aikido Security, SafeDep, Socket, StepSecurity, Google 소유의 Wiz 등 여러 보안 업체에 의해 발견되었으며, SAP의 JavaScript 및 클라우"
+  summary="보안 연구진이 SAP 관련 npm 패키지를 대상으로 자격 증명을 탈취하는 공급망 공격 캠페인을 경고하고 있습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -137,7 +137,7 @@ DevSecOps 실무자 관점에서 이번 공격은 **CI/CD 파이프라인, 컨�
   title="북한의 새로운 공격 물결, AI 삽입 npm 악성코드와 가짜 회사, RAT 사용"
   url="https://thehackernews.com/2026/04/new-wave-of-dprk-attacks-uses-ai.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgoAi4Ild7Dz2KtvraUPjGBgNHYScbOo2DzPh9iUn8IirHe8VYws7uF0A4wf2803kNMgLzCWg0oOZwXcdzRUx5-sbBPiABEN05-RtXTa2vMqOSa52E4FPELQba8QcIQBPXl6hOHuyN7cHldbTMMvxnA4UhxDk1Huh2W85I0EJeWdscqF5NdwRLjbtOXn7Zj/s1600/korean-hackers.jpg"
-  summary="북한(DPRK)의 새로운 공격 캠페인이 AI를 활용해 삽입된 npm 악성코드, 가짜 기업, 원격 접속 트로이목마(RAT)를 사용하는 것으로 드러났습니다. 보안 연구원들은 Anthropic의 Claude Opus LLM이 의존성으로 추가한 npm 패키지 '@validate-sdk/v2'에서 악성 코드를 발견했으며, 이 패키지는 해싱, 검증, 인코딩/디코딩 기"
+  summary="북한(DPRK)의 새로운 공격 캠페인이 AI를 활용해 삽입된 npm 악성코드, 가짜 기업, 원격 접속 트로이목마(RAT)를 사용하는 것으로 드러났습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-01-Tech_Security_Weekly_Digest_AI_AWS_Threat_Cloud.md
+++ b/_posts/2026-05-01-Tech_Security_Weekly_Digest_AI_AWS_Threat_Cloud.md
@@ -349,7 +349,7 @@ Google Cloud는 4월 22일 라스베이거스에서 Google Cloud Next를 개최�
   title="GitHub Copilot in Visual Studio — 4월 업데이트"
   url="https://github.blog/changelog/2026-04-30-github-copilot-in-visual-studio-april-update"
   image="https://github.blog/wp-content/themes/github-2021-child/dist/img/social-v3-new-releases.jpg"
-  summary="Visual Studio의 2026년 4월 업데이트는 에이전틱 워크플로우에 중점을 두어, IDE에서 직접 클라우드 에이전트 세션을 시작하고 사용자 수준의 커스텀 에이전트를 지원하며 새로운 Debugger agent가 검증 기능을 제공합니다. 이 소식은 GitHub Blog에 게시된 GitHub Copilot in Visual Studio — April up"
+  summary="Visual Studio의 2026년 4월 업데이트는 에이전틱 워크플로우에 중점을 두어, IDE에서 직접 클라우드 에이전트 세션을 시작하고 사용자 수준의 커스텀 에이전트를 지원하며 새로운 Debugger agent가 검증 기능을 제공합니다."
   source="GitHub Changelog"
   severity="Medium"
 %}

--- a/_posts/2026-05-02-Tech_Security_Weekly_Digest_AI_Go_Security_AWS.md
+++ b/_posts/2026-05-02-Tech_Security_Weekly_Digest_AI_Go_Security_AWS.md
@@ -279,7 +279,7 @@ GitHub Copilot 전반에서 GPT-5.2와 GPT-5.2-Codex 모델이 2026년 6월 5일
 {% include news-card.html
   title="Docker의 Virtual Agent 팀: Coding Agent Sandboxes 팀이 에이전트 함대를 활용하여 더 빠르게 출시하는 방법"
   url="https://www.docker.com/blog/a-virtual-agent-team-at-docker-how-the-coding-agent-sandboxes-team-uses-a-fleet-of-agents-to-ship-faster/"
-  summary="Docker의 Coding Agent Sandboxes 팀은 Claude Code, Gemini, Codex, Docker Agent, Kiro 같은 AI 코딩 에이전트를 위한 microVM 기반의 안전한 격리 환경을 제공합니다. 이 샌드박스 안에서 에이전트는 호스트 시스템에 영향을 주지 않고 자체 Docker daemon, 네트워크, 파일시스템을 갖춘 완"
+  summary="Docker의 Coding Agent Sandboxes 팀은 Claude Code, Gemini, Codex, Docker Agent, Kiro 같은 AI 코딩 에이전트를 위한 microVM 기반의 안전한 격리 환경을 제공합니다."
   source="Docker Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-05-Tech_Security_Weekly_Digest_AI_Patch_AWS.md
+++ b/_posts/2026-05-05-Tech_Security_Weekly_Digest_AI_Patch_AWS.md
@@ -254,7 +254,7 @@ Gemini API에서 Webhooks를 사용하여 장기 실행 작업의 지연 시간�
 {% include news-card.html
   title="BI를 넘어서: Amazon Quick의 데이터셋 Q&A 기능이 이끄는 차세대 데이터 의사결정"
   url="https://aws.amazon.com/blogs/machine-learning/beyond-bi-how-the-dataset-qa-feature-of-amazon-quick-powers-the-next-generation-of-data-decisions/"
-  summary="Amazon Quick의 Dataset Q&A 기능은 기존 대시보드가 해결하지 못하는 임시적이고 다차원적인 질문에 실시간으로 대응하여 데이터 의사결정의 병목 현상을 해소합니다. 비즈니스 리더들은 일상적인 운영 대시보드에 의존하지만, 예상치 못한 분석 요구가 발생하면 BI 팀이 새 뷰를 구축할 때까지 기다려야 했던 문제를 개선합니다. 이 기능은 사전 정의된 "
+  summary="Amazon Quick의 Dataset Q&A 기능은 기존 대시보드가 해결하지 못하는 임시적이고 다차원적인 질문에 실시간으로 대응하여 데이터 의사결정의 병목 현상을 해소합니다. 비즈니스 리더들은 일상적인 운영 대시보드에 의존하지만, 예상치 못한 분석 요구가 발생하면 BI 팀이 새 뷰를 구축할 때까지 기다려야 했던 문제를 개선합니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}

--- a/_posts/2026-05-06-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
+++ b/_posts/2026-05-06-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
@@ -316,7 +316,7 @@ Google Cloud Next '26에서 소개된 Gemini Enterprise Agent Platform은 데모
   title="보안 및 거버넌스를 위한 Agent Gateway ISV 에코시스템 소개"
   url="https://cloud.google.com/blog/products/identity-security/introducing-agent-gateway-isv-ecosystem-for-security-and-governance/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/image1_uHj4mOq.max-1000x1000.png"
-  summary="Google Cloud Next에서 발표된 Agent Gateway는 AI 에이전트의 보안과 거버넌스를 위한 ISV 에코시스템으로, 사용자-에이전트, 에이전트 간, 에이전트-도구 간 상호작용에 안전하고 통제된 연결을 제공합니다. 이는 Gemini Enterprise Agent Platform의 일부로, AI 에이전트를 위한 프로그래머블 데이터 플레인 역할을"
+  summary="Google Cloud Next에서 발표된 Agent Gateway는 AI 에이전트의 보안과 거버넌스를 위한 ISV 에코시스템으로, 사용자-에이전트, 에이전트 간, 에이전트-도구 간 상호작용에 안전하고 통제된 연결을 제공합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-07-Tech_Security_Weekly_Digest_AI_Botnet_AWS_Ransomware.md
+++ b/_posts/2026-05-07-Tech_Security_Weekly_Digest_AI_Botnet_AWS_Ransomware.md
@@ -282,7 +282,7 @@ Tomofun은 Furbo Pet Camera를 개발한 대만의 펫테크 스타트업으로,
   title="미래를 맞추다: Breuninger가 'be your own model' AI로 매출을 높인 방법"
   url="https://cloud.google.com/blog/topics/retail/how-breuninger-boosted-sales-with-its-be-your-own-model-ai/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/breuninger_virtuelle_anprobe_1.max-1000x1000.jpg"
-  summary="독일 패션 기업 Breuninger는 Google Cloud와 협력하여 고객이 셀피를 통해 자신의 체형에 하이엔드 패션을 입혀볼 수 있는 가상 피팅 경험을 구축했습니다. 이는 생성형 미디어 모델을 활용한 \”be your own model\” AI 기능으로, 온라인 쇼핑객의 핵심 질문인 \”이 옷이 나에게 어떻게 보일까?\”에 대한 해답을 제시하며 매출 증대에 기"
+  summary="독일 패션 기업 Breuninger는 Google Cloud와 협력하여 고객이 셀피를 통해 자신의 체형에 하이엔드 패션을 입혀볼 수 있는 가상 피팅 경험을 구축했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -405,7 +405,7 @@ Bitcoin Magazine의 Nick Ward는 eBay가 GameStop 대신 Bitcoin 결제를 도�
   title="Boltz, 비수탁형 USDC 스왑 출시, Bitcoin을 Circle의 규제 달러에 직접 연결"
   url="https://bitcoinmagazine.com/business/boltz-launches-non-custodial-usdc-swaps-bridging-bitcoin-directly-to-circles-regulated-dollar"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/05/Gemini_Generated_Image_l4r3qal4r3qal4r3.webp"
-  summary="Boltz가 Circle의 CCTP를 활용해 Bitcoin을 Circle의 규제 달러인 USDC로 신뢰 없이 교환할 수 있는 Non-Custodial 스왑을 출시했습니다. 이 서비스는 Lightning을 포함한 Bitcoin 레이어와 Stripe, Coinbase, Visa 등 글로벌 기관이 수용하는 규제 스테이블코인 간의 즉각적인 이동을 계정이나 수탁 없이 가"
+  summary="Boltz가 Circle의 CCTP를 활용해 Bitcoin을 Circle의 규제 달러인 USDC로 신뢰 없이 교환할 수 있는 Non-Custodial 스왑을 출시했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-05-08-Tech_Security_Weekly_Digest_CVE_Cloud_AI_Agent.md
+++ b/_posts/2026-05-08-Tech_Security_Weekly_Digest_CVE_Cloud_AI_Agent.md
@@ -100,7 +100,7 @@ redirect_from:
   title="Ivanti EPMM CVE-2026-6973 RCE가 활발히 악용 중, 관리자 수준 접근 권한 부여"
   url="https://thehackernews.com/2026/05/ivanti-epmm-cve-2026-6973-rce-under.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiX-v9Rdn-UppGqdbm0oFYXNg6myRCPn8r-d4BXVN0e2r2hqrYbGPUwOKafMbwKlojjbck4C8Ez6dxZ7WcLF45PNphvCo1K4OGhXl0u9fWanVMbO62iZoWMQJrplTa6VaXfI2rhQL40PoDK0ZNh2jqDJGBc9LylbIE92LWSNEIkVUhSpkGyAfV7g-DVZlU1/s1600/ivanti.jpg"
-  summary="Ivanti가 Endpoint Manager Mobile(EPMM)의 고위험 취약점 CVE-2026-6973(CVSS 7.2)이 제한적인 실제 공격에서 악용되고 있다고 경고했습니다. 이 취약점은 부적절한 입력 검증으로 인해 발생하며, 원격으로 인증된 관리자 수준의 사용자가 원격 코드 실행(RCE)을 통해 관리자 권한을 획득할 수 있도록 합니다. 영향을 받는"
+  summary="Ivanti가 Endpoint Manager Mobile(EPMM)의 고위험 취약점 CVE-2026-6973(CVSS 7.2)이 제한적인 실제 공격에서 악용되고 있다고 경고했습니다. 이 취약점은 부적절한 입력 검증으로 인해 발생하며, 원격으로 인증된 관리자 수준의 사용자가 원격 코드 실행(RCE)을 통해 관리자 권한을 획득할 수 있도록 합니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -150,7 +150,7 @@ mitre_attack:
   title="PCPJack 자격 증명 탈취기가 5개 CVE를 악용해 클라우드 시스템 전반에 웜처럼 확산"
   url="https://thehackernews.com/2026/05/pcpjack-credential-stealer-exploits-5.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh2N74T5rZvfRcHqUhwtyI3hbxAAQnB-RQQqpiGSIJqdplaQaZcjvqLR80d3pIjwJyGtAO5V0Ji6_3w4V4Ww901x4aSGY_Id3lzqXNdGUMbprz80zXoKzHVoIBqyhVBU_LvIMyJHV5MHaMWvZuWgREFmqG4jOdBLpW4gBtgKCrnfRS4mIXemDQ9U_fRERQf/s1600/clouds.jpg"
-  summary="사이버 보안 연구진이 클라우드 인프라를 노리는 새로운 자격 증명 탈취 프레임워크 PCPJack을 공개했으며, 이는 5개의 CVE를 악용해 웜처럼 확산됩니다. PCPJack은 클라우드, 컨테이너, 개발자, 생산성, 금융 서비스에서 자격 증명을 수집한 후 공격자 제어 인프라를 통해 데이터를 유출합니다. 또한 이 프레임워크는 환경에서 TeamPCP와 관련된 모든"
+  summary="사이버 보안 연구진이 클라우드 인프라를 노리는 새로운 자격 증명 탈취 프레임워크 PCPJack을 공개했으며, 이는 5개의 CVE를 악용해 웜처럼 확산됩니다. PCPJack은 클라우드, 컨테이너, 개발자, 생산성, 금융 서비스에서 자격 증명을 수집한 후 공격자 제어 인프라를 통해 데이터를 유출합니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -305,7 +305,7 @@ Gemini 3.1 Flash-Lite가 Gemini Enterprise Agent Platform에서 정식 출시되
 {% include news-card.html
   title="새로운 Bigtable 인메모리 계층으로 서브 밀리초 읽기 지연 시간 구현"
   url="https://cloud.google.com/blog/products/databases/scaling-real-time-performance-with-bigtable-in-memory-tier/"
-  summary="Google Cloud Next '26에서 발표된 Bigtable in-memory tier는 완전 관리형 클라우드 데이터베이스 서비스에 새로운 계층을 추가하여 시간에 민감한 데이터에 대해 서브 밀리초 읽기 지연 시간을 제공하고, 포인트 읽기 처리량을 비용 대비 약 10배 향상시켜 TCO를 절감합니다. 또한 단일 행에서 초당 최대 12만 쿼리를 지원하는 핫"
+  summary="Google Cloud Next '26에서 발표된 Bigtable in-memory tier는 완전 관리형 클라우드 데이터베이스 서비스에 새로운 계층을 추가하여 시간에 민감한 데이터에 대해 서브 밀리초 읽기 지연 시간을 제공하고, 포인트 읽기 처리량을 비용 대비 약 10배 향상시켜 TCO를 절감합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-09-Tech_Security_Weekly_Digest_Vulnerability_AI_Threat.md
+++ b/_posts/2026-05-09-Tech_Security_Weekly_Digest_Vulnerability_AI_Threat.md
@@ -97,7 +97,7 @@ redirect_from:
   title="TCLBANKER Banking Trojan이 WhatsApp 및 Outlook 웜을 통해 금융 플랫폼을 표적으로 삼다"
   url="https://thehackernews.com/2026/05/tclbanker-banking-trojan-targets.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiWchpptUYeW4vXSUXfGq-uMzB1mr_dzsvX8XIWssIKzaWa4_eYbaLwec5Zos3xCoD0s8-LDcGI7Vj8DjFq6RtUY68HP21YudHYdsFS2xdyzQE7OPyuTlqyO2X9uwlSCRuVl9tAUwq0mvGuXlYkxjdmC7ynyAcIDpbejkR45ucf_L3VCDupSZMteOby7BUp/s1600/banking.jpg"
-  summary="보안 연구진이 TCLBANKER라는 새로운 브라질산 banking trojan을 발견했으며, 이는 59개 금융 및 암호화폐 플랫폼을 대상으로 합니다. Elastic Security Labs는 이 활동을 REF3076으로 추적 중이며, 해당 악성코드는 worm인 SORVEPOTEL을 통해 WhatsApp과 Outlook으로 확산되는 Maverick의 주요 업"
+  summary="보안 연구진이 TCLBANKER라는 새로운 브라질산 banking trojan을 발견했으며, 이는 59개 금융 및 암호화폐 플랫폼을 대상으로 합니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -260,7 +260,7 @@ OpenAI는 샌드박싱, 승인 절차, 네트워크 정책 및 에이전트 기�
 {% include news-card.html
   title="Halliburton, Amazon Bedrock 및 생성형 AI로 지진 작업 흐름 구축 강화"
   url="https://aws.amazon.com/blogs/machine-learning/halliburton-enhances-seismic-workflow-creation-with-amazon-bedrock-and-generative-ai/"
-  summary="Halliburton은 Amazon Bedrock과 생성형 AI를 활용해 자연어 질의를 실행 가능한 지진 워크플로우로 변환하는 개념 증명을 구축했으며, 이는 최대 95%의 워크플로우 가속화를 보여주었다. 이 솔루션은 Halliburton의 Seismic Engine 도구 및 문서에 대한 질의응답 기능을 제공하며, 복잡한 기술 워크플로우를 개선하기 위한 주요"
+  summary="Halliburton은 Amazon Bedrock과 생성형 AI를 활용해 자연어 질의를 실행 가능한 지진 워크플로우로 변환하는 개념 증명을 구축했으며, 이는 최대 95%의 워크플로우 가속화를 보여주었다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 %}
@@ -279,7 +279,7 @@ Halliburton은 Amazon Bedrock과 생성형 AI를 활용해 자연어 질의를 �
   title="Gemini CLI DevOps Extension으로 몇 분 만에 코드를 배포하세요"
   url="https://cloud.google.com/blog/topics/developers-practitioners/ship-code-within-minutes-with-the-gemini-cli-devops-extension/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/guest_book.max-1000x1000.png"
-  summary="Gemini CLI DevOps Extension을 사용하면 Dockerfile, IAM, YAML 설정에 시간을 낭비하지 않고 몇 분 만에 코드를 배포할 수 있습니다. 기존에는 Antigravity나 Claude Code 같은 AI 코딩 도구로 빠르게 앱을 만들어도 배포 과정이 복잡해 포기하는 경우가 많았습니다. 이 확장 기능은 개발자가 로컬에서 작업을 "
+  summary="Gemini CLI DevOps Extension을 사용하면 Dockerfile, IAM, YAML 설정에 시간을 낭비하지 않고 몇 분 만에 코드를 배포할 수 있습니다. 기존에는 Antigravity나 Claude Code 같은 AI 코딩 도구로 빠르게 앱을 만들어도 배포 과정이 복잡해 포기하는 경우가 많았습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-10-Tech_Security_Weekly_Digest_Malware_Patch_AI_Agent.md
+++ b/_posts/2026-05-10-Tech_Security_Weekly_Digest_Malware_Patch_AI_Agent.md
@@ -126,7 +126,7 @@ DevSecOps 관점에서는 CI/CD 파이프라인과 아티팩트 관리 체계 �
   title="cPanel, WHM, 세 가지 새로운 취약점 수정 사항 발표 — 지금 패치하세요"
   url="https://thehackernews.com/2026/05/cpanel-whm-patch-3-new-vulnerabilities.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEj8HLwOMzo20kbZmflPvJJmY7su6wWOWgDLV-dJNx-k76m5ivbwVoCkFrnsLXkyO4PHAyLSkPXinjK71SDmWabyOcTlKb3juZgkXTzOVuMvZk6-LUFMhoJ-UGFvv0qEby7QmYcjTWn1m1L19VTKeB7CdmKvpvIP5ifniLO92ARSLjtf8rcXIbm8AFMZei-M/s72-c/cpanel-3.jpg"
-  summary="cPanel이 cPanel 및 Web Host Manager(WHM)에서 권한 상승, 코드 실행, 서비스 거부를 유발할 수 있는 세 가지 취약점을 해결하는 업데이트를 발표했습니다. 이 중 CVE-2026-29201(CVSS 점수 4.3)은 'feature::LOADFEATUREFILE' adminbin 호출의 기능 파일명에 대한 불충분한 입력 검증으로 인해"
+  summary="cPanel이 cPanel 및 Web Host Manager(WHM)에서 권한 상승, 코드 실행, 서비스 거부를 유발할 수 있는 세 가지 취약점을 해결하는 업데이트를 발표했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-12-Tech_Security_Weekly_Digest_AI_CVE_Zero-Day_Data.md
+++ b/_posts/2026-05-12-Tech_Security_Weekly_Digest_AI_CVE_Zero-Day_Data.md
@@ -100,7 +100,7 @@ redirect_from:
   title="TeamPCP, Checkmarx Jenkins AST 플러그인을 손상시키다, KICS 공급망 공격 몇 주 후"
   url="https://thehackernews.com/2026/05/teampcp-compromises-checkmarx-jenkins.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiq0A3_8O89uC968dpFnFxE4v3J4fpr5nEqC-2QiSJ_rtZlgPocPYIaowCvCMeONhcrFiaoSdBVeNsuTa2ipAZZ3HBMUDcfO8DZ06pughteYJItHhMLeBr_jnfLL-5WX6xBE_EjIfPDGjCYyDCa6aImjimPNl7FtM1evdnTUVEk54x9pczRaFlmEZy1Cv8B/s1600/Jenkins.jpg"
-  summary="Checkmarx는 Jenkins AST 플러그인의 변조된 버전이 Jenkins Marketplace에 게시된 것을 확인했습니다. 보안 회사는 사용자들에게 2025년 12월 17일에 게시된 버전 2.0.13-829.vc72453fa_1c16 이상을 사용하고 있는지 확인할 것을 권고했습니다. 이번 사건은 최근 KICS 공급망 공격 이후 발생한 또 다른 보안 "
+  summary="Checkmarx는 Jenkins AST 플러그인의 변조된 버전이 Jenkins Marketplace에 게시된 것을 확인했습니다. 보안 회사는 사용자들에게 2025년 12월 17일에 게시된 버전 2.0.13-829.vc72453fa_1c16 이상을 사용하고 있는지 확인할 것을 권고했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-14-Tech_Security_Weekly_Digest_AWS_Patch_AI_Update.md
+++ b/_posts/2026-05-14-Tech_Security_Weekly_Digest_AWS_Patch_AI_Update.md
@@ -137,7 +137,7 @@ CI/CD 파이프라인에 GuardDuty 결과를 통합하고, Terraform/Pulumi 같�
   title="Microsoft의 MDASH AI 시스템, 패치 화요일에 수정된 16개 Windows 결함 발견"
   url="https://thehackernews.com/2026/05/microsofts-mdash-ai-system-finds-16.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg1Iq16GS3jdGiIU24GHBkwg6unk05ctdgYwXO5df8zRu1qko95_XhszCjq6jlEIRozLsrtZHgi5GqDZnS1Sw_KDzUzsagwP0If3VswmYHsnuYwVseU2lapxQiPpItTdAiv-CCdTFR87ZVOu65buyvmvzmdWuJPKHuPA4DSo58HQIMAV__2ymsmRe2g3UVe/s1600/windows-ai.jpg"
-  summary="Microsoft가 MDASH라는 새로운 멀티모델 AI 기반 시스템을 공개하여 대규모 취약점 발견 및 수정을 지원하고 있으며, 일부 고객이 제한된 비공개 프리뷰로 테스트 중입니다. MDASH는 모델에 구애받지 않는 시스템으로, 각기 다른 취약점에 맞춤형 AI 에이전트를 사용합니다. 이 시스템은 최근 Patch Tuesday에서 수정된 16개의 Windows 결"
+  summary="Microsoft가 MDASH라는 새로운 멀티모델 AI 기반 시스템을 공개하여 대규모 취약점 발견 및 수정을 지원하고 있으며, 일부 고객이 제한된 비공개 프리뷰로 테스트 중입니다. MDASH는 모델에 구애받지 않는 시스템으로, 각기 다른 취약점에 맞춤형 AI 에이전트를 사용합니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-15-Tech_Security_Weekly_Digest_AI_Threat_AWS_Go.md
+++ b/_posts/2026-05-15-Tech_Security_Weekly_Digest_AI_Threat_AWS_Go.md
@@ -152,7 +152,7 @@ mitre_attack:
   title="Stealer Backdoor가 개발자 비밀을 노리는 3개 Node-IPC 버전에서 발견돼"
   url="https://thehackernews.com/2026/05/stealer-backdoor-found-in-3-node-ipc.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhTj2m9-HHmDEDzKIsalsJ_HJcwcUsIFajvcpTLP9QMyqS9F_JroTH7lXeOGZFuO6j6F-RzbIo1kBIQ0udSFQGzjN2hxO8ZfyFeHM5557BPI1sjiJ7cEMJJE62t11e07Wt1CsmAntpLHSM0XbnQDvVYNBfNdAOsob9kN6G6-mQjKX68fEE1nzy_Bn4TvxyK/s1600/node.jpg"
-  summary="보안 연구원들이 npm 패키지 node-ipc의 세 가지 버전(node-ipc@9.1.6, node-ipc@9.2.3, node-ipc@12.0.1)에서 악성 활동을 발견했습니다. 이 버전들은 개발자의 비밀 정보를 노리는 Stealer Backdoor를 포함한 것으로 확인되었습니다. Socket과 StepSecurity는 이 패키지들이 개발자 시크릿을 탈취"
+  summary="보안 연구원들이 npm 패키지 node-ipc의 세 가지 버전(node-ipc@9.1.6, node-ipc@9.2.3, node-ipc@12.0.1)에서 악성 활동을 발견했습니다. 이 버전들은 개발자의 비밀 정보를 노리는 Stealer Backdoor를 포함한 것으로 확인되었습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-16-Tech_Security_Weekly_Digest_Botnet_AI_AWS_Security.md
+++ b/_posts/2026-05-16-Tech_Security_Weekly_Digest_Botnet_AI_AWS_Security.md
@@ -134,7 +134,7 @@ DevSecOps 관점에서 이 위협은 **공급망 공격**, **CI/CD 파이프라�
 {% include news-card.html
   title="AWS AI 보안 프레임워크: 적절한 통제, 적절한 계층, 적절한 단계에서 AI 보안 확보"
   url="https://aws.amazon.com/blogs/security/the-aws-ai-security-framework-securing-ai-with-the-right-controls-at-the-right-layers-at-the-right-phases/"
-  summary="AWS AI Security Framework는 AI 워크로드가 프로토타입에서 프로덕션, 확장 단계로 진화함에 따라 보안을 처음부터 강화하도록 설계되었습니다. 보안 리더는 무료 SHIP engagement를 통해 현재 상태를 평가하고 우선순위 로드맵을 수립할 수 있습니다. 이 프레임워크는 적절한 통제를 적절한 계층과 단계에 적용하여 AI 보안을 신속하게 확"
+  summary="AWS AI Security Framework는 AI 워크로드가 프로토타입에서 프로덕션, 확장 단계로 진화함에 따라 보안을 처음부터 강화하도록 설계되었습니다. 보안 리더는 무료 SHIP engagement를 통해 현재 상태를 평가하고 우선순위 로드맵을 수립할 수 있습니다."
   source="AWS Security Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-19-Tech_Security_Weekly_Digest_Cloud_AI_Malware_Go.md
+++ b/_posts/2026-05-19-Tech_Security_Weekly_Digest_Cloud_AI_Malware_Go.md
@@ -179,7 +179,7 @@ DevSecOps 실무자에게 이 사건은 **"신뢰할 수 있는 자격 증명"�
   title="주간 요약: Exchange 제로데이, npm 웜, 가짜 AI 저장소, Cisco 익스플로잇 등"
   url="https://thehackernews.com/2026/05/weekly-recap-exchange-0-day-npm-worm.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjFzN7ITW3vwaWKn1m-BGZGI1JicT1T8d5v4LZbTvOTe7m1Xj4pk1pFECjAOvxey4XzXg7vGiU5Xzifs4qkzr9cbg2iPboHfPAHHBmi3O8OIAArhJlbr52gwKMkdqrIuIK77Pq8EzCTQM1hV5MsLuTbV4GXbXzr7miv0jA6o0Bn35RgBjc2cnd6qPq2-0Di/s1600/recapss.jpg"
-  summary="이번 주 보안 소식에서는 Exchange 제로데이 취약점, npm 웜, 가짜 AI 저장소, Cisco 익스플로잇 등이 주요 이슈로 다뤄졌습니다. 메일 서버 결함이 활발히 악용되고 있으며, 신뢰할 수 있는 패키지가 오염되고 가짜 모델 페이지가 정보 탈취 악성코드를 유포했습니다. 하나의 취약한 의존성이 키를 유출하고 클라우드 접근으로 이어져 전체 프로덕션 환경"
+  summary="이번 주 보안 소식에서는 Exchange 제로데이 취약점, npm 웜, 가짜 AI 저장소, Cisco 익스플로잇 등이 주요 이슈로 다뤄졌습니다. 메일 서버 결함이 활발히 악용되고 있으며, 신뢰할 수 있는 패키지가 오염되고 가짜 모델 페이지가 정보 탈취 악성코드를 유포했습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -224,7 +224,7 @@ DevSecOps 실무자에게 이번 뉴스는 다음과 같은 직접적 영향을 
   title="NVIDIA CEO Jensen Huang, Dell Technologies World에서 ”수요가 포물선을 그리며 폭발적으로 증가하고 있다, 완전히 포물선이다”"
   url="https://blogs.nvidia.com/blog/dell-technologies-agent-enterprise-ai/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/05/26-dtw-keynote-jhh-dell-CG3A2688_Option2-842x450.jpg"
-  summary="NVIDIA CEO Jensen Huang는 Dell Technologies World에서 AI 수요가 '포물선적으로 증가하고 있다'고 강조했습니다. NVIDIA Vera Rubin NVL72는 토큰당 비용을 10분의 1로 줄이고, Agent 샌드박스는 기존 CPU보다 50% 빠르며, Vera CPU는 엔터프라이즈 데이터 쿼리를 최대 3배 향상시킵니다. L"
+  summary="NVIDIA CEO Jensen Huang는 Dell Technologies World에서 AI 수요가 '포물선적으로 증가하고 있다'고 강조했습니다. NVIDIA Vera Rubin NVL72는 토큰당 비용을 10분의 1로 줄이고, Agent 샌드박스는 기존 CPU보다 50% 빠르며, Vera CPU는 엔터프라이즈 데이터 쿼리를 최대 3배 향상시킵니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -276,7 +276,7 @@ OpenAI와 Dell이 협력하여 Codex를 하이브리드 및 온프레미스 환�
 {% include news-card.html
   title="쿼리를 넘어서: 에이전틱 시대의 기초를 다지는 5가지 시나리오"
   url="https://cloud.google.com/blog/products/data-analytics/building-an-agentic-data-layer-on-google-cloud-5-key-scenarios/"
-  summary="기업 데이터 접근 방식이 정적 보고서에서 자율 시스템의 동적 활용으로 전환되면서, 조직은 SaaS, IoT, 레거시 소스의 분산 데이터를 안전하고 확장 가능한 엔드포인트로 라우팅해야 합니다. 그러나 AI 기반 데이터 노출로의 전환은 단순히 LLM을 데이터베이스에 연결하는 것을 넘어 보안, 비용, 의미 정확성을 관리하기 위한 근본적인 아키텍처 변화를 요구합니"
+  summary="기업 데이터 접근 방식이 정적 보고서에서 자율 시스템의 동적 활용으로 전환되면서, 조직은 SaaS, IoT, 레거시 소스의 분산 데이터를 안전하고 확장 가능한 엔드포인트로 라우팅해야 합니다."
   source="Google Cloud Blog"
   severity="High"
 %}

--- a/_posts/2026-05-20-Tech_Security_Weekly_Digest_AI_AWS_CVE_Vulnerability.md
+++ b/_posts/2026-05-20-Tech_Security_Weekly_Digest_AI_AWS_CVE_Vulnerability.md
@@ -95,7 +95,7 @@ summary_card:
   title="Trapdoor Android 광고 사기 방식, 455개 앱 사용해 하루 6억 5900만 건의 입찰 요청 발생"
   url="https://thehackernews.com/2026/05/trapdoor-android-ad-fraud-scheme-hit.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi4-ldAXS8Yw3BhdSS9xeJFNzwDm-mrNDxHr28zcknAKH8knTU_WleHEhmJ-vgNokgVbm9y8vRH18v9Oxz6F7twmnBoJfIQ2fVeuhEErRAF31F9MES02sZMhYG-i7F9Ty-C-yD64U4cmgq3CD7nuEnD9OZpxWCTKAPCXfIDKycUeZEfJIBBagPPW72JgWZO/s1600/android-ad-fraud.jpg"
-  summary="보안 연구진이 Android 기기 사용자를 대상으로 하는 새로운 광고 사기 및 멀버타이징 작전 'Trapdoor'를 공개했습니다. HUMAN의 Satori 위협 인텔리전스 및 연구팀에 따르면, 이 활동은 455개의 악성 Android 앱과 183개의 위협 행위자 소유 C2 도메인을 포함하며, 일일 입찰 요청 6억 5900만 건에 달하는 다단계 사기 파이프라"
+  summary="보안 연구진이 Android 기기 사용자를 대상으로 하는 새로운 광고 사기 및 멀버타이징 작전 'Trapdoor'를 공개했습니다."
   source="The Hacker News"
   severity="Medium"
 %}

--- a/_posts/2026-05-21-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Malware.md
+++ b/_posts/2026-05-21-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Malware.md
@@ -101,7 +101,7 @@ summary_card:
   title="Microsoft, AI 에이전트 개발 보안을 위해 RAMPART와 Clarity를 오픈소스로 공개"
   url="https://thehackernews.com/2026/05/microsoft-open-sources-rampart-and.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjPuhFp_KGzG3yZEzqIYh-at7Dm3vg4_QX97ilaSXDjsUbfhU7KCmRS-uQ2UrV9D855Nvy8HcBDKe25VMT63dfyzh-B2bzSx649SJQSQhL3bfm4Eitv4KLW4PhzRfE1HvoFOFDu2bB4alNLTFzvr6_IkKWjqxShcuWytNgDR4b3wR1xGE6z06xSyWo6NVg3/s1600/ms-tools.jpg"
-  summary="Microsoft가 AI 에이전트의 보안 테스트를 위해 RAMPART(Risk Assessment and Measurement Platform for Agentic Red Teaming)와 Clarity라는 두 가지 오픈소스 도구를 공개했습니다. RAMPART는 Pytest 기반의 안전 및 보안 테스트 프레임워크로, AI 에이전트를 위한 테스트 작성 및 실"
+  summary="Microsoft가 AI 에이전트의 보안 테스트를 위해 RAMPART(Risk Assessment and Measurement Platform for Agentic Red Teaming)와 Clarity라는 두 가지 오픈소스 도구를 공개했습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -258,7 +258,7 @@ Google 빔(Google Beam)에서 소규모 그룹 회의를 개선하는 새로운 
 {% include news-card.html
   title="Urban Outfitters, Sterling OMS를 AlloyDB for PostgreSQL로 이전하여 대규모 비용 절감 달성"
   url="https://cloud.google.com/blog/products/databases/urban-outfitters-moves-sterling-oms-to-alloydb-for-postgresql/"
-  summary="Urban Outfitters (URBN)이 IBM Sterling OMS를 Oracle 데이터베이스에서 Google Cloud의 AlloyDB for PostgreSQL로 마이그레이션하여 비용 절감을 달성했습니다. 이 전략적 전환은 Google Cloud와 IBM의 파트너십 강화를 보여주며, 효율성 향상과 미래 지향적인 기술 환경 구축에 기여할 것으로 기"
+  summary="Urban Outfitters (URBN)이 IBM Sterling OMS를 Oracle 데이터베이스에서 Google Cloud의 AlloyDB for PostgreSQL로 마이그레이션하여 비용 절감을 달성했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-22-Tech_Security_Weekly_Digest_AI_AWS_Malware_Threat.md
+++ b/_posts/2026-05-22-Tech_Security_Weekly_Digest_AI_AWS_Malware_Threat.md
@@ -183,7 +183,7 @@ DevSecOps 관점에서 **지속적 침투(APT)와 내부망 정찰**에 특화�
   title="ThreatsDay 게시판: Linux Rootkits, Router 0-Day, AI 침입, 사기 키트 및 25개의 새로운 기사"
   url="https://thehackernews.com/2026/05/threatsday-bulletin-linux-rootkits.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEifIiAs3r9mSWAyNYngQby6QllKy0gx1dGJB4MNtgMjRQLUIkp7-fr851xuTEe6-izLAtNHux1PgdVBiWmEQctN2QM1bzV_CP0bcR7_ReqHg-lXrDa-EqUsZAUgC8da72h6tdbZU6H8nWMzAfZEItMY49Big4dpxtSHr5r7sgm7W01mhA31E274dUfWBHMi/s1600/tday.png"
-  summary="이번 주 보안 소식은 Linux Rootkits, Router 0-Day, AI Intrusions, Scam Kits 등 25개의 새로운 이야기를 다루고 있습니다. 공격자들은 더 이상 시스템을 직접 뚫기보다는 업데이트, 앱, 클라우드, 지원 채팅 등 우리가 이미 신뢰하는 정상적인 요소들을 악용하는 패턴을 보이고 있습니다. 이러한 위협은 평범한 일상 속에 "
+  summary="이번 주 보안 소식은 Linux Rootkits, Router 0-Day, AI Intrusions, Scam Kits 등 25개의 새로운 이야기를 다루고 있습니다. 공격자들은 더 이상 시스템을 직접 뚫기보다는 업데이트, 앱, 클라우드, 지원 채팅 등 우리가 이미 신뢰하는 정상적인 요소들을 악용하는 패턴을 보이고 있습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -296,7 +296,7 @@ Google I/O '26에서 Google Cloud는 완전하고 개방적인 AI 스택을 강�
   title="AI Studio가 Cloud Run, Firebase, Cloud SQL로 풀스택 바이브 코딩을 지원하며 신용카드 불필요"
   url="https://cloud.google.com/blog/products/databases/vibe-coded-ai-studio-apps-with-firestore-firebase-cloud-sql/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/original_images/1-_publish.gif"
-  summary="Google I/O 2026에서 Google AI Studio와 Google Cloud의 통합 업데이트가 발표되었으며, 신규 사용자는 결제 계정 없이 Google Cloud Starter Tier에 최대 2개의 풀스택 애플리케이션을 배포할 수 있습니다. 비관계형 데이터베이스로 Firestore, 새로운 관계형 데이터베이스 옵션으로 Cloud SQL이 추가되"
+  summary="Google I/O 2026에서 Google AI Studio와 Google Cloud의 통합 업데이트가 발표되었으며, 신규 사용자는 결제 계정 없이 Google Cloud Starter Tier에 최대 2개의 풀스택 애플리케이션을 배포할 수 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-23-Tech_Security_Weekly_Digest_Ransomware_AI_Malware_Go.md
+++ b/_posts/2026-05-23-Tech_Security_Weekly_Digest_Ransomware_AI_Malware_Go.md
@@ -184,7 +184,7 @@ DevSecOps 관점에서, 이 공격은 **CI/CD 파이프라인에 직접 영향�
   title="Megalodon GitHub 공격, 악성 CI/CD 워크플로우로 5,561개 리포지토리 표적"
   url="https://thehackernews.com/2026/05/megalodon-github-attack-targets-5561.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjC_sjVeLejyyBZJ0DWW2y9-Z2Jvmrzz9h-5XEIKPFTcJvDj49Jlt-z1FNbSp51K9XcQ8FqC9MBDFPPPdZuzRfjqtYvKNaqT0Qzd61oCHVhNq59IcAVcWV3LvDmKCsX5pHn4nU3LclQPEozMp3XsgYZnVHCZEj89AGkWJpqL1EjCjiqMLnvggZLsgb08MYp/s1600/github-worm.jpg"
-  summary="사이버 보안 연구진이 Megalodon이라는 새로운 자동화 캠페인을 공개했으며, 이 캠페인은 6시간 동안 5,561개의 GitHub 저장소에 5,718개의 악성 커밋을 푸시했습니다. 공격자는 일회용 계정과 위조된 작성자 신원(build-bot, auto-ci, ci-bot, pipeline-bot)을 사용해 base64로 인코딩된 bash 페이로드가 포함된"
+  summary="사이버 보안 연구진이 Megalodon이라는 새로운 자동화 캠페인을 공개했으며, 이 캠페인은 6시간 동안 5,561개의 GitHub 저장소에 5,718개의 악성 커밋을 푸시했습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -319,7 +319,7 @@ Google Cloud의 최신 업데이트, 공지사항, 리소스, 이벤트 및 학�
 {% include news-card.html
   title="현대오토에버의 Amazon Bedrock으로 구축한 빅데이터 클러스터 장애 대응 자동화 에이전트 구축기"
   url="https://aws.amazon.com/ko/blogs/tech/hae-genai-sandbox-hackathon-3/"
-  summary="이 글은 현대오토에버의 GenAI Sandbox 활용 생산성 향상 해커톤 시리즈의 세번째 글이며, 현대오토에버의 오명우, 정세종님과 함께 작성하였습니다. 첫 번째 글에서는 현대오토에버와 AWS가 GenAI Sandbox를 활용해 어떻게 생산성 향상 해커톤을 기획하고 운영했는지, 그리고 14개 팀 150여 명이 참여한 이 행사의 전반적인 성과를 소개 했습니다"
+  summary="이 글은 현대오토에버의 GenAI Sandbox 활용 생산성 향상 해커톤 시리즈의 세번째 글이며, 현대오토에버의 오명우, 정세종님과 함께 작성하였습니다."
   source="AWS Korea Blog"
   severity="Medium"
 %}
@@ -355,7 +355,7 @@ GitHub이 npm의 공급망 보안 강화를 위해 staged publishing을 일반 �
   title="멀티 테넌트 SaaS 플랫폼을 위한 종단 간 인그레스 요청 추적 설계"
   url="https://www.cncf.io/blog/2026/05/22/designing-end-to-end-ingress-request-tracing-for-multi-tenant-saas-platforms/"
   image="https://www.cncf.io/wp-content/uploads/2026/05/Kubernetes-bug-fixes-blog-3.jpg"
-  summary="이 기사는 멀티테넌트 SaaS 플랫폼에서 인그레스 계층부터 마이크로서비스 전반을 거치는 단일 고객 요청을 추적하기 위한 end-to-end 인그레스 요청 트레이싱 설계 방법을 다룹니다. 클라우드 네이티브 아키텍처 기반의 현대 SaaS 플랫폼은 수십 개의 독립적으로 배포된 마이크로서비스로 구성되며, 인증, 오케스트레이션, 데이터 서비스 등을 거치는 요청의 가"
+  summary="이 기사는 멀티테넌트 SaaS 플랫폼에서 인그레스 계층부터 마이크로서비스 전반을 거치는 단일 고객 요청을 추적하기 위한 end-to-end 인그레스 요청 트레이싱 설계 방법을 다룹니다."
   source="CNCF Blog"
   severity="Medium"
 %}
@@ -391,7 +391,7 @@ SEC가 토큰화된 주식에 대한 '혁신 면제' 계획을 연기했다는 �
   title="내슈빌 출신 초선 하원의원, 국가 Bitcoin 비축 제도 영구화 추진"
   url="https://bitcoinmagazine.com/news/a-freshman-congressman-national-bitcoin"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/05/A-Freshman-Congressman-from-Nashville-Wants-to-Make-the-National-Bitcoin-Reserve-Permanent.jpg"
-  summary="미국 하원의원 Matt Van Epps가 내슈빌의 Bitcoin 허브 부상을 반영한 American Reserve Modernization Act of 2026을 통해 국가 Bitcoin 준비금을 영구화하려는 법안을 발의했습니다. 이 법안은 Bitcoin Magazine이 보도한 내용으로, 초선 의원이 Bitcoin의 전략적 자산화를 추진하는 것이 핵심입니"
+  summary="미국 하원의원 Matt Van Epps가 내슈빌의 Bitcoin 허브 부상을 반영한 American Reserve Modernization Act of 2026을 통해 국가 Bitcoin 준비금을 영구화하려는 법안을 발의했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-05-24-Tech_Security_Weekly_Digest_AI_Malware_AWS_Bitcoin.md
+++ b/_posts/2026-05-24-Tech_Security_Weekly_Digest_AI_Malware_AWS_Bitcoin.md
@@ -141,7 +141,7 @@ npm 생태계는 오픈소스 의존성 공급망 공격(예: typosquatting, dep
   title="Packagist 공급망 공격, GitHub 호스팅 Linux 악성코드로 8개 패키지 감염"
   url="https://thehackernews.com/2026/05/packagist-supply-chain-attack-infects-8.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiQ5LyRYJIkEVUSrrBV-_qvrXIKC-B4h0JAxyV4IalzuiEzXi6KeCnZNTUWIIld3oeC5kDx85xppqYm9tG_UB3_Sss9WqH2bYsOVxkB3PhjUk_cQrdyvr6JKsYgn35_sESYYsLC_OuKN9_2korX__RfHwkecLX_BGk7aajnm3sfNqbpV4Pl55B1fpSBpbOA/s1600/packagist.jpg"
-  summary="Packagist에서 발생한 공급망 공격 캠페인이 8개의 패키지에 영향을 미쳤으며, GitHub Releases URL에서 가져온 Linux 바이너리를 실행하는 악성 코드가 포함되었습니다. Socket에 따르면, 영향을 받은 패키지는 모두 Composer 패키지였지만 악성 코드는 composer.json이 아닌 package.json에 삽입되어 JavaSc"
+  summary="Packagist에서 발생한 공급망 공격 캠페인이 8개의 패키지에 영향을 미쳤으며, GitHub Releases URL에서 가져온 Linux 바이너리를 실행하는 악성 코드가 포함되었습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-05-26-Tech_Security_Weekly_Digest_AI_AWS_Botnet_CVE.md
+++ b/_posts/2026-05-26-Tech_Security_Weekly_Digest_AI_AWS_Botnet_CVE.md
@@ -191,7 +191,7 @@ mitre_attack:
   title="Alert Firehose가 드디어 맞수를 만나다"
   url="https://thehackernews.com/2026/05/the-alert-firehose-finally-meets-its.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhULc1VvUr1LQ1qZPTiw_sPmN3JbNIk0OSlxHRT0MFdY2kM5Z7psdZtrctiSOybvu8i1sCwcMeSUtXxHb0xBkQ2lCUt2l_kKmhp93ydvN4-E-qObRkmiFK2s-jOPqipBTGfBnv4o-d9nLuPIL2JMGO6FhCFsFV2NkBlARzWW9ScqccGvAVHzM9o-6MDwn4/s1600/corelight-main.jpg"
-  summary="사이버 보안 전문가들은 Network Detection and Response(NDR)가 여전히 시끄럽고 데이터가 많다고 평가하지만, 에이전틱 AI(agentic AI) 기능을 갖춘 NDR을 운영하는 팀들은 이를 통해 위협을 조기에 탐지하고, 신속히 분류하며, 오탐(false positive)을 줄이고 있다고 보고합니다. NDR에 대한 부정적 인식은 과거 "
+  summary="사이버 보안 전문가들은 Network Detection and Response(NDR)가 여전히 시끄럽고 데이터가 많다고 평가하지만, 에이전틱 AI(agentic AI) 기능을 갖춘 NDR을 운영하는 팀들은 이를 통해 위협을 조기에 탐지하고, 신속히 분류하며, 오탐(false positive)을 줄이고 있다고 보고합니다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -232,7 +232,7 @@ DevSecOps 실무자에게 이 변화는 **운영 효율성**과 **보안 거버�
   title="PhaaS 2 Furious: 중국어 피싱 서비스의 진화"
   url="https://cloud.google.com/blog/topics/threat-intelligence/chinese-language-phishing-services/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/phaas-fig1.max-1000x1000.png"
-  summary="러시아어 사용 위협 행위자들이 전통적으로 phishing-as-a-service(PhaaS) 환경을 지배해 왔지만, 중국어 언더그라운드에서 경쟁 생태계가 빠르게 성장하고 있습니다. Google Threat Intelligence Group(GTIG)은 중국 언더그라운드의 12개 현행 PhaaS 서비스를 분석했으며, 이들은 모두 성숙한 서비스로 대부분 해당 "
+  summary="러시아어 사용 위협 행위자들이 전통적으로 phishing-as-a-service(PhaaS) 환경을 지배해 왔지만, 중국어 언더그라운드에서 경쟁 생태계가 빠르게 성장하고 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-05-27-Tech_Security_Weekly_Digest_AI_AWS_CVE_Patch.md
+++ b/_posts/2026-05-27-Tech_Security_Weekly_Digest_AI_AWS_CVE_Patch.md
@@ -250,7 +250,7 @@ NVIDIA의 Vera CPU가 에이전틱 AI(agentic AI) 시대에 필요한 빠른 코
 {% include news-card.html
   title="기술 심층 분석: AgentCore 결제와 에이전틱 커머스의 혁신"
   url="https://aws.amazon.com/blogs/machine-learning/technical-deep-dive-agentcore-payments-and-innovation-in-agentic-commerce/"
-  summary="Amazon Bedrock AgentCore payments가 프리뷰로 출시되어 유료 외부 서비스에 대한 즉시 결제와 수동 청구 설정 없이 사용 가능하며, 소액 결제를 경제적으로 처리하는 스테이블코인 지원 및 에이전트 예산과 거래 한도를 세밀하게 제어할 수 있는 지출 가드레일을 제공합니다. 이 게시물에서는 AgentCore payments의 기술적 심층 분"
+  summary="Amazon Bedrock AgentCore payments가 프리뷰로 출시되어 유료 외부 서비스에 대한 즉시 결제와 수동 청구 설정 없이 사용 가능하며, 소액 결제를 경제적으로 처리하는 스테이블코인 지원 및 에이전트 예산과 거래 한도를 세밀하게 제어할 수 있는 지출 가드레일을 제공합니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}
@@ -318,7 +318,7 @@ IT 리더들은 Generative AI(GenAI)의 급속한 채택으로 브라우저가 �
 {% include news-card.html
   title="Part 3: Kiro로 RDS/Aurora 장애 분석 자동화하기 — 매일 자동으로 보고서 받기"
   url="https://aws.amazon.com/ko/blogs/tech/part-3-automate-rds-aurora-issue-analysis-with-kiro/"
-  summary="이 글은 ”Kiro로 RDS/Aurora 장애 분석 자동화하기” 시리즈의 세 번째 글입니다. Part 1: ”Kiro로 RDS/Aurora 장애 분석 자동화하기 — IDE에서 분석하기” Part 2: ”Kiro로 RDS/Aurora 장애 분석 자동화하기 — 터미널에서 분석하기” Part 3 (해당글): ”Kiro로 RDS/Aurora 장애 분석 자동화하기 "
+  summary="이 글은 ”Kiro로 RDS/Aurora 장애 분석 자동화하기” 시리즈의 세 번째 글입니다."
   source="AWS Korea Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-02-Tech_Security_Weekly_Digest_AI_Update_Data_Go.md
+++ b/_posts/2026-06-02-Tech_Security_Weekly_Digest_AI_Update_Data_Go.md
@@ -132,7 +132,7 @@ DevSecOps 실무자에게 가장 심각한 영향은 **신뢰할 수 있는 공�
   title="⚡ 주간 요약: 새로운 Linux 취약점, PAN-OS 익스플로잇, AI 기반 공격, OAuth 피싱 등"
   url="https://thehackernews.com/2026/06/weekly-recap-new-linux-flaw-pan-os.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiV-leTG-MQremNN5Ju342L6LQMn36xeD4jiS4YWT7EdYluHOtFDqIN8y3bQuV-A0D0wtsO5sRpG3Bpy5xdHhMs_sO_w3WoiiJzCd7o-7Hxw736ERxQs4WDd71EQEBIHLzT_UNFMwCDvC8Nij-gDNpMhsRnpsqoDHkuxUWLUEZSSTfDc4aXpx2qlpsaqlgH/s1600/cyberrecap.png"
-  summary="이번 주 보안 소식에는 새로운 Linux 취약점, PAN-OS 익스플로잇, AI 기반 공격, OAuth 피싱 등이 포함되었습니다. 오래된 인증 경로 문제와 저장소 측면의 실수, 이미 실제 환경에서 악용되고 있는 불완전한 패치가 발견되었습니다. 또한 악성 개발 도구, 포럼의 수상한 게시글, 생산성 도구로 위장한 피싱 키트, 그리고 'curl | sh'를 선호"
+  summary="이번 주 보안 소식에는 새로운 Linux 취약점, PAN-OS 익스플로잇, AI 기반 공격, OAuth 피싱 등이 포함되었습니다. 오래된 인증 경로 문제와 저장소 측면의 실수, 이미 실제 환경에서 악용되고 있는 불완전한 패치가 발견되었습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-06-03-Tech_Security_Weekly_Digest_Patch_Update_AWS_Go.md
+++ b/_posts/2026-06-03-Tech_Security_Weekly_Digest_Patch_Update_AWS_Go.md
@@ -233,7 +233,7 @@ mitre_attack:
   title="산업용 소프트웨어 리더들, NVIDIA NemoClaw로 안전하고 자율적인 AI 엔지니어 구축"
   url="https://blogs.nvidia.com/blog/industrial-software-leaders-secure-autonomous-ai-engineers-nemoclaw/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/06/industrial-ai-engineers-kv-1920x1080-1-842x450.jpg"
-  summary="NVIDIA와 12개 이상의 엔지니어링 소프트웨어 기업들이 GTC Taipei at COMPUTEX에서 NVIDIA NemoClaw를 활용해 안전하고 자율적인 AI 엔지니어를 구축하고 있다. 이는 시뮬레이션 시간을 획기적으로 단축시킨 가속 컴퓨팅의 성과를 바탕으로, CAD, 메싱, 시뮬레이션 설정 및 디버깅, 후처리 등 엔드투엔드 워크플로우의 남은 과제를 "
+  summary="NVIDIA와 12개 이상의 엔지니어링 소프트웨어 기업들이 GTC Taipei at COMPUTEX에서 NVIDIA NemoClaw를 활용해 안전하고 자율적인 AI 엔지니어를 구축하고 있다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -285,7 +285,7 @@ Travelers가 OpenAI와 협력하여 AI 기반 Claim Assistant를 구축, 전국�
   title="Google Cloud Storage MCP 서버로 비정형 데이터와 AI 에이전트 연결하기"
   url="https://cloud.google.com/blog/topics/developers-practitioners/build-ai-agents-faster-with-gcs-google-cloud-storage-mcp-server/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/original_images/image1_9FCB2cO.gif"
-  summary="Google Cloud Storage (GCS)는 현대 에이전트 기술 스택의 핵심이며 대규모 비정형 데이터의 저장소입니다. 기업이 에이전트를 프로덕션에 배포함에 따라 데이터를 컨텍스트로 전환하고 안전한 표준화된 통합을 구축하는 것이 중요해졌습니다. 이는 수동적인 객체를 추론을 위한 풍부한 컨텍스트로 전환하여 비정형 데이터를 에이전트에 바로 사용할 수 있게 "
+  summary="Google Cloud Storage (GCS)는 현대 에이전트 기술 스택의 핵심이며 대규모 비정형 데이터의 저장소입니다. 기업이 에이전트를 프로덕션에 배포함에 따라 데이터를 컨텍스트로 전환하고 안전한 표준화된 통합을 구축하는 것이 중요해졌습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-04-Tech_Security_Weekly_Digest_Go_AI_Zero-Day_CVE.md
+++ b/_posts/2026-06-04-Tech_Security_Weekly_Digest_Go_AI_Zero-Day_CVE.md
@@ -97,7 +97,7 @@ summary_card:
   title="WhatsApp, Slack 알림으로 Android에서 Google Gemini 하이재킹 가능"
   url="https://thehackernews.com/2026/06/whatsapp-slack-notifications-could.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjCJpW9I-QTgQOkP7AV3rwUtEOEs96ek2ySR06Go-xq5AThZV84qY3mDN1Dkh0oQ-94jZHc7zB21ax9ljU0dW2LtsSW5p7xuuX9ARsvoIZQTGaMSkESGxTjl-PgTy8hrnsI8ucVZpENLEuMa9QzoUYVmfp4aug4OnEZq3XeL3ZELNZVELSegpS398l8vKg/s1600/gemini-prompt.jpg"
-  summary="Android에서 WhatsApp, Slack, SMS, Signal, Instagram, Messenger 등에서 오는 악성 알림 하나로 Google Gemini 음성 비서가 하이재킹되어 연결된 창 열기, 상사 메시지 위조, Zoom 통화 강제 참여, 장기 기억 오염 등이 가능했습니다. 이를 위해 휴대폰에 악성 앱이 설치될 필요는 없었으며, Gemini가"
+  summary="Android에서 WhatsApp, Slack, SMS, Signal, Instagram, Messenger 등에서 오는 악성 알림 하나로 Google Gemini 음성 비서가 하이재킹되어 연결된 창 열기, 상사 메시지 위조, Zoom 통화 강제 참여, 장기 기억 오염 등이 가능했습니다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -178,7 +178,7 @@ DevSecOps 파이프라인에 미치는 주요 영향은 다음과 같습니다.
   title="제로데이를 넘어서: 공격자처럼 네트워크를 보는 법 | HD Moore와 함께하는 웨비나"
   url="https://thehackernews.com/2026/06/beyond-zero-day-see-your-network-like.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjzZPASJ7ymlBpeDWq_d-byWp58FpBR6tdX6QfLJFFoGRHK9xB5mTbx0guIcMFKFYV87inRtJyM-cKJXI0Td5fVtpC1ITBFmp2myS2wBynVSF3rZP2jZWH6uR-_14ZEalErJASiKWVDJ_TD551AC0pN5A3Mu8y-Z1zW5mKvFMOmdLzrdWnhYCif0FR1lOE/s1600/hd.jpg"
-  summary="HD Moore가 진행한 웨비나에서 Zero-Day 공격과 AI 기반 익스플로잇이 패치 속도를 앞지르는 현실을 강조하며, 네트워크의 구조적 취약점을 공격자의 시각으로 파악해야 한다고 주장했습니다. 더 이상 모든 취약점을 적시에 패치하는 것은 불가능하므로, 침해를 가정하고 공격이 발생했을 때 피해 범위를 통제할 수 있는 네트워크 설계가 중요하다고 설명했습니다"
+  summary="HD Moore가 진행한 웨비나에서 Zero-Day 공격과 AI 기반 익스플로잇이 패치 속도를 앞지르는 현실을 강조하며, 네트워크의 구조적 취약점을 공격자의 시각으로 파악해야 한다고 주장했습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-06-05-Tech_Security_Weekly_Digest_CVE_Patch_Go_AI.md
+++ b/_posts/2026-06-05-Tech_Security_Weekly_Digest_CVE_Patch_Go_AI.md
@@ -96,7 +96,7 @@ summary_card:
   title="Cisco, 익스플로잇 코드 공개로 Unified CM의 CVE-2026-20230 패치"
   url="https://thehackernews.com/2026/06/cisco-patches-cve-2026-20230-in-unified.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi6_xkmI_c8KreZ4cr2oC9gHJERU9xWsLGDrCNCaB11IQVGmJ-r0MYUjqGllvOFc0IVwGYBqnzLJl96WBTSVXUr5Z8KRym9SsnoUlNN6oEditbTFqW3kTfOhujPEPN-KIzGJmxaJGh9mCvY1TadCVfJJfIBoTjbXn2TCcbQE8NHsKhe8ld53YHYsG5MTYg/s1600/cisco-flaw.jpg"
-  summary="Cisco가 Unified CM에서 네트워크상의 인증되지 않은 공격자가 파일을 쓰고 루트 권한을 획득할 수 있는 취약점(CVE-2026-20230)을 패치했습니다. 이 취약점은 서버사이드 리퀘스트 포저리(SSRF) 유형이며, 개념 증명(PoC) 익스플로잇 코드가 이미 공개되었습니다. Cisco PSIRT는 아직 이 결함이 공격에 악용된 사례는 확인되지 않았다고"
+  summary="Cisco가 Unified CM에서 네트워크상의 인증되지 않은 공격자가 파일을 쓰고 루트 권한을 획득할 수 있는 취약점(CVE-2026-20230)을 패치했습니다. 이 취약점은 서버사이드 리퀘스트 포저리(SSRF) 유형이며, 개념 증명(PoC) 익스플로잇 코드가 이미 공개되었습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -183,7 +183,7 @@ Amazon Cognito는 차세대 스토리지 인프라로 마이그레이션하며 *
   title="Claude Code GitHub Action 결함으로 악성 이슈 하나가 저장소를 탈취할 수 있어"
   url="https://thehackernews.com/2026/06/claude-code-github-action-flaw-let-one.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhiaBF9jAklPh1ncr_eVPGnV229BSTNgAjkScVm-yTXAn4IcBjjZoLIglasRdu1XEPafCxJhqVZrC3zkNWilyAhN-6Ox8z2HBRjNg2D4aqJsDiRDg02BgAy4zgwU2100ZLIO8yTOtarI0Vxa3AGUQk0GZq1_zKSFQOhNiNoyVsP2AldJZoW8ZJ1rY936ZI/s1600/claude-code-hack.jpg"
-  summary="Anthropic의 Claude Code GitHub Action에서 발견된 보안 결함으로, 공격자가 단 하나의 GitHub issue를 열어 취약한 공개 저장소를 장악할 수 있었습니다. Anthropic 자체 action 저장소가 동일한 워크플로우를 사용했기 때문에, 공격이 성공하면 action 자체와 이를 사용하는 하위 프로젝트에 악성 코드가 유입될 수"
+  summary="Anthropic의 Claude Code GitHub Action에서 발견된 보안 결함으로, 공격자가 단 하나의 GitHub issue를 열어 취약한 공개 저장소를 장악할 수 있었습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-06-06-Tech_Security_Weekly_Digest_AI_Threat.md
+++ b/_posts/2026-06-06-Tech_Security_Weekly_Digest_AI_Threat.md
@@ -95,7 +95,7 @@ summary_card:
   title="IronWorm과 새로운 Miasma Worm 변종이 공급망 공격으로 npm을 타격"
   url="https://thehackernews.com/2026/06/ironworm-and-new-miasma-worm-variant.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjFimSGBOnvlCj_r6fiLdzK6V8DLTIQYjROKxHgQH8QxyRVIL3NDpQe9lBISjqCSjcZNl6VPhHVFtdJ8gPe2FfNjR9kGND1GSZmgx9T_32_Aii5nf_fMLkmBxwkKrJKbmZpcAG8xyj868aHfZ9RePlwlPDfMbI4uDlOCknlGH62Ifdf-nak6qmy4u-9i7X3/s1600/npm-worm.jpg"
-  summary="IronWorm과 새로운 Miasma Worm 변종이 공급망 공격에서 npm 생태계를 타격했으며, 위협 행위자는 50개 이상의 합법적인 패키지에 악성 및 변조된 버전을 사용해 Rust 기반 정보 탈취 악성코드와 자가 확산 웜을 유포했습니다. JFrog에 따르면 정보 탈취 악성코드는 개발자 머신에서 모든 비밀정보를 수집하며 eBPF 커널 루트킷 뒤에 숨습니다"
+  summary="IronWorm과 새로운 Miasma Worm 변종이 공급망 공격에서 npm 생태계를 타격했으며, 위협 행위자는 50개 이상의 합법적인 패키지에 악성 및 변조된 버전을 사용해 Rust 기반 정보 탈취 악성코드와 자가 확산 웜을 유포했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-06-07-Tech_Security_Weekly_Digest_GPT_Data_AI_API.md
+++ b/_posts/2026-06-07-Tech_Security_Weekly_Digest_GPT_Data_AI_API.md
@@ -132,7 +132,7 @@ DevSecOps 실무자에게 Lockdown Mode는 **LLM 사용 정책 수립과 보안 
   title="무료 앱들이 조용히 스마트 TV를 AI용 웹 스크래핑 프록시로 전환하고 있다"
   url="https://thehackernews.com/2026/06/free-apps-are-quietly-turning-smart-tvs.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjKr3KoscB_oGLqU5_JV16DIaB7jXY1ko8PiJDTuwrxbHcZV2DYJpfkx8lqwNbscwTSTVQUMwd8vBf-nI13mQE7vzzmUzwKF3BF6q7s5Lnq7kG7CovDsKaHYlvKpEXo2cvNk4mA27BdJSI6buZLqtVCKhYQ31GOaozmEHQecUa9Zdt-jwFJIZ0OCvlF27_p/s1600/smart-tv.jpg"
-  summary="한 연구자가 Bright Data가 소비자 앱에 내장한 iOS SDK를 리버스 엔지니어링하여, 항상 켜져 있는 스마트 TV를 포함한 기기들이 AI 산업을 대상으로 하는 웹 스크래핑 트래픽을 중계하는 출구 노드로 전환되는 방식을 문서화했습니다. Bright Data는 Luminati의 후신으로, 세계 최대 규모의 residential proxy 네트워크를 운"
+  summary="한 연구자가 Bright Data가 소비자 앱에 내장한 iOS SDK를 리버스 엔지니어링하여, 항상 켜져 있는 스마트 TV를 포함한 기기들이 AI 산업을 대상으로 하는 웹 스크래핑 트래픽을 중계하는 출구 노드로 전환되는 방식을 문서화했습니다."
   source="The Hacker News"
   severity="Medium"
 %}

--- a/_posts/2026-06-09-Tech_Security_Weekly_Digest_AWS_Security_AI.md
+++ b/_posts/2026-06-09-Tech_Security_Weekly_Digest_AWS_Security_AI.md
@@ -100,7 +100,7 @@ summary_card:
   title="Linux 커널의 단일 문자 결함으로 로컬 루트 접근 가능, 익스플로잇 공개됨"
   url="https://thehackernews.com/2026/06/one-character-linux-kernel-flaw-enables.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiA8UsvPZqRGiHkumM_jxIGyax3NmK9lBR-XAaVK3Stujz8_bExONh9gAroIEXnLQo9KaXb2MpyZsqb2kcfaUxNJJtFhiSpCZjHDzOtgt-sZczb2rx2eRi-rqMiqFtfs0lq6iqJd74J3aoFRN-azg51ZhnQq84Ve1y_-AMXudSuiePM0mi1UHwTh0MHtIE/s1600/linux.jpg"
-  summary="보안 연구진이 Linux kernel의 nf_tables 패킷 필터링 코드에서 발견된 use-after-free 취약점 CVE-2026-23111에 대한 상세한 working exploit을 공개했습니다. 이 취약점은 권한이 없는 로컬 사용자가 root 권한을 획득하고 컨테이너를 탈출할 수 있게 하며, 2026년 2월 5일 upstream에서 패치되었습니다"
+  summary="보안 연구진이 Linux kernel의 nf_tables 패킷 필터링 코드에서 발견된 use-after-free 취약점 CVE-2026-23111에 대한 상세한 working exploit을 공개했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-06-10-Tech_Security_Weekly_Digest_AI_Data_Zero-Day_Cloud.md
+++ b/_posts/2026-06-10-Tech_Security_Weekly_Digest_AI_Data_Zero-Day_Cloud.md
@@ -228,7 +228,7 @@ DevSecOps 실무자에게 이 사건은 **코드 저장소의 무결성 보증**
   title="NVIDIA Confidential Computing, Apple의 Private Cloud Compute 확장 지원"
   url="https://blogs.nvidia.com/blog/nvidia-confidential-computing-apple-private-cloud-compute/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/06/nvidia-confidential-computing-apple-pcc-842x450.jpeg"
-  summary="NVIDIA의 Confidential Computing 기술이 적용된 GPU가 Apple의 Private Cloud Compute(PCC)에서 기밀 추론을 위해 사용되며, Apple 데이터 센터를 넘어 Google Cloud로 확장되고 있습니다. Apple WWDC에서 공개된 이 기술은 Apple과 Google이 공동 구축한 Apple Foundation "
+  summary="NVIDIA의 Confidential Computing 기술이 적용된 GPU가 Apple의 Private Cloud Compute(PCC)에서 기밀 추론을 위해 사용되며, Apple 데이터 센터를 넘어 Google Cloud로 확장되고 있습니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-11-Tech_Security_Weekly_Digest_AI_Botnet_Patch_CVE.md
+++ b/_posts/2026-06-11-Tech_Security_Weekly_Digest_AI_Botnet_Patch_CVE.md
@@ -302,7 +302,7 @@ Lightning Engine은 Apache Spark 성능을 4.9배 향상시켜 데이터 처리 
   title="표면 선택하기: Antigravity 2.0, Antigravity CLI, Antigravity IDE 또는 Antigravity SDK"
   url="https://cloud.google.com/blog/topics/developers-practitioners/choosing-your-surface-antigravity-20-antigravity-cli-antigravity-ide-or-antigravity-sdk/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/antigravity-new-chat.max-1000x1000.png"
-  summary="Antigravity 2.0은 여러 자율 에이전트를 병렬로 조율하는 데스크톱 앱이며, Antigravity CLI는 명령줄 워크플로우와 헤드리스 실행을 위한 터미널 인터페이스입니다. Antigravity IDE는 에이전트와 함께 코드를 작성할 수 있는 개발자용 편집기이고, Antigravity SDK는 Antigravity Harness를 사용하는 맞춤형 "
+  summary="Antigravity 2.0은 여러 자율 에이전트를 병렬로 조율하는 데스크톱 앱이며, Antigravity CLI는 명령줄 워크플로우와 헤드리스 실행을 위한 터미널 인터페이스입니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-13-Tech_Security_Weekly_Digest_AI_Go_Agent.md
+++ b/_posts/2026-06-13-Tech_Security_Weekly_Digest_AI_Go_Agent.md
@@ -132,7 +132,7 @@ DevSecOps 관점에서 이번 공격은 **CI/CD 파이프라인**에 직접적�
   title="Google, 중국 스미싱 네트워크가 피싱에 Gemini AI 사용했다며 고소"
   url="https://thehackernews.com/2026/06/google-sues-chinese-smishing-network.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg2VG_lHXgOeahfKoUs6hQ7fOmh-dK1ZGloqzAWilTU73LKJF5mBDqw4OSpU8ViE0NEI1iW4cNS5vyz4TpqoJ_aGjHYt4-qJXfmZP2a3mi8GILe4OeP7qSFKeqDWrbHyoMmf49EtaDTylhnpLvem5LCwqX2e8MRSR5rQC5cNv9qH-H_ySeUT5uYHWRLGa5P/s1600/gemini-phishing.jpg"
-  summary="Google이 중국 사이버 범죄 네트워크를 상대로 소송을 제기하며, 해당 조직이 Gemini AI를 활용해 미국인을 대상으로 한 피싱 문자를 발송했다고 밝혔습니다. 이 네트워크는 Phishing-as-a-Service(PhaaS) 소프트웨어 키트인 Outsider를 개발하고 관리한 것으로 알려졌습니다. Google은 이들이 Gemini를 무기화하여 피싱 공"
+  summary="Google이 중국 사이버 범죄 네트워크를 상대로 소송을 제기하며, 해당 조직이 Gemini AI를 활용해 미국인을 대상으로 한 피싱 문자를 발송했다고 밝혔습니다. 이 네트워크는 Phishing-as-a-Service(PhaaS) 소프트웨어 키트인 Outsider를 개발하고 관리한 것으로 알려졌습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -365,7 +365,7 @@ SpaceX가 18,712 BTC(약 12억 9천만 달러)를 보유하며 공개 Bitcoin �
   title="샘 뱅크먼-프리드, FTX 사기 유죄 판결 뒤집으려 한 항소 기각"
   url="https://bitcoinmagazine.com/news/sam-bankman-fried-loses-appeal-ftx"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/06/Sam-Bankman-Fried-Loses-Appeal-to-Overturn-FTX-Fraud-Conviction.jpg"
-  summary="Sam Bankman-Fried의 FTX 사기 혐의에 대한 유죄 판결과 25년형을 뒤집으려는 항소가 연방 항소 법원에서 기각되었습니다. 이로 인해 그의 유죄 판결을 무효화할 수 있는 주요 경로 중 하나가 사라졌으며, 그는 계속 수감 생활을 유지하게 되었습니다. 이 소식은 Bitcoin Magazine이 Micah Zimmerman의 기사로 처음 보도했습니다"
+  summary="Sam Bankman-Fried의 FTX 사기 혐의에 대한 유죄 판결과 25년형을 뒤집으려는 항소가 연방 항소 법원에서 기각되었습니다. 이로 인해 그의 유죄 판결을 무효화할 수 있는 주요 경로 중 하나가 사라졌으며, 그는 계속 수감 생활을 유지하게 되었습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-06-15-Tech_Security_Weekly_Digest_AI_Security_Go_Ethereum.md
+++ b/_posts/2026-06-15-Tech_Security_Weekly_Digest_AI_Security_Go_Ethereum.md
@@ -172,7 +172,7 @@ DevSecOps 관점에서 이 사고는 다음과 같은 실무적 영향을 미칩
   title="정부가 AI 모델을 철회할 때: Fable 5와 Mythos 5 중단이 보안팀에 주는 의미"
   url="https://snyk.io/blog/fable-mythos-suspension-security-takeaways/"
   image="https://res.cloudinary.com/snyk/image/upload/v1646599410/wordpress-sync/blog-feature-security-alert-purple.jpg"
-  summary="2026년 6월 12일, 미국 수출 통제 지시에 따라 Anthropic이 특정 jailbreak 보고를 이유로 Claude Fable 5와 Mythos 5를 전 세계적으로 비활성화했습니다. 이번 사건은 보안 팀이 일상적으로 사용하는 코드 분석 기능이 트리거로 지목되었으며, 보안 커뮤니티는 이에 대해 다양한 해석을 내놓고 있습니다. 보안 팀은 이번 조치에서 "
+  summary="2026년 6월 12일, 미국 수출 통제 지시에 따라 Anthropic이 특정 jailbreak 보고를 이유로 Claude Fable 5와 Mythos 5를 전 세계적으로 비활성화했습니다. 이번 사건은 보안 팀이 일상적으로 사용하는 코드 분석 기능이 트리거로 지목되었으며, 보안 커뮤니티는 이에 대해 다양한 해석을 내놓고 있습니다."
   source="Snyk Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-16-Tech_Security_Weekly_Digest_AI_Go_Malware_Vulnerability.md
+++ b/_posts/2026-06-16-Tech_Security_Weekly_Digest_AI_Go_Malware_Vulnerability.md
@@ -249,7 +249,7 @@ Google DeepMind가 개발한 Gemma 4 모델 제품군이 Apache 2.0 라이선스
 {% include news-card.html
   title="Strands Evals을 활용한 AI 에이전트 장애 탐지 및 근본 원인 분석"
   url="https://aws.amazon.com/blogs/machine-learning/ai-agent-failure-detection-and-root-cause-analysis-with-strands-evals/"
-  summary="이 게시물에서는 Strands Evals를 활용해 AI Agent의 실패를 감지하고 근본 원인을 분석하는 방법을 다룹니다. 구조화된 출력을 통해 신뢰도 점수, 인과 관계 체인, 그리고 시스템 프롬프트나 도구 정의 중 어디를 수정해야 하는지에 대한 권장 사항을 확인할 수 있습니다. 또한 모든 테스트 실행에서 자동 진단이 가능하도록 평가 파이프라인에 감지 기능"
+  summary="이 게시물에서는 Strands Evals를 활용해 AI Agent의 실패를 감지하고 근본 원인을 분석하는 방법을 다룹니다. 구조화된 출력을 통해 신뢰도 점수, 인과 관계 체인, 그리고 시스템 프롬프트나 도구 정의 중 어디를 수정해야 하는지에 대한 권장 사항을 확인할 수 있습니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}

--- a/_posts/2026-06-17-Tech_Security_Weekly_Digest_AI_Go_Update_Malware.md
+++ b/_posts/2026-06-17-Tech_Security_Weekly_Digest_AI_Go_Update_Malware.md
@@ -96,7 +96,7 @@ summary_card:
   title="Google Vertex AI SDK 결함으로 공격자가 Bucket Squatting을 통해 모델 업로드를 가로챌 수 있어"
   url="https://thehackernews.com/2026/06/google-vertex-ai-sdk-flaw-let-attackers.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgpiAGZTnvo43enaVYkna4ZSp217mwwW5kW8kZOhaSiLAxicjvHQY-3d8rdLN47bsRvxUIj6R0h_Ttr8NcIJrgz6k_mbcx94KLuPD29KdhFcYQsrV8htgg_iDYMV9aXbr21kv6BdYTzLNOOqQLpsCfpDC4XxDPnu77uVQ3oCYbIUfIpUKdmqx-rZZWj6P0/s1600/Google-Vertex-AI.jpg"
-  summary="Google Cloud Vertex AI SDK for Python의 취약점으로 인해 공격자가 피해자의 프로젝트에 접근 권한 없이 머신러닝 모델 업로드를 가로채 Google 서빙 인프라 내에서 코드를 실행할 수 있었습니다. Palo Alto Networks Unit 42가 발견한 이 버그는 ”Pickle in the Middle” 기법으로 명명되었으며, 현"
+  summary="Google Cloud Vertex AI SDK for Python의 취약점으로 인해 공격자가 피해자의 프로젝트에 접근 권한 없이 머신러닝 모델 업로드를 가로채 Google 서빙 인프라 내에서 코드를 실행할 수 있었습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -137,7 +137,7 @@ DevSecOps 실무자 관점에서 이 취약점은 **ML 파이프라인의 공급
   title="ClickFix 캠페인, 새로운 로더와 가짜 업데이트 미끼로 악성코드 전송 확대"
   url="https://thehackernews.com/2026/06/clickfix-campaigns-expand-malware.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEilHq1gG2gCazQF6_B9H-W3ck6nmgu3L4IPuzaMg9RMEAbpHyVqfYmFOquQ9_ldT1kG2r1kYUqt-WlpWWvD3DA4vNH6S-lv6fbsDbSCkB55NP3TtRJA4l5lLCMzosdM1OJiDOatfx4zG284ftwuE9ahYlGfcIpnAy1PkVSfWloFY0zD9Cbh3CkHhNQHgqwF/s1600/clickfix-attacks.jpg"
-  summary="보안 연구진이 Morphisec, BlueVoyant, Huntress의 독립적인 보고서를 통해 BabaDeda Loader, Lorem Ipsum Loader, Potemkin이라는 세 가지 멀웨어 로더를 유포하는 여러 ClickFix 캠페인을 발견했습니다. 2026년 4월에 관찰된 BabaDeda Loader 공격은 교육 및 금융 기관을 표적으로 삼았습"
+  summary="보안 연구진이 Morphisec, BlueVoyant, Huntress의 독립적인 보고서를 통해 BabaDeda Loader, Lorem Ipsum Loader, Potemkin이라는 세 가지 멀웨어 로더를 유포하는 여러 ClickFix 캠페인을 발견했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-06-19-Tech_Security_Weekly_Digest_Patch_AWS_AI_Agent.md
+++ b/_posts/2026-06-19-Tech_Security_Weekly_Digest_Patch_AWS_AI_Agent.md
@@ -183,7 +183,7 @@ DevSecOps 파이프라인에서 이 문제는 **CI/CD 파이프라인 내 AI 에
   title="ThreatsDay 게시판: Claude 채팅 악용, NastyC2 npm 패키지, 디바이스 코드 피싱 외 25건"
   url="https://thehackernews.com/2026/06/threatsday-bulletin-claude-chat-abuse.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh6k3CSWsyKHS6UdXmxX-w92fdsWjTSL7JR7xeaPBPh8d5G6rkZbMhmJHr9o3gxF5G2I2GojubOJnzhRqxjtKYxlXTrmlgrdRFRrmmyEEIi_zXAQXT3zpq5KNQqOFHrfGKhUFHzsMx1E2Eqs7S_jvTFfN3Jnz1YO58Ryvk0urKEDUZggoQgI07lKFWQDMfw/s1600/threatss.jpg"
-  summary="이번 주 ThreatsDay Bulletin에서는 Claude 채팅 악용, NastyC2 npm 패키지, Device-Code 피싱을 포함한 25개 이상의 보안 이슈가 보고되었습니다. 악성 브라우저 확장 프로그램을 통한 검색 데이터 유출, AI 채팅 링크를 악용한 멀웨어 전파, 메모리 기반 macOS 공격, 클라우드 에이전트를 통한 쉘 접근, 노출된 엣지 "
+  summary="이번 주 ThreatsDay Bulletin에서는 Claude 채팅 악용, NastyC2 npm 패키지, Device-Code 피싱을 포함한 25개 이상의 보안 이슈가 보고되었습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-06-20-Tech_Security_Weekly_Digest_Patch_AI_Apple_Security.md
+++ b/_posts/2026-06-20-Tech_Security_Weekly_Digest_Patch_AI_Apple_Security.md
@@ -97,7 +97,7 @@ summary_card:
   title="패치 불가능한 'usbliter8' 익스플로잇, Apple A12 및 A13 SecureROM 부트 체인 해제"
   url="https://thehackernews.com/2026/06/unpatchable-usbliter8-exploit-breaks.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgIM725Ni41-PBwM_6zXNdsydP1eZO7oSsWIlAqpwdOu9dOcZM6ZI1iaqwSsL3yZKT4lbFRM-eZVq3ARKDbLRnid1pJ0Us3XX135nD0tV71gb1lnADzig_vE9c6CAiJdlJ-Wco11InBKUyGX9V5nRFn9qZxuxeJKCzsCV4tQTfFIgU3F05Wnp2VfsxyTPs/s1600/apple-chip.jpg"
-  summary="보안 연구팀 Paradigm Shift가 Apple A12 및 A13 칩의 SecureROM 내에서 임의 코드 실행을 가능하게 하는 'usbliter8' 익스플로잇을 공개했습니다. 이 취약점은 제조 시 실리콘에 각인되어 소프트웨어 업데이트로는 패치가 불가능하며, 해당 기기는 사용 기간 내내 이 결함을 안고 가게 됩니다. 원격 공격은 아니며 물리적 접근이 필"
+  summary="보안 연구팀 Paradigm Shift가 Apple A12 및 A13 칩의 SecureROM 내에서 임의 코드 실행을 가능하게 하는 'usbliter8' 익스플로잇을 공개했습니다. 이 취약점은 제조 시 실리콘에 각인되어 소프트웨어 업데이트로는 패치가 불가능하며, 해당 기기는 사용 기간 내내 이 결함을 안고 가게 됩니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -187,7 +187,7 @@ DevSecOps 실무자에게 이 위협은 **CI/CD 파이프라인과 프로덕션 
   title="AutoJack 공격으로 한 웹 페이지가 AI 에이전트를 하이재킹해 호스트 코드 실행 가능"
   url="https://thehackernews.com/2026/06/autojack-attack-lets-one-web-page.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg3wJOg5Y5vAn_dM0DcIB6SwV2B34iO0H-moeyuWLJ_DF1KgEEZMBGtKPDXYk0pL4wclWbnSmOB74sqReSZoGI2_SwUSzKSscUxEdvuJFx_sCIfU7UplU2k5s4UA0cOVAZT_s80PDTek6OGfrsnE8f6QxrQU58rBqPiuk_J__Yja3YNzZLzd-6s8Ji1PBhc/s1600/agent.jpg"
-  summary="Microsoft 연구진이 AutoJack이라는 익스플로잇 체인을 공개했으며, 이는 AI 브라우징 에이전트를 피해자 시스템에서 원격 코드 실행을 수행하는 도구로 전환시킵니다. 공격자의 웹 페이지를 로드하도록 에이전트를 유도하면 해당 페이지의 JavaScript가 동일 머신의 권한 있는 로컬 서비스에 접근해 호스트에서 프로세스를 생성할 수 있으며, 추가 사용"
+  summary="Microsoft 연구진이 AutoJack이라는 익스플로잇 체인을 공개했으며, 이는 AI 브라우징 에이전트를 피해자 시스템에서 원격 코드 실행을 수행하는 도구로 전환시킵니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -244,7 +244,7 @@ Amazon Bedrock AgentCore의 Web Search 기능이 정식 출시되었습니다. �
 {% include news-card.html
   title="Adobe Marketing Agent for Amazon Quick의 인사이트로 캠페인 워크플로우 가속화"
   url="https://aws.amazon.com/blogs/machine-learning/accelerate-campaign-workflow-with-insights-from-adobe-marketing-agent-for-amazon-quick/"
-  summary="이 게시물은 Model Context Protocol (MCP)을 사용하여 Adobe Marketing Agent for Amazon Quick를 활성화하는 방법을 보여줍니다. 통합 구성, Adobe 자격 증명 인증, Amazon Quick에서 최신 인사이트를 얻는 과정을 안내하며, 샘플 워크플로는 audience rankings, loyalty segme"
+  summary="이 게시물은 Model Context Protocol (MCP)을 사용하여 Adobe Marketing Agent for Amazon Quick를 활성화하는 방법을 보여줍니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}

--- a/_posts/2026-06-24-Tech_Security_Weekly_Digest_AI_Security_Agent_Update.md
+++ b/_posts/2026-06-24-Tech_Security_Weekly_Digest_AI_Security_Agent_Update.md
@@ -140,7 +140,7 @@ DevSecOps 실무자에게 이번 위협은 다음과 같은 직접적 영향을 
   title="가짜 AI 에이전트 스킬이 보안 검사를 통과해 26,000개 에이전트에 도달한 것으로 알려져"
   url="https://thehackernews.com/2026/06/fake-ai-agent-skill-passed-security.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgb14v3ddlfpybc15jRbk-cwHI-0S8BAzdp8Ix83L5ZCZ4AB8gCySG7J4tZr4od9q3Jbuic1a4J29VAvRcdSQag_-ju1o9ae9yCcL6XV_jRDVhgd31E5BljiThpXcfHu_gdsmSySY8o0WyjuUoSQ5CGOyKO3cKXVDYeGKa1b1up2VM5ZJE6_PjPNCVOD_M/s1600/skills.jpg"
-  summary="보안 업체 AIR가 가짜 AI 에이전트 스킬을 제작해 유명 스킬 마켓플레이스와 Instagram 광고를 통해 유포한 결과, 일부 기업 계정을 포함해 약 26,000개의 에이전트에 도달했습니다. 이 스킬은 모든 보안 스캐너에서 안전하다고 판정받았으며, 실제로는 사용자 이메일 주소만 수집하는 무해한 페이로드였습니다. 이 실험은 현재 보안 검사 체계의 허점을 드"
+  summary="보안 업체 AIR가 가짜 AI 에이전트 스킬을 제작해 유명 스킬 마켓플레이스와 Instagram 광고를 통해 유포한 결과, 일부 기업 계정을 포함해 약 26,000개의 에이전트에 도달했습니다. 이 스킬은 모든 보안 스캐너에서 안전하다고 판정받았으며, 실제로는 사용자 이메일 주소만 수집하는 무해한 페이로드였습니다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -178,7 +178,7 @@ DevSecOps 실무자에게 이 사건은 **AI 에이전트 보안을 기존 소�
   title="트럼프 행정명령, 연방 양자내성암호 전환 시한 2030년으로 설정"
   url="https://thehackernews.com/2026/06/trump-order-sets-2030-deadline-for.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhoC7KFWoDGkSi-UzAyKNUkw-Ogs4oy2tCOAYXiYAAkqEUC1WMotLAE1GUwoWApfXK3prWVctTP05aLGjru0hDBfJkZ1NzPiFeI1VObgSNCx4egTrYhKIUt4m1S14eQ6_GpdffFBL4Ak3Mgjw7UiiBethv1lmyd_OaPIfhk_b-zuMjxCHLZtih8Tk6MtRg/s1600/unitedstates.jpg"
-  summary="트럼프 대통령이 6월 22일 행정명령에 서명하여 연방 기관들이 고가치 자산과 고영향 시스템을 post-quantum cryptography로 전환하도록 2030년 12월 31일(키 수립)과 2031년 12월 31일(디지털 서명)의 기한을 설정했습니다. EO 14409는 국가 안보 시스템을 별도 트랙으로 분리했으며, 이 기한은 아직 실현되지 않은 위협에 대비"
+  summary="트럼프 대통령이 6월 22일 행정명령에 서명하여 연방 기관들이 고가치 자산과 고영향 시스템을 post-quantum cryptography로 전환하도록 2030년 12월 31일(키 수립)과 2031년 12월 31일(디지털 서명)의 기한을 설정했습니다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -216,7 +216,7 @@ DevSecOps 실무자에게 이번 행정명령은 다음과 같은 핵심 과제�
   title="NVIDIA와 AWS, AI를 대규모로 프로덕션에 도입하기 위해 협력"
   url="https://blogs.nvidia.com/blog/nvidia-aws-ai-production-scale/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/06/logo-lockup-tech-blog-aws-1920x1080-2-842x450.jpg"
-  summary="NVIDIA와 AWS가 협력하여 AI 시스템의 대규모 프로덕션 배포를 위한 인프라를 제공합니다. 이 협력은 Amazon OpenSearch와 Amazon EC2 전반에서 NVIDIA AI 인프라를 활용하여 낮은 지연 시간의 추론, 빠른 벡터 검색, 강력한 GPU 가격 대비 성능을 지원합니다. 이를 통해 기업들은 운영 복잡성 증가 없이 확장 가능한 AI 배포"
+  summary="NVIDIA와 AWS가 협력하여 AI 시스템의 대규모 프로덕션 배포를 위한 인프라를 제공합니다. 이 협력은 Amazon OpenSearch와 Amazon EC2 전반에서 NVIDIA AI 인프라를 활용하여 낮은 지연 시간의 추론, 빠른 벡터 검색, 강력한 GPU 가격 대비 성능을 지원합니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -351,7 +351,7 @@ GitHub Blog에 따르면, 코드 품질 결과를 위한 Repository-level REST A
 {% include news-card.html
   title="SBOM이란 무엇이며, 왜 이것 없이는 배포할 수 없나요?"
   url="https://www.docker.com/blog/what-is-an-sbom/"
-  summary="Omdia의 2026년 소프트웨어 공급망 보안 보고서에 따르면 SBOM을 생성하는 조직의 73%가 취약점 완화 효율성 향상을 경험했지만, 86%는 여전히 생성 과정에 어려움을 겪고 있습니다. 이러한 인식된 가치와 운영상의 어려움 사이의 격차가 대부분의 팀이 직면한 문제입니다. 컨테이너화된 애플리케이션을 구축하고 보호하는 팀은 SBOM이 무엇인지 이해하는 것"
+  summary="Omdia의 2026년 소프트웨어 공급망 보안 보고서에 따르면 SBOM을 생성하는 조직의 73%가 취약점 완화 효율성 향상을 경험했지만, 86%는 여전히 생성 과정에 어려움을 겪고 있습니다. 이러한 인식된 가치와 운영상의 어려움 사이의 격차가 대부분의 팀이 직면한 문제입니다."
   source="Docker Blog"
   severity="Medium"
 %}

--- a/_posts/2026-06-25-Tech_Security_Weekly_Digest_Malware_AWS_Go_AI.md
+++ b/_posts/2026-06-25-Tech_Security_Weekly_Digest_Malware_AWS_Go_AI.md
@@ -153,7 +153,7 @@ mitre_attack:
   title="Amadey 및 StealC 악성코드 네트워크 교란, 2,700만 개 도용된 자격 증명 복구"
   url="https://thehackernews.com/2026/06/amadey-and-stealc-malware-network.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjBVSibdiZdJ1tNYJFrsHtZ8Vr1EG28rqKLY4E7HvAtuax2i3vgpcaMZjEAcGDRxUVu5aa_BHzCAahpw5l2RP2HNw9t7PF6zknNICdw0iuW5jozt5fzqsSfb3Lw55MIvStq2vh5W0139JychUhhJHvchyphenhyphenm7tT2oTS555CkVZrBYSkhmlMKWaXMLtO4OcSp6/s1600/cybercrime-ms.jpg"
-  summary="국제 공조 수사와 Bitdefender, ESET, Microsoft 등 민간 기업의 협력으로 Amadey 및 StealC 악성코드의 범죄 인프라가 무력화되었습니다. 이 작전을 통해 2,700만 개의 도용된 자격 증명이 회수되었으며, Europol은 이번 작전이 랜섬웨어와 금융 사기에 사용되는 사이버 범죄자의 '조립 라인'을 교란하는 데 목적이 있었다고 밝"
+  summary="국제 공조 수사와 Bitdefender, ESET, Microsoft 등 민간 기업의 협력으로 Amadey 및 StealC 악성코드의 범죄 인프라가 무력화되었습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -186,7 +186,7 @@ DevSecOps 관점에서 이번 작전은 **외부 위협 인텔리전스(Threat I
 {% include news-card.html
   title="AWS Management Console 액세스를 로그인 리소스 기반 정책과 RCP로 예상 네트워크로 제한"
   url="https://aws.amazon.com/blogs/security/restrict-aws-management-console-access-to-expected-networks-with-sign-in-resource-based-policies-and-rcps/"
-  summary="Amazon Web Services(AWS)가 AWS Sign-In에 resource-based policies와 resource control policies(RCPs) 지원을 발표했습니다. 이를 통해 AWS Management Console 로그인과 aws login CLI 세션의 접근을 예상된 네트워크, 온프레미스 데이터 센터 네트워크, Amazon "
+  summary="Amazon Web Services(AWS)가 AWS Sign-In에 resource-based policies와 resource control policies(RCPs) 지원을 발표했습니다."
   source="AWS Security Blog"
   severity="Critical"
 %}

--- a/_posts/2026-06-26-Tech_Security_Weekly_Digest_AI_Threat.md
+++ b/_posts/2026-06-26-Tech_Security_Weekly_Digest_AI_Threat.md
@@ -223,7 +223,7 @@ DevSecOps 파이프라인에서 모바일 AI 에이전트 도입 시 다음과 �
 {% include news-card.html
   title="AI 네이티브 시대의 프라이버시 인식 인프라: 자산 분류 사례 연구"
   url="https://engineering.fb.com/2026/06/25/security/privacy-aware-infrastructure-in-the-ai-native-era-an-asset-classification-case-study/"
-  summary="프라이버시 통제 시스템이 효과적으로 작동하려면 데이터에 대한 정확한 이해가 필수적이며, 이는 ”age” 필드처럼 맥락에 따라 의미가 달라질 수 있어 복잡성을 야기합니다. AI-Native 시대의 Privacy-Aware Infrastructure 구축을 위해서는 이러한 데이터 분류(Asset Classification)가 선행되어야 함을 사례 연구를 통해 "
+  summary="프라이버시 통제 시스템이 효과적으로 작동하려면 데이터에 대한 정확한 이해가 필수적이며, 이는 ”age” 필드처럼 맥락에 따라 의미가 달라질 수 있어 복잡성을 야기합니다."
   source="Meta Engineering Blog"
   severity="High"
 %}
@@ -257,7 +257,7 @@ Google Finance가 새로운 앱을 포함한 최신 업그레이드를 발표했
   title="궁극의 여름 세일 조합: Steam 세일과 GeForce NOW 할인 만남"
   url="https://blogs.nvidia.com/blog/geforce-now-thursday-steam-summer-sale-2026/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/06/gfn-thursday-6-25-no-copy-kv-1536x920-1-842x450.jpg"
-  summary="이번 GFN Thursday에서는 Steam Summer Sale과 GeForce NOW 멤버십 할인이 결합된 이중 혜택이 제공됩니다. 또한 Devolver 라인업에 Dark Scrolls가 합류하고, Square Enix의 The Adventures of Elliot: The Millennium Tales도 추가됩니다. 클라우드 게이밍의 가치를 극대화할 "
+  summary="이번 GFN Thursday에서는 Steam Summer Sale과 GeForce NOW 멤버십 할인이 결합된 이중 혜택이 제공됩니다. 또한 Devolver 라인업에 Dark Scrolls가 합류하고, Square Enix의 The Adventures of Elliot: The Millennium Tales도 추가됩니다."
   source="NVIDIA AI Blog"
   severity="High"
 %}

--- a/_posts/2026-06-30-Tech_Security_Weekly_Digest_Go_AI_AWS_Malware.md
+++ b/_posts/2026-06-30-Tech_Security_Weekly_Digest_Go_AI_AWS_Malware.md
@@ -177,7 +177,7 @@ DevSecOps 관점에서 **CI/CD 파이프라인, 인프라 보안, 모니터링 �
   title="Mustang Panda, 인도 정부 공격에서 Zoho WorkDrive를 명령 채널로 활용"
   url="https://thehackernews.com/2026/06/mustang-panda-uses-zoho-workdrive-as.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEj4479X60pqma2HNkNzrVQuQlGImd-48w4eYTTW-wylTLfK7XfLPtmNOMi79oy48LNiFg-4a_vqF378ZobR2Dy6VTO38VxbsFc_l8xQypwe-V43txSB7f73JS142E4uBXjrLKx0lcS-UOUMZ45kLeYgaqCjg2Je2TElLosoBvARIQpzam5q3ckk5CVXsoAF/s1600/india-china.jpg"
-  summary="중국과 연계된 스파이 그룹 Mustang Panda가 인도 정부와 수력 발전 시설을 대상으로 두 가지 캠페인을 진행하며, 합법적인 클라우드 서비스인 Zoho WorkDrive를 명령 채널로 전환해 새로운 악성코드를 배포하고 있습니다. Acronis Threat Research Unit은 인도 정부 네트워크 내에서 고위 행정 직원이 사용하는 기계를 포함한 활"
+  summary="중국과 연계된 스파이 그룹 Mustang Panda가 인도 정부와 수력 발전 시설을 대상으로 두 가지 캠페인을 진행하며, 합법적인 클라우드 서비스인 Zoho WorkDrive를 명령 채널로 전환해 새로운 악성코드를 배포하고 있습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-07-01-Tech_Security_Weekly_Digest_AI_Agent_Data_Botnet.md
+++ b/_posts/2026-07-01-Tech_Security_Weekly_Digest_AI_Agent_Data_Botnet.md
@@ -96,7 +96,7 @@ summary_card:
   title="Microsoft, 오염된 MCP 도구 설명이 AI 에이전트의 데이터 유출을 초래할 수 있다고 경고"
   url="https://thehackernews.com/2026/06/microsoft-warns-poisoned-mcp-tool.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjbjfrraZ05p0kN5CedcQSOZYouoHGrdpCvi9TGxEZM_9zlXc_juWZ1F8VsvjV9c-iD7Ejgj0V6b0uYwOb9mLpb7ALcOVk53m2ppmg6mDI3qwANc8KZFMt3X7H7fT_Eym3OJijFmr0CZS6yJNTtf4kef0gOYtbx6A3LYa15PNzpzJuOg-nd6orLosZzfQ8/s1600/ms-ai.jpg"
-  summary="Microsoft의 새로운 연구는 공격자가 독이 포함된 MCP 도구 설명만으로 사용자를 대신해 작업하는 AI 에이전트를 하이재킹해 회사 데이터를 외부로 유출할 수 있음을 보여줍니다. 이 과정에서 에이전트는 규칙을 위반하지 않으며 모든 단계가 일상적으로 보여 기본 설정에서는 경보가 울리지 않을 수 있습니다. 해당 연구는 Microsoft Incident Resp"
+  summary="Microsoft의 새로운 연구는 공격자가 독이 포함된 MCP 도구 설명만으로 사용자를 대신해 작업하는 AI 에이전트를 하이재킹해 회사 데이터를 외부로 유출할 수 있음을 보여줍니다. 이 과정에서 에이전트는 규칙을 위반하지 않으며 모든 단계가 일상적으로 보여 기본 설정에서는 경보가 울리지 않을 수 있습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-07-02-Tech_Security_Weekly_Digest_Patch_Kubernetes_Go_AI.md
+++ b/_posts/2026-07-02-Tech_Security_Weekly_Digest_Patch_Kubernetes_Go_AI.md
@@ -164,7 +164,7 @@ Scattered Spider(일명 UNC3944)는 주로 **사회공학 기법과 MFA 우회 �
   title="SEO에 중독된 소프트웨어 사이트, ScreenConnect 악용해 AsyncRAT 유포"
   url="https://thehackernews.com/2026/07/seo-poisoned-software-sites-abuse.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhbKfADFEhazeaRztmVJkTBhFqZxALUDBwsOV_25bWjZ6Qm3pCBoSSawssWOOJC2ZQ7M6hrUDRXLfR5gcpWRkkaSdNtSPCz-FLrG5Dy4-Y-IzEMt_souSqJuc3JK9FNQ9p2-dT7Ojf3ufzPkWBpLNyDAVeeuYS7Ya-BJWT4MmAHz7OjHvwjMSCfF5Jvahyphenhyphenj/s1600/SEO-MALWARE.jpg"
-  summary="알려지지 않은 위협 행위자들이 ScreenConnect 원격 접속 도구를 악용하여 AsyncRAT을 배포하고 실행하고 있습니다. Kaspersky는 이 활동이 스푸핑된 웹사이트에 호스팅된 악성 설치 프로그램 아카이브를 유포하는 ”대규모의 다중 도메인, 다중 언어” 캠페인의 일환이라고 밝혔습니다. 이 설치 프로그램들은 OBS Studio, DNS Jumper"
+  summary="알려지지 않은 위협 행위자들이 ScreenConnect 원격 접속 도구를 악용하여 AsyncRAT을 배포하고 실행하고 있습니다. Kaspersky는 이 활동이 스푸핑된 웹사이트에 호스팅된 악성 설치 프로그램 아카이브를 유포하는 ”대규모의 다중 도메인, 다중 언어” 캠페인의 일환이라고 밝혔습니다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -311,7 +311,7 @@ Anthropic의 Claude Code가 Google Cloud와 통합되어, 개발자는 환경 �
   title="기업은 자동 모델 선택을 기본값으로 설정 가능"
   url="https://github.blog/changelog/2026-07-01-enterprises-can-default-to-auto-model-selection"
   image="https://github.blog/wp-content/uploads/2026/07/616003449-884dafc4-1024-44cb-895c-12c017040dcf.jpg"
-  summary="GitHub 블로그에 따르면, 기업 관리자는 이제 enterprise managed-settings.json에서 모델을 auto로 설정하여 Copilot의 자동 모델 선택을 새 대화의 기본값으로 지정할 수 있습니다. 이 설정은 .github-private/.github/copilot/managed-settings.json 파일에 auto를 추가하여 적용됩니"
+  summary="GitHub 블로그에 따르면, 기업 관리자는 이제 enterprise managed-settings.json에서 모델을 auto로 설정하여 Copilot의 자동 모델 선택을 새 대화의 기본값으로 지정할 수 있습니다."
   source="GitHub Changelog"
   severity="High"
 %}

--- a/_posts/2026-07-04-Tech_Security_Weekly_Digest_Patch_AWS_AI_Malware.md
+++ b/_posts/2026-07-04-Tech_Security_Weekly_Digest_Patch_AWS_AI_Malware.md
@@ -134,7 +134,7 @@ DevSecOps 관점에서 이 취약점은 **공급망 보안(SBOM)**과 **CI/CD �
   title="새로운 ”Bad Epoll” Linux 커널 결함으로 권한 없는 사용자가 루트 권한 획득 가능, Android에도 영향"
   url="https://thehackernews.com/2026/07/new-bad-epoll-linux-kernel-flaw-lets.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEggOXDckpE46PYIzBnXsx_kyHzFvlcB3l8qEr6feRNBhRQMKc2p5r2pQArl-NrsoB2z6vE917nXVHpuuMZOgZcRDMlwbVYC0ocK3uIsb-h59qed_kuvDKwvukQCAs-VDcE5Ail8mTRSPpnNfrPzKv5oAMQ9fJCDNE_2PpPrN9a9mOwGUIs0TnWq6_r58HM/s1600/root-linux.gif"
-  summary="최근 공개된 Linux 커널 취약점 Bad Epoll(CVE-2026-46242)은 권한이 없는 일반 사용자가 루트 권한을 획득해 시스템을 완전히 장악할 수 있게 하며, Linux 데스크톱, 서버 및 Android에 영향을 미칩니다. 이 취약점은 Anthropic의 AI 모델 Mythos가 최근 다른 버그를 발견한 동일한 커널 코드 영역에 존재하며, 현재 "
+  summary="최근 공개된 Linux 커널 취약점 Bad Epoll(CVE-2026-46242)은 권한이 없는 일반 사용자가 루트 권한을 획득해 시스템을 완전히 장악할 수 있게 하며, Linux 데스크톱, 서버 및 Android에 영향을 미칩니다."
   source="The Hacker News"
   severity="Medium"
 %}

--- a/_posts/2026-07-05-Tech_Security_Weekly_Digest_AI_Data_Go_Ransomware.md
+++ b/_posts/2026-07-05-Tech_Security_Weekly_Digest_AI_Data_Go_Ransomware.md
@@ -131,7 +131,7 @@ DevSecOps 파이프라인에서 이 사례가 시사하는 점:
   title="북한 해커, PolinRider 캠페인에서 108개의 악성 패키지 및 확장 프로그램 유포"
   url="https://thehackernews.com/2026/07/north-korean-hackers-publish-108.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgwdeBqtwl7nqoAp8TPhZmmr3mUTCcfxluYa7QukD2sI1AjCWoOko2YtQUrCtOLH-tJlYi2lXUA5E3RF51L26gZGyR7sT0GXu73OMB94HhINz5kajaR8-txb-tYNj2Hsm62zVwTaw7Rew6Wazf8eQgo_boWq7DjqbN1jjp5OmwSZ2yG7Y9e04hFVaroUSu6/s1600/go-code.jpg"
-  summary="북한 해커 그룹이 Contagious Interview 캠페인과 연계되어 PolinRider 활동의 일환으로 npm, Packagist, Go, Google Chrome 등에서 108개의 악성 패키지와 브라우저 확장 프로그램을 게시한 것으로 확인되었습니다. 이 캠페인은 여전히 활성 상태이며, 위협 행위자들이 관리자 계정을 탈취함에 따라 새로운 악성 패키지가"
+  summary="북한 해커 그룹이 Contagious Interview 캠페인과 연계되어 PolinRider 활동의 일환으로 npm, Packagist, Go, Google Chrome 등에서 108개의 악성 패키지와 브라우저 확장 프로그램을 게시한 것으로 확인되었습니다."
   source="The Hacker News"
   severity="Medium"
 %}

--- a/_posts/2026-07-06-Tech_Security_Weekly_Digest_AI_Agent_AWS.md
+++ b/_posts/2026-07-06-Tech_Security_Weekly_Digest_AI_Agent_AWS.md
@@ -171,7 +171,7 @@ sequenceDiagram
 {% include news-card.html
   title="Amazon OpenSearch 3.3 업그레이드로 미리캔버스의 검색 성능 개선"
   url="https://aws.amazon.com/ko/blogs/tech/miricanvas-dual-vector-search-opensearch-3-3-upgrade-2/"
-  summary="부제: derived source와 Lucene 10.3으로 stored fields 병목을 해소하고, 무중단·안전 롤백 전략으로 메이저 버전을 올린 이야기 본 게시글은 미리디의 김민석, 최시온, 이동진, 김백규님과 함께 작성하였습니다. 미리디의 미리캔버스 소개 미리캔버스는 ”누구나 쉽게, 함께 만드는 디자인”을 지향하는 실시간 협업 디자인 플랫폼입니다"
+  summary="부제: derived source와 Lucene 10.3으로 stored fields 병목을 해소하고, 무중단·안전 롤백 전략으로 메이저 버전을 올린 이야기 본 게시글은 미리디의 김민석, 최시온, 이동진, 김백규님과 함께 작성하였습니다."
   source="AWS Korea Blog"
   severity="High"
 %}
@@ -203,7 +203,7 @@ flowchart TD
 {% include news-card.html
   title="Amazon OpenSearch Service로 미리캔버스의 듀얼 벡터 검색 도입과 성능 최적화"
   url="https://aws.amazon.com/ko/blogs/tech/miricanvas-dual-vector-search-opensearch-3-3-upgrade-1/"
-  summary="부제: 4,000만 건 디자인 리소스의 의미 기반 검색을 위한 듀얼 벡터 설계, 그리고 OpenSearch 2.19에서 마주한 메모리와 IOPS 병목과의 싸움 본 게시글은 미리디의 김민석, 최시온, 이동진, 김백규님과 함께 작성하였습니다. 미리디의 미리캔버스 소개 미리캔버스는 ”누구나 쉽게, 함께 만드는 디자인”을 지향하는 실시간 협업 디자인 플랫폼입니다"
+  summary="부제: 4,000만 건 디자인 리소스의 의미 기반 검색을 위한 듀얼 벡터 설계, 그리고 OpenSearch 2.19에서 마주한 메모리와 IOPS 병목과의 싸움 본 게시글은 미리디의 김민석, 최시온, 이동진, 김백규님과 함께 작성하였습니다."
   source="AWS Korea Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-07-Tech_Security_Weekly_Digest_CVE_Docker_Threat_AI.md
+++ b/_posts/2026-07-07-Tech_Security_Weekly_Digest_CVE_Docker_Threat_AI.md
@@ -142,7 +142,7 @@ DevSecOps 실무자 관점에서 이 위협은 다음과 같은 영향을 미칩
   title="16년 된 Linux KVM 취약점으로 Intel 및 AMD x86 시스템에서 게스트 VM이 호스트로 탈출 가능"
   url="https://thehackernews.com/2026/07/16-year-old-linux-kvm-flaw-lets-guest.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjG42lgj1grtq5EQICr-9RYvPU59uHFRBluzVoZ3TZLXEXBcF5bOPerpb_Ck-e6oNz6P4MO1VAiqbBXuPbImhng1CoRnRYHWSZTGOloHmYB5khhpCK5wW348uMgqmWIjTQPnOwCGV7OiPXJoJDWV0n1IPGP80hADXD3AnmRKbTb8jxyGQenhlgIpvNo29I/s1600/linux-kvm.jpg"
-  summary="16년 된 Linux KVM 하이퍼바이저의 use-after-free 취약점(CVE-2026-53359, 'Januscape')이 게스트 VM에서 호스트 커널의 shadow-page 상태를 손상시킬 수 있습니다. 이 결함은 Intel과 AMD x86 시스템 모두에 영향을 미치는 KVM의 shadow MMU 코드에 존재하며, 공개된 PoC는 호스트를 패닉 상"
+  summary="16년 된 Linux KVM 하이퍼바이저의 use-after-free 취약점(CVE-2026-53359, 'Januscape')이 게스트 VM에서 호스트 커널의 shadow-page 상태를 손상시킬 수 있습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -335,7 +335,7 @@ SRE의 4-body 문제는 자율 운영이 성공하려면 단순한 자동화가 
   title="AI 네이티브 워크로드를 위한 플랫폼 엔지니어링의 진화"
   url="https://www.cncf.io/blog/2026/07/06/evolving-platform-engineering-for-ai-native-workloads/"
   image="https://www.cncf.io/wp-content/uploads/2026/07/Blog-Default-28.jpg"
-  summary="Platform Engineering 1.0은 Golden paths를 통한 배포 가속화와 Internal Developer Platforms(IDPs)를 통한 개발자 인지 부하 감소 등 실질적인 가치를 제공했습니다. 셀프서비스 인프라는 개발자들이 티켓 제출에 소모하던 시간을 절약해 주었고, 파이프라인은 표준화된 배포 방식을 제공했습니다. 이제 이러한 접근"
+  summary="Platform Engineering 1.0은 Golden paths를 통한 배포 가속화와 Internal Developer Platforms(IDPs)를 통한 개발자 인지 부하 감소 등 실질적인 가치를 제공했습니다. 셀프서비스 인프라는 개발자들이 티켓 제출에 소모하던 시간을 절약해 주었고, 파이프라인은 표준화된 배포 방식을 제공했습니다."
   source="CNCF Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-10-Tech_Security_Weekly_Digest_AWS.md
+++ b/_posts/2026-07-10-Tech_Security_Weekly_Digest_AWS.md
@@ -254,7 +254,7 @@ ChatGPT Work는 사용자의 앱과 파일을 넘나들며 장시간 프로젝�
   title="Cloud Run 샌드박스에서 AI 생성 코드를 안전하게 실행하기"
   url="https://cloud.google.com/blog/topics/developers-practitioners/google-cloud-run-sandboxes-are-in-public-preview/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/original_images/sandbox_1000_-_100_ok.gif"
-  summary="Google Cloud에서 AI가 생성한 코드나 신뢰할 수 없는 바이너리를 안전하게 실행하기 위해 Cloud Run 샌드박스를 사용하는 방법이 제시되었습니다. 이는 호스트 애플리케이션, 데이터, 클라우드 자격 증명을 위험에 빠뜨리지 않으면서 AI 프로그램을 신뢰할 수 있는 프로그램과 완전히 분리된 환경에서 실행할 수 있도록 합니다. 기존에는 복잡한 샌드박스"
+  summary="Google Cloud에서 AI가 생성한 코드나 신뢰할 수 없는 바이너리를 안전하게 실행하기 위해 Cloud Run 샌드박스를 사용하는 방법이 제시되었습니다. 이는 호스트 애플리케이션, 데이터, 클라우드 자격 증명을 위험에 빠뜨리지 않으면서 AI 프로그램을 신뢰할 수 있는 프로그램과 완전히 분리된 환경에서 실행할 수 있도록 합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-12-Tech_Security_Weekly_Digest_Rust_AI_Agent.md
+++ b/_posts/2026-07-12-Tech_Security_Weekly_Digest_Rust_AI_Agent.md
@@ -138,7 +138,7 @@ sequenceDiagram
   title="해커들, 다중 그룹 정찰 캠페인에서 Balochistan Police Portal 무기화"
   url="https://thehackernews.com/2026/07/hackers-weaponize-balochistan-police.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEimRVwRIhs54UhNHyRll9YzVxICmTpgqwjAK1Sy7vYt6FAzb9oImcFpuM0J8dOWdtdjCdlROkternhP9r5jZD9HNvwVwcyRzhesdYgbVjUpJk7p4rxDDJSdEUibs1Gk-Ihy1bTcxs8fA7kgG49ImfTWEZO6068Ui-_X6sTTraCg8lFuucYJrUJi2RhdXyG2/s1600/pakistan.jpg"
-  summary="보안 연구원들은 2024년 2월부터 2026년 4월까지 중국 및 인도와 연계된 것으로 의심되는 위협 행위자들이 파키스탄의 여러 법 집행 기관을 대상으로 지속적인 사이버 스파이 활동을 펼쳤다고 밝혔습니다. 이 과정에서 Balochistan Police의 포털이 무기화되었으며, 침해된 서버에는 범죄자 및 시민 데이터를 관리하는 웹 애플리케이션이 포함되어 있었습"
+  summary="보안 연구원들은 2024년 2월부터 2026년 4월까지 중국 및 인도와 연계된 것으로 의심되는 위협 행위자들이 파키스탄의 여러 법 집행 기관을 대상으로 지속적인 사이버 스파이 활동을 펼쳤다고 밝혔습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -215,7 +215,7 @@ DevSecOps 관점에서 이번 사례는 다음과 같은 실무적 함의를 가
 {% include news-card.html
   title="Amazon Bedrock 모델 promptfoo 로 성능 평가하기"
   url="https://aws.amazon.com/ko/blogs/tech/bedrock-promptfoo-eval/"
-  summary="들어가며 ”프롬프트를 바꿨는데, 정말 더 나아진 걸까?” 생성형 AI 애플리케이션을 개발하는 엔지니어라면 누구나 한 번쯤 마주치는 질문입니다. 프롬프트 한 줄을 수정하거나 모델을 교체할 때마다 품질이 좋아졌는지 확신하기 어렵고, 여러 모델을 두고 어느 쪽이 서비스에 더 맞는지 판단하려면 같은 질문을 양쪽에 던져 결과를 일일이 눈으로 비교해야 합니다"
+  summary="들어가며 ”프롬프트를 바꿨는데, 정말 더 나아진 걸까?” 생성형 AI 애플리케이션을 개발하는 엔지니어라면 누구나 한 번쯤 마주치는 질문입니다."
   source="AWS Korea Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-14-Tech_Security_Weekly_Digest_AI_Security_Malware_Go.md
+++ b/_posts/2026-07-14-Tech_Security_Weekly_Digest_AI_Security_Malware_Go.md
@@ -132,7 +132,7 @@ DevSecOps 관점에서 특히 주목할 점은 **AI가 공격의 ‘속도’와
   title="CrashStealer macOS 악성코드, 공증된 드로퍼 사용해 Gatekeeper 검사 우회"
   url="https://thehackernews.com/2026/07/crashstealer-macos-malware-uses.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhbZ5yNN1gA3Yzt-6i1sekVk3AFnHGEpas31-UowjFTXB9Rj4DhkS8H4cqjr655w9HCDKZIzcRAqn1NvLSmPLs_-oDDYpCteWgGlkUIpuyMkPIeXnfgxKCYRG54K8oV0j4vVaWj928DfJBsYJzR98e5BuZDp5OmoeFtDubZ90Qnz0a7G9VmukCII5kVE3rQ/s1600/macos-malware-1.jpg"
-  summary="보안 연구진이 CrashStealer라는 새로운 macOS 정보 탈취 악성코드를 발견했으며, 이는 AppleScript 드로퍼나 Objective-C 기반 래퍼 대신 네이티브 C++로 구현되었습니다. CrashStealer는 공증된 드로퍼를 사용하여 Gatekeeper 검사를 우회하며, 피해자의 로그인 비밀번호를 로컬에서 검증한 후 민감한 데이터를 수집합니"
+  summary="보안 연구진이 CrashStealer라는 새로운 macOS 정보 탈취 악성코드를 발견했으며, 이는 AppleScript 드로퍼나 Objective-C 기반 래퍼 대신 네이티브 C++로 구현되었습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -260,7 +260,7 @@ OpenAI의 GPT-5.6 Sol, Terra, Luna 모델이 Amazon Bedrock에서 정식 출시�
   title="GKE에서 AI 공급망 보안 강화: 자동화된 AI BOM을 위한 k8s-aibom 소개"
   url="https://cloud.google.com/blog/products/identity-security/introducing-k8s-aibom-on-gke-for-automated-ai-bills-of-materials/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/k8s-aibom.max-1000x1000.png"
-  summary="Google 클라우드는 GKE에서 AI 공급망 보안을 강화하기 위해 오픈소스 도구 k8s-aibom을 공개했습니다. 이 도구는 개발자가 공식 등록 없이 배포한 shadow AI 워크로드를 탐지하고, 전통적인 보안 스캐너가 놓치는 문제를 해결합니다. k8s-aibom은 권한 있는 Daemonset이나 커널 수준 접근 없이 AI BOM을 자동 생성하여 보안과 개발 속"
+  summary="Google 클라우드는 GKE에서 AI 공급망 보안을 강화하기 위해 오픈소스 도구 k8s-aibom을 공개했습니다. 이 도구는 개발자가 공식 등록 없이 배포한 shadow AI 워크로드를 탐지하고, 전통적인 보안 스캐너가 놓치는 문제를 해결합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -349,7 +349,7 @@ OpenTelemetry를 대규모로 운영하는 조직이 증가하면서, 이기종 
   title="Bitwise, Bitcoin의 최악 분위기 속 바닥을 감지하다: ”가장 어두운 때가 동트기 전이다"
   url="https://bitcoinmagazine.com/markets/bitwise-sees-a-bottom-in-bitcoin"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/05/Bitcoin-Backed-Loans-Could-Hit-1-Trillion-Ledn-Says-—-But-Most-Crypto-Holders-Still-Havent-Borrowed.jpg"
-  summary="Bitwise는 Bitcoin의 9개월간의 하락장이 역대 최악의 분위기를 형성했지만, 이면에는 기관 채택, 기업 매수, 시장 인프라 개선 등 그 어느 때보다 강력한 기반이 자리 잡고 있다고 분석했습니다. 기록적인 ETF 자금 유출과 약한 시장 심리에도 불구하고, 이러한 펀더멘털이 업계의 반등을 이끌 것이라고 전망하며 '가장 어두운 때가 새벽 직전'이라고 평가했습"
+  summary="Bitwise는 Bitcoin의 9개월간의 하락장이 역대 최악의 분위기를 형성했지만, 이면에는 기관 채택, 기업 매수, 시장 인프라 개선 등 그 어느 때보다 강력한 기반이 자리 잡고 있다고 분석했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-07-20-Tech_Security_Weekly_Digest_Vulnerability_AI_Malware_Zero-Day.md
+++ b/_posts/2026-07-20-Tech_Security_Weekly_Digest_Vulnerability_AI_Malware_Zero-Day.md
@@ -95,7 +95,7 @@ summary_card:
   title="치명적인 NGINX 취약점, 워커 충돌 유발 및 원격 코드 실행 가능"
   url="https://thehackernews.com/2026/07/critical-nginx-vulnerability-can-crash.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiVv10OUCjBseEZieeN1rxtwm17pPCAoe6OC1jvCTXCumjIImhz5Y08lYWBpSIGBSkDJN-wBcGmUTmPEp8U74bgd2Cv3rwmSmtUDlmOYR7f-0Xs3xL_xkjpkNm8W8vzNvFNfmTNiqs9TNcNmT1bo8xWb9XGzPnuaByxKSl9_eOqg3yDbtAtYh0epFo-4Wg/s1600/nginx-rce-flaw.jpg"
-  summary="F5가 nginx의 치명적인 취약점(CVE-2026-42533)에 대한 패치를 출시했습니다. 이 취약점은 원격의 인증되지 않은 공격자가 조작된 HTTP 요청을 통해 worker 프로세스에 heap buffer overflow를 유발할 수 있으며, worker를 충돌시키거나 재시작하여 서비스 거부를 일으킬 수 있습니다. nginx 1.30.4, 1.31.3 "
+  summary="F5가 nginx의 치명적인 취약점(CVE-2026-42533)에 대한 패치를 출시했습니다. 이 취약점은 원격의 인증되지 않은 공격자가 조작된 HTTP 요청을 통해 worker 프로세스에 heap buffer overflow를 유발할 수 있으며, worker를 충돌시키거나 재시작하여 서비스 거부를 일으킬 수 있습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-07-21-Tech_Security_Weekly_Digest_AI_Malware_Threat_Agent.md
+++ b/_posts/2026-07-21-Tech_Security_Weekly_Digest_AI_Malware_Threat_Agent.md
@@ -95,7 +95,7 @@ summary_card:
   title="FakeGit 캠페인, 7,600개 GitHub 저장소 이용해 SmartLoader 악성코드 유포"
   url="https://thehackernews.com/2026/07/fakegit-campaign-uses-7600-github.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjraCuGeWGgh9OrpC0vpcC6fFNsSdQEGhB_GPY0ZbuAzcOyqyTyHFA8fl97bDKYihy0MZGiU9_5a4s4x6oziT9-cCv1n2dpGZpGtvuipWUYoEObUWtQt0ZmNczKsM7wzqdtLbAvrIfJrFpCDzPD-koB8qxdpFYZ0w5EtnYW2Z4RTPz0v-JFVyFgyg3rQk8/s1600/github.jpg"
-  summary="사이버보안 연구진이 FakeGit 캠페인의 일환으로 약 7,600개의 악성 GitHub 리포지토리를 발견했으며, 이 중 800개 이상이 AI 스킬이나 Model Context Protocol (MCP) 서버로 위장해 SmartLoader 악성코드를 유포하고 있습니다. FakeGit은 복사된 프로젝트, 유사 개발자 프로필, 신뢰할 수 있는 README 및 악"
+  summary="사이버보안 연구진이 FakeGit 캠페인의 일환으로 약 7,600개의 악성 GitHub 리포지토리를 발견했으며, 이 중 800개 이상이 AI 스킬이나 Model Context Protocol (MCP) 서버로 위장해 SmartLoader 악성코드를 유포하고 있습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -256,7 +256,7 @@ OpenAI가 장기 실행 AI 모델 배포 경험을 공유하며 새로운 안전
   title="C4A-metal과 Panasonic Automotive vSkipGen으로 자동차 혁신 가속화"
   url="https://cloud.google.com/blog/topics/partners/panasonic-automotive-vskipgen-runs-on-axion-based-c4a-metal/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/1_rib6Qrb.max-1000x1000.png"
-  summary="C4A-metal과 Panasonic Automotive의 vSkipGen 기술이 차량용 Cockpit Domain Controller(CDC) 소프트웨어 개발을 가속화합니다. 이는 하드웨어 독립적인 환경에서 고성능 그래픽 요구사항을 충족하며 글로벌 개발팀의 물리적 하드웨어 제약을 해결합니다. 결과적으로 소프트웨어 정의 차량 시대의 혁신과 시장 출시 시간 "
+  summary="C4A-metal과 Panasonic Automotive의 vSkipGen 기술이 차량용 Cockpit Domain Controller(CDC) 소프트웨어 개발을 가속화합니다. 이는 하드웨어 독립적인 환경에서 고성능 그래픽 요구사항을 충족하며 글로벌 개발팀의 물리적 하드웨어 제약을 해결합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-22-Tech_Security_Weekly_Digest_AI_Apple_AWS_Go.md
+++ b/_posts/2026-07-22-Tech_Security_Weekly_Digest_AI_Apple_AWS_Go.md
@@ -123,7 +123,7 @@ Apple이 Hide My Email 서비스의 보안 결함을 수정했습니다. 이 결
   title="AWS Kiro 결함으로 오염된 웹 페이지가 설정을 덮어쓰고 코드를 실행할 수 있어"
   url="https://thehackernews.com/2026/07/aws-kiro-flaw-let-poisoned-web-page.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjJfMUQ_pVP5as41uM_4cR8oRUsCwuXPMLLG63jNd5Djqso9kJyQZLiZgQrMQzykhRaX8BQCydIMPokGoITYY30kc3dH-8iy4Bd-ux36RoIjyNYXtKwb1F1fPdP00hoHD-9Q9s5CGD30w58s5wfyzBGOQvnIxM8JlHkig881HSQQuu4Hk6GBiDJicUYE8o/s1600/AWS-Kiro.jpg"
-  summary="AWS의 코딩 IDE인 Kiro에서 웹 페이지의 숨겨진 텍스트를 통해 설정 파일이 임의로 수정되고 공격자의 코드가 실행될 수 있는 취약점이 발견되었습니다. Intezer와 Kodem Security의 연구에 따르면 페이지 요약 요청과 같은 일반적인 동작만으로도 원격 코드 실행이 가능했으며, 승인 단계를 거치지 않았습니다. AWS는 이 문제를 패치했으며 별도"
+  summary="AWS의 코딩 IDE인 Kiro에서 웹 페이지의 숨겨진 텍스트를 통해 설정 파일이 임의로 수정되고 공격자의 코드가 실행될 수 있는 취약점이 발견되었습니다. Intezer와 Kodem Security의 연구에 따르면 페이지 요약 요청과 같은 일반적인 동작만으로도 원격 코드 실행이 가능했으며, 승인 단계를 거치지 않았습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -214,7 +214,7 @@ OpenAI가 중소기업을 위한 ChatGPT for Small Businesses 프로그램을 �
   title="NVIDIA Vera Rubin, 파트너 전 세계에 최저 토큰 비용 제공, 성능 대비 와트당 효율 주도"
   url="https://blogs.nvidia.com/blog/vera-rubin/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/07/vera-tech-blog-vera-rubin-nvl72-1920x1080-1-842x450.png"
-  summary="NVIDIA Vera Rubin이 출시되어 기가스케일로 확장 중이며, CoreWeave, Google Cloud, Microsoft Azure, Oracle Cloud Infrastructure에서 랙 생산이 진행 중입니다. 30개국 350개 이상의 공장을 통해 가장 성숙한 랙스케일 공급망을 갖추고 파트너에게 최저 토큰 비용과 성능 대비 전력 효율을 제공합"
+  summary="NVIDIA Vera Rubin이 출시되어 기가스케일로 확장 중이며, CoreWeave, Google Cloud, Microsoft Azure, Oracle Cloud Infrastructure에서 랙 생산이 진행 중입니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -270,7 +270,7 @@ AlloyDB는 PostgreSQL 호환 관리형 데이터베이스 서비스로, Google�
   title="지금 미리보기: CodeMender로 소프트웨어 취약점 찾기 및 수정"
   url="https://cloud.google.com/blog/products/identity-security/find-and-fix-software-vulnerabilities-with-codemender/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/2_LNSezkk.max-1000x1000.png"
-  summary="CodeMender는 코드 스캔 및 수정 기능을 제공하는 관리형 코드 보안 에이전트로, 프리뷰로 제공됩니다. Gemini Enterprise Agent Platform을 통해 일반 공급 모델에 접근하거나 AI Threat Defense의 핵심 구성 요소로 배포할 수 있습니다. 이는 AI 기반 위협에 대응하여 코드 취약점을 자동으로 찾고 수정하는 데 도움을 "
+  summary="CodeMender는 코드 스캔 및 수정 기능을 제공하는 관리형 코드 보안 에이전트로, 프리뷰로 제공됩니다. Gemini Enterprise Agent Platform을 통해 일반 공급 모델에 접근하거나 AI Threat Defense의 핵심 구성 요소로 배포할 수 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -326,7 +326,7 @@ Google의 최신 Flash 모델인 Gemini 3.6 Flash가 GitHub Copilot에서 사용
   title="에이전트가 문서에 접근해야 하는 이유"
   url="https://www.cncf.io/blog/2026/07/21/why-your-agent-needs-access-to-your-documentation/"
   image="https://www.cncf.io/wp-content/uploads/2026/07/Two-months-of-Open-Community-Groups-5.jpg"
-  summary="최근 한 기업이 자사 제품 내에 에이전트를 탑재한 후 1,192건의 대화를 분석한 결과, 에이전트가 효과적으로 작동하려면 사용자의 문서(knowledge base)에 대한 접근 권한이 필수적이라는 사실을 발견했습니다. 이 에이전트는 사용자가 배포 관련 질문을 할 수 있도록 설계되었으며, 문서 접근 없이는 정확한 답변을 제공하기 어려웠습니다. 따라서 에이전트"
+  summary="최근 한 기업이 자사 제품 내에 에이전트를 탑재한 후 1,192건의 대화를 분석한 결과, 에이전트가 효과적으로 작동하려면 사용자의 문서(knowledge base)에 대한 접근 권한이 필수적이라는 사실을 발견했습니다. 이 에이전트는 사용자가 배포 관련 질문을 할 수 있도록 설계되었으며, 문서 접근 없이는 정확한 답변을 제공하기 어려웠습니다."
   source="CNCF Blog"
   severity="Medium"
 %}

--- a/_posts/2026-07-28-Tech_Security_Weekly_Digest_AI_Open-Source_Botnet_Blockchain.md
+++ b/_posts/2026-07-28-Tech_Security_Weekly_Digest_AI_Open-Source_Botnet_Blockchain.md
@@ -97,7 +97,7 @@ summary_card:
   title="NVIDIA, 37개 회원으로 구성된 Open Secure AI Alliance 결성 및 NOOA 프레임워크 오픈소스화"
   url="https://thehackernews.com/2026/07/nvidia-forms-37-member-open-secure-ai.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEij-O7sLARD9c2QGCheTeoamew1jlKiNe2KRKqw4_8f6VTxZo0MHNIQdizHhyphenhyphen-Bchq9tTzlYBJrJcJDhhhzNB17wPMHDT00pAikN61fAgOh7AdibxKPt5fQ_1KwMvkUXx1J7IzZBbtONSSIAOjRV74KSkmlsKYB7hFWy17AaQu02BqwngqCzlubslSbKvg/s1600/nvidia.jpg"
-  summary="NVIDIA가 36개 조직과 함께 Open Secure AI Alliance를 결성하고 NOOA 프레임워크를 오픈소스로 공개했습니다. 이 연합은 Microsoft, Cisco, Cloudflare, CrowdStrike, Hugging Face, IBM, Palo Alto Networks, Red Hat, Linux 재단 등 클라우드, 보안, 엔터프라이즈 "
+  summary="NVIDIA가 36개 조직과 함께 Open Secure AI Alliance를 결성하고 NOOA 프레임워크를 오픈소스로 공개했습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-07-29-Tech_Security_Weekly_Digest_AI_Botnet_Zero-Day_Cloud.md
+++ b/_posts/2026-07-29-Tech_Security_Weekly_Digest_AI_Botnet_Zero-Day_Cloud.md
@@ -134,7 +134,7 @@ Anthropic의 Claude Mythos Preview가 **HAWK-256** 서명 체계에 대한 end-t
   title="Tengu Botnet, 방어자가 프로세스를 종료하면 손상된 Linux 장치를 재부팅한다"
   url="https://thehackernews.com/2026/07/tengu-botnet-reboots-compromised-linux.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi0zv7PihU6xAba7-fb5OY-Xv5YIEPM1HhmCu2ET65l5TSKYrPh6q4pYVQRNJtHb9RkvO1oNsBBrsxs50Hm_GRnPKCu4XoG1hhtPOoeGILfRHN99ICGSO72NOGQ6AdUc_haCrQvHRUn4YiyFmCy99WgH1v4-4GRLirZzsV1b5MmCjfTX3a2yWmg1tWOr38/s1600/tengu-botnet.jpg"
-  summary="Tengu라는 새로운 Mirai 기반 봇넷이 방어자가 주요 프로세스를 종료할 때 손상된 Linux 장치의 하드웨어 watchdog을 이용해 재부팅을 트리거하며, 이를 통해 다른 지속성 메커니즘이 다시 실행될 기회를 얻습니다. Nozomi Networks Labs는 Telnet 자격 증명 무차별 대입을 통해 드로퍼가 허니팟에 도달하는 것을 관찰했으며, Ten"
+  summary="Tengu라는 새로운 Mirai 기반 봇넷이 방어자가 주요 프로세스를 종료할 때 손상된 Linux 장치의 하드웨어 watchdog을 이용해 재부팅을 트리거하며, 이를 통해 다른 지속성 메커니즘이 다시 실행될 기회를 얻습니다."
   source="The Hacker News"
   severity="Critical"
 %}

--- a/_posts/2026-07-30-Tech_Security_Weekly_Digest_AI_AWS_Open-Source.md
+++ b/_posts/2026-07-30-Tech_Security_Weekly_Digest_AI_AWS_Open-Source.md
@@ -133,7 +133,7 @@ DevSecOps 실무자에게 이 위협은 CI/CD 파이프라인 및 보안 거버�
   title="중요 Rails 취약점으로 인증되지 않은 공격자가 이미지 업로드를 통해 서버 파일을 읽을 수 있어"
   url="https://thehackernews.com/2026/07/critical-rails-flaw-could-let.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjwRhCsS9eOb_YSXM57bDGZOPg4d9kipGTxFJ2_jC48mztPkE1_sZzuBe7ArzC4jl1TiWM9JiY20pu5uorCtSNIlmaX3EwT0trxI_HjmT_3dAJftY49-4bna-J5wnZlxs9CccsarbhZ9_L2Rxo9xtZbIszYc2mLKh0UdxKJsGftqHPggGLvtkrwWfD2-Wk/s1600/rails.jpg"
-  summary="Ruby on Rails가 인증되지 않은 공격자가 조작된 이미지 업로드를 통해 서버 파일을 읽을 수 있는 치명적인 Active Storage 취약점(CVE-2026-66066, CVSS 9.5)에 대한 수정 사항을 발표했습니다. 이 결함은 Rails 프로세스 환경과 secret_key_base, Rails 마스터 키, 데이터베이스 비밀번호, 클라우드 스토리"
+  summary="Ruby on Rails가 인증되지 않은 공격자가 조작된 이미지 업로드를 통해 서버 파일을 읽을 수 있는 치명적인 Active Storage 취약점(CVE-2026-66066, CVSS 9.5)에 대한 수정 사항을 발표했습니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-07-31-Tech_Security_Weekly_Digest_Update_Malware_AI_Agent.md
+++ b/_posts/2026-07-31-Tech_Security_Weekly_Digest_Update_Malware_AI_Agent.md
@@ -96,7 +96,7 @@ summary_card:
   title="북한 연계 macOS 멀버타이징, 가짜 업데이트로 암호화폐 탈취 멀웨어 유포"
   url="https://thehackernews.com/2026/07/dprk-linked-macos-malvertising-uses.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhCHbm6QCC9jjGwa-7P1N2PwhDjRvpC2hlS2hl09-DUZa5xdDeHt9qH1zISepl2ERqDzmDbdQ_zfE2vkHDsvE7G8QsetJHjzC45DpPr5-83lc1BGaLHfEwMfdYEA04d5xc7GL02_qkz1HjhIenSKBWF0FZqHnICaLn9agLEoEGnnN2n-smXxYFuQQaYNd8A/s1600/all-secure.jpg"
-  summary="북한과 연계된 위협 행위자가 macOS 사용자를 가짜 업데이트 화면으로 유도해 암호화폐 탈취형 악성코드를 유포하는 정교한 malvertising 캠페인을 벌이고 있으며, 이는 기존 Contagious Interview 캠페인의 새로운 변종입니다. 공격의 핵심은 전체 화면으로 표시되는 가짜 macOS 소프트웨어 업데이트 화면이 사용자 모르게 악성코드를 설치하"
+  summary="북한과 연계된 위협 행위자가 macOS 사용자를 가짜 업데이트 화면으로 유도해 암호화폐 탈취형 악성코드를 유포하는 정교한 malvertising 캠페인을 벌이고 있으며, 이는 기존 Contagious Interview 캠페인의 새로운 변종입니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -122,7 +122,7 @@ DevSecOps 관점에서 이 공격은 **개발자 및 IT 관리자 macOS 워크�
 {% include news-card.html
   title="속도와 안전의 균형: AI 코딩 에이전트를 위한 제어 프레임워크"
   url="https://aws.amazon.com/blogs/security/balancing-speed-and-safety-a-control-framework-for-ai-coding-agents/"
-  summary="AI coding agents는 개발자 도구로 자리 잡았으며, Kiro와 Claude Code 같은 도구가 자연어 프롬프트로 기능, 테스트, 코드 리팩토링을 생성합니다. 단일 에이전트가 오후에 수십 개의 pull requests(PRs)를 열 수 있는 생산성은 기계 속도의 작업 완료 최적화라는 대가를 수반합니다. 이에 따라 속도와 안전성의 균형을 맞추는 제"
+  summary="AI coding agents는 개발자 도구로 자리 잡았으며, Kiro와 Claude Code 같은 도구가 자연어 프롬프트로 기능, 테스트, 코드 리팩토링을 생성합니다. 단일 에이전트가 오후에 수십 개의 pull requests(PRs)를 열 수 있는 생산성은 기계 속도의 작업 완료 최적화라는 대가를 수반합니다."
   source="AWS Security Blog"
   severity="Medium"
 %}

--- a/_posts/2026-08-01-Tech_Security_Weekly_Digest_Go_Malware_AWS_Security.md
+++ b/_posts/2026-08-01-Tech_Security_Weekly_Digest_Go_Malware_AWS_Security.md
@@ -95,7 +95,7 @@ summary_card:
   title="중국어를 사용하는 것으로 추정되는 해커들이 OctLurk와 SilkLurk로 중앙아시아 정부를 표적으로 삼아"
   url="https://thehackernews.com/2026/08/suspected-chinese-speaking-hackers.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjmBagWdesuJqVgNAHPh7t75IGrajY_oJeL9HHI7r23AK7CuLUN22-GBwDCWJWTlIutBApsdhSGproqxtR6kV_Dg04FT2zc6vZXZCQed8Kx3bD-jw-VXkYfAHlJsNgcQOcqRFW8TTh1kyN34MisnGx3ImU9vejv_oNy4jN0sPNcPM7jclq7klrMmGrnROjk/s1600/chinese-hackers.jpg"
-  summary="2025년 1월부터 아프가니스탄, 키르기스스탄, 타지키스탄, 우즈베키스탄, 카자흐스탄, 시리아 등 중앙아시아 정부 기관을 대상으로 한 새로운 사이버 공격이 중국어를 사용하는 위협 행위자에 의해 수행된 것으로 의심됩니다. 이 공격은 의료, 연구, 정부 사무소 등 여러 분야의 조직을 표적으로 삼고 있으며, OctLurk와 SilkLurk라는 도구가 사용된 것으"
+  summary="2025년 1월부터 아프가니스탄, 키르기스스탄, 타지키스탄, 우즈베키스탄, 카자흐스탄, 시리아 등 중앙아시아 정부 기관을 대상으로 한 새로운 사이버 공격이 중국어를 사용하는 위협 행위자에 의해 수행된 것으로 의심됩니다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-08-02-Tech_Security_Weekly_Digest_Bitcoin_AI_Update_Malware.md
+++ b/_posts/2026-08-02-Tech_Security_Weekly_Digest_Bitcoin_AI_Update_Malware.md
@@ -91,7 +91,7 @@ summary_card:
   title="Coldcard 하드웨어 지갑 결함, 41분 만에 7천만 달러 Bitcoin 도난과 연관"
   url="https://thehackernews.com/2026/08/coldcard-hardware-wallet-flaw-linked-to.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiea5Kw_2TLtPI4Ts3s3anmPIQr3S8VxO0G9yL-UV1dSlRrW1Z_L41XoHcSFuk2ThCBDKLFy-xZl_y7DnA0FM2nWHk4G1TpV2iMx6-X6EDT3gK7s0pJu6e1wMUoEsuPifcXseXuqOIHL3W9voWoD_se5gKJPyii4X0mJY7sxJ3uOPlTWVfAyrKs4ixa-18/s1600/coldcard.jpg"
-  summary="2025년 7월 30일, 공격자가 41분 만에 1,196개 Bitcoin 주소에서 약 7,020만 달러 상당의 1,082.65 BTC를 탈취했습니다. Galaxy Research는 이 사건이 캐나다 업체 Coinkite의 Bitcoin 전용 하드웨어 지갑 Coldcard의 펌웨어 결함과 연관되어 있으며, 2021년 3월 펌웨어 통합 오류로 시드 생성이 결정"
+  summary="2025년 7월 30일, 공격자가 41분 만에 1,196개 Bitcoin 주소에서 약 7,020만 달러 상당의 1,082.65 BTC를 탈취했습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -121,7 +121,7 @@ summary_card:
   title="해커들이 Adform 스크립트를 오염시켜 고객 사이트 전반의 암호화폐 지갑 주소를 교체하다"
   url="https://thehackernews.com/2026/08/hackers-poison-adform-script-to-swap.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiX-el4ovGAmKfllRfhupL0SzdEoZKlouDb1_YmhCOl3owxN1ks0Do-WphuD77rka_3ukbqvPxSmFYMdBKBirYyw0DJpvSxVP5riGBR_vd7wKwnpgZfNm0RFEDLTzsvzzQB7qGtawMvpccd700dfNM2zZeFTy9cyHf4oFyHSASKRU3gmxbMgTJRtDFsSNs/s1600/adform.jpg"
-  summary="공격자들이 광고 기술 기업 Adform이 제공하는 JavaScript 파일을 변조해 브라우저 측에서 암호화폐 지갑 주소를 바꿔치기하는 도구로 악용했다. Adform은 2026년 7월 27일 이 사고를 탐지하고 악성 코드를 제거했으며, 영향을 받은 고객사에 통보하고 당국에 신고했다. 해당 날짜에 영향을 받은 스크립트가 포함된 사이트를 방문해 Bitcoin 주"
+  summary="공격자들이 광고 기술 기업 Adform이 제공하는 JavaScript 파일을 변조해 브라우저 측에서 암호화폐 지갑 주소를 바꿔치기하는 도구로 악용했다. Adform은 2026년 7월 27일 이 사고를 탐지하고 악성 코드를 제거했으며, 영향을 받은 고객사에 통보하고 당국에 신고했다."
   source="The Hacker News"
   severity="High"
 %}

--- a/_posts/2026-08-04-Tech_Security_Weekly_Digest_Malware_Go_AWS_Ransomware.md
+++ b/_posts/2026-08-04-Tech_Security_Weekly_Digest_Malware_Go_AWS_Ransomware.md
@@ -129,7 +129,7 @@ DevSecOps 관점에서 이번 사건은 **개발 환경의 신뢰 경계(Trust B
   title="Google Password Manager 공격으로 멀웨어가 패스키 보호 계정을 탈취할 수 있어"
   url="https://thehackernews.com/2026/08/google-password-manager-attacks-could.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjNiuQky0C3uTOSaOEyGLg0O7h1B0VAP9nU8bwdZe-8DKD_pOBihrvWw-2ecGt03mmT0V1F0bg7xOQuv88cZlLcLqavDM9gWnZHku-skIzJMEWw3lBNvrVcDaeaezVTvt1yBCecBTQBT_SUsY1rTV-ygCEH1vUjttcAx8swmGljZPAXYRQ2APBwPrUhvPI/s1600/google-passkeys.jpg"
-  summary="Google Password Manager의 cloud authenticator를 대상으로 한 세 가지 공격 경로(Pass-ta-key, Silver Pass-ta-key, Golden Pass-ta-key)가 Unit 42에 의해 공개되었습니다. Windows에서 일반 사용자 권한으로 실행되는 Malware가 피해자의 화면에 아무것도 표시하지 않고 지문이"
+  summary="Google Password Manager의 cloud authenticator를 대상으로 한 세 가지 공격 경로(Pass-ta-key, Silver Pass-ta-key, Golden Pass-ta-key)가 Unit 42에 의해 공개되었습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -224,7 +224,7 @@ GPT-Live는 턴리스 음성 모델과 저지연 아키텍처를 활용해 AI와
 {% include news-card.html
   title="수주에서 수 분으로: Formula 1®이 AWS에서 에이전틱 AI를 활용해 데이터 운영을 가속화하는 방법"
   url="https://aws.amazon.com/blogs/machine-learning/from-weeks-to-minutes-how-formula-1-uses-agentic-ai-on-aws-to-accelerate-data-operations/"
-  summary="Formula 1®는 AWS와 협력하여 Amazon Bedrock AgentCore 기반의 agentic AI를 활용한 Data Accelerator를 구축, MarTech 데이터 플랫폼을 혁신했습니다. 이를 통해 데이터 소스 온보딩 시간을 최대 8주에서 약 40분으로 단축하고, 스키마 진화를 자동화했으며, 팬 참여 데이터 전반에 걸친 종단 간 관찰 가능성"
+  summary="Formula 1®는 AWS와 협력하여 Amazon Bedrock AgentCore 기반의 agentic AI를 활용한 Data Accelerator를 구축, MarTech 데이터 플랫폼을 혁신했습니다."
   source="AWS Machine Learning Blog"
   severity="High"
 %}
@@ -262,7 +262,7 @@ Formula 1®는 AWS와 협력하여 Amazon Bedrock AgentCore 기반의 agentic AI
   title="Cortex Framework v7 GA 출시: SAP 운영을 중단하지 않고 에이전틱 워크플로 구축"
   url="https://cloud.google.com/blog/products/sap-google-cloud/cortex-framework-v7-power-ai-agents-with-sap-data-faster/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/Image_1__Deployed_data_products_inside_Big.max-1000x1000.png"
-  summary="Google Cloud Cortex Framework v7가 일반 공급(GA)되며, SAP 운영을 중단하지 않고 에이전틱 워크플로우를 구축할 수 있게 되었다. 이 프레임워크는 AI 에이전트가 사용할 수 있는 상호운용 가능한 데이터 제품을 제공해 원시 데이터를 명확한 비즈니스 용어로 변환한다. 기업은 이를 통해 수익 창출, 리스크 완화, 자본 최적화를 안전하"
+  summary="Google Cloud Cortex Framework v7가 일반 공급(GA)되며, SAP 운영을 중단하지 않고 에이전틱 워크플로우를 구축할 수 있게 되었다. 이 프레임워크는 AI 에이전트가 사용할 수 있는 상호운용 가능한 데이터 제품을 제공해 원시 데이터를 명확한 비즈니스 용어로 변환한다."
   source="Google Cloud Blog"
   severity="High"
 %}

--- a/_posts/2026-08-05-Tech_Security_Weekly_Digest_AI_Agent_Update.md
+++ b/_posts/2026-08-05-Tech_Security_Weekly_Digest_AI_Agent_Update.md
@@ -122,7 +122,7 @@ DevSecOps 관점에서 가장 치명적인 영향은 **CI/CD 파이프라인 자
   title="Greatness PhaaS, 기기 코드 피싱을 추가해 MFA 우회 및 토큰 탈취"
   url="https://thehackernews.com/2026/08/greatness-phaas-adds-device-code.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi8YRyOCSodUbPpWMicgOiuGbEQWDBmu_W-47PAUFkS7yKEQe4Do6svH4cQb-U0tC53C9mqq8ijjlG9gwuzyqYfNwtS61WxvNxIgk1dVC7wX598rncb_MgQ5t4yxc8NUYVdb6PT5cu7ZXJ7w3KaYG_7vtU5xixHel1jSADbtR-GC1bmngZPArXw-NjkTH1x/s1600/Greatness.jpg"
-  summary="상업용 PhaaS 툴킷인 Greatness가 OAuth 2.0 Device Authorization Grant를 악용하는 device code phishing 기능을 추가하여 MFA를 우회하고 사용자 계정을 탈취하는 최신 범죄웨어로 부상했습니다. 이는 AiTM(adversary-in-the-middle) 자격 증명 및 세션 토큰 탈취를 지원하는 방식으로 확"
+  summary="상업용 PhaaS 툴킷인 Greatness가 OAuth 2.0 Device Authorization Grant를 악용하는 device code phishing 기능을 추가하여 MFA를 우회하고 사용자 계정을 탈취하는 최신 범죄웨어로 부상했습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -240,7 +240,7 @@ NVIDIA의 로보택시 및 자율주행차(AV)용 오픈 모델인 Alpamayo 2 Su
   title="Database Operations Agents 소개: 자율 데이터베이스 관리의 미래"
   url="https://cloud.google.com/blog/products/databases/deep-dive-on-new-ai-powered-database-agents/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/original_images/1_Je5hDe1.gif"
-  summary="Google Cloud Next '26에서 Agentic Data Cloud 출시와 함께 Database Onboarding Agent(Day 0 운영: 설정, 구성, 초기 배포)와 Database Observability Agent(Day 1·2 운영: 모니터링, 문제 해결, 유지보수)라는 두 가지 AI 기반 database agent를 발표했다. 이들은"
+  summary="Google Cloud Next '26에서 Agentic Data Cloud 출시와 함께 Database Onboarding Agent(Day 0 운영: 설정, 구성, 초기 배포)와 Database Observability Agent(Day 1·2 운영: 모니터링, 문제 해결, 유지보수)라는 두 가지 AI 기반 database agent를 발표했다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -275,7 +275,7 @@ Target의 Guest Product Confidence 플랫폼 팀은 Spanner Graph를 활용하�
   title="다중 결과 집합: Database Migration Service가 SQL Server에서 PostgreSQL로의 변환을 자동화하는 방법"
   url="https://cloud.google.com/blog/products/databases/automating-postgres-translations-with-database-migration-service/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/2_mgkHjQS.max-1000x1000.jpg"
-  summary="Database Migration Service는 SQL Server의 다중 결과 집합 처리를 PostgreSQL로 자동 변환하며, SQL Server의 MARS와 PostgreSQL의 SETOF REFCURSOR 간 구조적 차이를 해결합니다. 이 과정에서 단일 실행에서 여러 테이블 스트림을 스트리밍하는 SQL Server와 달리, PostgreSQL은 명"
+  summary="Database Migration Service는 SQL Server의 다중 결과 집합 처리를 PostgreSQL로 자동 변환하며, SQL Server의 MARS와 PostgreSQL의 SETOF REFCURSOR 간 구조적 차이를 해결합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/_posts/2026-08-06-Tech_Security_Weekly_Digest_AI_Malware_GPT_AWS.md
+++ b/_posts/2026-08-06-Tech_Security_Weekly_Digest_AI_Malware_GPT_AWS.md
@@ -158,7 +158,7 @@ DevSecOps 실무자에게 이번 사건은 **"AI 사용 정책"과 "위협 인�
   title="Poison Claude, 할인된 Claude 접근권 판매, 운영자는 모든 고객 프롬프트를 볼 수 있어"
   url="https://thehackernews.com/2026/08/poison-claude-sells-discounted-claude.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhp3V9f5UsiH1E6dHfRvy0DEOYvcK14BatMbbLVfdPjLbu3PMInRmVXDi4xoGw-pSIuxUjZS1rdv4X7N1V9xRoV9RRVfaYdAWI6OTxKZzOhAlHYh6dKZNeAWCPkaPdGAvwgcOwFQ0atoRBUxKfE_KfhJpnm1yV1tXr5_Wv2yqND0vZCMMEfRB0V220SZbne/s1600/ai-access.jpg"
-  summary="사이버보안 연구진이 지하 포럼과 메신저 플랫폼에서 AI 모델 불법 접근 서비스 광고 6건 이상을 발견했으며, 그중 Poison Claude는 Anthropic의 LLM(Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6)에 대한 할인 접근을 제공한다고 주장한다. 이 서비스의 운영자는 모든 고객 프롬프트를 열람할 수 있는 구조로, 사용자"
+  summary="사이버보안 연구진이 지하 포럼과 메신저 플랫폼에서 AI 모델 불법 접근 서비스 광고 6건 이상을 발견했으며, 그중 Poison Claude는 Anthropic의 LLM(Opus 4.8, Opus 4.7, Opus 4.6, Sonnet 4.6)에 대한 할인 접근을 제공한다고 주장한다."
   source="The Hacker News"
   severity="Medium"
 %}
@@ -185,7 +185,7 @@ DevSecOps 실무자에게 이번 사건은 **"AI 사용 정책"과 "위협 인�
 {% include news-card.html
   title="사용자 시퀀스에서 스케일링 법칙까지: Meta 광고 랭킹을 위한 다단계 아키텍처"
   url="https://engineering.fb.com/2026/08/05/ml-applications/from-user-sequences-to-scaling-laws-a-multi-stage-architecture-for-metas-ads-ranking/"
-  summary="Meta의 광고 랭킹 시스템은 매일 수십억 건의 사용자 상호작용에서 생성된 풍부한 시간적 신호를 활용하며, 2024년 게시물에서 정적 스파스 피처 대신 사용자 행동의 순서와 타이밍을 모델링하는 sequence learning 접근법을 제시했습니다. 이번 아키텍처는 사용자 시퀀스에서 scaling law까지 도달하는 다단계 구조를 통해 광고 추천 성능을 개선"
+  summary="Meta의 광고 랭킹 시스템은 매일 수십억 건의 사용자 상호작용에서 생성된 풍부한 시간적 신호를 활용하며, 2024년 게시물에서 정적 스파스 피처 대신 사용자 행동의 순서와 타이밍을 모델링하는 sequence learning 접근법을 제시했습니다."
   source="Meta Engineering Blog"
   severity="Medium"
 %}
@@ -276,7 +276,7 @@ UiPath는 기업용 에이전틱 자동화 및 비즈니스 오케스트레이�
 {% include news-card.html
   title="공유 스토리지의 미래를 열다: Colossus의 Filestore"
   url="https://cloud.google.com/blog/products/storage-data-transfer/filestore-file-service-runs-on-colossus/"
-  summary="Google Cloud의 Filestore가 Colossus 기반의 cloud-native 백엔드 스토리지 계층을 통합하여 엔터프라이즈 워크로드와 AI 및 agentic 워크플로우를 위한 확장성과 민첩성을 크게 강화했습니다. 이번 업데이트는 Filestore의 NFS 파일 서비스 성능을 향상시키며, Google의 분산 스토리지 시스템인 Colossus를 직"
+  summary="Google Cloud의 Filestore가 Colossus 기반의 cloud-native 백엔드 스토리지 계층을 통합하여 엔터프라이즈 워크로드와 AI 및 agentic 워크플로우를 위한 확장성과 민첩성을 크게 강화했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}

--- a/scripts/rewind_truncated_summaries.py
+++ b/scripts/rewind_truncated_summaries.py
@@ -1,0 +1,106 @@
+"""Rewind mid-sentence card summaries to their last complete sentence.
+
+PR #506 fixed the generator's blind ``ko_summary[:200]`` slice, but the summaries
+already published stayed cut mid-word ("…Java 바이트 스트림 역"). Measured
+2026-08-07: 128 such summaries across 79 digests.
+
+Chosen over re-summarising from the source article because rewinding is free of
+the two costs that matter here — it makes no network call and invents no text.
+The result is always a PREFIX of what was published, so there is nothing to
+fact-check: 132 chars survive on average (66% of 200), and 126 of the 128 keep
+at least one complete sentence. The other 2 have no sentence boundary at all and
+are left exactly as they are; emptying them would be worse than a rough tail.
+
+Only the trailing partial sentence is dropped, and the runtime contract enforces
+that a file may only ever shrink — this edits inside a Liquid include, the same
+place a context-blind rewrite corrupted cover images in PR #509.
+
+Usage:
+    python3 scripts/rewind_truncated_summaries.py --posts-glob '_posts/*Weekly_Digest*.md' --dry-run
+    python3 scripts/rewind_truncated_summaries.py _posts/2026-04-*.md
+"""
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Below this a summary was never near the old 200-char cap, so a missing final
+# period is a headline-shaped source, not truncation — not this script's job.
+TRUNCATION_SUSPECT_LEN = 195
+
+_CARD_RE = re.compile(r"\{%\s*include\s+news-card\.html.*?%\}", re.DOTALL)
+_SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+\w+="|\s*%\}|\s*$))', re.DOTALL)
+_TERMINATED = (".", "!", "?")
+
+
+def rewind(text: str) -> str:
+    """Drop the trailing partial sentence. Returns a prefix, or text unchanged."""
+    if not text or text.endswith(_TERMINATED):
+        return text
+    idx = text.rfind("다.")
+    return text[: idx + 2] if idx > 0 else text
+
+
+def _fix_card(card: str) -> str:
+    def _sub(m):
+        value = m.group(2)
+        if len(value.strip()) < TRUNCATION_SUSPECT_LEN:
+            return m.group(0)
+        return m.group(1) + rewind(value.strip()) + m.group(3)
+
+    return _SUMMARY_RE.sub(_sub, card)
+
+
+def transform(text: str) -> str:
+    return _CARD_RE.sub(lambda m: _fix_card(m.group(0)), text)
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+def _violates_shrink_only(old: str, new: str) -> bool:
+    """This transform may only remove characters, never add or rewrite."""
+    return len(new) > len(old)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description="Rewind truncated card summaries.")
+    ap.add_argument("paths", nargs="*")
+    ap.add_argument("--posts-glob")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    files = [Path(p) for p in (args.paths or [])]
+    if args.posts_glob:
+        files += [Path(p) for p in sorted(glob.glob(args.posts_glob))]
+    files = [f for f in files if _is_digest_post(f)]
+    if not files:
+        print("[rewind-summaries] no digest post files to process.")
+        return 0
+
+    changed = 0
+    for f in files:
+        original = f.read_text(encoding="utf-8")
+        new = transform(original)
+        if new == original:
+            continue
+        if _violates_shrink_only(original, new):
+            print(f"ABORT {f}: rewind grew the file", file=sys.stderr)
+            return 1
+        changed += 1
+        if args.dry_run:
+            print(f"DRY  {f}")
+        else:
+            f.write_text(new, encoding="utf-8")
+            print(f"FIXED {f}")
+    verb = "would rewrite" if args.dry_run else "rewrote"
+    print(f"[rewind-summaries] {verb} {changed}/{len(files)} post(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_rewind_truncated_summaries.py
+++ b/scripts/tests/test_rewind_truncated_summaries.py
@@ -1,0 +1,146 @@
+"""Tests for scripts/rewind_truncated_summaries.py.
+
+PR #506 fixed the generator's blind ``ko_summary[:200]`` slice, but the 128 card
+summaries already cut mid-sentence stayed that way. Measured 2026-08-07:
+
+* 128 truncated summaries across 79 digests
+* rewinding to the last complete sentence keeps 132 chars on average (66%)
+* 126 of 128 keep at least one complete sentence; **2 keep none** and are left
+  untouched rather than emptied
+
+Rewinding only ever DROPS a trailing partial sentence, so the result is always a
+prefix of what was already published — no fetching, no LLM, nothing invented.
+That prefix property is the contract these tests pin.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import rewind_truncated_summaries as rw  # noqa: E402
+
+_FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
+
+
+def _card(summary, **extra):
+    attrs = "".join(f'  {k}="{v}"\n' for k, v in extra.items())
+    return (
+        "{% include news-card.html\n"
+        '  title="제목"\n'
+        '  url="https://example.com/a"\n'
+        f'  summary="{summary}"\n'
+        f"{attrs}"
+        '  source="Example"\n'
+        "%}\n"
+    )
+
+
+def _truncated(head="가" * 150):
+    """A summary shaped like the corpus defect: complete sentence + cut tail."""
+    return f"{head}라고 경고합니다. 공격자가 원격으로 루트 접근 권한을 얻을 수 있게 하는 Java 바이트 스트림 역"
+
+
+# --- the rewind --------------------------------------------------------------
+
+
+def test_truncated_summary_rewinds_to_the_last_complete_sentence():
+    src = _FM + _card(_truncated())
+    out = rw.transform(src)
+    assert '경고합니다."' in out
+    assert "Java 바이트 스트림 역" not in out
+
+
+def test_result_is_always_a_prefix_of_the_original():
+    original = _truncated()
+    out = rw.transform(_FM + _card(original))
+    new = out.split('summary="')[1].split('"\n')[0]
+    assert original.startswith(new), "rewind may only drop a tail, never rewrite"
+
+
+def test_rewind_keeps_the_sentence_period():
+    out = rw.transform(_FM + _card(_truncated()))
+    new = out.split('summary="')[1].split('"\n')[0]
+    assert new.endswith("다.")
+
+
+# --- what must NOT change ----------------------------------------------------
+
+
+def test_summary_with_no_complete_sentence_is_left_alone():
+    """2 corpus cards are in this state — emptying them would be worse."""
+    src = _FM + _card("가" * 210)
+    assert rw.transform(src) == src
+
+
+def test_short_summary_is_left_alone():
+    src = _FM + _card("짧은 요약입니다")
+    assert rw.transform(src) == src
+
+
+def test_properly_terminated_long_summary_is_left_alone():
+    src = _FM + _card("가" * 200 + "라고 밝혔습니다.")
+    assert rw.transform(src) == src
+
+
+def test_other_attributes_are_never_touched():
+    nested = (
+        "https://images.cointelegraph.com/cdn-cgi/image/f=auto,w=1200/"
+        "https://s3.cointelegraph.com/uploads/x.jpg"
+    )
+    out = rw.transform(_FM + _card(_truncated(), image=nested))
+    assert f'image="{nested}"' in out
+
+
+def test_prose_outside_cards_is_untouched():
+    body = "본문 문장이 여기 있고 잘리지 않았습니다.\n\n"
+    out = rw.transform(_FM + body + _card(_truncated()))
+    assert body in out
+
+
+def test_transform_is_idempotent():
+    once = rw.transform(_FM + _card(_truncated()))
+    assert rw.transform(once) == once
+
+
+# --- runtime contract --------------------------------------------------------
+
+
+def test_shrink_only_contract_rejects_added_text():
+    old = _FM + _card(_truncated())
+    assert rw._violates_shrink_only(old, old + "extra") is True
+    assert rw._violates_shrink_only(old, rw.transform(old)) is False
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("완성된 문장입니다. 잘린 꼬리", "완성된 문장입니다."),
+        ("완성된 문장입니다.", "완성된 문장입니다."),
+        ("완성 문장 없음", "완성 문장 없음"),
+        ("", ""),
+    ],
+)
+def test_rewind_unit(raw, expected):
+    assert rw.rewind(raw) == expected
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_dry_run_does_not_write(tmp_path):
+    p = tmp_path / "2026-08-07-Tech_Blog_Weekly_Digest_x.md"
+    src = _FM + _card(_truncated())
+    p.write_text(src, encoding="utf-8")
+    assert rw.main([str(p), "--dry-run"]) == 0
+    assert p.read_text(encoding="utf-8") == src
+
+
+def test_non_digest_is_skipped(tmp_path):
+    p = tmp_path / "2026-08-07-Some_Guide.md"
+    src = _FM + _card(_truncated())
+    p.write_text(src, encoding="utf-8")
+    assert rw.main([str(p)]) == 0
+    assert p.read_text(encoding="utf-8") == src


### PR DESCRIPTION
#506이 생성기의 맹목 슬라이스를 고쳤지만, 이미 발행된 요약은 문장 중간에 잘린 채 남아 있었습니다 (`…Java 바이트 스트림 역`).

## 규모 정정: 9건이 아니라 128건

앞서 보고한 9건은 그중 "우연히 종결어미로 끝나 마침표 백필 가드(#512)에 걸린" **부분집합**이었습니다. 실제 절단은 **79개 포스트 / 128건**입니다.

## 방식 선택 — 착수 전 실측으로 결정

되감기(마지막 완성 문장까지) 시 잔여 분량:

| 잔여 비율 | 건수 |
|---|---|
| 85%+ | 18 |
| 70–84% | 34 |
| 50–69% | 55 |
| 1–49% | 19 |
| **0% (완성 문장 없음)** | **2** |

평균 **132자 잔여**(원본 200자, 66%). 원문 URL은 128/128 보유.

**LLM 재요약 대신 되감기를 택한 이유**: 분량은 LLM이 더 복원하지만 128건을 원문과 대조 검증해야 하고 링크 사멸·페이월 처리가 필요합니다. 되감기는 결과가 **항상 원문의 접두사**라 검증할 사실 자체가 없고 외부 호출도 없습니다.

126건에 적용하고, **완성 문장이 아예 없는 2건은 비우는 편이 더 나쁘므로 그대로** 뒀습니다.

## 런타임 계약

파일은 **줄어들기만** 해야 하며 늘어나면 `ABORT`. Liquid 속성값을 편집하는 지점이라(#509에서 커버 이미지를 깨뜨린 바로 그곳) 명시적으로 강제합니다.

## 검증

| 검증 | 결과 |
|---|---|
| 변경 | 78개 파일 / **126건 되감김** |
| 전부 원문의 **접두사**이고 `다.`로 종결 | 위반 **0** |
| 카드 외 콘텐츠 바이트 동일 · 파일 증가 | **0** |
| 게이트 4종 (구조·고유명사·미번역·체크리스트제목) | 각 186개 / 위반 0 |
| `fix_malformed_liquid_includes --check` | 0 / 258 |
| `linkify_bare_urls --check --all` | 0 / 258 |
| 품질 점수 | 상승 0 / 하락 0 / **동일 78** → baseline 갱신 불필요 |
| `pytest scripts/tests/` | **3218 passed, 5 skipped** (신규 16건) |

## 부수 확인 — 생성기 수정의 실전 검증

#506·#511 머지 후 **첫 크론 발행**(`2026-08-07`)의 카드 **15/15가 문장 종결**이고 200자 정확 일치(맹목 절단 지문) **0건**입니다. 두 수정이 프로덕션에서 작동합니다.