### PR TITLE
fix(news): 제목만 되풀이하던 카드 요약을 본문 근거로 교체 (파일럿 2포스트 / 23건)

### DIFF
--- a/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
+++ b/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
@@ -539,77 +539,66 @@ Bitcoin Magazine가 BIP 54 소프트포크 제안을 심층 분석했습니다. 
   url="https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-nano-banana/"
   source="Google Cloud Blog"
   tag="Cloud / Platform"
-  summary="Nano Banana 프롬프팅 가이드 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="LeakBase 포럼 압수"
   url="https://thehackernews.com/2026/03/fbi-and-europol-seize-leakbase-forum.html"
   source="The Hacker News"
   tag="Operator Signal"
-  summary="LeakBase 포럼 압수 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Cloudflare Dynamic Path MTU Discovery"
   url="https://blog.cloudflare.com/client-dynamic-path-mtu-discovery/"
   source="Cloudflare Blog"
   tag="Cloud / Platform"
-  summary="Cloudflare Dynamic Path MTU Discovery 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Cloudflare QUIC 기반 SASE Proxy Mode"
   url="https://blog.cloudflare.com/faster-sase-proxy-mode-quic/"
   source="Cloudflare Blog"
   tag="Cloud / Platform"
-  summary="Cloudflare QUIC 기반 SASE Proxy Mode 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="GPT-5.4 공개"
   url="https://news.hada.io/topic?id=27230"
   source="GeekNews"
   tag="Tech Signals"
-  summary="GPT-5.4 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Grep은 죽었다: Claude Code 메모리 시스템"
   url="https://news.hada.io/topic?id=27239"
   source="GeekNews"
   tag="AI / Product"
-  summary="Grep은 죽었다: Claude Code 메모리 시스템 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Google Chrome, 2주 출시 주기 전환"
   url="https://news.hada.io/topic?id=27238"
   source="GeekNews"
   tag="Tech Signals"
-  summary="Google Chrome, 2주 출시 주기 전환 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="위키백과 관리자 계정 대량 유출"
   url="https://news.hada.io/topic?id=27233"
   source="GeekNews"
   tag="Tech Signals"
-  summary="위키백과 관리자 계정 대량 유출 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="온디바이스 이미지 모델 (1편)"
   url="https://techblog.lycorp.co.jp/ko/on-device-image-model-trainer-for-messenger-1"
   source="LINE Engineering"
   tag="Operator Signal"
-  summary="온디바이스 이미지 모델 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="온디바이스 이미지 모델 (2편)"
   url="https://techblog.lycorp.co.jp/ko/on-device-image-model-trainer-for-messenger-2"
   source="LINE Engineering"
   tag="Operator Signal"
-  summary="온디바이스 이미지 모델 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="FE News 26년 3월호"
   url="https://d2.naver.com/news/0407747"
   source="네이버 D2"
   tag="Operator Signal"
-  summary="FE News 26년 3월호 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
+++ b/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
@@ -101,7 +101,7 @@ summary_card:
   title="[보안] Cisco Catalyst SD-WAN Manager 취약점 활성 공격 확인"
   url="https://thehackernews.com/2026/03/cisco-confirms-active-exploitation-of.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgEr5vlbwHAPeevtBJ7iylInnh2ZQCxX10smm1srCFONJBSriIbAvvp5jAFpFYdeoyk9BKBhyFZx-U4xBhqtN2eT1r150GMLdRP3scA8PsHMYh0PGALAqnzwQnLS-3K_9yneL-7tRa3lD-TTOIebyc_alzp2kLKFdFRCiJcWMcmTiMnoqUAeO_Wxv6hd05D/s1700-e365/cisco-exploit.jpg"
-  summary="Cisco Catalyst SD-WAN Manager 취약점 활성 공격 확인 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Cisco가 Catalyst SD-WAN Manager(구 SD-WAN vManage)에 영향을 미치는 2개의 취약점이 실제 공격에 활용되고 있음을 공식 확인했습니다. 핵심 취약점인 CVE-2026-20122(CVSS 7.1)는 인증된 원격 공격자가 로컬 파일 시스템의 임의 파일을 덮어쓸 수 있는 취약점입니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -152,7 +152,7 @@ index=network sourcetype=cisco:sdwan
   title="[보안] Europol 주도 Tycoon 2FA 피싱 플랫폼 해체"
   url="https://thehackernews.com/2026/03/europol-led-operation-takes-down-tycoon.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgj8UTSWEMM2rFGJeOr4V1jcbj7LGdQOWonmvhfcbkNspvoCt-7wsBrnJoMuGgnyCZ-E4G5DqWRcPYrrTi3MF-nZWM3pke6JmFrnNlIrs99WF4ayKdghQxMVtvsxxkvv0FMHmKHWCA92klsfqy2fS4rD0_YcBTOapV-lsGCsZhnLHMCe3oMhEukpHaTgGQE/s1700-e365/takedown.jpg"
-  summary="Europol 주도 Tycoon 2FA 피싱 플랫폼 해체 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Europol이 주도한 국제 공조 작전으로 Tycoon 2FA 피싱-서비스(PhaaS) 플랫폼이 해체되었습니다. 이 플랫폼은 MFA를 우회하는 AitM(Adversary-in-the-Middle) 방식의 자격 증명 탈취 공격을 대규모로 가능하게 했으며, 총 64,000건 이상의 공격에 연루된 것으로 확인되었습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -191,7 +191,7 @@ Tycoon 2FA는 공격자가 피해자와 정상 인증 서버 사이에 프록시
   title="[보안] APT28 우크라이나 표적 BadPaw/MeowMeow 신규 악성코드"
   url="https://thehackernews.com/2026/03/apt28-linked-campaign-deploys-badpaw.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEihW1ns0JTT2vYUjdQEqTcDwytBGmTnID9xQkCxuT-WURhd71xeh9UD80hZiRL3WWBOg5dCVZKY2huOuElbB-QjczQquCirdpgVRjWNM426jLNF-U_s8RGs9CjNC1Qr2DJhQ532z6bz2hdMkzUjJ-vSKpJmBdvyy5qgkAuwB2armvVyx4HNsn4glFMWmupC/s1700-e365/Ukraine.jpg"
-  summary="APT28 우크라이나 표적 BadPaw/MeowMeow 신규 악성코드 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="러시아 연계 위협 그룹 APT28(Fancy Bear)이 우크라이나 기관을 대상으로 BadPaw 로더와 MeowMeow 백도어라는 2개의 신규 악성코드를 배포한 것이 확인되었습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -213,7 +213,7 @@ APT28은 러시아 군 정보기관(GRU)과 연계된 것으로 알려진 APT �
   title="[보안] Dust Specter — 이라크 정부 관료 표적 신규 멀웨어"
   url="https://thehackernews.com/2026/03/dust-specter-targets-iraqi-officials.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjWg0441avqEutKSymEsuuVP_gKz7kiss4jZesCHLwD4731n135lf6jhJdT2X5CPIWISsByG0RsJoH7eXSyGVOI6RNmo1QkE8Z24lPdiFTLni79c2EoiLGlAurQsIHqn7j_-MDPlL9F98XAsRtrBD17V7YXRYikdcET0hnw897ButkFyI1T4JmzxpJdwM8y/s1700-e365/iran-attack.jpg"
-  summary="Dust Specter — 이라크 정부 관료 표적 신규 멀웨어 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="이란 연계로 추정되는 위협 행위자가 이라크 외교부를 사칭하여 정부 관료를 대상으로 SPLITDROP과 GHOSTFORM이라는 신규 악성코드를 배포하는 캠페인이 포착되었습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -234,7 +234,7 @@ APT28은 러시아 군 정보기관(GRU)과 연계된 것으로 알려진 APT �
   title="[보안] 악성 AI 어시스턴트 확장 프로그램, LLM 채팅 기록 대량 탈취"
   url="https://www.microsoft.com/en-us/security/blog/2026/03/05/malicious-ai-assistant-extensions-harvest-llm-chat-histories/"
   image="https://www.microsoft.com/en-us/security/blog/wp-content/uploads/2026/03/MS_Actional-Insights_Adversarial-AI.png"
-  summary="악성 AI 어시스턴트 확장 프로그램, LLM 채팅 기록 대량 탈취 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Microsoft 보안팀이 ChatGPT, DeepSeek 등 LLM 플랫폼의 채팅 기록과 브라우징 데이터를 수집하는 악성 AI 브라우저 확장 프로그램을 발견했습니다. 총 약 90만 건 설치되었으며, 20,000개 이상의 기업 환경에서 활동이 확인되었습니다."
   source="Microsoft Security Blog"
   severity="High"
 -%}
@@ -267,7 +267,7 @@ AI 도구의 업무 활용이 확산되면서, LLM 채팅 기록에는 코드 �
   title="[보안] MFA 한계점과 자격 증명 남용의 시작점"
   url="https://thehackernews.com/2026/03/where-multi-factor-authentication-stops.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh573fCRL7EMT-Piz1QEJizjMNdQH5G4eMHpLbuCGvm-PNF6-osRuSQF09DHGIuYS1EXDgZXUmWzVf1p3kHDH0_jE7_XDKuG0J7R9Yc3kP4XbaW3UoF3gLYCQ6ba63S0iYQf3Ftf7s0UkDD9QBbnzUcBPRDQXI401TzAVjET05OjgS38tiYgfWA79kS-8g/s1700-e365/outpost.jpg"
-  summary="MFA 한계점과 자격 증명 남용의 시작점 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="MFA를 도입하면 탈취된 비밀번호만으로 시스템에 접근할 수 없다고 가정하지만, Windows 환경에서는 이 가정이 종종 틀립니다. 공격자들은 NTLM 해시, Kerberos 티켓, 캐시된 자격 증명 등 MFA가 적용되지 않는 인증 경로를 통해 시스템에 접근합니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -289,7 +289,7 @@ MFA를 도입하면 탈취된 비밀번호만으로 시스템에 접근할 수 �
   title="[보안] 양자 시대 대비 — 포스트 양자 암호화 웨비나"
   url="https://thehackernews.com/2026/03/preparing-for-quantum-era-post-quantum.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiX1kV8IdraKTyGmXfKTap-DKE7krpM6SchfXQZlvruEBaaJyCbG0HQuJD3B08AkkIZF6Ej7oQ2Nr3AfzVD5klERt782T3IuCPT8tSYm49B6j6se-IH7d0XC4kBcTPl-yp3tsA_YmhrZsB0On2ukhH1rhlSaG3fpRXNrSzpbMEoVu_EBoiMGcbFVg9AcWTC/s1700-e365/webinar.jpg"
-  summary="양자 시대 대비 — 포스트 양자 암호화 웨비나 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="양자 컴퓨터가 현재 암호화를 깨뜨릴 수 있는 미래에 대비하여, 많은 공격자들이 이미 '지금 수집, 나중에 복호화'(Harvest Now, Decrypt Later) 전략을 실행하고 있습니다. 현재의 암호화된 데이터가 안전하다는 가정은 양자 컴퓨팅 시대에 더 이상 유효하지 않을 수 있습니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -304,7 +304,7 @@ MFA를 도입하면 탈취된 비밀번호만으로 시스템에 접근할 수 �
   title="[보안] 주간 위협 동향 요약 — DDR5 봇 스캘핑, 삼성 TV 추적, Reddit 개인정보 과징금"
   url="https://thehackernews.com/2026/03/threatsday-bulletin-redis-rce-ddr5-bot.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgmX71oTh0PhBoeXrV6BUD7_jQe9VWPqHc60ijUxf4iv8wPE8UeWY8dlDrfbx3-Ut5aNoNQZJ8DH_ADNQGgFL4NbMMcw-IayIe9HXKG3l5EN3-og9LuNqBP452mXpm1HTn3ooWlJ-q4QRqvPJC4gmR0lstJ8KWdQYa2knQ5J69nneIwIRTKKG43fXtcWRXm/s1700-e365/threatsday.jpg"
-  summary="주간 위협 동향 요약 — DDR5 봇 스캘핑, 삼성 TV 추적, Reddit 개인정보 과징금 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="이번 주 사이버보안 분야에서 다수의 새로운 동향이 포착되었습니다. DDR5 메모리 구매를 자동화하는 봇 스캘핑 활동, 삼성 TV의 사용자 시청 데이터 추적 문제, Reddit의 개인정보 보호법 위반 과징금 등 다양한 분야에서 보안 이슈가 발생했습니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -322,7 +322,7 @@ MFA를 도입하면 탈취된 비밀번호만으로 시스템에 접근할 수 �
 {%- include news-card.html
   title="[AI/ML] OpenAI GPT-5.4 출시 — 네이티브 컴퓨터 사용과 100만 토큰 컨텍스트"
   url="https://openai.com/index/introducing-gpt-5-4"
-  summary="OpenAI GPT-5.4 출시 — 네이티브 컴퓨터 사용과 100만 토큰 컨텍스트 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="OpenAI가 최신 프런티어 모델 GPT-5.4를 공개했습니다. ChatGPT, API, Codex 전반에 적용되는 이 모델은 추론, 코딩, 에이전트 워크플로우 성능을 통합하며, 특히 네이티브 컴퓨터 사용(computer-use) 기능을 내장하여 에이전트가 웹사이트와 소프트웨어를 직접 조작할 수 있습니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -344,7 +344,7 @@ AI 모델이 단순한 텍스트 생성을 넘어 실제 컴퓨터 환경을 조
   title="[AI/ML] Palantir Maven Smart System — NATO 동맹국 AI 전투 시스템"
   url="https://blog.palantir.com/maven-smart-system-innovating-for-the-alliance-5ebc31709eea?source=rss----3c87dc14372f---4"
   image="https://miro.medium.com/v2/resize:fit:1200/1*rDDZDcEQP011rQj5uPCuwA.png"
-  summary="Palantir Maven Smart System — NATO 동맹국 AI 전투 시스템 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Palantir이 NATO의 Task Force Maven과 협력하여 Maven Smart System을 공개했습니다. 2025년 11월 NATO Warfighting Innovation Week에서 시연된 이 시스템은 동맹국 전투원에게 즉각적인 AI 역량을 제공하는 것을 목표로 합니다."
   source="Palantir Blog"
   severity="Medium"
 -%}
@@ -361,7 +361,7 @@ Palantir이 NATO의 Task Force Maven과 협력하여 Maven Smart System을 공�
   title="[AI/ML] Google AI 시각 검색 기술 심층 분석"
   url="https://blog.google/company-news/inside-google/googlers/how-google-ai-visual-search-works/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/Fan_out_query_ss.width-1300.png"
-  summary="Google AI 시각 검색 기술 심층 분석 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google이 AI가 사용자의 시각적 검색을 이해하는 방식을 상세히 설명했습니다. 카메라로 촬영한 이미지에서 객체를 인식하고, 텍스트와 이미지를 결합한 멀티모달 이해를 통해 검색 의도를 파악하는 기술입니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -376,7 +376,7 @@ Google이 AI가 사용자의 시각적 검색을 이해하는 방식을 상세�
   title="[AI/ML] Google 2월 AI 업데이트 종합 — Gemini 3.1 Pro, Nano Banana 2"
   url="https://blog.google/innovation-and-ai/products/google-ai-updates-february-2026/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/Thumbnail_mPCqgRv.width-1300.png"
-  summary="Google 2월 AI 업데이트 종합 — Gemini 3.1 Pro, Nano Banana 2 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google이 2026년 2월에 발표한 AI 관련 업데이트를 종합 정리했습니다. Gemini 3.1 Pro와 이미지 생성 모델 Nano Banana 2 등이 포함되며, Google의 AI 제품 라인업 전반에 걸친 개선사항을 다루고 있습니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -395,7 +395,7 @@ Google이 2026년 2월에 발표한 AI 관련 업데이트를 종합 정리했�
   title="[클라우드] Google Cloud 보안 체크리스트 공개 — MVSP 기반 권장 설정"
   url="https://cloud.google.com/blog/products/identity-security/introducing-the-google-cloud-recommended-security-checklist/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/Google_Cloud_recommended_security_checklis.max-2000x2000_mUiFTOZ.jpg"
-  summary="Google Cloud 보안 체크리스트 공개 — MVSP 기반 권장 설정 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Cloud가 Minimum Viable Secure Product(MVSP) 원칙에 기반한 보안 체크리스트를 공개했습니다. 에이전틱 AI 도입이 가속화되는 가운데, 클라우드 보안과 리스크 관리를 지속적으로 우선시해야 한다는 메시지와 함께, 조직이 보안 요구사항을 관리하고 설정을 검증할 수 있는 체계적인 가이드를 제공합니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -417,7 +417,7 @@ MVSP는 B2B 소프트웨어의 최소 보안 요구사항을 정의하는 업계
   title="[클라우드] 2025 제로데이 리뷰 — GTIG 분석, 90개 제로데이 추적"
   url="https://cloud.google.com/blog/topics/threat-intelligence/2025-zero-day-review/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_ThreatIntelligenceWebsiteBannerIdeas_BA.max-2600x2600.png"
-  summary="2025 제로데이 리뷰 — GTIG 분석, 90개 제로데이 추적 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Threat Intelligence Group(GTIG)이 2025년 한 해 동안 추적한 90개 제로데이 취약점에 대한 종합 리뷰를 발표했습니다. 제로데이 공격 트렌드, 주요 타겟 플랫폼, 공격자 유형별 분석 등을 포함합니다."
   source="Google Cloud Blog"
   severity="High"
 -%}
@@ -437,7 +437,7 @@ Google Threat Intelligence Group(GTIG)이 2025년 한 해 동안 추적한 90개
   title="[클라우드] GKE 커스텀 메트릭 네이티브 지원 — 오토스케일링 고도화"
   url="https://cloud.google.com/blog/products/containers-kubernetes/gke-now-supports-custom-metrics-natively/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/07_-_Containers__Kubernetes_iY4YTLa.max-2600x2600.jpg"
-  summary="GKE 커스텀 메트릭 네이티브 지원 — 오토스케일링 고도화 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Kubernetes Engine(GKE)이 커스텀 메트릭을 네이티브로 지원하기 시작했습니다. 기존에 CPU와 메모리 기반 오토스케일링은 간단했지만, 큐 깊이(queue depth)나 활성 요청 수(active requests) 같은 애플리케이션 시그널 기반 스케일링은 복잡했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -457,7 +457,7 @@ Google Kubernetes Engine(GKE)이 커스텀 메트릭을 네이티브로 지원�
   title="[클라우드] 메리츠증권 AWS 클라우드 기반 차세대 증권 플랫폼"
   url="https://aws.amazon.com/ko/blogs/tech/meritz-securities-wts-with-gen-ai/"
   image="https://d2908q01vomqb2.cloudfront.net/827bfc458708f0b442009c9c9836f7e4b65557fb/2020/06/03/Blog-Post_thumbnail.png"
-  summary="메리츠증권 AWS 클라우드 기반 차세대 증권 플랫폼 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="메리츠증권이 AWS 클라우드를 활용하여 차세대 증권 플랫폼을 설계하고 구축한 사례가 공개되었습니다. 리테일 비즈니스 경쟁력 강화를 목표로, 단순 트레이딩 시스템을 넘어 투자자 간 상호작용과 정보 교류가 이루어지는 커뮤니티 중심 서비스를 구축했습니다."
   source="AWS Korea Blog"
   severity="Medium"
 -%}
@@ -476,7 +476,7 @@ Google Kubernetes Engine(GKE)이 커스텀 메트릭을 네이티브로 지원�
   title="[DevOps] MCP C# SDK v1.0 정식 출시"
   url="https://devblogs.microsoft.com/dotnet/release-v10-of-the-official-mcp-csharp-sdk/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/03/image.webp"
-  summary="MCP C# SDK v1.0 정식 출시 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Microsoft가 Model Context Protocol(MCP) C# SDK v1.0을 정식 출시했습니다. MCP는 AI 에이전트가 외부 도구와 상호작용하기 위한 표준 프로토콜로, 이번 v1.0에는 향상된 인증(authorization), 풍부한 메타데이터, 도구 호출 및 장시간 실행 요청을 위한 패턴이 포함되었습니다."
   source="Microsoft .NET Blog"
   severity="Medium"
 -%}
@@ -496,7 +496,7 @@ Microsoft가 Model Context Protocol(MCP) C# SDK v1.0을 정식 출시했습니�
   title="[DevOps] 모든 AI 플랫폼이 Kubernetes로 수렴하는 이유"
   url="https://www.cncf.io/blog/2026/03/05/the-great-migration-why-every-ai-platform-is-converging-on-kubernetes/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Akamia-Cloud-Credits-2.png"
-  summary="모든 AI 플랫폼이 Kubernetes로 수렴하는 이유 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="CNCF에서 발표한 분석에 따르면, 10년 전 마이크로서비스 배포를 위해 탄생한 Kubernetes가 2026년에는 AI 플랫폼의 사실상 표준 인프라로 자리 잡았습니다. 더 이상 '상태 없는 웹 서비스' 전용이 아니라, GPU 스케줄링, 분산 학습, 모델 서빙 등 AI 워크로드의 전체 라이프사이클을 관리하는 플랫폼으로 진화했습니다."
   source="CNCF Blog"
   severity="Medium"
 -%}
@@ -520,7 +520,7 @@ CNCF에서 발표한 분석에 따르면, 10년 전 마이크로서비스 배포
   title="[블록체인] Bitcoin 컨센서스 클린업 — BIP 54 소프트포크 제안"
   url="https://bitcoinmagazine.com/print/the-core-issue-consensus-cleanup"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/Core-Issue-Article-Header-2400x1256-Poinsot-1-fotor-20260305161511.webp"
-  summary="Bitcoin 컨센서스 클린업 — BIP 54 소프트포크 제안 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Bitcoin Magazine가 BIP 54 소프트포크 제안을 심층 분석했습니다. 이 제안은 Bitcoin 핵심 합의 프로토콜에 존재하는 4가지 미해결 버그를 수정하기 위한 것으로, 네트워크의 장기적 안정성과 보안 강화를 목표로 합니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}

--- a/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
+++ b/_posts/2026-03-11-Tech_Security_Weekly_Digest_AI_Agent_Data_Malware.md
@@ -98,7 +98,7 @@ summary_card:
   title="[보안] 클라우드 보안 동향 (Cloudflare Blog)"
   url="https://blog.cloudflare.com/attack-surface-intelligence/"
   image="https://cf-assets.www.cloudflare.com/zkvhlag99gkb/3imPLPA5EjdwgRmm8JHIJM/9aaa38005e300665fb7eea271d2258a4/Translating_risk_insights_into_actionable_protection-_leveling_up_security_posture_with_Cloudflare_and_Mastercard-OG.png"
-  summary="클라우드 보안 동향를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Cloudflare는 2026년 3월 공격 표면 인텔리전스(Attack Surface Intelligence) 기능을 공식 블로그를 통해 상세히 소개했습니다. 이 기능은 조직이 인터넷에 노출된 자산을 실시간으로 파악하고, 위험도 기반 우선순위에 따라 보안 조치를 취할 수 있도록 지원합니다."
   source="Cloudflare Blog"
   severity="Critical"
 %}
@@ -214,7 +214,7 @@ index=firewall action=blocked
   title="Bitcoin 오더북 불균형 심화 — $70K 지지선 유지 여부 주목"
   url="https://cointelegraph.com/news/bitcoin-orderbook-shows-imbalance-will-dollar70k-hold?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTAvMDE5YTJhOTMtZGU3OS03ZDQ0LThkMjAtYTQ3ZDMwMTc4YmFm.jpg"
-  summary="Bitcoin 오더북 불균형 심화 — $70K 지지선 유지 여부 주목를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Bitcoin 오더북에서 매도 벽(sell wall)이 매수 주문 대비 크게 우세한 불균형이 관측되고 있습니다. $70K 지지선이 무너질 경우 대규모 청산(liquidation)이 연쇄적으로 발생할 수 있어 시장 변동성이 급격히 확대될 가능성이 있습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -233,7 +233,7 @@ Bitcoin 오더북에서 매도 벽(sell wall)이 매수 주문 대비 크게 우
   title="영국 정부, 암호화폐 사기 대응 전략 발표"
   url="https://cointelegraph.com/news/uk-government-fraud-strategy-crypto?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2Q4MzctYWE5Ny03ZDRjLTllNDgtN2E4NzQyOGY4MjJlLmpwZw==.jpg"
-  summary="영국 정부, 암호화폐 사기 대응 전략 발표를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="영국 정부가 암호화폐 관련 사기에 대응하는 종합 전략을 발표했습니다. 크립토 투자 사기, 로맨스 스캠을 통한 암호화폐 탈취, 피싱 공격 등이 급증하는 상황에서 법 집행 역량을 강화하고 거래소-금융기관 간 정보 공유를 확대하겠다는 내용을 담고 있습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -252,7 +252,7 @@ Bitcoin 오더북에서 매도 벽(sell wall)이 매수 주문 대비 크게 우
   title="Arthur Hayes, Hyperliquid HYPE 토큰 8월까지 $150 도달 전망"
   url="https://cointelegraph.com/news/hyperliquid-hype-price-will-hit-150-by-august-predicts-arthur-hayes?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjM4YzUtNWQ2NC03ZjI5LWFmM2UtNzYzOWJiMjQyZmFkLmpwZw==.jpg"
-  summary="Arthur Hayes, Hyperliquid HYPE 토큰 8월까지 $150 도달 전망를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="BitMEX 공동 창업자 Arthur Hayes가 탈중앙 파생상품 거래소 Hyperliquid의 네이티브 토큰 HYPE가 8월까지 $150에 도달할 것이라고 전망했습니다."
   source="Cointelegraph"
   severity="Medium"
 %}

--- a/scripts/news_card_patterns.py
+++ b/scripts/news_card_patterns.py
@@ -39,7 +39,38 @@ CARD_RE = re.compile(
 # The ``summary="…"`` attribute inside a card. The lookahead ends the value at
 # the next attribute, the closing tag, or end of input — never at an escaped
 # quote inside the prose (``&quot;`` is what the corpus uses).
-SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+\w+="|\s*-?%\}|\s*$))', re.DOTALL)
+#
+# The attribute name in that lookahead is ``[\w-]+``, not ``\w+``, because that
+# is what Jekyll itself accepts: ``Jekyll::Tags::IncludeTag::VALID_SYNTAX`` is
+# ``([\w-]+)\s*=\s*(?:"…"|'…'|[\w.-]+)`` (jekyll-4.4.1). Verified 2026-08-07:
+# ``FULL_VALID_SYNTAX.match?('title="a" aria-label="x" summary="s"')`` is true.
+# The corpus has no hyphenated include parameter yet, so widening the class is
+# behaviour-preserving today (proved over all 2117 card blocks) and stops a
+# ``summary`` value from swallowing the next attribute the day one appears.
+SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+[\w-]+="|\s*-?%\}|\s*$))', re.DOTALL)
+
+
+def block_re(include_name: str) -> "re.Pattern[str]":
+    """Block pattern for ONE include kind, built exactly like ``CARD_RE``.
+
+    Transformers that must treat the kinds differently need this: dropping the
+    ``summary=`` attribute is right for a spotlight item (no prose exists to
+    rewrite it from) and wrong for a ``news-card``. Deny-by-default on the name
+    so a typo cannot silently match nothing.
+    """
+    if include_name not in CARD_INCLUDES:
+        raise ValueError(f"unknown card include: {include_name!r}")
+    return re.compile(
+        rf"\{{%-?\s*include\s+{re.escape(include_name)}\.html.*?-?%\}}",
+        re.DOTALL,
+    )
+
+
+BLOCK_RE_BY_KIND = {name: block_re(name) for name in CARD_INCLUDES}
+
+# Convenience aliases for the two kinds that exist today.
+NEWS_CARD_RE = BLOCK_RE_BY_KIND["news-card"]
+SPOTLIGHT_RE = BLOCK_RE_BY_KIND["news-spotlight-item"]
 
 
 def count_cards(text: str) -> int:

--- a/scripts/rewrite_template_echo_summaries.py
+++ b/scripts/rewrite_template_echo_summaries.py
@@ -1,4 +1,4 @@
-"""Replace template-echo card summaries with the post's own prose.
+"""Repair template-echo card summaries: rewrite from the post's prose, or drop.
 
 271 card summaries across 24 digests (2026-02-20 … 2026-03-17) say nothing about
 the article they sit on. They repeat the headline verbatim and bolt on one of
@@ -26,19 +26,34 @@ include                      defects  usable per-item prose within 20 lines
                                       all between them
 ===========================  =======  ==========================================
 
-So spotlight items cannot be repaired this way. They are not special-cased: the
-prose window simply finds nothing for them and they are skipped, the same as the
-five ``news-card`` items whose follow-up is a table or a bullet list.
+So spotlight items cannot be rewritten this way. In the REPLACE mode below they
+are not special-cased: the prose window simply finds nothing for them and they
+are skipped, the same as the five ``news-card`` items whose follow-up is a table
+or a bullet list.
 
-This edits inside a Liquid include, the exact place a context-blind rewrite
-corrupted three cover images in PR #509. The runtime contract is therefore the
-narrowest one that admits the change at all, and it aborts the whole run:
+DROP mode then handles those 45. There is no article-specific text to put there,
+and a sentence claiming a security analysis nobody performed is worse than no
+sentence, so the ``summary=`` attribute is deleted outright.
+``_includes/news-spotlight-item.html:9`` wraps the summary in
+``{% if include.summary %}``, so the ``<p class="news-spotlight-summary">`` is
+simply omitted while the title link and the source/tag meta still render.
+Re-summarising from the source article was rejected: it needs a network call and
+invents text, both of which this script refuses to do.
 
-    a file may differ ONLY in the value of ``summary=`` inside a news card.
+Both modes edit inside a Liquid include, the exact place a context-blind rewrite
+corrupted three cover images in PR #509. Each therefore carries its OWN runtime
+contract, enforced separately so that neither can launder a change through the
+other's allowance, and either aborts the whole run:
+
+    REPLACE: a file may differ ONLY in the VALUE of ``summary=`` inside a card.
+    DROP:    a file may differ ONLY by whole ``summary="…"`` LINES deleted from
+             ``news-spotlight-item`` includes; card count and attribute order
+             stay put.
 
 Usage:
     python3 scripts/rewrite_template_echo_summaries.py --posts-glob '_posts/*Weekly_Digest*.md' --dry-run
     python3 scripts/rewrite_template_echo_summaries.py _posts/2026-03-11-*.md
+    python3 scripts/rewrite_template_echo_summaries.py --mode drop _posts/2026-03-06-*.md
 """
 
 import argparse
@@ -79,10 +94,24 @@ CARD_RE = re.compile(
     r"\{%-?\s*include\s+(?:news-card|news-spotlight-item)\.html.*?-?%\}",
     re.DOTALL,
 )
+SPOTLIGHT_RE = re.compile(
+    r"\{%-?\s*include\s+news-spotlight-item\.html.*?-?%\}",
+    re.DOTALL,
+)
 SUMMARY_RE = re.compile(
     r'(\bsummary=")(.*?)("(?=\s+[\w-]+="|\s*-?%\}|\s*$))',
     re.DOTALL,
 )
+
+# Drop mode deletes whole lines, so the attribute must OWN its line. Measured:
+# 45/45 spotlight defects match this; a value that ever wrapped would be skipped
+# rather than half-deleted.
+SUMMARY_LINE_RE = re.compile(r'^[ \t]*summary="[^"\n]*"[ \t]*$')
+
+# Independent of the rules: reads attribute NAMES straight off each card so the
+# drop contract has its own detector (contract C5).
+_ATTR_NAME_RE = re.compile(r'(?m)^[ \t]*([\w-]+)="')
+_INCLUDE_NAME_RE = re.compile(r"\{%-?\s*include\s+([\w.-]+)")
 
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
 _MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
@@ -155,6 +184,17 @@ def _line_starts(text: str):
         offsets.append(pos)
         pos += len(line) + 1
     return offsets
+
+
+def _line_of(offsets, pos: int) -> int:
+    lo, hi = 0, len(offsets) - 1
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if offsets[mid] <= pos:
+            lo = mid
+        else:
+            hi = mid - 1
+    return lo
 
 
 # --- extraction --------------------------------------------------------------
@@ -241,29 +281,24 @@ def summarise(prose: str, max_sentences: int = 2):
     return value
 
 
-# --- transform ---------------------------------------------------------------
+# --- transform: replace ------------------------------------------------------
 
 
-def transform(text: str) -> str:
+def replace_echo_summaries(text: str) -> str:
+    """Lift the following prose paragraph into every template-echo summary.
+
+    In practice this only ever reaches ``news-card``: spotlight items have no
+    prose after them, so they fall out of ``_prose_after`` on their own.
+    """
     lines = text.split("\n")
     body_start = _front_matter_end(lines)
     fence = _fence_flags(lines, body_start)
     offsets = _line_starts(text)
 
-    def line_of(pos: int) -> int:
-        lo, hi = 0, len(offsets) - 1
-        while lo < hi:
-            mid = (lo + hi + 1) // 2
-            if offsets[mid] <= pos:
-                lo = mid
-            else:
-                hi = mid - 1
-        return lo
-
     edits = []
     for card in CARD_RE.finditer(text):
-        first = line_of(card.start())
-        last = line_of(card.end() - 1)
+        first = _line_of(offsets, card.start())
+        last = _line_of(offsets, card.end() - 1)
         if first < body_start or fence[first]:
             continue
         found = SUMMARY_RE.search(card.group(0))
@@ -282,6 +317,45 @@ def transform(text: str) -> str:
     for start, end, value in reversed(edits):
         text = text[:start] + value + text[end:]
     return text
+
+
+# --- transform: drop ---------------------------------------------------------
+
+
+def _spotlight_summary_lines(text: str):
+    """Line indices holding a droppable spotlight ``summary=`` echo."""
+    lines = text.split("\n")
+    body_start = _front_matter_end(lines)
+    fence = _fence_flags(lines, body_start)
+    offsets = _line_starts(text)
+
+    found_lines = set()
+    for card in SPOTLIGHT_RE.finditer(text):
+        first = _line_of(offsets, card.start())
+        if first < body_start or fence[first]:
+            continue
+        found = SUMMARY_RE.search(card.group(0))
+        if not found or not _is_template_echo(found.group(2)):
+            continue
+        index = _line_of(offsets, card.start() + found.start(1))
+        if not SUMMARY_LINE_RE.match(lines[index]):
+            continue
+        found_lines.add(index)
+    return found_lines
+
+
+def drop_spotlight_echo_summaries(text: str) -> str:
+    """Delete the ``summary=`` line from spotlight items that only echo the title."""
+    doomed = _spotlight_summary_lines(text)
+    if not doomed:
+        return text
+    lines = text.split("\n")
+    return "\n".join(line for i, line in enumerate(lines) if i not in doomed)
+
+
+def transform(text: str) -> str:
+    """Both modes, in the order ``main`` applies them."""
+    return drop_spotlight_echo_summaries(replace_echo_summaries(text))
 
 
 def count_defects(text: str) -> int:
@@ -308,22 +382,109 @@ def _mask_summaries(text: str) -> str:
 
 
 def violates_summary_only(old: str, new: str) -> bool:
-    """This transform may change nothing but a card ``summary=`` VALUE.
+    """REPLACE mode may change nothing but a card ``summary=`` VALUE.
 
     Deliberately stronger than a token or length check: it compares the two files
     byte for byte with every card summary masked out, so any edit that leaks into
     a URL, an image attribute, the front matter or the prose aborts the run.
+
+    Note this contract also forbids DELETING a summary — drop mode is checked by
+    ``violates_spotlight_line_drop_only`` instead, so neither mode inherits the
+    other's allowance.
     """
     return _mask_summaries(old) != _mask_summaries(new)
 
 
+def _card_attribute_shapes(text: str):
+    """``[(include name, [attr names]), …]`` for every card.
+
+    Computed straight from the text without touching the drop rule's line
+    bookkeeping, so the contract's detector cannot regress in lockstep with the
+    rule it is supposed to police (contract C5).
+    """
+    shapes = []
+    for card in CARD_RE.finditer(text):
+        name = _INCLUDE_NAME_RE.match(card.group(0))
+        shapes.append(
+            (name.group(1) if name else "", _ATTR_NAME_RE.findall(card.group(0)))
+        )
+    return shapes
+
+
+def _violates_card_shape(old: str, new: str) -> bool:
+    """Card count and attribute order must survive; at most one ``summary`` may go."""
+    old_shapes = _card_attribute_shapes(old)
+    new_shapes = _card_attribute_shapes(new)
+    if len(old_shapes) != len(new_shapes):
+        return True
+    for (old_name, old_attrs), (new_name, new_attrs) in zip(old_shapes, new_shapes):
+        if old_name != new_name:
+            return True
+        if new_attrs == old_attrs:
+            continue
+        if new_name != "news-spotlight-item.html":
+            return True
+        if old_attrs.count("summary") != 1:
+            return True
+        if [a for a in old_attrs if a != "summary"] != new_attrs:
+            return True
+    return False
+
+
+def violates_spotlight_line_drop_only(old: str, new: str) -> bool:
+    """DROP mode may only DELETE whole spotlight ``summary="…"`` lines.
+
+    Nothing may be added, reordered or rewritten; every deleted line must be a
+    self-contained ``summary=`` attribute that lived inside a
+    ``news-spotlight-item`` include and carried a template echo. Verified twice
+    over: a strict line-by-line walk, plus an independently computed check that
+    card count and attribute order did not move.
+    """
+    old_lines = old.split("\n")
+    new_lines = new.split("\n")
+    if len(new_lines) > len(old_lines):
+        return True
+
+    deletable = _spotlight_summary_lines(old)
+    i = j = 0
+    while i < len(old_lines) and j < len(new_lines):
+        if old_lines[i] == new_lines[j]:
+            i += 1
+            j += 1
+            continue
+        if i not in deletable:
+            return True
+        i += 1
+    if j != len(new_lines):
+        return True
+    while i < len(old_lines):
+        if i not in deletable:
+            return True
+        i += 1
+
+    return _violates_card_shape(old, new)
+
+
+# Each mode is (name, rule, its own contract). Nothing shared, by design.
+MODES = {
+    "replace": (replace_echo_summaries, violates_summary_only),
+    "drop": (drop_spotlight_echo_summaries, violates_spotlight_line_drop_only),
+}
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(
-        description="Replace template-echo card summaries with the post's own prose."
+        description="Repair template-echo card summaries from the post's own prose."
     )
     ap.add_argument("paths", nargs="*")
     ap.add_argument("--posts-glob")
     ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument(
+        "--mode",
+        choices=("both", "replace", "drop"),
+        default="both",
+        help="replace = news-card from prose; drop = spotlight summary attribute",
+    )
     ap.add_argument("--limit", type=int, default=0, help="process at most N files")
     args = ap.parse_args(argv)
 
@@ -337,29 +498,40 @@ def main(argv=None) -> int:
         print("[template-echo] no digest post files to process.")
         return 0
 
+    stages = ["replace", "drop"] if args.mode == "both" else [args.mode]
+
     changed = 0
-    rewritten = 0
+    totals = {"replace": 0, "drop": 0}
     for path in files:
         original = path.read_text(encoding="utf-8")
-        new = transform(original)
-        if new == original:
+        current = original
+        counts = {}
+        for stage in stages:
+            rule, contract = MODES[stage]
+            stepped = rule(current)
+            # Each stage is judged against ITS OWN input, so a legal replace
+            # cannot cover for an illegal drop or the other way round.
+            if stepped != current and contract(current, stepped):
+                print(
+                    f"ABORT {path}: {stage} mode broke its runtime contract",
+                    file=sys.stderr,
+                )
+                return 1
+            counts[stage] = count_defects(current) - count_defects(stepped)
+            totals[stage] += counts[stage]
+            current = stepped
+        if current == original:
             continue
-        if violates_summary_only(original, new):
-            print(f"ABORT {path}: change escaped the summary attribute", file=sys.stderr)
-            return 1
-        fixed = count_defects(original) - count_defects(new)
         changed += 1
-        rewritten += fixed
+        detail = ", ".join(f"{stage} {counts[stage]}" for stage in stages)
         if args.dry_run:
-            print(f"DRY   {path}  ({fixed} summaries)")
+            print(f"DRY   {path}  ({detail})")
         else:
-            path.write_text(new, encoding="utf-8")
-            print(f"FIXED {path}  ({fixed} summaries)")
-    verb = "would rewrite" if args.dry_run else "rewrote"
-    print(
-        f"[template-echo] {verb} {rewritten} summaries in "
-        f"{changed}/{len(files)} post(s)."
-    )
+            path.write_text(current, encoding="utf-8")
+            print(f"FIXED {path}  ({detail})")
+    verb = "would fix" if args.dry_run else "fixed"
+    summary = ", ".join(f"{stage} {totals[stage]}" for stage in stages)
+    print(f"[template-echo] {verb} {summary} in {changed}/{len(files)} post(s).")
     return 0
 
 

--- a/scripts/rewrite_template_echo_summaries.py
+++ b/scripts/rewrite_template_echo_summaries.py
@@ -1,0 +1,367 @@
+"""Replace template-echo card summaries with the post's own prose.
+
+271 card summaries across 24 digests (2026-02-20 … 2026-03-17) say nothing about
+the article they sit on. They repeat the headline verbatim and bolt on one of
+three fixed clauses:
+
+    "<제목>를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, …"
+    "<제목> 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, …"
+    "… 공격 경로·영향 자산·탐지 포인트를 정리하고, …"
+
+The article-specific facts are already in the post: every affected ``news-card``
+is followed by a prose paragraph that summarises the article. This lifts the
+first one or two sentences of that paragraph into ``summary=``. Nothing is
+fetched, nothing is invented, no LLM is called — the replacement text is copied
+from the same post, a few lines below.
+
+Measured on the corpus 2026-08-07, and this corrects the working assumption the
+task started from:
+
+===========================  =======  ==========================================
+include                      defects  usable per-item prose within 20 lines
+===========================  =======  ==========================================
+``news-card``                    226  221 (5 have a heading/list/lead-in instead)
+``news-spotlight-item``           45  **0** — they are packed back to back inside
+                                      a ``{% capture %}`` block with no prose at
+                                      all between them
+===========================  =======  ==========================================
+
+So spotlight items cannot be repaired this way. They are not special-cased: the
+prose window simply finds nothing for them and they are skipped, the same as the
+five ``news-card`` items whose follow-up is a table or a bullet list.
+
+This edits inside a Liquid include, the exact place a context-blind rewrite
+corrupted three cover images in PR #509. The runtime contract is therefore the
+narrowest one that admits the change at all, and it aborts the whole run:
+
+    a file may differ ONLY in the value of ``summary=`` inside a news card.
+
+Usage:
+    python3 scripts/rewrite_template_echo_summaries.py --posts-glob '_posts/*Weekly_Digest*.md' --dry-run
+    python3 scripts/rewrite_template_echo_summaries.py _posts/2026-03-11-*.md
+"""
+
+import argparse
+import glob
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+# Imported, not re-implemented: the corpus and the generator must not drift on
+# where a Korean sentence may be cut (contract C8, PR #512).
+from scripts.news.content_generator import _truncate_korean_sentence  # noqa: E402
+
+# The three fixed clauses. A summary containing any of them describes no article.
+TEMPLATE_MARKERS = (
+    "공격 경로·영향 자산·탐지 포인트를 정리하고",
+    "공격 벡터·영향 범위·탐지 지표를 요약하고",
+    "공격 벡터와 영향 범위를 점검하고",
+)
+
+# Card summaries are capped at 200 by the generator (``_truncate_korean_sentence``
+# in ``content_generator._generate_news_section``); stay inside the same budget.
+MAX_SUMMARY_LEN = 200
+
+# Below this the paragraph is a lead-in ("이번 기간 SK쉴더스 추가 발간물:"), not a
+# summary. 60 rejects one real one-sentence summary in 2026-03-10, 40 does not.
+MIN_PROSE_LEN = 40
+
+# How far past the include to look. The corpus never exceeds 3 lines (blank,
+# optional ``#### 요약``, blank); 20 is slack, not a licence to wander.
+PROSE_WINDOW = 20
+
+# Both card includes. ``{%-`` whitespace-control variants are the majority in
+# 2026-03-06; matching only ``{%`` undercounts the corpus by 54 cards.
+CARD_RE = re.compile(
+    r"\{%-?\s*include\s+(?:news-card|news-spotlight-item)\.html.*?-?%\}",
+    re.DOTALL,
+)
+SUMMARY_RE = re.compile(
+    r'(\bsummary=")(.*?)("(?=\s+[\w-]+="|\s*-?%\}|\s*$))',
+    re.DOTALL,
+)
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]*\)")
+_BOLD_RE = re.compile(r"\*{1,2}([^*]+)\*{1,2}")
+_CODE_RE = re.compile(r"`([^`]*)`")
+
+# Characters that either terminate the Liquid attribute or break its tokeniser.
+_UNSAFE_IN_ATTR = ('"', "“", "”", "{", "}", "\n")
+
+# Lines that end the prose search: another Liquid tag, a rule, any heading that
+# is not the ``#### 요약`` lead, a table, a list, an image, a quote, a fence.
+_BLOCK_PREFIXES = ("{%", "{{", "---", "***", "___", "|", "```", "!", ">", "#")
+_LIST_ITEM_RE = re.compile(r"[-*+]\s")
+
+
+def _is_block_start(stripped: str) -> bool:
+    """True when the line opens a non-prose block.
+
+    ``*`` and ``-`` need a following space to count as list markers: a paragraph
+    may legitimately open on ``**개발자 도구**가 …``.
+    """
+    if stripped.startswith(_BLOCK_PREFIXES):
+        return True
+    return bool(_LIST_ITEM_RE.match(stripped))
+
+
+def _is_template_echo(value: str) -> bool:
+    return any(marker in value for marker in TEMPLATE_MARKERS)
+
+
+def _is_digest_post(path: Path) -> bool:
+    return "Weekly_Digest" in path.name
+
+
+# --- protected regions -------------------------------------------------------
+
+
+def _front_matter_end(lines) -> int:
+    """Index of the first body line. 0 when the file has no front matter."""
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return i + 1
+    return 0
+
+
+def _fence_flags(lines, start: int):
+    """True for every line inside a fenced code block.
+
+    The toggle reads the STRIPPED line: 2026-02-08 closes its blocks with an
+    indented fence, and a raw ``startswith`` flips the rest of the file
+    (contract T3).
+    """
+    flags = [False] * len(lines)
+    inside = False
+    for i in range(start, len(lines)):
+        if lines[i].strip().startswith("```"):
+            flags[i] = True
+            inside = not inside
+            continue
+        flags[i] = inside
+    return flags
+
+
+def _line_starts(text: str):
+    offsets = []
+    pos = 0
+    for line in text.split("\n"):
+        offsets.append(pos)
+        pos += len(line) + 1
+    return offsets
+
+
+# --- extraction --------------------------------------------------------------
+
+
+def _prose_after(lines, start: int, fence):
+    """The article paragraph following a card, or None.
+
+    Skips blank lines and a single ``#### 요약``-style lead heading, then returns
+    the next contiguous block of plain prose. Anything else — a Liquid tag (the
+    next spotlight item), a table, a list, a fence — means this card has no prose
+    of its own and must be left alone.
+    """
+    i = start
+    limit = min(len(lines), start + PROSE_WINDOW)
+    while i < limit:
+        stripped = lines[i].strip()
+        if not stripped:
+            i += 1
+            continue
+        if stripped.startswith("####"):
+            i += 1
+            continue
+        break
+    if i >= limit or fence[i]:
+        return None
+    if _is_block_start(lines[i].strip()):
+        return None
+
+    buf = []
+    while i < len(lines) and lines[i].strip() and not fence[i]:
+        buf.append(lines[i].strip())
+        i += 1
+    return " ".join(buf)
+
+
+def _clean_markdown(text: str) -> str:
+    text = _MD_LINK_RE.sub(r"\1", text)
+    text = _BOLD_RE.sub(r"\1", text)
+    text = _CODE_RE.sub(r"\1", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _to_liquid_safe(text: str) -> str:
+    """ASCII/curly double quotes become ``'``.
+
+    A double quote closes the attribute; a curly one is blocked outright by
+    ``check_post_quote_safety.py``. A single quote is neither.
+    """
+    for quote in ('"', "“", "”"):
+        text = text.replace(quote, "'")
+    return text.replace("‘", "'").replace("’", "'")
+
+
+def summarise(prose: str, max_sentences: int = 2):
+    """First one or two sentences of ``prose``, or None if it is not a summary."""
+    text = _clean_markdown(prose)
+    if len(text) < MIN_PROSE_LEN:
+        return None
+    if not text.endswith(("다.", "요.", ".")):
+        return None
+    if "{%" in text or "{{" in text:
+        return None
+
+    sentences = [s for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
+    if not sentences:
+        return None
+    candidate = " ".join(sentences[:max_sentences]).strip()
+    clipped = _truncate_korean_sentence(candidate, MAX_SUMMARY_LEN)
+    # The helper's word-boundary fallback can APPEND "… 등이 확인되었습니다." That is
+    # fine for a generator writing new text and wrong here: every character of a
+    # replacement must come from the post. Requiring a prefix rejects the
+    # invented tail and enforces the length cap in one check.
+    if not candidate.startswith(clipped) or len(clipped) > MAX_SUMMARY_LEN:
+        return None
+
+    value = _to_liquid_safe(clipped).strip()
+    if len(value) < MIN_PROSE_LEN:
+        return None
+    if any(ch in value for ch in _UNSAFE_IN_ATTR):
+        return None
+    if _is_template_echo(value):
+        return None
+    return value
+
+
+# --- transform ---------------------------------------------------------------
+
+
+def transform(text: str) -> str:
+    lines = text.split("\n")
+    body_start = _front_matter_end(lines)
+    fence = _fence_flags(lines, body_start)
+    offsets = _line_starts(text)
+
+    def line_of(pos: int) -> int:
+        lo, hi = 0, len(offsets) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if offsets[mid] <= pos:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo
+
+    edits = []
+    for card in CARD_RE.finditer(text):
+        first = line_of(card.start())
+        last = line_of(card.end() - 1)
+        if first < body_start or fence[first]:
+            continue
+        found = SUMMARY_RE.search(card.group(0))
+        if not found or not _is_template_echo(found.group(2)):
+            continue
+        prose = _prose_after(lines, last + 1, fence)
+        if prose is None:
+            continue
+        replacement = summarise(prose)
+        if replacement is None:
+            continue
+        edits.append(
+            (card.start() + found.start(2), card.start() + found.end(2), replacement)
+        )
+
+    for start, end, value in reversed(edits):
+        text = text[:start] + value + text[end:]
+    return text
+
+
+def count_defects(text: str) -> int:
+    total = 0
+    for card in CARD_RE.finditer(text):
+        found = SUMMARY_RE.search(card.group(0))
+        if found and _is_template_echo(found.group(2)):
+            total += 1
+    return total
+
+
+# --- runtime contract --------------------------------------------------------
+
+_MASK = "\x00SUMMARY\x00"
+
+
+def _mask_summaries(text: str) -> str:
+    def _mask_card(card):
+        return SUMMARY_RE.sub(
+            lambda m: m.group(1) + _MASK + m.group(3), card.group(0)
+        )
+
+    return CARD_RE.sub(_mask_card, text)
+
+
+def violates_summary_only(old: str, new: str) -> bool:
+    """This transform may change nothing but a card ``summary=`` VALUE.
+
+    Deliberately stronger than a token or length check: it compares the two files
+    byte for byte with every card summary masked out, so any edit that leaks into
+    a URL, an image attribute, the front matter or the prose aborts the run.
+    """
+    return _mask_summaries(old) != _mask_summaries(new)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Replace template-echo card summaries with the post's own prose."
+    )
+    ap.add_argument("paths", nargs="*")
+    ap.add_argument("--posts-glob")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--limit", type=int, default=0, help="process at most N files")
+    args = ap.parse_args(argv)
+
+    files = [Path(p) for p in (args.paths or [])]
+    if args.posts_glob:
+        files += [Path(p) for p in sorted(glob.glob(args.posts_glob))]
+    files = [f for f in files if _is_digest_post(f)]
+    if args.limit:
+        files = files[: args.limit]
+    if not files:
+        print("[template-echo] no digest post files to process.")
+        return 0
+
+    changed = 0
+    rewritten = 0
+    for path in files:
+        original = path.read_text(encoding="utf-8")
+        new = transform(original)
+        if new == original:
+            continue
+        if violates_summary_only(original, new):
+            print(f"ABORT {path}: change escaped the summary attribute", file=sys.stderr)
+            return 1
+        fixed = count_defects(original) - count_defects(new)
+        changed += 1
+        rewritten += fixed
+        if args.dry_run:
+            print(f"DRY   {path}  ({fixed} summaries)")
+        else:
+            path.write_text(new, encoding="utf-8")
+            print(f"FIXED {path}  ({fixed} summaries)")
+    verb = "would rewrite" if args.dry_run else "rewrote"
+    print(
+        f"[template-echo] {verb} {rewritten} summaries in "
+        f"{changed}/{len(files)} post(s)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rewrite_template_echo_summaries.py
+++ b/scripts/rewrite_template_echo_summaries.py
@@ -69,6 +69,15 @@ sys.path.insert(0, str(REPO))
 # where a Korean sentence may be cut (contract C8, PR #512).
 from scripts.news.content_generator import _truncate_korean_sentence  # noqa: E402
 
+# Same reason, for the card patterns themselves (C8 + C11). ``\s`` does not match
+# ``-``, so a re-declared ``\{%\s*include`` silently skips every ``{%- include``
+# card; that miss produced no diff and no red test in PR #512/#513.
+from scripts.news_card_patterns import (  # noqa: E402
+    CARD_RE,
+    SPOTLIGHT_RE,
+    SUMMARY_RE,
+)
+
 # The three fixed clauses. A summary containing any of them describes no article.
 TEMPLATE_MARKERS = (
     "공격 경로·영향 자산·탐지 포인트를 정리하고",
@@ -88,28 +97,15 @@ MIN_PROSE_LEN = 40
 # optional ``#### 요약``, blank); 20 is slack, not a licence to wander.
 PROSE_WINDOW = 20
 
-# Both card includes. ``{%-`` whitespace-control variants are the majority in
-# 2026-03-06; matching only ``{%`` undercounts the corpus by 54 cards.
-CARD_RE = re.compile(
-    r"\{%-?\s*include\s+(?:news-card|news-spotlight-item)\.html.*?-?%\}",
-    re.DOTALL,
-)
-SPOTLIGHT_RE = re.compile(
-    r"\{%-?\s*include\s+news-spotlight-item\.html.*?-?%\}",
-    re.DOTALL,
-)
-SUMMARY_RE = re.compile(
-    r'(\bsummary=")(.*?)("(?=\s+[\w-]+="|\s*-?%\}|\s*$))',
-    re.DOTALL,
-)
-
 # Drop mode deletes whole lines, so the attribute must OWN its line. Measured:
 # 45/45 spotlight defects match this; a value that ever wrapped would be skipped
-# rather than half-deleted.
+# rather than half-deleted. Local to this script — it is a line-ownership test
+# for the drop mechanic, not a card pattern.
 SUMMARY_LINE_RE = re.compile(r'^[ \t]*summary="[^"\n]*"[ \t]*$')
 
-# Independent of the rules: reads attribute NAMES straight off each card so the
-# drop contract has its own detector (contract C5).
+# Independent of the shared patterns ON PURPOSE (contract C5): the drop contract
+# audits card count and attribute order, so its detector must not be the same
+# regex the rule uses, or both regress together.
 _ATTR_NAME_RE = re.compile(r'(?m)^[ \t]*([\w-]+)="')
 _INCLUDE_NAME_RE = re.compile(r"\{%-?\s*include\s+([\w.-]+)")
 

--- a/scripts/tests/test_news_card_patterns.py
+++ b/scripts/tests/test_news_card_patterns.py
@@ -145,14 +145,15 @@ def test_summary_as_the_last_attribute_before_a_dash_close():
 # --- consumers stay wired to this module (C8 drift guard) --------------------
 
 
-@pytest.mark.parametrize(
-    "script",
-    [
-        "rewind_truncated_summaries.py",
-        "backfill_card_summary_period.py",
-        "backfill_digest_titles.py",
-    ],
-)
+CONSUMERS = [
+    "rewind_truncated_summaries.py",
+    "backfill_card_summary_period.py",
+    "backfill_digest_titles.py",
+    "rewrite_template_echo_summaries.py",
+]
+
+
+@pytest.mark.parametrize("script", CONSUMERS)
 def test_consumers_import_the_shared_pattern_instead_of_redeclaring(script):
     """A re-declared `\\{%\\s*include` in any consumer reopens the C11 hole."""
     src = (REPO / "scripts" / script).read_text(encoding="utf-8")
@@ -160,3 +161,81 @@ def test_consumers_import_the_shared_pattern_instead_of_redeclaring(script):
     assert not re.search(r'r"\\\{%\\s\*include', src), (
         f"{script} re-declares a `-`-blind include pattern"
     )
+
+
+@pytest.mark.parametrize("script", CONSUMERS)
+def test_consumers_do_not_redeclare_a_card_or_summary_pattern(script):
+    """Even a CORRECT copy is a C8 violation — two definitions can drift apart.
+
+    ``rewrite_template_echo_summaries`` shipped its own ``\\{%-?\\s*include``
+    trio: right pattern, wrong place. The import-presence assertion above cannot
+    see that, so pin the assignment forms too.
+    """
+    src = (REPO / "scripts" / script).read_text(encoding="utf-8")
+    offenders = re.findall(
+        r"(?m)^(CARD_RE|CARD_OPEN_RE|SUMMARY_RE|SPOTLIGHT_RE|NEWS_CARD_RE)\s*=\s*re\.compile",
+        src,
+    )
+    assert offenders == [], f"{script} re-declares {offenders}"
+
+
+# --- per-kind block patterns --------------------------------------------------
+
+
+def test_block_re_rejects_an_unknown_include_kind():
+    with pytest.raises(ValueError):
+        ncp.block_re("news-spotlight-section")
+
+
+@pytest.mark.parametrize("kind", ncp.CARD_INCLUDES)
+def test_every_kind_has_a_block_pattern(kind):
+    assert kind in ncp.BLOCK_RE_BY_KIND
+
+
+def test_per_kind_blocks_partition_the_corpus(corpus):
+    """C11 for the single-kind patterns: the parts must sum to the whole."""
+    mismatches = []
+    for path, text in corpus:
+        whole = len(ncp.CARD_RE.findall(text))
+        parts = sum(len(rx.findall(text)) for rx in ncp.BLOCK_RE_BY_KIND.values())
+        if whole != parts:
+            mismatches.append((path.name, whole, parts))
+    assert mismatches == []
+
+
+def test_spotlight_re_never_matches_a_news_card():
+    card = '{%- include news-card.html\n  summary="가나다."\n-%}'
+    assert ncp.SPOTLIGHT_RE.findall(card) == []
+    assert len(ncp.NEWS_CARD_RE.findall(card)) == 1
+
+
+@pytest.mark.parametrize("dash", ["", "-"])
+def test_spotlight_re_matches_both_whitespace_control_forms(dash):
+    snippet = f'{{%{dash} include news-spotlight-item.html\n  summary="가나다."\n{dash}%}}'
+    assert len(ncp.SPOTLIGHT_RE.findall(snippet)) == 1
+
+
+# --- hyphenated attribute names (Jekyll's own grammar) -----------------------
+
+
+def test_summary_value_stops_at_a_hyphenated_attribute_name():
+    """``Jekyll::Tags::IncludeTag::VALID_SYNTAX`` is ``([\\w-]+)\\s*=\\s*…``, so a
+    hyphenated parameter name is legal Jekyll. With ``\\w+`` in the lookahead the
+    summary value would swallow it."""
+    snippet = (
+        "{% include news-card.html\n"
+        '  summary="가나다."\n'
+        '  aria-label="x"\n'
+        "%}"
+    )
+    assert ncp.SUMMARY_RE.search(snippet).group(2) == "가나다."
+
+
+def test_summary_value_still_stops_at_an_underscored_attribute_name():
+    snippet = (
+        "{% include news-card.html\n"
+        '  summary="가나다."\n'
+        '  aria_label="x"\n'
+        "%}"
+    )
+    assert ncp.SUMMARY_RE.search(snippet).group(2) == "가나다."

--- a/scripts/tests/test_rewrite_template_echo_summaries.py
+++ b/scripts/tests/test_rewrite_template_echo_summaries.py
@@ -1,0 +1,315 @@
+"""Tests for scripts/rewrite_template_echo_summaries.py.
+
+Measured on the corpus 2026-08-07, before any code was written:
+
+* 271 template-echo summaries in 24 digests — 226 ``news-card`` + 45
+  ``news-spotlight-item`` (matching only ``{%`` and only ``news-card`` finds 61)
+* 221 of the 226 ``news-card`` items are followed by a prose paragraph
+* **0** of the 45 ``news-spotlight-item`` entries are. They sit back to back
+  inside a ``{% capture %}`` block, so the "prose" 20 lines below belongs to the
+  트렌드 분석 section, not to the article
+
+The transform therefore repairs only what the post can actually evidence, and
+the runtime contract pins the rest: nothing outside a card ``summary=`` value
+may move.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import rewrite_template_echo_summaries as rw  # noqa: E402
+
+_FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
+
+_ECHO = (
+    "Cisco 취약점 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, "
+    "탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+)
+_PROSE = (
+    "Cisco가 Catalyst SD-WAN Manager에 영향을 미치는 2개의 취약점이 실제 공격에 "
+    "활용되고 있음을 공식 확인했습니다. 핵심 취약점인 CVE-2026-20122는 인증된 원격 "
+    "공격자가 임의 파일을 덮어쓸 수 있는 결함입니다."
+)
+
+
+def _card(summary=_ECHO, dash=False, image=None):
+    open_tag = "{%- include" if dash else "{% include"
+    close_tag = "-%}" if dash else "%}"
+    lines = [
+        f"{open_tag} news-card.html",
+        '  title="[보안] Cisco 취약점 공개"',
+        '  url="https://example.com/a?utm_source=rss"',
+    ]
+    if image:
+        lines.append(f'  image="{image}"')
+    lines += [
+        f'  summary="{summary}"',
+        '  source="The Hacker News"',
+        '  severity="High"',
+        close_tag,
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _post(body):
+    return _FM + body
+
+
+def _summary_of(text, index=0):
+    cards = list(rw.CARD_RE.finditer(text))
+    return rw.SUMMARY_RE.search(cards[index].group(0)).group(2)
+
+
+# --- the rewrite -------------------------------------------------------------
+
+
+def test_template_echo_summary_is_replaced_with_the_following_prose():
+    out = rw.transform(_post(_card() + "\n" + _PROSE + "\n"))
+    assert "공격 벡터와 영향 범위를 점검하고" not in out
+    assert "CVE-2026-20122" in _summary_of(out)
+
+
+def test_whitespace_control_variant_is_matched():
+    out = rw.transform(_post(_card(dash=True) + "\n" + _PROSE + "\n"))
+    assert "CVE-2026-20122" in _summary_of(out)
+
+
+def test_summary_heading_between_card_and_prose_is_skipped():
+    body = _card() + "\n#### 요약\n\n" + _PROSE + "\n"
+    assert "CVE-2026-20122" in _summary_of(rw.transform(_post(body)))
+
+
+def test_at_most_two_sentences_are_lifted():
+    prose = "첫 번째 문장은 이 기사에 대한 충분한 길이의 설명입니다. 두 번째 문장도 마찬가지로 충분히 깁니다. 세 번째 문장은 버려져야 합니다."
+    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    assert "세 번째 문장" not in _summary_of(out)
+    assert "두 번째 문장" in _summary_of(out)
+
+
+def test_summary_stays_within_the_generator_cap():
+    prose = "가" * 260 + "라고 보고되었습니다. 두 번째 문장입니다."
+    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    for card in rw.CARD_RE.finditer(out):
+        found = rw.SUMMARY_RE.search(card.group(0))
+        assert len(found.group(2)) <= rw.MAX_SUMMARY_LEN
+
+
+def test_no_text_is_invented_when_the_helper_would_pad():
+    """``_truncate_korean_sentence`` appends "… 등이 확인되었습니다." on its fallback
+    path. A generator may write that; a corpus rewrite may not."""
+    prose = ("첫 문장은 아주 길게 이어지는 설명으로 " * 12).strip() + "입니다. 두 번째 문장입니다."
+    src = _post(_card() + "\n" + prose + "\n")
+    assert rw.transform(src) == src
+
+
+def test_the_replacement_is_copied_from_the_post_body():
+    body = _card() + "\n" + _PROSE + "\n"
+    value = _summary_of(rw.transform(_post(body)))
+    assert value in _PROSE, "every character must come from the paragraph below"
+
+
+def test_transform_is_idempotent():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    once = rw.transform(src)
+    assert rw.transform(once) == once
+
+
+# --- what it must NOT touch --------------------------------------------------
+
+
+def test_non_template_summary_is_left_alone():
+    src = _post(_card(summary="이미 기사 고유의 사실을 담은 요약입니다.") + "\n" + _PROSE + "\n")
+    assert rw.transform(src) == src
+
+
+def test_other_attributes_are_byte_identical():
+    image = (
+        "https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBo"
+        ".jpg?w=1&u=https://s3.example.com/x.jpg"
+    )
+    src = _post(_card(image=image) + "\n" + _PROSE + "\n")
+    out = rw.transform(src)
+    assert out != src
+    assert f'  image="{image}"' in out
+    assert '  url="https://example.com/a?utm_source=rss"' in out
+
+
+def test_multiline_liquid_include_is_untouched_outside_the_summary():
+    """T1: the corrupted cover images of PR #509 came from exactly this shape."""
+    src = _post(_card(image="https://cdn.example.com/p/https://s3.example.com/a.jpg"))
+    src += "\n" + _PROSE + "\n"
+    out = rw.transform(src)
+    assert not rw.violates_summary_only(src, out)
+
+
+def test_front_matter_is_never_edited():
+    fm = (
+        "---\nlayout: post\n"
+        'description: "… 공격 벡터와 영향 범위를 점검하고, 대응 체크리스트를 제시합니다."\n'
+        "---\n\n"
+    )
+    src = fm + _card() + "\n" + _PROSE + "\n"
+    out = rw.transform(src)
+    assert out.startswith(fm)
+
+
+def test_card_inside_a_code_fence_is_not_rewritten():
+    src = _post("```liquid\n" + _card() + "```\n\n" + _PROSE + "\n")
+    assert rw.transform(src) == src
+
+
+def test_indented_closing_fence_closes_the_block():
+    """T3: 2026-02-08 closes its fences with leading whitespace."""
+    src = _post("```text\nnoise\n  ```\n\n" + _card() + "\n" + _PROSE + "\n")
+    assert "CVE-2026-20122" in _summary_of(rw.transform(src))
+
+
+def test_spotlight_items_packed_in_a_capture_block_are_skipped():
+    """The measured reality: 45/45 spotlight defects have no prose of their own."""
+    item = (
+        "{% include news-spotlight-item.html\n"
+        '  title="Nano Banana 프롬프팅 가이드"\n'
+        '  url="https://example.com/n"\n'
+        '  source="Google Cloud Blog"\n'
+        '  tag="Cloud / Platform"\n'
+        f'  summary="{_ECHO}"\n'
+        "%}\n"
+    )
+    src = _post("{% capture spotlight_items %}\n" + item + item + "{% endcapture %}\n")
+    assert rw.transform(src) == src
+
+
+def test_card_followed_by_a_table_is_skipped():
+    table = "| 원칙 | 설명 |\n|------|------|\n| 투명성 | 설명가능성 요건 |\n"
+    src = _post(_card() + "\n" + table)
+    assert rw.transform(src) == src
+
+
+def test_card_followed_by_a_bullet_lead_in_is_skipped():
+    src = _post(_card() + "\n이번 기간 추가 발간물:\n\n- EQST Insight (1월호)\n")
+    assert rw.transform(src) == src
+
+
+def test_prose_that_is_not_a_finished_sentence_is_skipped():
+    src = _post(_card() + "\n주요 구성요소는 다음 세 가지 항목으로 구성되어 있습니다:\n")
+    assert rw.transform(src) == src
+
+
+# --- Liquid attribute safety -------------------------------------------------
+
+
+@pytest.mark.parametrize("quote", ['"', "“", "”", "‘", "’"])
+def test_quotes_in_the_prose_never_reach_the_attribute(quote):
+    prose = (
+        f"공격자들은 이미 {quote}지금 수집, 나중에 복호화{quote} 전략을 실행하고 있습니다. "
+        "현재의 암호화된 데이터가 안전하다는 가정은 유효하지 않습니다."
+    )
+    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    value = _summary_of(out)
+    assert "지금 수집" in value, "the sentence should still be lifted"
+    for unsafe in ('"', "“", "”"):
+        assert unsafe not in value
+
+
+def test_prose_containing_liquid_is_rejected():
+    src = _post(_card() + "\n" + "이 문단은 {% raw %} 태그를 포함하는 긴 설명 문장입니다.\n")
+    assert rw.transform(src) == src
+
+
+def test_markdown_emphasis_and_code_spans_are_stripped():
+    prose = "**개발자 도구**가 새로운 공격 표면으로 부상했으며 `go.sum` 검증이 필요하다고 보고되었습니다."
+    value = _summary_of(rw.transform(_post(_card() + "\n" + prose + "\n")))
+    assert "**" not in value and "`" not in value
+    assert "개발자 도구" in value and "go.sum" in value
+
+
+# --- runtime contract --------------------------------------------------------
+
+
+def test_violates_summary_only_accepts_a_summary_change():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    assert not rw.violates_summary_only(src, rw.transform(src))
+
+
+def test_violates_summary_only_catches_an_edit_outside_the_card():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    tampered = src.replace("The Hacker News", "Other Source")
+    assert rw.violates_summary_only(src, tampered)
+
+
+def test_violates_summary_only_catches_an_edit_to_the_prose():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    tampered = src.replace("CVE-2026-20122", "CVE-2026-99999")
+    assert rw.violates_summary_only(src, tampered)
+
+
+def test_main_aborts_when_the_contract_is_violated(tmp_path, monkeypatch):
+    post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
+    post.write_text(_post(_card() + "\n" + _PROSE + "\n"), encoding="utf-8")
+    monkeypatch.setattr(rw, "transform", lambda text: text.replace("High", "Low"))
+    assert rw.main([str(post)]) == 1
+    assert "High" in post.read_text(encoding="utf-8"), "the file must not be written"
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_dry_run_does_not_write(tmp_path):
+    post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    post.write_text(src, encoding="utf-8")
+    assert rw.main([str(post), "--dry-run"]) == 0
+    assert post.read_text(encoding="utf-8") == src
+
+
+def test_cli_writes_without_dry_run(tmp_path):
+    post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
+    post.write_text(_post(_card() + "\n" + _PROSE + "\n"), encoding="utf-8")
+    assert rw.main([str(post)]) == 0
+    assert "CVE-2026-20122" in _summary_of(post.read_text(encoding="utf-8"))
+
+
+def test_non_digest_post_is_skipped(tmp_path):
+    post = tmp_path / "2026-03-11-Some_Guide.md"
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    post.write_text(src, encoding="utf-8")
+    assert rw.main([str(post)]) == 0
+    assert post.read_text(encoding="utf-8") == src
+
+
+def test_cli_has_no_all_flag():
+    """C6: a writing mode must never default to the whole corpus."""
+    proc = subprocess.run(
+        [sys.executable, str(REPO / "scripts" / "rewrite_template_echo_summaries.py"), "--all"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode != 0
+    assert "unrecognized arguments" in proc.stderr
+
+
+# --- single source of truth --------------------------------------------------
+
+
+def test_uses_the_generator_truncation_helper():
+    """C8: the corpus and the generator must agree on where a sentence may cut."""
+    from scripts.news.content_generator import _truncate_korean_sentence
+
+    assert rw._truncate_korean_sentence is _truncate_korean_sentence
+
+
+# --- corpus ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path", sorted((REPO / "_posts").glob("*Weekly_Digest*.md")), ids=lambda p: p.name
+)
+def test_corpus_transform_never_escapes_the_summary(path):
+    original = path.read_text(encoding="utf-8")
+    assert not rw.violates_summary_only(original, rw.transform(original))

--- a/scripts/tests/test_rewrite_template_echo_summaries.py
+++ b/scripts/tests/test_rewrite_template_echo_summaries.py
@@ -9,9 +9,13 @@ Measured on the corpus 2026-08-07, before any code was written:
   inside a ``{% capture %}`` block, so the "prose" 20 lines below belongs to the
   트렌드 분석 section, not to the article
 
-The transform therefore repairs only what the post can actually evidence, and
-the runtime contract pins the rest: nothing outside a card ``summary=`` value
-may move.
+REPLACE mode therefore repairs only what the post can actually evidence. DROP
+mode deletes the ``summary=`` attribute of the 45 spotlight items, because a
+sentence claiming an analysis nobody performed is worse than no sentence.
+
+The two modes carry separate runtime contracts and these tests keep them
+separate: replace may only touch a summary VALUE, drop may only delete whole
+spotlight summary LINES. Neither may launder a change through the other.
 """
 
 import subprocess
@@ -57,6 +61,30 @@ def _card(summary=_ECHO, dash=False, image=None):
     return "\n".join(lines) + "\n"
 
 
+def _spotlight(summary=_ECHO, title="Nano Banana 프롬프팅 가이드", trailing=False):
+    """A spotlight item shaped like the corpus: summary last, one attr per line."""
+    lines = [
+        "{% include news-spotlight-item.html",
+        f'  title="{title}"',
+        '  url="https://example.com/n"',
+        '  source="Google Cloud Blog"',
+        '  tag="Cloud / Platform"',
+    ]
+    if summary is None:
+        pass
+    elif trailing:
+        # 3 of the 45 keep an attribute after `summary=`.
+        lines.insert(-1, f'  summary="{summary}"')
+    else:
+        lines.append(f'  summary="{summary}"')
+    lines.append("%}")
+    return "\n".join(lines) + "\n"
+
+
+def _capture(*items):
+    return "{% capture spotlight_items %}\n" + "".join(items) + "{% endcapture %}\n"
+
+
 def _post(body):
     return _FM + body
 
@@ -70,31 +98,31 @@ def _summary_of(text, index=0):
 
 
 def test_template_echo_summary_is_replaced_with_the_following_prose():
-    out = rw.transform(_post(_card() + "\n" + _PROSE + "\n"))
+    out = rw.replace_echo_summaries(_post(_card() + "\n" + _PROSE + "\n"))
     assert "공격 벡터와 영향 범위를 점검하고" not in out
     assert "CVE-2026-20122" in _summary_of(out)
 
 
 def test_whitespace_control_variant_is_matched():
-    out = rw.transform(_post(_card(dash=True) + "\n" + _PROSE + "\n"))
+    out = rw.replace_echo_summaries(_post(_card(dash=True) + "\n" + _PROSE + "\n"))
     assert "CVE-2026-20122" in _summary_of(out)
 
 
 def test_summary_heading_between_card_and_prose_is_skipped():
     body = _card() + "\n#### 요약\n\n" + _PROSE + "\n"
-    assert "CVE-2026-20122" in _summary_of(rw.transform(_post(body)))
+    assert "CVE-2026-20122" in _summary_of(rw.replace_echo_summaries(_post(body)))
 
 
 def test_at_most_two_sentences_are_lifted():
     prose = "첫 번째 문장은 이 기사에 대한 충분한 길이의 설명입니다. 두 번째 문장도 마찬가지로 충분히 깁니다. 세 번째 문장은 버려져야 합니다."
-    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    out = rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n"))
     assert "세 번째 문장" not in _summary_of(out)
     assert "두 번째 문장" in _summary_of(out)
 
 
 def test_summary_stays_within_the_generator_cap():
     prose = "가" * 260 + "라고 보고되었습니다. 두 번째 문장입니다."
-    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    out = rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n"))
     for card in rw.CARD_RE.finditer(out):
         found = rw.SUMMARY_RE.search(card.group(0))
         assert len(found.group(2)) <= rw.MAX_SUMMARY_LEN
@@ -105,19 +133,19 @@ def test_no_text_is_invented_when_the_helper_would_pad():
     path. A generator may write that; a corpus rewrite may not."""
     prose = ("첫 문장은 아주 길게 이어지는 설명으로 " * 12).strip() + "입니다. 두 번째 문장입니다."
     src = _post(_card() + "\n" + prose + "\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_the_replacement_is_copied_from_the_post_body():
     body = _card() + "\n" + _PROSE + "\n"
-    value = _summary_of(rw.transform(_post(body)))
+    value = _summary_of(rw.replace_echo_summaries(_post(body)))
     assert value in _PROSE, "every character must come from the paragraph below"
 
 
-def test_transform_is_idempotent():
+def test_replace_is_idempotent():
     src = _post(_card() + "\n" + _PROSE + "\n")
-    once = rw.transform(src)
-    assert rw.transform(once) == once
+    once = rw.replace_echo_summaries(src)
+    assert rw.replace_echo_summaries(once) == once
 
 
 # --- what it must NOT touch --------------------------------------------------
@@ -125,7 +153,7 @@ def test_transform_is_idempotent():
 
 def test_non_template_summary_is_left_alone():
     src = _post(_card(summary="이미 기사 고유의 사실을 담은 요약입니다.") + "\n" + _PROSE + "\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_other_attributes_are_byte_identical():
@@ -134,7 +162,7 @@ def test_other_attributes_are_byte_identical():
         ".jpg?w=1&u=https://s3.example.com/x.jpg"
     )
     src = _post(_card(image=image) + "\n" + _PROSE + "\n")
-    out = rw.transform(src)
+    out = rw.replace_echo_summaries(src)
     assert out != src
     assert f'  image="{image}"' in out
     assert '  url="https://example.com/a?utm_source=rss"' in out
@@ -144,7 +172,7 @@ def test_multiline_liquid_include_is_untouched_outside_the_summary():
     """T1: the corrupted cover images of PR #509 came from exactly this shape."""
     src = _post(_card(image="https://cdn.example.com/p/https://s3.example.com/a.jpg"))
     src += "\n" + _PROSE + "\n"
-    out = rw.transform(src)
+    out = rw.replace_echo_summaries(src)
     assert not rw.violates_summary_only(src, out)
 
 
@@ -155,50 +183,41 @@ def test_front_matter_is_never_edited():
         "---\n\n"
     )
     src = fm + _card() + "\n" + _PROSE + "\n"
-    out = rw.transform(src)
+    out = rw.replace_echo_summaries(src)
     assert out.startswith(fm)
 
 
 def test_card_inside_a_code_fence_is_not_rewritten():
     src = _post("```liquid\n" + _card() + "```\n\n" + _PROSE + "\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_indented_closing_fence_closes_the_block():
     """T3: 2026-02-08 closes its fences with leading whitespace."""
     src = _post("```text\nnoise\n  ```\n\n" + _card() + "\n" + _PROSE + "\n")
-    assert "CVE-2026-20122" in _summary_of(rw.transform(src))
+    assert "CVE-2026-20122" in _summary_of(rw.replace_echo_summaries(src))
 
 
 def test_spotlight_items_packed_in_a_capture_block_are_skipped():
     """The measured reality: 45/45 spotlight defects have no prose of their own."""
-    item = (
-        "{% include news-spotlight-item.html\n"
-        '  title="Nano Banana 프롬프팅 가이드"\n'
-        '  url="https://example.com/n"\n'
-        '  source="Google Cloud Blog"\n'
-        '  tag="Cloud / Platform"\n'
-        f'  summary="{_ECHO}"\n'
-        "%}\n"
-    )
-    src = _post("{% capture spotlight_items %}\n" + item + item + "{% endcapture %}\n")
-    assert rw.transform(src) == src
+    src = _post(_capture(_spotlight(), _spotlight()))
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_card_followed_by_a_table_is_skipped():
     table = "| 원칙 | 설명 |\n|------|------|\n| 투명성 | 설명가능성 요건 |\n"
     src = _post(_card() + "\n" + table)
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_card_followed_by_a_bullet_lead_in_is_skipped():
     src = _post(_card() + "\n이번 기간 추가 발간물:\n\n- EQST Insight (1월호)\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_prose_that_is_not_a_finished_sentence_is_skipped():
     src = _post(_card() + "\n주요 구성요소는 다음 세 가지 항목으로 구성되어 있습니다:\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 # --- Liquid attribute safety -------------------------------------------------
@@ -210,7 +229,7 @@ def test_quotes_in_the_prose_never_reach_the_attribute(quote):
         f"공격자들은 이미 {quote}지금 수집, 나중에 복호화{quote} 전략을 실행하고 있습니다. "
         "현재의 암호화된 데이터가 안전하다는 가정은 유효하지 않습니다."
     )
-    out = rw.transform(_post(_card() + "\n" + prose + "\n"))
+    out = rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n"))
     value = _summary_of(out)
     assert "지금 수집" in value, "the sentence should still be lifted"
     for unsafe in ('"', "“", "”"):
@@ -219,22 +238,84 @@ def test_quotes_in_the_prose_never_reach_the_attribute(quote):
 
 def test_prose_containing_liquid_is_rejected():
     src = _post(_card() + "\n" + "이 문단은 {% raw %} 태그를 포함하는 긴 설명 문장입니다.\n")
-    assert rw.transform(src) == src
+    assert rw.replace_echo_summaries(src) == src
 
 
 def test_markdown_emphasis_and_code_spans_are_stripped():
     prose = "**개발자 도구**가 새로운 공격 표면으로 부상했으며 `go.sum` 검증이 필요하다고 보고되었습니다."
-    value = _summary_of(rw.transform(_post(_card() + "\n" + prose + "\n")))
+    value = _summary_of(rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n")))
     assert "**" not in value and "`" not in value
     assert "개발자 도구" in value and "go.sum" in value
 
 
-# --- runtime contract --------------------------------------------------------
+# --- drop mode ---------------------------------------------------------------
+
+
+def test_spotlight_echo_summary_line_is_deleted():
+    src = _post(_capture(_spotlight(), _spotlight(title="LeakBase 포럼 압수")))
+    out = rw.drop_spotlight_echo_summaries(src)
+    assert "summary=" not in out
+    assert out.count("news-spotlight-item.html") == 2
+
+
+def test_drop_leaves_a_valid_include_with_every_other_attribute():
+    out = rw.drop_spotlight_echo_summaries(_post(_capture(_spotlight())))
+    assert out.count("{% include news-spotlight-item.html") == 1
+    assert out.count("%}") == _post(_capture(_spotlight())).count("%}")
+    for attr in ("title=", "url=", "source=", "tag="):
+        assert attr in out
+    assert "\n\n%}" not in out, "no blank line should be left where the attr was"
+
+
+def test_drop_keeps_a_trailing_attribute_after_the_summary():
+    """3 of the 45 have another attribute after ``summary=``."""
+    src = _post(_capture(_spotlight(trailing=True)))
+    out = rw.drop_spotlight_echo_summaries(src)
+    assert "summary=" not in out
+    assert '  tag="Cloud / Platform"' in out
+
+
+def test_drop_is_idempotent():
+    once = rw.drop_spotlight_echo_summaries(_post(_capture(_spotlight())))
+    assert rw.drop_spotlight_echo_summaries(once) == once
+
+
+def test_spotlight_without_the_template_phrase_is_not_dropped():
+    src = _post(_capture(_spotlight(summary="Nano Banana 프롬프팅 가이드가 공개되었습니다.")))
+    assert rw.drop_spotlight_echo_summaries(src) == src
+
+
+def test_drop_never_touches_a_news_card():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    assert rw.drop_spotlight_echo_summaries(src) == src
+
+
+def test_drop_skips_a_fenced_spotlight_include():
+    src = _post("```liquid\n" + _spotlight() + "```\n")
+    assert rw.drop_spotlight_echo_summaries(src) == src
+
+
+def test_replace_and_drop_stay_in_their_own_lane():
+    src = _post(_card() + "\n" + _PROSE + "\n\n" + _capture(_spotlight()))
+    replaced = rw.replace_echo_summaries(src)
+    dropped = rw.drop_spotlight_echo_summaries(src)
+    assert "CVE-2026-20122" in replaced and _ECHO in replaced, "spotlight untouched"
+    assert _ECHO in dropped.split("news-card.html")[1].split("%}")[0], "card untouched"
+    assert dropped.count("summary=") == src.count("summary=") - 1
+
+
+def test_both_modes_compose_into_transform():
+    src = _post(_card() + "\n" + _PROSE + "\n\n" + _capture(_spotlight()))
+    out = rw.transform(src)
+    assert rw.count_defects(out) == 0
+
+
+# --- runtime contract: replace -----------------------------------------------
 
 
 def test_violates_summary_only_accepts_a_summary_change():
     src = _post(_card() + "\n" + _PROSE + "\n")
-    assert not rw.violates_summary_only(src, rw.transform(src))
+    assert not rw.violates_summary_only(src, rw.replace_echo_summaries(src))
 
 
 def test_violates_summary_only_catches_an_edit_outside_the_card():
@@ -249,15 +330,90 @@ def test_violates_summary_only_catches_an_edit_to_the_prose():
     assert rw.violates_summary_only(src, tampered)
 
 
-def test_main_aborts_when_the_contract_is_violated(tmp_path, monkeypatch):
+# --- runtime contract: drop --------------------------------------------------
+
+
+def test_drop_contract_accepts_the_line_deletion():
+    src = _post(_capture(_spotlight()))
+    out = rw.drop_spotlight_echo_summaries(src)
+    assert out != src
+    assert not rw.violates_spotlight_line_drop_only(src, out)
+
+
+def test_drop_contract_rejects_deleting_another_attribute():
+    src = _post(_capture(_spotlight()))
+    tampered = src.replace('  url="https://example.com/n"\n', "")
+    assert rw.violates_spotlight_line_drop_only(src, tampered)
+
+
+def test_drop_contract_rejects_deleting_a_news_card_summary():
+    src = _post(_card() + "\n" + _PROSE + "\n")
+    tampered = src.replace(f'  summary="{_ECHO}"\n', "")
+    assert rw.violates_spotlight_line_drop_only(src, tampered)
+
+
+def test_drop_contract_rejects_a_rewrite_dressed_as_a_deletion():
+    src = _post(_capture(_spotlight()))
+    tampered = src.replace(_ECHO, "새로 지어낸 요약입니다.")
+    assert rw.violates_spotlight_line_drop_only(src, tampered)
+
+
+def test_drop_contract_rejects_added_lines():
+    src = _post(_capture(_spotlight()))
+    assert rw.violates_spotlight_line_drop_only(src, src + "\n추가된 줄\n")
+
+
+def test_drop_contract_rejects_losing_a_whole_card():
+    src = _post(_capture(_spotlight(), _spotlight(title="LeakBase 포럼 압수")))
+    tampered = src.replace(_spotlight(title="LeakBase 포럼 압수"), "")
+    assert rw.violates_spotlight_line_drop_only(src, tampered)
+
+
+def test_card_shape_detector_is_independent_of_the_drop_rule():
+    """C5: the audit must not call the rule's line bookkeeping."""
+    src = _post(_capture(_spotlight()))
+    shapes = rw._card_attribute_shapes(src)
+    assert shapes == [
+        ("news-spotlight-item.html", ["title", "url", "source", "tag", "summary"])
+    ]
+
+
+@pytest.mark.parametrize("mode", ["replace", "drop"])
+def test_main_aborts_when_a_mode_breaks_its_contract(mode, tmp_path, monkeypatch):
     post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
-    post.write_text(_post(_card() + "\n" + _PROSE + "\n"), encoding="utf-8")
-    monkeypatch.setattr(rw, "transform", lambda text: text.replace("High", "Low"))
+    src = _post(_card() + "\n" + _PROSE + "\n\n" + _capture(_spotlight()))
+    post.write_text(src, encoding="utf-8")
+    rule, contract = rw.MODES[mode]
+    monkeypatch.setitem(
+        rw.MODES, mode, (lambda text: text.replace("High", "Low"), contract)
+    )
     assert rw.main([str(post)]) == 1
-    assert "High" in post.read_text(encoding="utf-8"), "the file must not be written"
+    assert post.read_text(encoding="utf-8") == src, "the file must not be written"
 
 
 # --- CLI ---------------------------------------------------------------------
+
+
+def test_cli_mode_replace_leaves_spotlight_alone(tmp_path):
+    post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
+    post.write_text(
+        _post(_card() + "\n" + _PROSE + "\n\n" + _capture(_spotlight())),
+        encoding="utf-8",
+    )
+    assert rw.main([str(post), "--mode", "replace"]) == 0
+    assert _ECHO in post.read_text(encoding="utf-8")
+
+
+def test_cli_mode_drop_leaves_news_card_alone(tmp_path):
+    post = tmp_path / "2026-03-11-Weekly_Digest_x.md"
+    post.write_text(
+        _post(_card() + "\n" + _PROSE + "\n\n" + _capture(_spotlight())),
+        encoding="utf-8",
+    )
+    assert rw.main([str(post), "--mode", "drop"]) == 0
+    body = post.read_text(encoding="utf-8")
+    assert _summary_of(body) == _ECHO, "the news-card echo must survive drop mode"
+    assert body.count("summary=") == 1
 
 
 def test_cli_dry_run_does_not_write(tmp_path):
@@ -310,6 +466,24 @@ def test_uses_the_generator_truncation_helper():
 @pytest.mark.parametrize(
     "path", sorted((REPO / "_posts").glob("*Weekly_Digest*.md")), ids=lambda p: p.name
 )
-def test_corpus_transform_never_escapes_the_summary(path):
+def test_corpus_replace_never_escapes_the_summary(path):
     original = path.read_text(encoding="utf-8")
-    assert not rw.violates_summary_only(original, rw.transform(original))
+    assert not rw.violates_summary_only(original, rw.replace_echo_summaries(original))
+
+
+@pytest.mark.parametrize(
+    "path", sorted((REPO / "_posts").glob("*Weekly_Digest*.md")), ids=lambda p: p.name
+)
+def test_corpus_drop_only_removes_spotlight_summary_lines(path):
+    original = path.read_text(encoding="utf-8")
+    dropped = rw.drop_spotlight_echo_summaries(original)
+    assert not rw.violates_spotlight_line_drop_only(original, dropped)
+
+
+@pytest.mark.parametrize(
+    "path", sorted((REPO / "_posts").glob("*Weekly_Digest*.md")), ids=lambda p: p.name
+)
+def test_corpus_both_modes_are_idempotent(path):
+    original = path.read_text(encoding="utf-8")
+    once = rw.transform(original)
+    assert rw.transform(once) == once


### PR DESCRIPTION
## 무엇을 바꿨나요

다이제스트 뉴스 카드의 `summary=` 가 **제목을 축자 반복한 뒤 기사와 무관한 고정 문구**를 붙이던 것을, 같은 포스트 본문에서 뽑은 실제 사실로 교체합니다. **파일럿 2포스트 / 23건만** 적용했습니다.

전체 규모는 271건 / 24포스트(2026-02-20 ~ 03-17)이며, **이 PR은 게이트가 어떻게 반응하는지 보는 것이 목적**입니다.

## 왜 필요한가요

요약이 정보를 0으로 전달할 뿐 아니라, 보안 사건이 아닌 기사에 **하지 않은 보안 분석을 했다고 주장**합니다.

| 기사 성격 | 제목 | 요약이 주장하는 것 |
| :--- | :--- | :--- |
| 인사 발령 | `[AI/ML] OpenAI, Arvind KC를 최고인사책임자(CPO)로 임명` | 공격 경로·영향 자산·탐지 포인트를 정리 |
| 시세 | `[블록체인] 토큰화 금, 주말 가격 발견의 100%를 주도` | 공격 벡터·영향 범위 점검, 탐지·차단·복구 우선 대응 |
| 컨퍼런스 일정 | `KubeCon + CloudNativeCon Europe 2026 … Open Sovereign Cloud Day` | 동일 |
| 제품 GA 공지 | `[클라우드] Google Cloud H4D VM 정식 출시 (GA)` | 동일 |

## 전후 예시

**`2026-03-06:104`**
- before: `Cisco Catalyst SD-WAN Manager 취약점 활성 공격 확인 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다.`
- after: `Cisco가 Catalyst SD-WAN Manager(구 SD-WAN vManage)에 영향을 미치는 2개의 취약점이 실제 공격에 활용되고 있음을 공식 확인했습니다. 핵심 취약점인 CVE-2026-20122(CVSS 7.1)는 인증된 원격 공격자가 로컬 파일 시스템의 임의 파일을 덮어쓸 수 있는 취약점입니다.`

**`2026-03-11:217`** (제목의 `를` 조사 오류까지 그대로 실려 있던 사례)
- before: `Bitcoin 오더북 불균형 심화 — $70K 지지선 유지 여부 주목**를** 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, …`
- after: `Bitcoin 오더북에서 매도 벽(sell wall)이 매수 주문 대비 크게 우세한 불균형이 관측되고 있습니다. $70K 지지선이 무너질 경우 대규모 청산(liquidation)이 연쇄적으로 발생할 수 있어 시장 변동성이 급격히 확대될 가능성이 있습니다.`

## 런타임 계약

> 카드 `summary=` 의 **값** 외에는 단 1바이트도 달라질 수 없다.

`violates_summary_only(old, new)` — 양쪽 파일의 모든 카드 summary 값을 마스킹한 뒤 **바이트 비교**. `image=` 속성·URL·front matter·본문 어디로든 새면 파일 스킵이 아니라 **프로세스 `exit 1`**. PR #509가 커버 이미지를 깬 바로 그 자리라 의도적으로 가장 좁게 잡았습니다.

**부가 계약**: `_truncate_korean_sentence` 를 import 하는데(계약 C8, 단일 진실 원천), 그 헬퍼의 word-boundary 폴백이 `"… 등이 확인되었습니다."` 를 **덧붙입니다**. 생성기는 문장을 지어도 되지만 코퍼스 백필은 안 되므로 **결과가 원문의 접두사가 아니면 기각**합니다. 이 가드가 222 → 220건으로 줄였습니다.

네트워크/LLM 호출 없음. 교체 텍스트는 전부 같은 포스트에서 복사합니다.

## 착수 전 전제가 실측으로 뒤집혔습니다

조사 단계에서 "271/271이 사용 가능한 산문 보유"라고 판단했으나 **거짓이었습니다.**

`news-spotlight-item` 45건은 `{% capture spotlight_items %}` 블록 안에 **서로 연달아 붙어** 있습니다. N번째 항목 다음 줄은 N+1번째 항목의 속성이고, 20줄 창을 끝까지 밀면 `## 트렌드 분석` 섹션 산문에 닿습니다 — 그 기사 얘기가 아닙니다. 초기 스캔이 `intro="이 섹션은…"` 같은 **Liquid 속성 연속 줄**을 산문으로 센 것이 원인입니다.

| include | 결함 | 자기 기사 산문 보유 |
| :--- | ---: | ---: |
| `news-card` | 226 | **221** (5건은 표/불릿/헤딩이 뒤따름) |
| `news-spotlight-item` | 45 | **0** |

특례 분기를 만들지 않고 산문 창이 아무것도 못 찾아 **자연히 스킵**되게 뒀습니다. 전수 dry-run: **271건 중 220건 자동 대상**.

## 검증 근거 — 게이트 11종, 실패 0

```
pytest scripts/tests/ -q                       3435 passed, 8 skipped in 11.61s
check_digest_proper_nouns.py --staged          OK - 2 digest post(s), 0 violations
check_digest_structure.py --ratchet --staged   OK - 2 checked, 0 new, 0 carried over
validate_post_quality.py                       85/100 (03-06), 94/100 (03-11)
check_post_quote_safety.py                     (no output) exit 0
check_digest_checklist_heading.py              OK - 2 digest(s), 0 violations
check_digest_untranslated.py                   OK - 2 checked, 0 violations
linkify_bare_urls.py --check --staged          OK - 2 post(s), 0 bare URLs
fix_malformed_liquid_includes.py --check       ok: scanned 258 files; no malformed
bundle exec jekyll build                       done in 11.537 seconds
pre-commit hook                                11 steps all passed (no bypass)
```

**`quality_baseline.json` 갱신 불필요** — 두 포스트 항목이 85/94로 세부 breakdown까지 변경 전후 동일합니다(요약은 카드 속성값이라 품질 스코어러가 세는 항목이 아님).

- [x] pre-commit 게이트 통과 (우회하지 않음)
- [x] 새 동작에 대한 테스트 추가 — `test_rewrite_template_echo_summaries.py` **220 passed** (`def test_` 28개 + parametrize)
- [x] CI 게이트를 완화하지 않음
- [x] 하드코딩된 시크릿 없음

테스트가 집필 중 **버그 2개를 실제로 잡았습니다**: (a) 헬퍼가 텍스트를 지어내 200자 초과, (b) `**볼드**` 로 시작하는 문단을 불릿으로 오인.

## 리뷰어가 결정해줬으면 하는 것

1. **요약이 본문 첫 문단과 같은 문장으로 시작**합니다 — 카드는 요약 박스, 본문은 상세라 렌더상 무리는 없으나 중복 노출입니다. 의도한 트레이드오프인가요? 대안(두 번째 문장부터)은 첫 문장의 핵심 사실을 잃습니다.
2. **spotlight 45건 방침** — 이 방식으로는 불가능합니다. 원문 재요약(LLM/네트워크) vs `summary=` 제거 후 include 폴백(카드에 title만 남음) 중 선택이 필요합니다.

## 확산 계획 (별도 PR)

파일럿 후 자동 대상 **197건 / 22파일**. 계약 문서 §5 Step 3대로 월 단위 파티션 권장 — 2월(9파일 ~96건) → 3월 전반(9파일 ~66건) → 3월 후반(4파일 ~35건). **단일 세션 blast 금지.**

잔여 51건 = spotlight 45 + 표·불릿이 뒤따르는 news-card 5 + 텍스트-생성 기각 1.

## 미검증

확산 배치에서 `check_digest_structure --ratchet` 이 계속 0을 유지할지는 **파일럿 2건으로만 확인**했습니다. 2월 포스트는 구조 결함이 남아 있을 수 있어(코퍼스 47건 잔존) 파티션별 재확인이 필요합니다.