### PR TITLE
fix(ci): Lighthouse 게이트를 합성 점수에서 metric 단위로 전환 — 무작위 red 제거

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -113,8 +113,19 @@ jobs:
           // full LHR it writes to the absolute path in `jsonPath`.
           // Raising a budget weakens the gate; guarded by
           // scripts/tests/test_ci_lighthouse_gate_guard.py.
+          //
+          // LCP is deliberately NOT a budget here. It is bimodal on this
+          // runner: over 60 real runs of this workflow, 55 measured
+          // 4218-4373ms and 5 measured 6921-9695ms, and the split is not
+          // caused by anything the CI controls. Runs 31150603094 and
+          // 31151236111 have the SAME observed FCP (147ms) and the same
+          // benchmarkIndex (3294 vs 3293) yet simulate 4297ms vs 9693ms — the
+          // spread is produced inside Lighthouse's Lantern simulation of a
+          // ~1.66MB page over the mobile preset (1.6Mbps / 150ms RTT / 4x CPU).
+          // Any budget between the two modes reds ~8.3% of runs for no signal.
+          // LCP is logged below instead, so the numbers keep accumulating and
+          // the budget can be recomputed once transfer weight comes down.
           const METRIC_BUDGETS = {
-            'largest-contentful-paint': { max: 4600, unit: 'ms', digits: 0 },
             'cumulative-layout-shift': { max: 0.05, unit: '', digits: 3 },
           };
 
@@ -154,12 +165,17 @@ jobs:
 
             // Observability only — never gates. Logged so a red build can be
             // triaged as "slow runner" vs "real regression" from the job log
-            // alone, without downloading the artifact.
+            // alone, without downloading the artifact. `largest-contentful-paint`
+            // is here rather than in METRIC_BUDGETS on purpose (see above); it
+            // MUST keep being printed, because these logged values are the only
+            // record from which an LCP budget can later be recomputed.
+            const lcp = (audits['largest-contentful-paint'] || {}).numericValue;
             const tbt = (audits['total-blocking-time'] || {}).numericValue;
             const bench = (lhr.environment || {}).benchmarkIndex;
             const perf = summary.performance;
             console.log(
               `  [observed, not gated] performance: ${typeof perf === 'number' ? (perf * 100).toFixed(0) : 'n/a'}` +
+              `, largest-contentful-paint: ${typeof lcp === 'number' ? lcp.toFixed(0) + 'ms' : 'n/a'}` +
               `, total-blocking-time: ${typeof tbt === 'number' ? tbt.toFixed(0) + 'ms' : 'n/a'}` +
               `, benchmarkIndex: ${typeof bench === 'number' ? bench.toFixed(0) : 'n/a'}`
             );

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -12,6 +12,17 @@ on:
       - 'vercel.json'
   pull_request:
     branches: [main]
+    # Same paths as the push trigger above. Without this filter every PR ran
+    # Lighthouse — including pure `_posts/**` content PRs that cannot move any
+    # of the measured metrics — which is where most of the random red came from.
+    paths:
+      - '_includes/**'
+      - '_layouts/**'
+      - '_sass/**'
+      - 'assets/css/**'
+      - 'assets/js/**'
+      - '_config.yml'
+      - 'vercel.json'
   workflow_dispatch:
 
 concurrency:
@@ -69,23 +80,80 @@ jobs:
       - name: Check Lighthouse scores
         run: |
           node - <<'EOF'
+          const fs = require('fs');
           const manifest = JSON.parse(process.env.LIGHTHOUSE_MANIFEST || '[]');
-          const thresholds = {
-            performance: 0.5,
+
+          // Category score gates. 'performance' is deliberately ABSENT.
+          // It is a composite in which total-blocking-time carries ~30% of the
+          // weight, and TBT on a GitHub runner is decided by the CPU the VM
+          // lottery hands out (measured over 60 runs of this workflow:
+          // benchmarkIndex 1966-3439, TBT 0-2452ms, performance 0.55-0.86 on
+          // unchanged content). Gating on it produced random red. The metrics
+          // we actually care about are gated absolutely in METRIC_BUDGETS.
+          // The three below moved in NONE of those 60 runs.
+          const CATEGORY_THRESHOLDS = {
             accessibility: 0.8,
             'best-practices': 0.75,
             seo: 0.9,
           };
+
+          // Absolute, metric-level budgets. Read from the LHR, NOT from
+          // manifest.summary — lhci's filesystem upload target puts only
+          // CATEGORY scores in `summary` (see @lhci/cli upload.js
+          // runFilesystemTarget), while the metric numericValues live in the
+          // full LHR it writes to the absolute path in `jsonPath`.
+          // Raising a budget weakens the gate; guarded by
+          // scripts/tests/test_ci_lighthouse_gate_guard.py.
+          const METRIC_BUDGETS = {
+            'largest-contentful-paint': { max: 4600, unit: 'ms', digits: 0 },
+            'cumulative-layout-shift': { max: 0.05, unit: '', digits: 3 },
+          };
+
           let failed = false;
           for (const result of manifest) {
-            const summary = result.summary;
+            const summary = result.summary || {};
             console.log('URL:', result.url);
-            for (const [category, min] of Object.entries(thresholds)) {
+
+            for (const [category, min] of Object.entries(CATEGORY_THRESHOLDS)) {
               const score = summary[category];
               const status = score >= min ? 'PASS' : 'FAIL';
               console.log(`  ${category}: ${(score * 100).toFixed(0)} (required: ${min * 100}) [${status}]`);
-              if (score < min) failed = true;
+              if (!(score >= min)) failed = true;
             }
+
+            let lhr;
+            try {
+              lhr = JSON.parse(fs.readFileSync(result.jsonPath, 'utf8'));
+            } catch (err) {
+              console.error(`  cannot read LHR at ${result.jsonPath}: ${err.message} [FAIL]`);
+              failed = true;
+              continue;
+            }
+            const audits = lhr.audits || {};
+
+            for (const [auditId, budget] of Object.entries(METRIC_BUDGETS)) {
+              const value = (audits[auditId] || {}).numericValue;
+              if (typeof value !== 'number') {
+                console.error(`  ${auditId}: missing numericValue in LHR [FAIL]`);
+                failed = true;
+                continue;
+              }
+              const status = value <= budget.max ? 'PASS' : 'FAIL';
+              console.log(`  ${auditId}: ${value.toFixed(budget.digits)}${budget.unit} (budget: <= ${budget.max}${budget.unit}) [${status}]`);
+              if (!(value <= budget.max)) failed = true;
+            }
+
+            // Observability only — never gates. Logged so a red build can be
+            // triaged as "slow runner" vs "real regression" from the job log
+            // alone, without downloading the artifact.
+            const tbt = (audits['total-blocking-time'] || {}).numericValue;
+            const bench = (lhr.environment || {}).benchmarkIndex;
+            const perf = summary.performance;
+            console.log(
+              `  [observed, not gated] performance: ${typeof perf === 'number' ? (perf * 100).toFixed(0) : 'n/a'}` +
+              `, total-blocking-time: ${typeof tbt === 'number' ? tbt.toFixed(0) + 'ms' : 'n/a'}` +
+              `, benchmarkIndex: ${typeof bench === 'number' ? bench.toFixed(0) : 'n/a'}`
+            );
           }
           if (failed) {
             console.error('Lighthouse thresholds not met.');

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -83,6 +83,15 @@ jobs:
           const fs = require('fs');
           const manifest = JSON.parse(process.env.LIGHTHOUSE_MANIFEST || '[]');
 
+          // Fail closed. An absent/empty manifest means Lighthouse measured
+          // nothing, so none of the gates below can be asserted -- without this
+          // the loop would simply not execute and the step would report
+          // "All Lighthouse thresholds met." on a run that checked nothing.
+          if (!Array.isArray(manifest) || manifest.length === 0) {
+            console.error('Lighthouse produced no manifest — nothing was measured, so nothing can be asserted. Failing closed.');
+            process.exit(1);
+          }
+
           // Category score gates. 'performance' is deliberately ABSENT.
           // It is a composite in which total-blocking-time carries ~30% of the
           // weight, and TBT on a GitHub runner is decided by the CPU the VM

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -138,33 +138,56 @@ Exit code 0 = no regression. Exit code 1 = at least one URL exceeded the thresho
   | Gate | Value | Source |
   |------|-------|--------|
   | accessibility / best-practices / seo | ≥ 0.80 / 0.75 / 0.90 | `manifest[].summary` (category scores) |
-  | largest-contentful-paint | ≤ 4600 ms | LHR at `manifest[].jsonPath` |
   | cumulative-layout-shift | ≤ 0.05 | LHR at `manifest[].jsonPath` |
 
-  The composite **`performance` score is NOT a gate** — it is ~30% weighted on
-  TBT, and TBT on a GitHub runner tracks whatever CPU the VM lottery hands out
-  (measured over 60 runs of the workflow: benchmarkIndex 1966–3439, TBT
-  0–2452 ms, performance 0.55–0.86 on unchanged content). It is logged for
-  triage alongside TBT and benchmarkIndex, but never fails the job.
+  Logged for triage but **not gated**: `performance`, `largest-contentful-paint`,
+  `total-blocking-time`, `benchmarkIndex` — all on one `[observed, not gated]`
+  line per URL.
 
   The step **fails closed**: an empty or absent manifest (Lighthouse measured
   nothing) exits 1 rather than reporting success on a run that asserted nothing.
   An unreadable LHR at `jsonPath` likewise fails rather than skipping the metric
-  budgets.
+  budget.
 
   The gate values are protected by
   `scripts/tests/test_ci_lighthouse_gate_guard.py`; loosening one without
-  updating that guard fails the build.
+  updating that guard fails the build. Replaying 60 real `lighthouse-results`
+  artifacts through the gate as configured: **0 red**.
 
-  **Known residual flake.** Replaying 60 real `lighthouse-results` artifacts
-  through this gate, 5 (8.3%) breach the 4600 ms LCP budget (6921–9695 ms). The
-  cause is *not* a cold cache, a slow server or a slow CPU: those runs' observed
-  (unthrottled) metrics are indistinguishable from a passing run's — e.g. run
-  `31150603094` (observed FCP 147 ms, benchmarkIndex 3294) simulated LCP
-  4297 ms, while run `31151236111` (observed FCP 147 ms, benchmarkIndex 3293)
-  simulated 9693 ms. The spread is produced inside Lighthouse's Lantern
-  *simulation* of a ~1.66 MB page over the mobile preset (1.6 Mbps / 150 ms RTT
-  / 4× CPU), which is bistable for this page. A warm-cache prerun of the kind
-  used by `lighthouse-ci.yml` does not address it — outliers skew toward the
-  *fastest* runners (median benchmarkIndex 3293 vs 2250 for passing runs).
-  Reducing the page's transfer weight is the real fix.
+### Why `performance` is not gated
+
+The composite score is ~30% weighted on TBT, and TBT on a GitHub runner tracks
+whatever CPU the VM lottery hands out. Measured over 60 runs of this workflow on
+unchanged content: benchmarkIndex 1966–3439, TBT 0–2452 ms, performance
+0.55–0.86. Run `29005388708` (2026-07-09) scored 30 and went red on nothing.
+
+### Why `largest-contentful-paint` is not gated (yet)
+
+LCP is **bimodal** on this runner and the split is not caused by anything CI
+controls. Over the same 60 runs, 55 measured 4218–4373 ms and 5 measured
+6921–9695 ms. The outliers are not a cold cache, a slow server or a slow CPU —
+their *observed* (unthrottled) metrics are indistinguishable from a passing run's:
+
+| | run `31150603094` | run `31151236111` |
+|---|---|---|
+| observed FCP | 147 ms | 147 ms |
+| benchmarkIndex | 3294 | 3293 |
+| **simulated LCP** | **4297 ms** | **9693 ms** |
+
+The 5396 ms gap is produced inside Lighthouse's Lantern *simulation* of a
+~1.66 MB page over the mobile preset (1.6 Mbps / 150 ms RTT / 4× CPU), which is
+bistable for this page — the worst outlier amplifies observed FCP 42×. A
+warm-cache prerun of the kind `lighthouse-ci.yml` uses does **not** address it:
+outliers skew toward the *fastest* runners (median benchmarkIndex 3293 vs 2250,
+median observed FCP 176 ms vs 1335 ms), the opposite of a cold-start signature.
+
+Any budget placed between the two modes reds ~8.3% of runs while catching
+nothing, so LCP is logged instead of gated.
+
+**Re-adding an LCP budget.** Reduce the page's transfer weight first — the
+`assets/fonts/` set is ~1374 KB across 4 files, and tier-2 (972 KB) declares the
+same `unicode-range` as tier-1 (402 KB), so all four land before FCP. Once
+weight is down, collect a fresh sample from the `[observed, not gated]` log
+lines, confirm the bimodality is gone, then set the budget and update
+`test_ci_lighthouse_gate_guard.py::test_lcp_stays_observable_but_ungated` in the
+same PR. Do not re-add a budget from the old numbers.

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -147,6 +147,24 @@ Exit code 0 = no regression. Exit code 1 = at least one URL exceeded the thresho
   0–2452 ms, performance 0.55–0.86 on unchanged content). It is logged for
   triage alongside TBT and benchmarkIndex, but never fails the job.
 
+  The step **fails closed**: an empty or absent manifest (Lighthouse measured
+  nothing) exits 1 rather than reporting success on a run that asserted nothing.
+  An unreadable LHR at `jsonPath` likewise fails rather than skipping the metric
+  budgets.
+
   The gate values are protected by
   `scripts/tests/test_ci_lighthouse_gate_guard.py`; loosening one without
   updating that guard fails the build.
+
+  **Known residual flake.** Replaying 60 real `lighthouse-results` artifacts
+  through this gate, 5 (8.3%) breach the 4600 ms LCP budget (6921–9695 ms). The
+  cause is *not* a cold cache, a slow server or a slow CPU: those runs' observed
+  (unthrottled) metrics are indistinguishable from a passing run's — e.g. run
+  `31150603094` (observed FCP 147 ms, benchmarkIndex 3294) simulated LCP
+  4297 ms, while run `31151236111` (observed FCP 147 ms, benchmarkIndex 3293)
+  simulated 9693 ms. The spread is produced inside Lighthouse's Lantern
+  *simulation* of a ~1.66 MB page over the mobile preset (1.6 Mbps / 150 ms RTT
+  / 4× CPU), which is bistable for this page. A warm-cache prerun of the kind
+  used by `lighthouse-ci.yml` does not address it — outliers skew toward the
+  *fastest* runners (median benchmarkIndex 3293 vs 2250 for passing runs).
+  Reducing the page's transfer weight is the real fix.

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -127,4 +127,26 @@ Exit code 0 = no regression. Exit code 1 = at least one URL exceeded the thresho
 
 ## Related
 
-- `.github/workflows/lighthouse.yml` — the existing absolute-threshold check (Performance ≥ 0.5, etc.) that runs on push to main. Coexists with this workflow; covers different concern.
+- `.github/workflows/lighthouse.yml` — the absolute-threshold check. It runs on
+  **both** `push` to main and `pull_request` against main (plus
+  `workflow_dispatch`), with the *same* `paths` filter on both triggers, so a
+  content-only PR does not trigger it. Coexists with this workflow; covers a
+  different concern — absolute budgets vs. head-to-base regression.
+
+  It gates on:
+
+  | Gate | Value | Source |
+  |------|-------|--------|
+  | accessibility / best-practices / seo | ≥ 0.80 / 0.75 / 0.90 | `manifest[].summary` (category scores) |
+  | largest-contentful-paint | ≤ 4600 ms | LHR at `manifest[].jsonPath` |
+  | cumulative-layout-shift | ≤ 0.05 | LHR at `manifest[].jsonPath` |
+
+  The composite **`performance` score is NOT a gate** — it is ~30% weighted on
+  TBT, and TBT on a GitHub runner tracks whatever CPU the VM lottery hands out
+  (measured over 60 runs of the workflow: benchmarkIndex 1966–3439, TBT
+  0–2452 ms, performance 0.55–0.86 on unchanged content). It is logged for
+  triage alongside TBT and benchmarkIndex, but never fails the job.
+
+  The gate values are protected by
+  `scripts/tests/test_ci_lighthouse_gate_guard.py`; loosening one without
+  updating that guard fails the build.

--- a/scripts/tests/test_ci_lighthouse_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_gate_guard.py
@@ -232,6 +232,21 @@ class TestLighthouseGateConfig:
                 "regression from the job log alone."
             )
 
+    def test_empty_manifest_fails_closed(self):
+        """An empty manifest must not report success.
+
+        The gates all live inside ``for (const result of manifest)``. With an
+        empty manifest that loop body never runs, so without an explicit
+        length check the step prints "All Lighthouse thresholds met." and exits
+        0 on a run that measured nothing at all.
+        """
+        code = _uncommented(_check_script(_workflow()))
+        assert re.search(r"manifest\.length\s*===?\s*0", code), (
+            "the empty-manifest fail-closed check was removed; a Lighthouse run "
+            "that produced no manifest would pass the gate green while asserting "
+            "nothing. If intentional, update this guard."
+        )
+
     def test_step_not_neutralized(self):
         step = _check_step(_workflow())
         assert step.get("continue-on-error") is not True, (
@@ -348,6 +363,37 @@ class TestLighthouseGateBehaviour:
     def test_category_regression_fails(self):
         r = _run_gate(_GOOD_LHR, dict(_GOOD_SUMMARY, accessibility=0.5))
         assert r.returncode == 1, f"accessibility 0.50 was not caught:\n{r.stdout}"
+
+    def test_empty_manifest_exits_nonzero(self):
+        script = _check_script(_workflow())
+        r = subprocess.run(
+            ["node", "-"],
+            input=script,
+            capture_output=True,
+            text=True,
+            env={"PATH": __import__("os").environ["PATH"],
+                 "LIGHTHOUSE_MANIFEST": "[]"},
+        )
+        assert r.returncode == 1, (
+            "an empty manifest passed the gate — the step would report success "
+            f"having asserted nothing:\n{r.stdout}\n{r.stderr}"
+        )
+        assert "All Lighthouse thresholds met." not in r.stdout
+
+    def test_absent_manifest_env_exits_nonzero(self):
+        """The action sets `manifest` to '' when it produced no manifest.json."""
+        script = _check_script(_workflow())
+        r = subprocess.run(
+            ["node", "-"],
+            input=script,
+            capture_output=True,
+            text=True,
+            env={"PATH": __import__("os").environ["PATH"],
+                 "LIGHTHOUSE_MANIFEST": ""},
+        )
+        assert r.returncode == 1, (
+            f"an empty LIGHTHOUSE_MANIFEST passed the gate:\n{r.stdout}\n{r.stderr}"
+        )
 
     def test_unreadable_lhr_fails_closed(self):
         """A missing LHR must not silently pass the metric budgets."""

--- a/scripts/tests/test_ci_lighthouse_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_gate_guard.py
@@ -16,24 +16,29 @@ So the gate was rebuilt around things that actually mean something:
 
 * the composite ``performance`` floor is GONE (it was measuring the runner),
 * ``accessibility`` / ``best-practices`` / ``seo`` stay blocking,
-* absolute metric budgets (LCP, CLS) are read from the LHR at ``jsonPath``
-  -- NOT from ``manifest.summary``, which only carries category scores,
+* one absolute metric budget -- CLS -- is read from the LHR at ``jsonPath``
+  rather than from ``manifest.summary``, which only carries category scores,
+* LCP is measured and LOGGED but deliberately NOT gated, because it is bimodal
+  on this runner for reasons CI does not control (see
+  :meth:`TestLighthouseGateConfig.test_lcp_stays_observable_but_ungated`),
 * the ``pull_request`` trigger got the same ``paths`` filter the ``push``
   trigger already had, so content-only PRs stop running Lighthouse at all.
 
-Each of those can be undone silently: raise a budget "just a little", drop a
-category threshold, delete the paths filter, or refactor the check step so the
-budget constants are still there but nothing reads ``jsonPath`` any more (a
-vacuous gate). This guard makes any of that fail loudly and reviewably.
+Each of those can be undone silently: raise the CLS budget "just a little", drop
+a category threshold, delete the paths filter, drop the LCP log line that is the
+evidence trail for re-deriving a budget, or refactor the check step so the budget
+constants are still there but nothing reads ``jsonPath`` any more (a vacuous
+gate). This guard makes any of that fail loudly and reviewably.
 
 Maps to OWASP CICD-SEC-1 (Insufficient Flow Control) / NIST SSDF PW.4.
 
 Direction
 ---------
 * Category thresholds are FLOORS -> asserted ``>=`` (raising them stays green).
-* Metric budgets are CEILINGS -> asserted ``<=`` (tightening stays green,
+* The CLS budget is a CEILING -> asserted ``<=`` (tightening stays green,
   loosening trips).
-* The paths filter and the jsonPath wiring are PRESENCE assertions.
+* The paths filter, the jsonPath wiring and the LCP log line are PRESENCE
+  assertions. The LCP *budget* is an ABSENCE assertion.
 
 If a change here is intentional, update this guard in the same PR and say why.
 """
@@ -53,8 +58,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lighthouse.yml"
 
-# Direction: ceilings. Loosening (raising) must fail.
-MAX_LCP_MS = 4600
+# Direction: ceiling. Loosening (raising) must fail.
 MAX_CLS = 0.05
 # Direction: floors. Weakening (lowering) must fail.
 MIN_CATEGORY_SCORES = {
@@ -180,25 +184,69 @@ class TestLighthouseGateConfig:
                 "the gate. If intentional, update this guard."
             )
 
-    def test_metric_budgets_not_loosened(self):
+    def test_cls_budget_not_loosened(self):
         code = _uncommented(_check_script(_workflow()))
-        lcp = re.search(
-            r"'largest-contentful-paint':\s*\{\s*max:\s*([\d.]+)", code
-        )
         cls = re.search(
             r"'cumulative-layout-shift':\s*\{\s*max:\s*([\d.]+)", code
         )
-        assert lcp, "the largest-contentful-paint budget was removed"
-        assert cls, "the cumulative-layout-shift budget was removed"
-        assert float(lcp.group(1)) <= MAX_LCP_MS, (
-            f"the LCP budget was raised to {lcp.group(1)}ms (ceiling: "
-            f"{MAX_LCP_MS}ms). Raising it is how this gate stops catching a real "
-            "regression. If intentional, update this guard and say why."
+        assert cls, (
+            "the cumulative-layout-shift budget was removed. CLS is the one "
+            "metric that is stable on this runner (0.000-0.014 across 60 runs), "
+            "so it is the only absolute budget the gate can carry."
         )
         assert float(cls.group(1)) <= MAX_CLS, (
             f"the CLS budget was raised to {cls.group(1)} (ceiling: {MAX_CLS}). "
             "Measured CLS never exceeded 0.014 over 60 runs, so a raise means "
             "something regressed. If intentional, update this guard."
+        )
+
+    def test_lcp_stays_observable_but_ungated(self):
+        """LCP must be LOGGED, and must NOT be a budget.
+
+        Why LCP is not gated: it is bimodal on this runner and the split is not
+        caused by anything CI controls. Over 60 real runs of this workflow, 55
+        measured 4218-4373ms and 5 measured 6921-9695ms. Runs `31150603094` and
+        `31151236111` have the same observed FCP (147ms) and effectively the same
+        benchmarkIndex (3294 vs 3293), yet simulate 4297ms vs 9693ms — a 5396ms
+        gap produced entirely inside Lighthouse's Lantern simulation of a ~1.66MB
+        page over the mobile preset. A warm-cache prerun does not address it:
+        outliers skew toward the FASTEST runners (median benchmarkIndex 3293 vs
+        2250) and the fastest observed loads (median observed FCP 176ms vs
+        1335ms), which is the opposite of a cold-start signature. Any budget
+        placed between the two modes reds ~8.3% of runs while catching nothing.
+
+        Why it must still be logged: these job-log values are the only running
+        record of LCP once the gate stops asserting it. Reducing the page's
+        transfer weight is the real fix, and re-deriving a budget afterwards
+        needs this data. If the log line goes, the evidence trail goes with it.
+
+        Direction: presence assertions on BOTH sides — the log must exist, and
+        LCP must not reappear in METRIC_BUDGETS without a fresh measurement.
+        """
+        code = _uncommented(_check_script(_workflow()))
+        assert re.search(r"audits\['largest-contentful-paint'\]", code), (
+            "largest-contentful-paint is no longer read from the LHR, so it can "
+            "no longer be logged. That log is the only record from which an LCP "
+            "budget can be recomputed after transfer weight comes down."
+        )
+        assert re.search(
+            r"\[observed, not gated\][^\n]*largest-contentful-paint"
+            r"|largest-contentful-paint:\s*\$\{typeof lcp",
+            code,
+        ), (
+            "largest-contentful-paint dropped out of the '[observed, not gated]' "
+            "log line. Keep it: it is the evidence trail for re-deriving the "
+            "budget later."
+        )
+        assert not re.search(
+            r"'largest-contentful-paint':\s*\{\s*max:", code
+        ), (
+            "an LCP budget was re-added to METRIC_BUDGETS. LCP is bimodal on "
+            f"this runner (55/60 runs 4218-4373ms, 5/60 runs 6921-9695ms with "
+            "identical observed inputs), so a budget between the modes reds "
+            "~8.3% of runs for no signal. Re-add one only with a fresh "
+            "measurement showing the bimodality is gone — and update this guard "
+            "in the same PR."
         )
 
     def test_budgets_are_read_from_the_lhr(self):
@@ -332,6 +380,10 @@ class TestLighthouseGateBehaviour:
         assert "benchmarkIndex: 2180" in r.stdout, r.stdout
         assert "total-blocking-time: 672ms" in r.stdout, r.stdout
         assert "performance: 64" in r.stdout, r.stdout
+        assert "largest-contentful-paint: 4298ms" in r.stdout, (
+            "LCP must appear in the observability log even though it is not "
+            f"gated:\n{r.stdout}"
+        )
 
     def test_high_tbt_alone_does_not_fail(self):
         """The exact regression this rework targets.
@@ -348,12 +400,22 @@ class TestLighthouseGateBehaviour:
             f"the gate:\n{r.stdout}\n{r.stderr}"
         )
 
-    def test_lcp_over_budget_fails(self):
-        # 9693ms — the real outlier measured on run 31151236111.
+    def test_lcp_outlier_is_logged_but_does_not_fail(self):
+        """LCP is observability, not a gate.
+
+        9693ms is the real value measured on run 31151236111, whose observed
+        inputs were indistinguishable from the passing run 31150603094. It must
+        be visible in the log and must NOT red the build.
+        """
         r = _run_gate(_mutate(largest_contentful_paint=9693.3), _GOOD_SUMMARY)
-        assert r.returncode == 1, f"LCP 9693ms was not caught:\n{r.stdout}"
-        assert "largest-contentful-paint: 9693ms" in r.stdout
-        assert "[FAIL]" in r.stdout
+        assert r.returncode == 0, (
+            "the LCP outlier failed the gate — LCP is bimodal on this runner and "
+            f"is intentionally ungated:\n{r.stdout}\n{r.stderr}"
+        )
+        assert "largest-contentful-paint: 9693ms" in r.stdout, (
+            f"the outlier value was not logged:\n{r.stdout}"
+        )
+        assert "[FAIL]" not in r.stdout, r.stdout
 
     def test_cls_over_budget_fails(self):
         r = _run_gate(_mutate(cumulative_layout_shift=0.21), _GOOD_SUMMARY)

--- a/scripts/tests/test_ci_lighthouse_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_gate_guard.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""CI regression guard: the Lighthouse gate must stay metric-based and scoped.
+
+Why this guard exists
+---------------------
+``.github/workflows/lighthouse.yml`` used to gate on the composite
+``performance`` category score with a 0.5 floor. That score is ~30% weighted on
+total-blocking-time, and TBT on a GitHub runner is decided by the CPU the VM
+lottery hands out. Measured over 60 real runs of this workflow (artifacts
+downloaded from ``lighthouse-results``): benchmarkIndex 1966-3439, TBT
+0-2452 ms, performance 0.55-0.86 -- on unchanged content. One run scored 30 and
+went red (run 29005388708, 2026-07-09). Meanwhile accessibility / best-practices
+/ seo did not move at all, and CLS never exceeded 0.014.
+
+So the gate was rebuilt around things that actually mean something:
+
+* the composite ``performance`` floor is GONE (it was measuring the runner),
+* ``accessibility`` / ``best-practices`` / ``seo`` stay blocking,
+* absolute metric budgets (LCP, CLS) are read from the LHR at ``jsonPath``
+  -- NOT from ``manifest.summary``, which only carries category scores,
+* the ``pull_request`` trigger got the same ``paths`` filter the ``push``
+  trigger already had, so content-only PRs stop running Lighthouse at all.
+
+Each of those can be undone silently: raise a budget "just a little", drop a
+category threshold, delete the paths filter, or refactor the check step so the
+budget constants are still there but nothing reads ``jsonPath`` any more (a
+vacuous gate). This guard makes any of that fail loudly and reviewably.
+
+Maps to OWASP CICD-SEC-1 (Insufficient Flow Control) / NIST SSDF PW.4.
+
+Direction
+---------
+* Category thresholds are FLOORS -> asserted ``>=`` (raising them stays green).
+* Metric budgets are CEILINGS -> asserted ``<=`` (tightening stays green,
+  loosening trips).
+* The paths filter and the jsonPath wiring are PRESENCE assertions.
+
+If a change here is intentional, update this guard in the same PR and say why.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lighthouse.yml"
+
+# Direction: ceilings. Loosening (raising) must fail.
+MAX_LCP_MS = 4600
+MAX_CLS = 0.05
+# Direction: floors. Weakening (lowering) must fail.
+MIN_CATEGORY_SCORES = {
+    "accessibility": 0.8,
+    "best-practices": 0.75,
+    "seo": 0.9,
+}
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(wf: dict) -> dict:
+    """The ``on:`` mapping.
+
+    PyYAML resolves the bare key ``on`` to the boolean ``True`` (YAML 1.1
+    truthiness), so ``wf["on"]`` is not reliable -- look both up.
+    """
+    return wf.get("on") or wf.get(True) or {}
+
+
+def _check_step(wf: dict) -> dict:
+    steps = wf["jobs"]["lighthouse"]["steps"]
+    for step in steps:
+        if step.get("name") == "Check Lighthouse scores":
+            return step
+    return {}
+
+
+def _check_script(wf: dict) -> str:
+    """The JS between ``node - <<'EOF'`` and its terminator.
+
+    Returned verbatim as the shell would feed it to node's stdin, so the tests
+    below execute the code that actually ships rather than a copy of it.
+    """
+    run = _check_step(wf).get("run", "")
+    lines = run.splitlines()
+    start = next(
+        (i for i, ln in enumerate(lines) if re.match(r"\s*node\s+-\s+<<'EOF'\s*$", ln)),
+        None,
+    )
+    if start is None:
+        return ""
+    body = []
+    for ln in lines[start + 1:]:
+        if ln.strip() == "EOF":
+            return "\n".join(body)
+        body.append(ln)
+    return ""
+
+
+def _uncommented(script: str) -> str:
+    """Script with ``//`` comment-only lines dropped.
+
+    The check step's comments legitimately MENTION ``performance``, ``jsonPath``
+    and the budget numbers; asserting on the raw text would let the executable
+    code be gutted while stale prose kept this guard green.
+    """
+    return "\n".join(
+        ln for ln in script.splitlines() if not ln.lstrip().startswith("//")
+    )
+
+
+# --------------------------------------------------------------------------
+# Static invariants
+# --------------------------------------------------------------------------
+
+
+class TestLighthouseGateConfig:
+    def test_workflow_exists(self):
+        assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
+
+    def test_pull_request_has_paths_filter(self):
+        pr = _triggers(_workflow()).get("pull_request") or {}
+        paths = pr.get("paths")
+        assert paths, (
+            "the pull_request trigger lost its 'paths' filter — every PR, "
+            "including content-only _posts/** PRs that cannot move any measured "
+            "metric, would run Lighthouse again. If intentional, update this guard."
+        )
+
+    def test_pull_request_paths_match_push_paths(self):
+        on = _triggers(_workflow())
+        push_paths = (on.get("push") or {}).get("paths") or []
+        pr_paths = (on.get("pull_request") or {}).get("paths") or []
+        assert push_paths, "the push trigger lost its 'paths' filter"
+        assert sorted(pr_paths) == sorted(push_paths), (
+            "pull_request and push 'paths' filters diverged "
+            f"(push={sorted(push_paths)}, pull_request={sorted(pr_paths)}). "
+            "They must stay identical so a PR is gated on exactly what a push "
+            "to main is gated on. If intentional, update this guard."
+        )
+
+    def test_check_step_present(self):
+        assert _check_script(_workflow()), (
+            "the 'Check Lighthouse scores' step (or its node heredoc) "
+            "disappeared — nothing enforces any Lighthouse result any more."
+        )
+
+    def test_composite_performance_is_not_a_gate(self):
+        code = _uncommented(_check_script(_workflow()))
+        assert not re.search(r"^\s*performance:\s*0?\.\d", code, re.M), (
+            "a numeric 'performance:' threshold came back. The composite "
+            "performance score is ~30% TBT and swings 0.55-0.86 on unchanged "
+            "content across GitHub runners; gating on it is what caused the "
+            "random red this workflow was fixed for."
+        )
+
+    def test_category_floors_not_weakened(self):
+        code = _uncommented(_check_script(_workflow()))
+        for category, floor in MIN_CATEGORY_SCORES.items():
+            key = f"'{category}'" if "-" in category else category
+            m = re.search(rf"^\s*{re.escape(key)}:\s*([\d.]+),", code, re.M)
+            assert m, (
+                f"the '{category}' category threshold was removed from "
+                "CATEGORY_THRESHOLDS; it is stable across runners and costs "
+                "nothing to keep blocking."
+            )
+            assert float(m.group(1)) >= floor, (
+                f"the '{category}' threshold was lowered to {m.group(1)} "
+                f"(floor: {floor}). Raising is fine; lowering silently weakens "
+                "the gate. If intentional, update this guard."
+            )
+
+    def test_metric_budgets_not_loosened(self):
+        code = _uncommented(_check_script(_workflow()))
+        lcp = re.search(
+            r"'largest-contentful-paint':\s*\{\s*max:\s*([\d.]+)", code
+        )
+        cls = re.search(
+            r"'cumulative-layout-shift':\s*\{\s*max:\s*([\d.]+)", code
+        )
+        assert lcp, "the largest-contentful-paint budget was removed"
+        assert cls, "the cumulative-layout-shift budget was removed"
+        assert float(lcp.group(1)) <= MAX_LCP_MS, (
+            f"the LCP budget was raised to {lcp.group(1)}ms (ceiling: "
+            f"{MAX_LCP_MS}ms). Raising it is how this gate stops catching a real "
+            "regression. If intentional, update this guard and say why."
+        )
+        assert float(cls.group(1)) <= MAX_CLS, (
+            f"the CLS budget was raised to {cls.group(1)} (ceiling: {MAX_CLS}). "
+            "Measured CLS never exceeded 0.014 over 60 runs, so a raise means "
+            "something regressed. If intentional, update this guard."
+        )
+
+    def test_budgets_are_read_from_the_lhr(self):
+        """Budgets must be evaluated, not merely declared.
+
+        ``manifest.summary`` carries CATEGORY scores only (see @lhci/cli
+        ``runFilesystemTarget``); metric values exist only in the LHR written to
+        ``jsonPath``. A refactor that keeps METRIC_BUDGETS but stops reading the
+        LHR would leave the constants in place and enforce nothing.
+        """
+        code = _uncommented(_check_script(_workflow()))
+        # Assert on the READ expression, not the bare identifier: 'jsonPath'
+        # also appears in the failure message, so a substring check would still
+        # pass after the readFileSync call was removed.
+        assert re.search(r"readFileSync\(\s*result\.jsonPath", code), (
+            "the check step no longer reads result.jsonPath — metric budgets "
+            "cannot be evaluated from manifest.summary (category scores only), "
+            "so the LCP/CLS budgets would be dead constants."
+        )
+        assert "numericValue" in code, (
+            "the check step no longer reads audit numericValue; the metric "
+            "budgets are not actually compared against anything."
+        )
+
+    def test_observability_fields_logged(self):
+        code = _uncommented(_check_script(_workflow()))
+        for field in ("total-blocking-time", "benchmarkIndex"):
+            assert field in code, (
+                f"'{field}' is no longer logged. It is not a gate, but without "
+                "it a red build cannot be triaged as slow-runner vs real "
+                "regression from the job log alone."
+            )
+
+    def test_step_not_neutralized(self):
+        step = _check_step(_workflow())
+        assert step.get("continue-on-error") is not True, (
+            "the check step is marked continue-on-error; a FAIL would no longer "
+            "block the job."
+        )
+        assert "|| true" not in step.get("run", ""), (
+            "the check step is neutralised with '|| true'; a FAIL would be "
+            "swallowed."
+        )
+
+
+# --------------------------------------------------------------------------
+# Behavioural verification: run the shipped script against LHR-shaped fixtures
+# --------------------------------------------------------------------------
+
+# Shaped after a real LHR downloaded from this workflow's own
+# `lighthouse-results` artifact (run 31068899103): mobile preset, simulate
+# throttling, lighthouse 12.6.1.
+_GOOD_LHR = {
+    "requestedUrl": "http://localhost:4000/",
+    "environment": {"benchmarkIndex": 2180},
+    "categories": {"performance": {"score": 0.64}},
+    "audits": {
+        "largest-contentful-paint": {"numericValue": 4298.2, "numericUnit": "millisecond"},
+        "cumulative-layout-shift": {"numericValue": 0.0, "numericUnit": "unitless"},
+        "total-blocking-time": {"numericValue": 671.7, "numericUnit": "millisecond"},
+    },
+}
+_GOOD_SUMMARY = {
+    "performance": 0.64,
+    "accessibility": 0.97,
+    "best-practices": 1,
+    "seo": 1,
+}
+
+
+def _run_gate(lhr: dict, summary: dict) -> subprocess.CompletedProcess:
+    """Execute the workflow's own check script over one manifest entry."""
+    script = _check_script(_workflow())
+    assert script, "could not extract the check script from the workflow"
+    with tempfile.TemporaryDirectory() as tmp:
+        lhr_path = Path(tmp) / "lhr-1.json"
+        lhr_path.write_text(json.dumps(lhr), encoding="utf-8")
+        manifest = [{
+            "url": lhr["requestedUrl"],
+            "isRepresentativeRun": True,
+            "htmlPath": str(Path(tmp) / "lhr-1.html"),
+            "jsonPath": str(lhr_path),
+            "summary": summary,
+        }]
+        return subprocess.run(
+            ["node", "-"],
+            input=script,
+            capture_output=True,
+            text=True,
+            env={"PATH": __import__("os").environ["PATH"],
+                 "LIGHTHOUSE_MANIFEST": json.dumps(manifest)},
+        )
+
+
+def _mutate(**audits) -> dict:
+    lhr = json.loads(json.dumps(_GOOD_LHR))
+    for audit_id, value in audits.items():
+        lhr["audits"][audit_id.replace("_", "-")]["numericValue"] = value
+    return lhr
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not on PATH; the check script cannot be executed here",
+)
+
+
+class TestLighthouseGateBehaviour:
+    def test_passes_on_a_healthy_run(self):
+        r = _run_gate(_GOOD_LHR, _GOOD_SUMMARY)
+        assert r.returncode == 0, f"gate failed a healthy run:\n{r.stdout}\n{r.stderr}"
+        assert "All Lighthouse thresholds met." in r.stdout
+
+    def test_logs_observability_fields(self):
+        r = _run_gate(_GOOD_LHR, _GOOD_SUMMARY)
+        assert "benchmarkIndex: 2180" in r.stdout, r.stdout
+        assert "total-blocking-time: 672ms" in r.stdout, r.stdout
+        assert "performance: 64" in r.stdout, r.stdout
+
+    def test_high_tbt_alone_does_not_fail(self):
+        """The exact regression this rework targets.
+
+        Run 31150566340 measured TBT 1825ms / performance 0.57 on unchanged
+        content. Under the old composite gate that trended toward red; it must
+        now pass, because LCP and CLS were both fine.
+        """
+        lhr = _mutate(total_blocking_time=1824.5)
+        summary = dict(_GOOD_SUMMARY, performance=0.30)
+        r = _run_gate(lhr, summary)
+        assert r.returncode == 0, (
+            "a slow-CPU run (high TBT, low composite performance) still fails "
+            f"the gate:\n{r.stdout}\n{r.stderr}"
+        )
+
+    def test_lcp_over_budget_fails(self):
+        # 9693ms — the real outlier measured on run 31151236111.
+        r = _run_gate(_mutate(largest_contentful_paint=9693.3), _GOOD_SUMMARY)
+        assert r.returncode == 1, f"LCP 9693ms was not caught:\n{r.stdout}"
+        assert "largest-contentful-paint: 9693ms" in r.stdout
+        assert "[FAIL]" in r.stdout
+
+    def test_cls_over_budget_fails(self):
+        r = _run_gate(_mutate(cumulative_layout_shift=0.21), _GOOD_SUMMARY)
+        assert r.returncode == 1, f"CLS 0.21 was not caught:\n{r.stdout}"
+        assert "cumulative-layout-shift: 0.210" in r.stdout
+
+    def test_category_regression_fails(self):
+        r = _run_gate(_GOOD_LHR, dict(_GOOD_SUMMARY, accessibility=0.5))
+        assert r.returncode == 1, f"accessibility 0.50 was not caught:\n{r.stdout}"
+
+    def test_unreadable_lhr_fails_closed(self):
+        """A missing LHR must not silently pass the metric budgets."""
+        script = _check_script(_workflow())
+        manifest = [{
+            "url": "http://localhost:4000/",
+            "isRepresentativeRun": True,
+            "htmlPath": "/nonexistent/lhr-1.html",
+            "jsonPath": "/nonexistent/lhr-1.json",
+            "summary": _GOOD_SUMMARY,
+        }]
+        r = subprocess.run(
+            ["node", "-"],
+            input=script,
+            capture_output=True,
+            text=True,
+            env={"PATH": __import__("os").environ["PATH"],
+                 "LIGHTHOUSE_MANIFEST": json.dumps(manifest)},
+        )
+        assert r.returncode == 1, (
+            "an unreadable LHR passed the gate — the metric budgets would be "
+            f"silently skipped:\n{r.stdout}\n{r.stderr}"
+        )


### PR DESCRIPTION
## 문제

`.github/workflows/lighthouse.yml` 의 `performance: 0.5` 게이트가 **동일 콘텐츠에서 무작위 red** 를 냈습니다. 이 워크플로의 `lighthouse-results` 아티팩트 **60건을 실제로 내려받아** 측정한 결과:

| 지표 | 실측 범위 (60건, 콘텐츠 무관) |
|---|---|
| benchmarkIndex | 1966 – 3439 |
| total-blocking-time | 0 – 2452 ms |
| **performance** | **0.55 – 0.86** |
| accessibility / best-practices / seo | 0.97 / 1.00 / 1.00 — **무변동** |
| cumulative-layout-shift | 0.000 – 0.014 |

합성 `performance` 점수는 TBT에 약 30% 가중되고, TBT는 GitHub 러너가 어떤 CPU를 뽑는지에 따라 결정됩니다. run [`29005388708`](https://github.com/Twodragon0/tech-blog/actions/runs/29005388708) (2026-07-09) 은 `performance: 30 (required: 50) [FAIL]` 로 red가 됐습니다 — 코드 변경이 아니라 러너 때문입니다.

현행 실패율은 최근 200건 기준 **2.5%** (`success 194 / failure 5 / cancelled 1`) 입니다.

## 변경

### 1. `pull_request` 트리거에 경로 필터 추가

`push` 에는 이미 있었지만 `pull_request` 는 무필터여서, 측정 지표를 움직일 수 없는 `_posts/**` 전용 콘텐츠 PR도 매번 Lighthouse를 돌렸습니다. `push` 와 **동일한 7개 항목** 으로 맞췄습니다(추가·삭제 없음).

### 2. 합성 `performance` 게이트 제거 → metric 단위로 전환

게이트하는 것:

| 게이트 | 값 | 출처 |
|---|---|---|
| accessibility / best-practices / seo | ≥ 0.80 / 0.75 / 0.90 | `manifest[].summary` (카테고리 점수) |
| cumulative-layout-shift | ≤ 0.05 | `manifest[].jsonPath` 의 LHR |

게이트하지 않고 로그만 남기는 것 (`[observed, not gated]` 한 줄):
`performance`, `largest-contentful-paint`, `total-blocking-time`, `benchmarkIndex`.

`manifest` 의 `summary` 에는 **카테고리 점수만** 있습니다. metric 실값은 `jsonPath` 의 LHR에서 읽습니다 — 핀된 액션 소스(`src/utils/lhci-helpers.js:8` typedef)와 manifest 생성 원본(`@lhci/cli` `upload.js:558-576`, `summary[key] = lhr.categories[key].score`)에서 확인했습니다.

### 3. `fail-closed`

`manifest` 가 비었거나 없으면 게이트 루프가 아예 실행되지 않아 **"All Lighthouse thresholds met." 로 green** 이 되던 구멍이 있었습니다. 액션이 `manifest.json` 을 못 만들면 출력이 빈 문자열이 되는 경로(`src/utils/output.js:23`)까지 함께 막았습니다. 읽을 수 없는 LHR도 통과가 아니라 실패입니다.

### 4. 회귀 가드 `scripts/tests/test_ci_lighthouse_gate_guard.py` (신규, 21 tests)

워크플로 YAML을 PyYAML로 파싱해 heredoc 안의 **실제 셸에 넘어가는 JS** 를 추출하고, `//` 주석 라인은 제거 후 검사합니다(주석이 숫자를 언급해서 실행 코드가 삭제돼도 green으로 남는 걸 막기 위함).

막는 것: CLS 상한 인상·삭제 / a11y·BP·SEO 임계값 하향·삭제 / 경로 필터 삭제 또는 `push` 와의 분기 / 합성 `performance` 게이트 부활 / `readFileSync(result.jsonPath` 미사용으로 인한 **무효 게이트** / TBT·benchmarkIndex 로깅 제거 / `continue-on-error`·`|| true` 무력화 / fail-closed 블록 삭제 / **LCP 예산 재추가** / **LCP 관측 로그 삭제**.

행동 검증은 shipped 스크립트를 실제 LHR 형태 픽스처로 직접 실행합니다(정상 통과 / TBT 1825ms+perf 0.30 통과 / LCP 9693ms 통과하되 로깅 / CLS 0.21 실패 / a11y 0.5 실패 / 빈 manifest·빈 env·읽기 실패 각각 exit 1).

**비-공허성**: 실제 파일은 건드리지 않고 임시 사본에 **17가지 변형** 을 가해 각 가드가 실제로 실패하는지 확인 → **17/17 트립, vacuous 0**. 초기에 1건이 공허했습니다(`jsonPath` 문자열이 에러 메시지에도 등장) → `readFileSync(result.jsonPath` 정규식으로 조여 재확인.

## warm-cache prerun을 구현하지 않은 이유

`lighthouse-ci.yml:103-109` 에는 콜드 스타트 이상치를 warm-cache prerun으로 잡은 전례(PR #326, `+721 ms` 오탐)가 있습니다. 여기에는 **적용되지 않습니다.**

이상치 5건의 관측값이 통과 run과 구별되지 않습니다:

| | run [`31150603094`](https://github.com/Twodragon0/tech-blog/actions/runs/31150603094) | run [`31151236111`](https://github.com/Twodragon0/tech-blog/actions/runs/31151236111) |
|---|---|---|
| **observed** FCP (스로틀 없는 실제 로드) | **147 ms** | **147 ms** |
| benchmarkIndex | 3294 | 3293 |
| server-response-time | 5.4 ms | 5.4 ms |
| **simulated** LCP | **4297 ms (PASS)** | **9693 ms (FAIL)** |

그리고 이상치는 **가장 빠른** 러너·**가장 빠른** 관측 로드에 쏠립니다:

| | OUTLIER (5건) | NORMAL (55건) |
|---|---|---|
| benchmarkIndex (median) | **3293** | 2250 |
| observed FCP (median) | **176 ms** | 1335 ms |
| server-response-time (median) | **7.0 ms** | 24.2 ms |

benchmarkIndex ≥ 3000 인 12건 중 3건(25%)이 이상치, < 3000 인 48건 중 2건(4.2%). **콜드 스타트 시그니처의 정반대** 입니다. prerun이 예열하는 대상(서버·OS 파일 캐시·모듈 캐시)은 이미 warm 상태이고(`lighthouse.yml` 의 `curl -sf` 준비 루프), prerun은 머신을 더 빠르게 만들므로 효과 방향이 반대입니다.

가설 2개를 추가로 세워 둘 다 기각했습니다:
- **서버/파일 캐시 콜드** → `server-response-time` 5.4 ms, observed FCP 147 ms 로 기각
- **폰트가 critical path에 얹히는 횟수 차이** → 이상치·정상 모두 폰트 4개(1376 KB) 전량 pre-FCP, 요청 27건, pre-FCP 전송량 ~1615 KB 로 동일 → 기각

또한 `lighthouse.yml` 에는 lighthouse CLI 설치가 없어(`npx --yes serve@14` 만 있음) prerun을 넣으려면 설치 비용이 추가되는데, 측정된 효용이 0입니다. prerun에 회귀 가드까지 걸면 무효한 스텝을 영구 고정하게 됩니다.

## LCP를 게이트에서 뺀 이유와 재산정 조건

LCP는 이 러너에서 **bimodal** 입니다: 55건이 4218–4373 ms, 5건이 6921–9695 ms. 두 모드 사이 어떤 값을 골라도 breach율은 동일하게 8.3% 이고, 9695 위로 올리면 무의미해집니다. 편차는 ~1.66 MB 페이지를 mobile preset(1.6 Mbps / 150 ms RTT / CPU 4×)으로 시뮬레이션하는 **Lantern 내부** 에서 생성되며, 최악 이상치의 증폭률은 observed FCP의 **42배** 입니다.

그래서 **검증된 CLS만 게이트** 하고 LCP는 로그로 남깁니다. 실측 60건을 이 게이트로 재생하면 **red 0건** 입니다(LCP 4600 예산이었을 때 5건).

**재산정 조건**: 전송량을 먼저 줄입니다 — `assets/fonts/` 4개 = 1374.6 KB 이고 tier-2(972 KB)가 tier-1(402 KB)과 **동일한 `unicode-range` 를 선언** 해 4개가 모두 pre-FCP에 실립니다. 축소 후 `[observed, not gated]` 로그에서 새 표본을 모아 bimodality 소멸을 확인한 뒤 예산을 설정하고, **같은 PR에서** `test_lcp_stays_observable_but_ungated` 를 갱신합니다. 옛 숫자로 예산을 되돌리지 않습니다.

## 검증

```
$ python3 -c "import yaml;yaml.safe_load(open('.github/workflows/lighthouse.yml'))"
YAML OK

$ python3 -m pytest scripts/tests/test_ci_lighthouse_gate_guard.py -q
21 passed

$ python3 -m pytest scripts/tests/ -q
3236 passed, 8 skipped

# 임시 사본에 17가지 변형 → 각 가드가 실제로 실패하는지
vacuous guards: 0

# 실측 아티팩트 60건을 shipped 스크립트로 재생
replayed n=60 real runs through the NEW gate
would go red: 0 (0.0%)
```

실제 LHR 재생 샘플 (러너 CPU가 느렸던 run `31150566340`, TBT 1825 ms / perf 0.57 — 이번 수정의 목표):

```
URL: http://localhost:4000/
  accessibility: 97 (required: 80) [PASS]
  best-practices: 100 (required: 75) [PASS]
  seo: 100 (required: 90) [PASS]
  cumulative-layout-shift: 0.000 (budget: <= 0.05) [PASS]
  [observed, not gated] performance: 57, largest-contentful-paint: 4223ms, total-blocking-time: 1825ms, benchmarkIndex: 2089
All Lighthouse thresholds met.
```

pre-commit 훅 통과(우회 없음). `origin/main` (`a55fa7aa`) 기준 rebase 후 재검증 완료.

## 실제 러너 실증 (`workflow_dispatch` 3회)

`gh workflow run lighthouse.yml --ref fix/lighthouse-gate-metric-budget` — **3/3 success.**

| run | conclusion | performance | LCP | TBT | benchmarkIndex |
|---|---|---|---|---|---|
| [`31161912191`](https://github.com/Twodragon0/tech-blog/actions/runs/31161912191) | success | 85 | 4372 ms | 0 ms | 3351 |
| [`31162079229`](https://github.com/Twodragon0/tech-blog/actions/runs/31162079229) | success | 60 | 4297 ms | 852 ms | 2103 |
| [`31162192240`](https://github.com/Twodragon0/tech-blog/actions/runs/31162192240) | success | **48** | 4566 ms | **4208 ms** | 1933 |

세 run 모두 동일하게 출력했습니다:

```
URL: http://localhost:4000/
  accessibility: 97 (required: 80) [PASS]
  best-practices: 100 (required: 75) [PASS]
  seo: 100 (required: 90) [PASS]
  cumulative-layout-shift: 0.000 (budget: <= 0.05) [PASS]
  [observed, not gated] performance: 48, largest-contentful-paint: 4566ms, total-blocking-time: 4208ms, benchmarkIndex: 1933
All Lighthouse thresholds met.
```

확인된 것:

1. **heredoc이 실제 러너에서 동작** — `node - <<'EOF'` + `require('fs')` 가 `package.json` 의 `"type": "module"` 과 무관하게 CommonJS로 실행됩니다.
2. **`[observed, not gated]` 4개 필드 전부 출력** — performance / LCP / TBT / benchmarkIndex.
3. **CLS 예산이 실제로 평가됨** — `(budget: <= 0.05) [PASS]`.
4. **run `31162192240` 이 이번 수정의 직접 증거입니다.** performance **48** 은 옛 임계값 0.5 미달이므로 **옛 게이트에서는 red** 였을 run입니다. 지금은 통과합니다. TBT 4208 ms / benchmarkIndex 1933 으로, 아티팩트 60건 표본의 최대 TBT(2452 ms)와 최저 benchmarkIndex(1966)를 모두 넘어섰습니다 — 러너 편차가 표본보다 더 넓다는 뜻입니다.
5. **`paths` 필터 동작 확인** — 이 PR은 `.github/workflows/lighthouse.yml`, `docs/`, `scripts/tests/` 만 건드리므로 필터에 걸리지 않고, 이 브랜치의 `pull_request` 이벤트 Lighthouse run은 **0건** 입니다(`workflow_dispatch` 5건만 존재). 의도대로입니다.

**LCP 4600 예산을 뺀 판단이 여기서 한 번 더 확인됩니다**: run `31162192240` 의 LCP는 4566 ms 로, 정상 모드에서도 4600 ms 에 34 ms 까지 접근했습니다(아티팩트 60건 표본의 정상 모드 최대는 4373 ms). bimodal 이상치 8.3% 와 별개로, 정상 모드만으로도 4600 예산은 아슬아슬했습니다.

부수 확인: 워크플로가 `concurrency: cancel-in-progress: true` 를 선언하므로 같은 ref로 연속 dispatch하면 앞선 run이 취소됩니다(`31161868569`, `31161905523` 이 그렇게 취소됨). 측정은 직렬화해야 합니다.

## 미검증

- **Lantern이 동일 입력에서 다른 그래프를 만드는 이유** — `network-requests` 집계 필드로는 그래프 엣지를 관찰할 수 없어 trace 원본이 필요합니다.
- **`node` 부재 환경** — 행동 테스트 11건은 `shutil.which("node") is None` 이면 skip합니다. GitHub ubuntu 러너에는 node가 기본 설치되어 있고 위 dispatch로 간접 확인됐지만, 부재 환경 자체를 실증하진 않았습니다. 정적 가드 10건은 항상 실행됩니다.
- **prerun 효과** — 구현하지 않았으므로 측정 대상 없음.
- **이상치율 재측정** — dispatch 3회는 스텝 동작 확인용이며, 8.3% 를 확정하거나 반박할 표본이 아닙니다(3회 전부 정상 모드였습니다).

## 범위 밖

- `.github/workflows/lighthouse-ci.yml` (별개의 head/base delta 게이트) 미변경.
- `isRepresentativeRun` 중앙값 평가 미구현 — `runs: 1` 이라 현재는 무의미하고 별도 결정 사안입니다. 다만 현재 로직은 manifest 항목을 전부 순회하므로, 향후 `runs:` 를 올리면 **최솟값 게이트** 가 된다는 점을 남겨둡니다.
- `Vercel` 체크는 계정 빌드 레이트 리밋으로 24시간 실패 중이며 이 변경과 무관합니다.
