### PR TITLE
fix: 뉴스 카드 정규식 재현율(C11) + `...` 를 종결로 오판한 절단 요약 9건

### DIFF
--- a/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
+++ b/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
@@ -280,7 +280,7 @@ AzureDiagnostics
   title="[보안] Microsoft Develops Scanner to Detect Backdoors in Open-Weight Large Language Models"
   url="https://thehackernews.com/2026/02/microsoft-develops-scanner-to-detect.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiBZPWiqEqWIj0fKQtxyusGomOmOzx4xkp4zh-TUGEtbgZP0yDEl91QHC-tP-8fiufd0Nue-dUYt1ajpkSkJZfV9_7M03gegp2LZaiIAyDJ1B03MCQVSn77Q8zH8x7UVq3Lir0uMWEvB7rzMEZ5jz1w3rfwTwM59h-_paVKuEdozFOAsjPb7e6aND1KapHV/s1700-e365/llm-scanner.jpg"
-  summary="Microsoft는 수요일 오픈 웨이트 대규모 언어 모델(LLM)에서 백도어를 탐지하고 인공지능(AI) 시스템에 대한 전반적인 신뢰를 향상시킬 수 있는 경량 스캐너를 개발했다고 발표했습니다. 이 기술 대기업의 AI Security 팀은 해당 스캐너가 낮은 오탐률을 유지하면서 백도어의 존재를 안정적으로 탐지할 수 있는 세 가지 관찰 가능한 신호를 활용한다고..."
+  summary="Microsoft는 수요일 오픈 웨이트 대규모 언어 모델(LLM)에서 백도어를 탐지하고 인공지능(AI) 시스템에 대한 전반적인 신뢰를 향상시킬 수 있는 경량 스캐너를 개발했다고 발표했습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -628,7 +628,7 @@ Google이 2026년 1월에 발표한 최신 AI 관련 뉴스를 종합 정리한 
   title="[클라우드] The platform usage trap part 2: Choosing meaningful monitoring metrics"
   url="https://cloud.google.com/blog/products/application-development/how-john-lewis-partnership-chose-its-monitoring-metrics/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_-_Application_Development_SWHuGHU.max-2600x2600.jpg"
-  summary="이 시리즈의 1부에서 John Lewis Partnership의 Alex Moss가 개발자 플랫폼 가치 측정에 사용하는 메트릭을 다루었습니다. 이번 2부에서는 측정 전략의 핵심 요소인 &quot;올바른 측정 대상 선택&quot;에 대해 논의합니다. 데이터의 바다에서 길을 잃거나 인상적으로 보이지만 플랫폼 상태나 개발자 경험을 실제로 반영하지 못하는 메트릭에 집중하기..."
+  summary="이 시리즈의 1부에서 John Lewis Partnership의 Alex Moss가 개발자 플랫폼 가치 측정에 사용하는 메트릭을 다루었습니다. 이번 2부에서는 측정 전략의 핵심 요소인 &quot;올바른 측정 대상 선택&quot;에 대해 논의합니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -683,7 +683,7 @@ AWS가 호스트 서버에 물리적으로 연결된 NVMe 기반 SSD 블록 수�
   title="[DevOps] Get Started with the Atlassian Rovo MCP Server Using Docker"
   url="https://www.docker.com/blog/atlassian-remote-mcp-server-getting-started-with-docker/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="원격 Atlassian Rovo MCP 서버가 Docker의 MCP Catalog 및 Toolkit에서 사용 가능하게 되었습니다. 이를 통해 AI 어시스턴트를 Jira 및 Confluence에 연결하는 것이 더욱 쉬워졌으며, 기술 팀이 몇 번의 클릭만으로 선호하는 AI 에이전트를 사용하여 Jira 이슈, 에픽, Confluence 페이지를 생성 및..."
+  summary="원격 Atlassian Rovo MCP 서버가 Docker의 MCP Catalog 및 Toolkit에서 사용 가능하게 되었습니다."
   source="Docker Blog"
   severity="Medium"
 -%}

--- a/_posts/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.md
+++ b/_posts/2026-02-11-Tech_Security_Weekly_Digest_Security_Ransomware_Patch_AI.md
@@ -380,7 +380,7 @@ Amazon이 신규 물류 센터 개소 시 Amazon Bedrock의 Nova 모델을 활�
   title="[클라우드] Google Distributed Cloud, air-gapped 환경에 퍼블릭 클라우드급 네트워킹 제공"
   url="https://cloud.google.com/blog/products/networking/google-distributed-cloud-gdc-air-gapped-1-15-networking/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/24_-_Networking_vCB4Wjq.max-2600x2600.jpg"
-  summary="고도 규제 산업의 조직들은 air-gapped 환경의 엄격한 보안과 클라우드가 제공하는 민첩성·유연성 사이의 균형을 맞추는 데 어려움을 겪어왔습니다. 이를 해결하기 위해 Google Distributed Cloud(GDC) air-gapped 1.15 버전에서 보안 수준을 유지하면서 더 직접적인 제어와 가시성을 제공하는 새로운 네트워킹 기능(프리뷰)과..."
+  summary="고도 규제 산업의 조직들은 air-gapped 환경의 엄격한 보안과 클라우드가 제공하는 민첩성·유연성 사이의 균형을 맞추는 데 어려움을 겪어왔습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -402,7 +402,7 @@ Amazon이 신규 물류 센터 개소 시 Amazon Bedrock의 Nova 모델을 활�
   title="[클라우드] Gemini Enterprise Agent Ready(GEAR) 프로그램 공개 — 대규모 AI 에이전트 구축 경로 제시"
   url="https://cloud.google.com/blog/products/ai-machine-learning/gear-program-now-available/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/GEAR_Website_Graphics_1920x1080-2.max-2000x2000.png"
-  summary="소프트웨어가 복잡한 워크플로우를 스스로 추론·계획·실행하는 에이전틱 시대가 도래하고 있습니다. 이에 발맞춰 Google이 Gemini Enterprise Agent Ready(GEAR) 학습 프로그램을 전체 공개했습니다. Google Developer Program 내 신규 전문 트랙으로, 개발자와 전문가가 Google AI로 엔터프라이즈급 에이전트를..."
+  summary="소프트웨어가 복잡한 워크플로우를 스스로 추론·계획·실행하는 에이전틱 시대가 도래하고 있습니다. 이에 발맞춰 Google이 Gemini Enterprise Agent Ready(GEAR) 학습 프로그램을 전체 공개했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}

--- a/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
+++ b/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
@@ -294,7 +294,7 @@ NVIDIA가 일본어 소버린 AI를 지원하기 위해 Nemotron 2 Nano 9B Japan
   title="[클라우드] BRICKSTORM에서 GRIMBOLT까지: UNC6201의 Dell RecoverPoint VM 제로데이 악용"
   url="https://cloud.google.com/blog/topics/threat-intelligence/unc6201-exploiting-dell-recoverpoint-zero-day/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_ThreatIntelligenceWebsiteBannerIdeas_BA.max-2600x2600.png"
-  summary="Mandiant와 Google Threat Intelligence Group(GTIG)은 Dell RecoverPoint for Virtual Machines의 고위험 제로데이(CVE-2026-22769, CVSS 10.0) 악용 정황을 확인했습니다. 사고 대응 분석 결과, UNC6201(중국 연계 추정 위협 클러스터)이 최소 2025년 중반부터 해당..."
+  summary="Mandiant와 Google Threat Intelligence Group(GTIG)은 Dell RecoverPoint for Virtual Machines의 고위험 제로데이(CVE-2026-22769, CVSS 10.0) 악용 정황을 확인했습니다."
   source="Google Cloud Blog"
   severity="Critical"
 -%}

--- a/_posts/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.md
+++ b/_posts/2026-02-19-Tech_Security_Weekly_Digest_AWS_Security_Zero-Day_CVE.md
@@ -121,7 +121,7 @@ Dell RecoverPoint for Virtual Machines에서 발견된 제로데이 취약점(CV
   title="[보안] Grandstream GXP1600 VoIP 전화기 비인증 원격 코드 실행 취약점"
   url="https://thehackernews.com/2026/02/grandstream-gxp1600-voip-phones-exposed.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiJkDWw2o7gwfV4NseVpa6WnSALfRD1COOQfDjRYsORg5EN_NXyMNj43q0uSXkGZbgNC6kUJx-suEri4OMmg1v9UULThdAImIdK04DyIkj4iabnRcDqfl2bUXFWz-nsGeR7y8W0YC1ykqt3VauFhW7saH9iblk6kA8KTEKcG74A4fPWPf9BAmH4ifiiu2Hv/s1700-e365/root.jpg"
-  summary="사이버보안 연구원들이 Grandstream GXP1600 시리즈 VoIP 폰에서 인증 없이 원격 코드 실행이 가능한 치명적 보안 취약점을 공개했습니다. CVE-2026-2329로 추적되는 이 취약점은 CVSS 9.3점(Critical)으로, 스택 기반 버퍼 오버플로우를 통해 공격자가 네트워크에 접근 가능한 경우 별도 인증 없이 장치를 완전히 장악할 수..."
+  summary="사이버보안 연구원들이 Grandstream GXP1600 시리즈 VoIP 폰에서 인증 없이 원격 코드 실행이 가능한 치명적 보안 취약점을 공개했습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -173,7 +173,7 @@ Dell RecoverPoint for Virtual Machines에서 발견된 제로데이 취약점(CV
   title="[보안] Cellebrite 포렌식 도구, 케냐 활동가 감시에 사용 적발"
   url="https://thehackernews.com/2026/02/citizen-lab-finds-cellebrite-tool-used.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjcKg1ustDlFg4Z8PIFRlPPO6LEfnuCsAZRD59FSKmiMZuhKtTrL6mOL43EJt1_iczcPYcYlwaEqf8xNFE6suEy3qtcXhv3vBAizeuenRGoan22ouXKyetDLoHME-y3wr0vKLr0OFAPkOuEjVjhokDssNgQpXnvauTbjQvDo2p31Cwv7s0qmr7pMG-ajXSY/s1700-e365/sam.jpg"
-  summary="Citizen Lab의 새로운 연구에 따르면, 케냐 경찰이 이스라엘 회사 Cellebrite가 제조한 상업용 모바일 포렌식 추출 도구를 사용하여 저명한 반체제 활동가의 휴대폰을 불법적으로 분석한 증거가 발견되었습니다. 해당 활동가는 경찰 구금 중 디바이스를 압수당했으며, Citizen Lab은 포렌식 아티팩트 분석을 통해 Cellebrite UFED..."
+  summary="Citizen Lab의 새로운 연구에 따르면, 케냐 경찰이 이스라엘 회사 Cellebrite가 제조한 상업용 모바일 포렌식 추출 도구를 사용하여 저명한 반체제 활동가의 휴대폰을 불법적으로 분석한 증거가 발견되었습니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -310,7 +310,7 @@ Google이 인도에서 개최한 AI Impact Summit 2026에서 AI 기술의 사회
   title="[클라우드] Google Cloud MCP — AI 에이전트와 데이터베이스 통합 확대"
   url="https://cloud.google.com/blog/products/databases/managed-mcp-servers-for-google-cloud-databases/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/Gemini_Generated_Image_jcq8tgjcq8tgjcq8.max-2600x2600.png"
-  summary="커스텀 에이전트와 챗봇을 포함한 AI 애플리케이션을 구축하는 개발자를 위해, 오픈소스 Model Context Protocol(MCP) 표준은 데이터와 도구에 일관되고 안전하게 접근할 수 있게 합니다. Google이 2025년 말 도입한 관리형 MCP 지원을 확대하여 Cloud Spanner, AlloyDB, BigQuery 등 주요 데이터베이스와 AI..."
+  summary="커스텀 에이전트와 챗봇을 포함한 AI 애플리케이션을 구축하는 개발자를 위해, 오픈소스 Model Context Protocol(MCP) 표준은 데이터와 도구에 일관되고 안전하게 접근할 수 있게 합니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}

--- a/scripts/backfill_card_summary_period.py
+++ b/scripts/backfill_card_summary_period.py
@@ -21,7 +21,6 @@ Usage:
 """
 import argparse
 import glob
-import re
 import sys
 from pathlib import Path
 
@@ -29,6 +28,8 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO))
 
 from scripts.news.content_generator import _restore_sentence_period  # noqa: E402
+from scripts.news_card_patterns import CARD_RE as _CARD_RE  # noqa: E402
+from scripts.news_card_patterns import SUMMARY_RE as _SUMMARY_RE  # noqa: E402
 
 restore = _restore_sentence_period
 
@@ -38,9 +39,6 @@ restore = _restore_sentence_period
 # hiding the very defect #506 fixed. Those 9 cards need a re-summary from the
 # source article, not a period, so this backfill leaves them alone.
 TRUNCATION_SUSPECT_LEN = 195
-
-_CARD_RE = re.compile(r"\{%\s*include\s+news-card\.html.*?%\}", re.DOTALL)
-_SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+\w+="|\s*%\}|\s*$))', re.DOTALL)
 
 
 def _fix_card(card: str) -> str:

--- a/scripts/backfill_digest_titles.py
+++ b/scripts/backfill_digest_titles.py
@@ -23,7 +23,12 @@ from pathlib import Path
 
 import yaml
 
-POSTS_DIR = Path(__file__).resolve().parent.parent / "_posts"
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.news_card_patterns import count_cards  # noqa: E402
+
+POSTS_DIR = REPO / "_posts"
 
 SERIES_PREFIX = {
     "security": "주간 보안 다이제스트",
@@ -131,8 +136,26 @@ def extract_theme(fm: dict, body: str, mode: str) -> str:
 
 
 def extract_total(fm: dict, body: str) -> int:
-    """Count news-card includes; fall back to highlights or default 5."""
-    count = body.count("{% include news-card.html")
+    """Count the news items the post renders; fall back to highlights or 5.
+
+    The generator's own ``(N건)`` comes from ``total = sum(stats.values())`` —
+    every collected item (``content_generator.py:1419``). This backfill cannot
+    see that historical pool, so it approximates N from the rendered body, and
+    the approximation should count every rendered news item.
+
+    A literal ``body.count("{% include news-card.html")`` counted neither the
+    282 ``{%- include`` cards nor the 64 spotlight items (C11). It read 0 cards
+    for all 31 whitespace-control posts and silently fell through to the
+    3-entry ``highlights`` fallback — which is why e.g. 2026-02-05 claims
+    "(3건)" while rendering 16 cards + 2 spotlight items.
+
+    Spotlight items count because they are distinct news items, not a restyled
+    view of the cards: they render title/url/source/summary under their own
+    numbered section ("기타 주목할 뉴스", migrated from tables in ``b6fe65a5``),
+    and 0 of the 64 reuse a news-card URL (measured 2026-08-07). Counting them
+    moves N toward the generator's "items covered" meaning, not away from it.
+    """
+    count = count_cards(body)
     if count >= 1:
         return count
     sc = fm.get("summary_card") or {}

--- a/scripts/news_card_patterns.py
+++ b/scripts/news_card_patterns.py
@@ -1,0 +1,47 @@
+"""Canonical patterns for the news-card includes a digest post renders.
+
+This exists because of C11 ("대상 재현율") in
+``notes/corpus-transformer-contract.md``: C1-C10 all constrain *where a
+transformer must not write*, and nothing constrained *whether it found every
+target*. A missed card produces no diff, so no protected-region test can see it.
+
+``\\s`` does not match ``-``. A pattern written ``\\{%\\s*include`` therefore
+skips every ``{%- include`` card — 282 of 2117 on 2026-08-07 — which is how
+PR #512 (period backfill) and PR #513 (rewind) came to be *under*-fixes rather
+than wrong fixes. Two more scripts (``check_posts``, ``cleanup_news_cards``)
+already spelled it ``\\{%-?\\s*include``, so the corpus disagreed with itself.
+
+Both include kinds carry a ``summary=`` attribute (see
+``_includes/news-card.html`` and ``_includes/news-spotlight-item.html``), so a
+transformer that rewrites summaries must cover both.
+
+Importing these rather than re-declaring them is C8: one source of truth, so the
+scripts cannot drift apart again. ``scripts/tests/test_news_card_patterns.py``
+pins the match count against the corpus itself.
+"""
+import re
+
+# Every include kind that renders a news item with a ``summary=`` attribute.
+CARD_INCLUDES = ("news-card", "news-spotlight-item")
+
+_NAMES = "|".join(re.escape(name) for name in CARD_INCLUDES)
+
+# Opening tag only — for counting how many news items a post renders.
+CARD_OPEN_RE = re.compile(rf"\{{%-?\s*include\s+(?:{_NAMES})\.html")
+
+# The whole include block, in either whitespace-control form (``{% … %}`` and
+# ``{%- … -%}``). Non-greedy, so it stops at the first closing tag.
+CARD_RE = re.compile(
+    rf"\{{%-?\s*include\s+(?:{_NAMES})\.html.*?-?%\}}",
+    re.DOTALL,
+)
+
+# The ``summary="…"`` attribute inside a card. The lookahead ends the value at
+# the next attribute, the closing tag, or end of input — never at an escaped
+# quote inside the prose (``&quot;`` is what the corpus uses).
+SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+\w+="|\s*-?%\}|\s*$))', re.DOTALL)
+
+
+def count_cards(text: str) -> int:
+    """Number of news-item includes in ``text`` (both kinds, both forms)."""
+    return len(CARD_OPEN_RE.findall(text))

--- a/scripts/rewind_truncated_summaries.py
+++ b/scripts/rewind_truncated_summaries.py
@@ -36,10 +36,19 @@ TRUNCATION_SUSPECT_LEN = 195
 
 _TERMINATED = (".", "!", "?")
 
+# A trailing ellipsis is the OPPOSITE of a terminator: it is the marker an
+# earlier generator appended when it cut a summary at the 200-char cap. Because
+# it ends in ".", the plain `endswith(_TERMINATED)` guard read it as a finished
+# sentence and skipped the card. Those 9 cards all sit in the `{%-` blind spot,
+# so this only became reachable once the include pattern was fixed.
+_TRUNCATION_MARKERS = ("...", "…")
+
 
 def rewind(text: str) -> str:
     """Drop the trailing partial sentence. Returns a prefix, or text unchanged."""
-    if not text or text.endswith(_TERMINATED):
+    if not text:
+        return text
+    if text.endswith(_TERMINATED) and not text.endswith(_TRUNCATION_MARKERS):
         return text
     idx = text.rfind("다.")
     return text[: idx + 2] if idx > 0 else text

--- a/scripts/rewind_truncated_summaries.py
+++ b/scripts/rewind_truncated_summaries.py
@@ -21,18 +21,19 @@ Usage:
 """
 import argparse
 import glob
-import re
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts.news_card_patterns import CARD_RE as _CARD_RE  # noqa: E402
+from scripts.news_card_patterns import SUMMARY_RE as _SUMMARY_RE  # noqa: E402
 
 # Below this a summary was never near the old 200-char cap, so a missing final
 # period is a headline-shaped source, not truncation — not this script's job.
 TRUNCATION_SUSPECT_LEN = 195
 
-_CARD_RE = re.compile(r"\{%\s*include\s+news-card\.html.*?%\}", re.DOTALL)
-_SUMMARY_RE = re.compile(r'(\bsummary=")(.*?)("(?=\s+\w+="|\s*%\}|\s*$))', re.DOTALL)
 _TERMINATED = (".", "!", "?")
 
 

--- a/scripts/tests/test_backfill_card_summary_period.py
+++ b/scripts/tests/test_backfill_card_summary_period.py
@@ -23,17 +23,28 @@ import backfill_card_summary_period as bf  # noqa: E402
 _FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
 
 
-def _card(summary, **extra):
+def _card(summary, include="news-card", open_ws="", close_ws="", **extra):
     attrs = "".join(f'  {k}="{v}"\n' for k, v in extra.items())
     return (
-        "{% include news-card.html\n"
+        f"{{%{open_ws} include {include}.html\n"
         '  title="제목"\n'
         '  url="https://example.com/a"\n'
         f'  summary="{summary}"\n'
         f"{attrs}"
         '  source="Example"\n'
-        "%}\n"
+        f"{close_ws}%}}\n"
     )
+
+
+# Every shape the corpus actually uses (C11). `\s` does not match `-`, so the
+# `{%-` rows were invisible to this script until 2026-08-07.
+_CARD_SHAPES = {
+    "plain": {},
+    "whitespace_control": {"open_ws": "-", "close_ws": "-"},
+    "dash_open_only": {"open_ws": "-"},
+    "spotlight": {"include": "news-spotlight-item"},
+    "spotlight_dash": {"include": "news-spotlight-item", "open_ws": "-", "close_ws": "-"},
+}
 
 
 # --- what gets fixed ---------------------------------------------------------
@@ -48,6 +59,13 @@ def test_multi_sentence_summary_gains_only_the_final_period():
     src = _FM + _card("A가 발생했습니다. B가 확인됐습니다")
     out = bf.transform(src)
     assert 'summary="A가 발생했습니다. B가 확인됐습니다."' in out
+
+
+@pytest.mark.parametrize("shape,kwargs", sorted(_CARD_SHAPES.items()))
+def test_every_card_shape_is_reached(shape, kwargs):
+    """C11 recall: a `{%-` or spotlight card must be fixed like a plain one."""
+    out = bf.transform(_FM + _card("공격자가 서버를 장악했습니다", **kwargs))
+    assert 'summary="공격자가 서버를 장악했습니다."' in out, shape
 
 
 # --- what must NOT change ----------------------------------------------------

--- a/scripts/tests/test_news_card_patterns.py
+++ b/scripts/tests/test_news_card_patterns.py
@@ -1,0 +1,162 @@
+"""C11 target-recall tests for scripts/news_card_patterns.py.
+
+C1-C10 of ``notes/corpus-transformer-contract.md`` all pin *where a transformer
+must not write*. None of them can catch a transformer that never found a target:
+a skipped card produces no diff, so every protected-region test passes while the
+defect survives. C11 closes that hole by pinning the other direction —
+
+    number of cards the pattern matches == number of cards in the corpus
+
+The concrete failure this backstops: ``\\s`` does not match ``-``, so
+``\\{%\\s*include`` skipped all 282 ``{%- include news-card`` instances and all
+64 ``news-spotlight-item`` instances. PR #512 and PR #513 both shipped with that
+pattern and therefore under-fixed the corpus without any test going red.
+
+These tests derive ground truth by scanning ``_posts/`` with an independently
+written scanner (C5: the audit detector must not call the detector it audits),
+so they keep working as the corpus grows — they assert agreement, not a frozen
+count.
+"""
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts import news_card_patterns as ncp  # noqa: E402
+
+POSTS = sorted((REPO / "_posts").glob("*.md"))
+
+# --- ground truth ------------------------------------------------------------
+# Deliberately NOT built from ncp's own regexes (C5). One explicit literal per
+# include kind per whitespace-control form, so a bug in ncp cannot hide here.
+_GROUND_TRUTH_OPENERS = (
+    "{% include news-card.html",
+    "{%- include news-card.html",
+    "{% include news-spotlight-item.html",
+    "{%- include news-spotlight-item.html",
+)
+
+
+def _ground_truth_count(text: str) -> int:
+    return sum(text.count(opener) for opener in _GROUND_TRUTH_OPENERS)
+
+
+@pytest.fixture(scope="module")
+def corpus():
+    return [(p, p.read_text(encoding="utf-8")) for p in POSTS]
+
+
+# --- the recall contract -----------------------------------------------------
+
+
+def test_corpus_is_not_empty(corpus):
+    """Guard against a vacuous pass if _posts/ ever moves."""
+    assert len(corpus) > 100
+    assert sum(_ground_truth_count(t) for _, t in corpus) > 2000
+
+
+def test_card_open_re_matches_every_card_in_the_corpus(corpus):
+    """C11: matched == actual, file by file so a failure names the file."""
+    mismatches = [
+        (p.name, ncp.count_cards(t), _ground_truth_count(t))
+        for p, t in corpus
+        if ncp.count_cards(t) != _ground_truth_count(t)
+    ]
+    assert mismatches == []
+
+
+def test_card_re_finds_a_block_for_every_opening_tag(corpus):
+    """A block regex that swallows two cards at once is also a recall failure."""
+    mismatches = [
+        (p.name, len(ncp.CARD_RE.findall(t)), _ground_truth_count(t))
+        for p, t in corpus
+        if len(ncp.CARD_RE.findall(t)) != _ground_truth_count(t)
+    ]
+    assert mismatches == []
+
+
+def test_every_corpus_card_block_exposes_its_summary(corpus):
+    """SUMMARY_RE must reach the value in every card that carries one."""
+    misses = []
+    for p, text in corpus:
+        for block in ncp.CARD_RE.findall(text):
+            if "summary=" in block and not ncp.SUMMARY_RE.search(block):
+                misses.append((p.name, block[:80]))
+    assert misses == []
+
+
+def test_both_include_kinds_are_actually_present_in_the_corpus(corpus):
+    """Non-vacuity: the two kinds and both forms must each be exercised."""
+    joined = "\n".join(t for _, t in corpus)
+    for opener in _GROUND_TRUTH_OPENERS[:3]:
+        assert opener in joined, f"{opener} vanished — retune this test"
+
+
+# --- regression cases per variant --------------------------------------------
+
+_VARIANTS = {
+    "card_plain": '{% include news-card.html\n  summary="가나다."\n%}',
+    "card_dash": '{%- include news-card.html\n  summary="가나다."\n-%}',
+    "card_dash_open_only": '{%- include news-card.html\n  summary="가나다."\n%}',
+    "card_plain_dash_close": '{% include news-card.html\n  summary="가나다."\n-%}',
+    "spotlight_plain": '{% include news-spotlight-item.html\n  summary="가나다."\n%}',
+    "spotlight_dash": '{%- include news-spotlight-item.html\n  summary="가나다."\n-%}',
+    "no_space_after_dash": '{%-include news-card.html\n  summary="가나다."\n%}',
+}
+
+
+@pytest.mark.parametrize("name,snippet", sorted(_VARIANTS.items()))
+def test_every_whitespace_control_variant_is_matched(name, snippet):
+    assert ncp.count_cards(snippet) == 1, name
+    assert len(ncp.CARD_RE.findall(snippet)) == 1, name
+    assert ncp.SUMMARY_RE.search(snippet).group(2) == "가나다.", name
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        '{% include ai-summary-card.html summary="x" %}',
+        '{% include news-spotlight-section.html body=items %}',
+        '{% include news-card-legacy.html summary="x" %}',
+    ],
+)
+def test_unrelated_includes_are_not_matched(snippet):
+    """Deny-by-default: only the two enumerated kinds count."""
+    assert ncp.count_cards(snippet) == 0
+
+
+def test_adjacent_cards_are_matched_separately():
+    """Non-greedy close: two cards must not collapse into one block."""
+    two = _VARIANTS["card_dash"] + "\n\n" + _VARIANTS["card_plain"]
+    assert ncp.count_cards(two) == 2
+    assert len(ncp.CARD_RE.findall(two)) == 2
+
+
+def test_summary_as_the_last_attribute_before_a_dash_close():
+    """``-%}`` must not swallow the closing quote of the last attribute."""
+    snippet = '{%- include news-card.html\n  summary="가나다."\n-%}'
+    assert ncp.SUMMARY_RE.search(snippet).group(2) == "가나다."
+
+
+# --- consumers stay wired to this module (C8 drift guard) --------------------
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "rewind_truncated_summaries.py",
+        "backfill_card_summary_period.py",
+        "backfill_digest_titles.py",
+    ],
+)
+def test_consumers_import_the_shared_pattern_instead_of_redeclaring(script):
+    """A re-declared `\\{%\\s*include` in any consumer reopens the C11 hole."""
+    src = (REPO / "scripts" / script).read_text(encoding="utf-8")
+    assert "news_card_patterns import" in src, f"{script} must import the shared pattern"
+    assert not re.search(r'r"\\\{%\\s\*include', src), (
+        f"{script} re-declares a `-`-blind include pattern"
+    )

--- a/scripts/tests/test_rewind_truncated_summaries.py
+++ b/scripts/tests/test_rewind_truncated_summaries.py
@@ -25,17 +25,28 @@ import rewind_truncated_summaries as rw  # noqa: E402
 _FM = '---\nlayout: post\ntitle: "x"\n---\n\n'
 
 
-def _card(summary, **extra):
+def _card(summary, include="news-card", open_ws="", close_ws="", **extra):
     attrs = "".join(f'  {k}="{v}"\n' for k, v in extra.items())
     return (
-        "{% include news-card.html\n"
+        f"{{%{open_ws} include {include}.html\n"
         '  title="제목"\n'
         '  url="https://example.com/a"\n'
         f'  summary="{summary}"\n'
         f"{attrs}"
         '  source="Example"\n'
-        "%}\n"
+        f"{close_ws}%}}\n"
     )
+
+
+# Every shape the corpus actually uses (C11). `\s` does not match `-`, so all
+# 282 `{%-` cards and all 64 spotlight items were invisible until 2026-08-07.
+_CARD_SHAPES = {
+    "plain": {},
+    "whitespace_control": {"open_ws": "-", "close_ws": "-"},
+    "dash_open_only": {"open_ws": "-"},
+    "spotlight": {"include": "news-spotlight-item"},
+    "spotlight_dash": {"include": "news-spotlight-item", "open_ws": "-", "close_ws": "-"},
+}
 
 
 def _truncated(head="가" * 150):
@@ -64,6 +75,14 @@ def test_rewind_keeps_the_sentence_period():
     out = rw.transform(_FM + _card(_truncated()))
     new = out.split('summary="')[1].split('"\n')[0]
     assert new.endswith("다.")
+
+
+@pytest.mark.parametrize("shape,kwargs", sorted(_CARD_SHAPES.items()))
+def test_every_card_shape_is_reached(shape, kwargs):
+    """C11 recall: a `{%-` or spotlight card must be rewound like a plain one."""
+    out = rw.transform(_FM + _card(_truncated(), **kwargs))
+    assert '경고합니다."' in out, shape
+    assert "Java 바이트 스트림 역" not in out, shape
 
 
 # --- what must NOT change ----------------------------------------------------

--- a/scripts/tests/test_rewind_truncated_summaries.py
+++ b/scripts/tests/test_rewind_truncated_summaries.py
@@ -104,6 +104,35 @@ def test_properly_terminated_long_summary_is_left_alone():
     assert rw.transform(src) == src
 
 
+# --- trailing ellipsis is truncation, not termination ------------------------
+
+
+@pytest.mark.parametrize("marker", ["...", "…"])
+def test_ellipsis_cut_summary_is_rewound_despite_ending_in_a_period(marker):
+    """9 corpus cards end this way; `endswith(".")` had skipped them all."""
+    body = "공격자가 원격 코드 실행에 성공했다고 밝혔습니다. " + "가" * 180
+    assert len(body + marker) >= rw.TRUNCATION_SUSPECT_LEN, "fixture must be in band"
+    out = rw.transform(_FM + _card(body + marker))
+    assert "밝혔습니다.\"" in out
+    assert marker not in out.split('summary="')[1].split('"\n')[0]
+
+
+def test_ellipsis_summary_with_no_complete_sentence_is_left_alone():
+    src = _FM + _card("가" * 210 + "...")
+    assert rw.transform(src) == src
+
+
+def test_ellipsis_rewind_is_idempotent():
+    once = rw.transform(_FM + _card("완성했습니다. " + "가" * 200 + "..."))
+    assert rw.transform(once) == once
+
+
+def test_mid_text_ellipsis_does_not_trigger_a_rewind():
+    """Only a TRAILING marker is truncation evidence."""
+    src = _FM + _card("중간에 ... 이 있지만 문장은 완성되었습니다. " + "가" * 170 + "종료입니다.")
+    assert rw.transform(src) == src
+
+
 def test_other_attributes_are_never_touched():
     nested = (
         "https://images.cointelegraph.com/cdn-cgi/image/f=auto,w=1200/"


### PR DESCRIPTION
## 무엇을 바꿨나요

커밋 2개, 성격이 다릅니다.

1. **`461ef17b`** — 카드 매칭 정규식의 사각지대 제거 + **C11 대상 재현율 테스트** 배선 (코퍼스 변경 0)
2. **`1f9d084f`** — 그 사각지대에 숨어 있던 **절단 요약 9건** 되감기 (4개 포스트)

## 왜 필요한가요

`\s` 는 `-` 를 매칭하지 않으므로 `\{%\s*include` 패턴은 `{%- include`(whitespace control) 변형을 전부 놓칩니다. 저장소 안에서 정규식이 갈려 있었습니다.

| 스크립트 | 패턴 | 매칭 / 누락 |
| :--- | :--- | ---: |
| `check_posts.py:510` | `\{%-?\s*include` | 2053 / **0** ✅ |
| `cleanup_news_cards.py:107` | `\{%-?\s*include` | 2053 / **0** ✅ |
| `rewind_truncated_summaries.py:34` | `\{%\s*include` | 1771 / **282** ❌ |
| `backfill_card_summary_period.py:42` | `\{%\s*include` | 1771 / **282** ❌ |
| `backfill_digest_titles.py:135` | 문자열 `.count()` | 1771 / **282** ❌ |

여기에 `news-spotlight-item` 64건은 **어떤 스크립트도 참조하지 않았습니다.**

`notes/corpus-transformer-contract.md` 의 **C11 「대상 재현율」** 이 이 문제 때문에 신설됐고(#520), 이 PR이 그 계약을 구현합니다.

## 진짜 발견 — 정규식 수정만으로는 아무것도 안 고쳐집니다

정규식을 고쳐도 **코퍼스는 0건 변경**이었습니다(양쪽 `--dry-run` → `0/186`). 파고들었더니 2차 버그가 있었습니다.

`scripts/rewind_truncated_summaries.py:36,41`
```python
_TERMINATED = (".", "!", "?")
if not text or text.endswith(_TERMINATED):   # ← '...' 도 여기서 통과
    return
```

**`...` 로 끝나는 요약을 "완성 문장"으로 판정해 건너뛰고 있었습니다.** 그 `...` 는 200자 캡 절단 마커이므로 종결의 **반대 증거**입니다.

분포를 실측했습니다 — `...` 로 끝나는 195자 이상 요약:

```
card_plain (`{% include`)      0
card_dash  (`{%- include`)    10   ← 전부 여기
spotlight                      0
```

즉 **#513은 이 형태를 만난 적이 없습니다.** 사각지대(`{%-`)와 종결 오판이 겹쳐야 드러나는 결함이라, 정규식 수정과 되감기를 별도 커밋으로 분리했습니다. 기존 1771개 카드에는 no-op(실측).

## 제 사전 추정이 둘 다 틀렸습니다 — 재측정 결과

| 착수 전 추정 | 실측 | 실제 정체 |
| :--- | :--- | :--- |
| 마침표 누락 2건 | **0건 (수정 대상 아님)** | `…주요 위협을 다룹니다:`(콜론 리드인), `1. 기술적 배경 및 위협 분석`(헤딩 조각). `_restore_sentence_period` 가 **정당하게 거부** — 마침표를 붙이면 잘못된 한국어 |
| 절단 요약 14건 | **12건 suspect → 9건 실결함** | 195자 이상은 12건, 그중 3건은 단지 긴 완성 문장 |

**고친 것: 4개 포스트 / 9건** — `2026-02-05`(3), `02-11`(2), `02-18`(1), `02-19`(3). 9/9 모두 완성 문장으로 종료, 잔여 36~70%(평균 54%)로 #513이 채택한 분포 대역 내입니다. `_posts/` diff는 `summary=` 외 줄 변경 **0건**(9 삭제 / 9 추가).

## C11 테스트 — 비-공허성 실측 확인

`scripts/tests/test_news_card_patterns.py` (20건). 핵심은 **`매칭 수 == 코퍼스 실제 인스턴스 수`를 파일 단위로 고정**하는 것입니다. ground truth는 ncp의 정규식이 아니라 **리터럴 4종 문자열 `.count()` 로 독립 산출**했습니다(계약 C5 — 감사 검출기를 룰 검출기와 분리). 프로즌 숫자가 아니라 *일치*를 검증하므로 코퍼스가 커져도 유효합니다.

정규식을 **일부러 되돌려** 가드가 실제로 트립하는지 확인했습니다:

| 되돌린 것 | 결과 |
| :--- | :--- |
| `CARD_OPEN_RE` → `\{%\s*include\s+news-card\.html` | **7 failed**, 13 passed |
| `CARD_RE` → `\{%\s*include\s+news-card\.html.*?%\}` | **7 failed**, 13 passed |
| 복원 후 | 20 passed |

추가 가드: `test_consumers_import_the_shared_pattern_instead_of_redeclaring` 가 3종에서 `-`-블라인드 패턴 재선언을 차단하고, `test_corpus_is_not_empty` 가 `_posts/` 이동 시 공허한 통과를 막습니다.

## 공통 헬퍼 추출 — `scripts/news_card_patterns.py`

3종이 원하는 카드 집합이 **실측 결과 동일**했고(요약 2종은 rewrite용, 제목은 count용이지만 "무엇이 뉴스 카드인가" 정의는 같음), `_SUMMARY_RE` 는 두 스크립트에 **바이트 동일하게 중복**돼 있었습니다. 계약 C8이 "import 가능하면 import"라 하고 실제로 가능했습니다.

## spotlight 포함 판단

요약 2종은 **포함** — `_includes/news-spotlight-item.html:9` 에 `summary=` 가 있어 구조적으로 대상입니다. 다만 spotlight 64건의 현재 결함은 **0건**(마침표 0 / 절단 0)이라 **오늘은 no-op** 이고, 순수 재현율 확보입니다. 그리고 그 no-op 임이 테스트로 증명됩니다.

`backfill_digest_titles` 도 **포함** — 호출부를 읽고 판단했습니다. 생성기의 `(N건)` 은 수집 항목 전수(`content_generator.py:1419`)이고 카드 수가 아닙니다(186개 중 114개가 `N ≠ 카드수`, 5~6월은 `claimed=29 / cards=15`). 백필은 그 pool을 볼 수 없어 본문에서 근사하므로 **렌더된 뉴스 항목을 다 세는 쪽이 근사를 개선**합니다. spotlight는 뉴스카드 URL과 중복 0건, 자체 번호 섹션에 렌더되는 별개 항목입니다.

> **주의**: 이 스크립트는 `is_already_new_schema` 게이트 때문에 `--force` 없이는 아무것도 재작성하지 않습니다(`--dry-run`: `Updated: 0  Skipped: 186`). **코퍼스 제목은 건드리지 않았습니다.**

## 검증 근거

```
pytest scripts/tests/                        3250 passed, 8 skipped in 9.76s  (신규 25건)
check_digest_proper_nouns.py --staged        OK — 4 digest post(s), 0 violations
check_digest_structure.py --ratchet --staged OK — 4 posts, 0 new, 0 pre-existing
check_post_quote_safety.py                   (no output) exit 0
fix_malformed_liquid_includes.py --check     ok: scanned 258 files; no malformed
check_digest_checklist_heading.py --all      OK — 186 digest(s), 0 violations
bundle exec jekyll build                     done in 11.99 seconds
```

- **`quality_baseline.json` 갱신 불필요** — `test_regen_quality_baseline` 통과, regen 미실행
- 렌더 확인: `2026-02-05` 의 Microsoft LLM 카드가 `…발표했습니다.` 로 정상 종료
- pre-commit 훅 우회 없음 (두 커밋 모두 전체 훅 통과)

- [x] 새 동작에 대한 테스트 추가
- [x] CI 게이트를 완화하지 않음
- [x] 하드코딩된 시크릿 없음

## 후속으로 남긴 것 (범위 밖, 미수정)

1. **비-digest 포스트의 `{%-` 카드 2건** — `2026-02-09-Security_Cloud_Digest_…`. `_is_digest_post`(`"Weekly_Digest" in name`)가 제외합니다. 이 중 1건이 `...` 절단(len=197)으로 남아 있습니다. **C1 대상 선별 문제이고 C11 재현율 문제가 아닙니다.** (제가 확인: `...` 절단 10건 = digest 9 + 이 1건)
2. **소수점 절단 2건 (신규 발견)** — `2026-02-05` 의 `CVE-2025-68613(CVSS 점수: 9.`(len=181), `React2Shell(…CVSS 점수: 10.`(len=171). 괄호가 닫히지 않은 중간 절단인데 `.` 로 끝나 rewind가 건너뛰고, len<195라 마침표 스크립트 몫도 아닙니다. **"195 미만은 절단이 아니다"는 T9 파티션 전제가 깨지는 사례** — 임계값 하향은 코퍼스 전역 영향이라 측정 없이 손대지 않았습니다.
3. `notes/corpus-transformer-contract.md` 의 C11 행이 여전히 "0/5 전부 미보유"입니다. 이 PR 머지 후 갱신이 필요합니다.
4. `--force` 제목 재작성 미실행 — spotlight 포함 결정의 실효는 `--force` 시점에만 나타나며 111개 포스트가 대상입니다.

## 미검증

지시된 6개 명령 외 CI 전용 체크(cover honesty, SVG size/drift 등)는 로컬에서 실행하지 않았습니다 — CI가 확인합니다.