### PR TITLE
fix(news): 제목만 되풀이하던 카드 요약 236건을 본문 근거로 교체 — 코퍼스 잔여 0

### DIFF
--- a/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
+++ b/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
@@ -94,7 +94,7 @@ summary_card:
   title="[보안] PromptSpy Android 악성코드, Gemini AI를 악용해 최근 앱 지속성 자동화"
   url="https://thehackernews.com/2026/02/promptspy-android-malware-abuses-google.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEidDhkNjYF9Khe4u-ECtSVv3ezo7dUK80WV06lgCNtOdV51GuCKCMmxgdm10lbAhP7MRPVY7Pq5yMuiYPAJ0Opk2xPijnkjHOWfPqiD9oR6k56GqDX6l5IgjYa_9ZTnvxvN6KnazUB0LBZ3aZMOnVrtoodDr-Hx_JTTNjMyzm-u1alcCL6VXeqoeTl12jFE/s1700-e365/android-ai.jpg"
-  summary="PromptSpy Android 악성코드, Gemini AI를 악용해 최근 앱 지속성 자동화 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Gemini AI를 런타임에 악용하는 최초의 Android 악성코드가 발견됐습니다. VNC 원격 접근과 PIN 가로채기 기능을 탑재하고 Chase Bank 피싱 페이지로 위장 배포되어, AI 서비스가 새로운 공격 표면으로 전용되는 실제 사례를 보여줍니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -135,7 +135,7 @@ Google Gemini AI를 런타임에 악용하는 최초의 Android 악성코드가 
   title="[보안] INTERPOL Operation Red Card 2.0, 아프리카 사이버범죄 단속으로 651명 체포"
   url="https://thehackernews.com/2026/02/interpol-operation-red-card-20-arrests.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhltf-8sYx4UcRPT_qBv92hmitOenRSgB2OctxYx4hdCPglcMJzeHR8Dmffrt5xjjtp0Tz2ur0wPSbvig7cnEyrdtJrOx8V4Z2sTGeR6eBlFwOO4pgPUISeLWGuMbUO4bnruvRWx-O6zYRUy_xw1F1CohPk2fZDkpM1YGXusO-8h8rgwQhLvZSlfp4ho5RJ/s1700-e365/interpol.jpg"
-  summary="INTERPOL Operation Red Card 2.0, 아프리카 사이버범죄 단속으로 651명 체포 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="INTERPOL이 주도한 국제 공조 작전으로 아프리카 전역에서 사이버 범죄자 651명을 일제 검거하고 430만 달러 이상을 회수했습니다. 모바일 뱅킹 사기와 투자 사기가 주요 표적이었으며, 국경을 초월한 사이버 범죄 단속의 실효성을 보여주는 사례입니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -162,7 +162,7 @@ INTERPOL이 주도한 국제 공조 작전으로 아프리카 전역에서 사�
   title="[보안] Microsoft, Windows Admin Center 권한 상승 취약점 CVE-2026-26119 패치 발표"
   url="https://thehackernews.com/2026/02/microsoft-patches-cve-2026-26119.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiTYrWKU78qUjsLRxRje4c7MEejHM-e4bg7D2mFbFEomGbCI39Um78JNkCJKcjrcH2FYinO-dVUiV0_rB60jmErrc4lyMkYOK-qIX3HnYCFJ8aWfFwcnaZOHe_38JSgbLPnVqWrQaXhvbXmMCAaJpb6qnANjxjsqB3S4NM89kemycwHA8kDGlwrS-306oP8/s1700-e365/windows-admin.jpg"
-  summary="Microsoft, Windows Admin Center 권한 상승 취약점 CVE-2026-26119 패치 발표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Microsoft가 Windows Admin Center의 권한 상승 취약점 CVE-2026-26119에 대한 패치를 발표했습니다. 관리 콘솔 접근 권한이 있는 공격자가 시스템 수준 권한을 획득할 수 있는 결함으로, 즉시 패치 적용이 필요합니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -198,7 +198,7 @@ Microsoft가 Windows Admin Center의 권한 상승 취약점 CVE-2026-26119에 �
   title="[보안] 가짜 IPTV 앱, 모바일 뱅킹 사용자 대상 Massiv Android 악성코드 유포"
   url="https://thehackernews.com/2026/02/fake-iptv-apps-spread-massiv-android.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEj67LPvqhfl_NCfP1wUAUN8p7ISQ_x3wCwavSYjJJkMl9jkcDnk0gP2Om7d1O0UqaQnwqeU4GzTfpLxUok2ei5tiNhArCqldBzaS6yzNe_mudDAbzllZcD1BA0FOfbn1LQRSiK36eB69u4hfK_Pa0XA0eZti_KN8Q43d_k1xRmp_LQCW6gA9ZWNvdrBx_py/s1700-e365/android-banking.jpg"
-  summary="가짜 IPTV 앱, 모바일 뱅킹 사용자 대상 Massiv Android 악성코드 유포 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="합법적인 IPTV 앱으로 위장한 'Massiv' 트로이 목마가 모바일 뱅킹 사용자를 직접 표적으로 삼아 기기 탈취(Device Take Over) 공격을 수행하고 있습니다. 공식 마켓 외부의 IPTV 앱 설치가 주요 감염 경로로, MDM 정책 강화가 핵심 대응 수단입니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -226,7 +226,7 @@ Microsoft가 Windows Admin Center의 권한 상승 취약점 CVE-2026-26119에 �
   title="[보안] CRESCENTHARVEST 캠페인, RAT 악성코드로 이란 시위 지지자 표적 공격"
   url="https://thehackernews.com/2026/02/crescentharvest-campaign-targets-iran.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiFD_PtNViVDHZuayLVtVYwd7N2scLLqDjTvVq8WGWrnvOCZ7tt92yiynt44EBuHUv2Y4b-sujz_BlBBx2Vl9af8ZzAXzTJH2UzFpsqC5KyxWWvB6FD-Ini78yxU9MsffuVeYsU2wQQCP5mTPs7xlI73PBSZ3RYj1RUMbjxfH06NhmoNjHkpapxBNwyEMrI/s1700-e365/protest.jpg"
-  summary="CRESCENTHARVEST 캠페인, RAT 악성코드로 이란 시위 지지자 표적 공격 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="국가 후원 위협 행위자로 추정되는 그룹이 이란 시위 지지자를 표적으로 RAT 악성코드를 배포하는 사이버 스파이 캠페인을 전개하고 있습니다. 정치적·지정학적 리스크가 높은 지역과 연관된 네트워크 트래픽에 대한 추가 모니터링이 필요합니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -254,7 +254,7 @@ Microsoft가 Windows Admin Center의 권한 상승 취약점 CVE-2026-26119에 �
   title="&quot;Clinejection&quot;: AI 봇을 공급망 공격 벡터로 전환한 방법"
   url="https://snyk.io/blog/cline-supply-chain-attack-prompt-injection-github-actions/"
   image="https://res.cloudinary.com/snyk/image/upload/v1646599410/wordpress-sync/blog-feature-security-alert-purple.jpg"
-  summary="&quot;Clinejection&quot;: AI 봇을 공급망 공격 벡터로 전환한 방법 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Snyk 연구팀이 AI 코딩 에이전트 Cline을 프롬프트 인젝션으로 조작해 GitHub Actions 캐시 포이즈닝과 결합한 공급망 공격을 시연했습니다. AI 에이전트가 자동으로 코드를 실행하는 환경에서 기존 보안 모델로는 탐지하기 어려운 새로운 공격 표면이 열렸다는 점이 핵심입니다."
   source="Snyk Blog"
   severity="High"
 -%}
@@ -291,7 +291,7 @@ Snyk 연구팀이 AI 코딩 에이전트 Cline을 프롬프트 인젝션으로 �
 {%- include news-card.html
   title="Kubernetes 프로젝트, Ingress NGINX 은퇴 경고 발표"
   url="https://securitylabs.datadoghq.com/articles/kubernetes-ingress-nginx-retirement-warning/"
-  summary="Kubernetes 프로젝트, Ingress NGINX 은퇴 경고 발표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Kubernetes 커뮤니티가 2026년 3월 이후 Ingress NGINX 공식 지원을 종료한다고 공식 발표했습니다. 클라우드 네이티브 환경의 약 50%에서 사용 중인 만큼 영향 범위가 크고, 최근 고위험 CVE 4건도 함께 공개되어 지금 당장 마이그레이션 계획을 수립해야 합니다."
   source="Datadog Security Labs"
   severity="High"
 -%}
@@ -333,7 +333,7 @@ Kubernetes 커뮤니티가 2026년 3월 이후 Ingress NGINX 공식 지원을 �
   title="[AI/ML] Google Cloud에서 Gemini 3.1 Pro 출시"
   url="https://cloud.google.com/blog/products/ai-machine-learning/gemini-3-1-pro-on-gemini-cli-gemini-enterprise-and-vertex-ai/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/gemini-3.1_pro_meta_dark.max-2000x2000.png"
-  summary="Google Cloud에서 Gemini 3.1 Pro 출시 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud가 ARC-AGI-2 벤치마크에서 77.1%를 기록한 Gemini 3.1 Pro를 공식 출시했습니다. 이전 세대 대비 2배 이상의 추론 성능을 제공하며, Gemini CLI와 Vertex AI에서 즉시 사용 가능해 기업 AI 워크플로우에 바로 적용할 수 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -360,7 +360,7 @@ Google Cloud가 ARC-AGI-2 벤치마크에서 77.1%를 기록한 Gemini 3.1 Pro�
 {%- include news-card.html
   title="[AI/ML] AI 정렬 독립 연구 지원 확대"
   url="https://openai.com/index/advancing-independent-research-ai-alignment"
-  summary="AI 정렬 독립 연구 지원 확대 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="OpenAI가 독립적인 AI 정렬 연구 기관인 The Alignment Project에 750만 달러를 투자하겠다고 발표했습니다. AGI 안전성 확보를 위해 외부 연구 생태계를 직접 지원하는 움직임으로, 기업 AI 거버넌스 정책에도 정렬 검증 단계를 포함하는 흐름이 가속화될 전망입니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -387,7 +387,7 @@ OpenAI가 독립적인 AI 정렬 연구 기관인 The Alignment Project에 750�
   title="[AI/ML] Union.ai와 Flyte로 Amazon EKS에서 AI 워크플로우 구축"
   url="https://aws.amazon.com/blogs/machine-learning/build-ai-workflows-on-amazon-eks-with-union-ai-and-flyte/"
   image="https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/02/19/ML-19776-1120x630.png"
-  summary="Union.ai와 Flyte로 Amazon EKS에서 AI 워크플로우 구축 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS가 Union.ai 2.0과 Flyte Python SDK를 활용해 Amazon EKS 위에서 AI/ML 워크플로우를 구축하는 실전 가이드를 공개했습니다. 컨테이너 네이티브 ML 파이프라인의 보안 설정(RBAC, 시크릿 관리)까지 다루고 있어 프로덕션 배포 시 참고할 만한 내용입니다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 -%}
@@ -412,7 +412,7 @@ AWS가 Union.ai 2.0과 Flyte Python SDK를 활용해 Amazon EKS 위에서 AI/ML 
   title="[클라우드] Conversational Analytics API로 BigQuery에서 대화형 에이전트 구축"
   url="https://cloud.google.com/blog/products/data-analytics/build-data-agents-with-conversational-analytics-api/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/09_-_Data_Analytics_tFH57V6.max-2600x2600.jpg"
-  summary="Conversational Analytics API로 BigQuery에서 대화형 에이전트 구축 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud의 Conversational Analytics API를 이용하면 BigQuery 데이터에 자연어로 질의하는 대화형 에이전트를 별도 ML 인프라 없이 구축할 수 있습니다. 데이터 민주화와 셀프서비스 분석 환경을 강화하려는 팀에게 주목할 만한 업데이트입니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -433,7 +433,7 @@ Google Cloud의 Conversational Analytics API를 이용하면 BigQuery 데이터�
   title="[클라우드] BigQuery 자율 임베딩 생성으로 AI 워크플로우 간소화"
   url="https://cloud.google.com/blog/products/data-analytics/introducing-bigquery-autonomous-embedding-generation/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/09_-_Data_Analytics_tFH57V6.max-2600x2600.jpg"
-  summary="BigQuery 자율 임베딩 생성으로 AI 워크플로우 간소화 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google이 BigQuery 내부에서 임베딩을 자동 생성·관리하는 기능을 도입했습니다. RAG 파이프라인 구축 시 별도 임베딩 서버 없이 BigQuery 단일 환경에서 완결되는 AI 워크플로우가 가능해져 운영 복잡도를 크게 줄일 수 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -454,7 +454,7 @@ Google이 BigQuery 내부에서 임베딩을 자동 생성·관리하는 기능�
   title="[클라우드] Amazon Bedrock 사용량 관리 및 최적화 하기"
   url="https://aws.amazon.com/ko/blogs/tech/optimzie-and-manage-amazon-bedrock-usage/"
   image="https://d2908q01vomqb2.cloudfront.net/2a459380709e2fe4ac2dae5733c73225ff6cfee1/2026/02/19/Screenshot-2026-02-19-at-11.53.05 AM-1117x630.png"
-  summary="Amazon Bedrock 사용량 관리 및 최적화 하기 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS Korea가 Amazon Bedrock 기반 AI 서비스의 토큰 사용량 관리와 비용 최적화 방법을 상세히 정리한 가이드를 공개했습니다. PoC를 넘어 프로덕션 운영 단계에 진입한 팀이라면 모델별 비용-성능 트레이드오프와 프롬프트 최적화 전략을 지금 검토할 시점입니다."
   source="AWS Korea Blog"
   severity="Medium"
 -%}
@@ -475,7 +475,7 @@ AWS Korea가 Amazon Bedrock 기반 AI 서비스의 토큰 사용량 관리와 �
   title="[클라우드] 주권과 유럽 경쟁력: 파트너십 기반 AI 성장 접근 방식"
   url="https://cloud.google.com/blog/products/identity-security/sovereignty-and-european-competitiveness-a-partnership-led-approach-to-ai-growth/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/17_-_Security__Identity_NrORvDT.max-2600x2600.jpg"
-  summary="주권과 유럽 경쟁력: 파트너십 기반 AI 성장 접근 방식 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud가 유럽 데이터 주권 요구사항을 반영한 파트너십 기반 AI 인프라 전략을 발표했습니다. 현지 규제 준수와 기술 혁신을 동시에 달성하는 접근법으로, GDPR 및 EU AI Act 대응을 고려하는 클라우드 아키텍처 설계에 참고할 만한 내용입니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -500,7 +500,7 @@ Google Cloud가 유럽 데이터 주권 요구사항을 반영한 파트너십 �
   title="[DevOps] 클라우드 네이티브 현황 2026: CNCF CTO의 인사이트와 전망"
   url="https://www.cncf.io/blog/2026/02/19/state-of-cloud-native-2026-cncf-ctos-insights-and-predictions/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Akamia-Cloud-Credits-35.png"
-  summary="클라우드 네이티브 현황 2026: CNCF CTO의 인사이트와 전망 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CNCF 10주년을 맞아 CTO가 클라우드 네이티브 생태계의 현재와 향후 방향을 정리한 인사이트를 공개했습니다. AI 워크로드와 Kubernetes의 통합 가속화, 보안 표준 강화가 2026년 핵심 화두로 제시되어 클라우드 네이티브 전략 수립 시 기준점으로 활용할 수 있습니다."
   source="CNCF Blog"
   severity="Medium"
 -%}
@@ -521,7 +521,7 @@ CNCF 10주년을 맞아 CTO가 클라우드 네이티브 생태계의 현재와 
   title="[DevOps] Medplum, Docker Hardened Images(DHI)로 헬스케어 플랫폼 보안 강화 사례"
   url="https://www.docker.com/blog/medplum-healthcare-docker-hardened-images/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="Medplum, Docker Hardened Images로 헬스케어 플랫폼 보안 강화 사례 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="오픈소스 의료 플랫폼 Medplum이 Docker Hardened Images 도입을 통해 HIPAA 규제 준수 수준의 컨테이너 보안을 달성한 과정을 공유했습니다. 헬스케어처럼 규제가 엄격한 환경에서 컨테이너 이미지 보안을 강화하려는 팀에게 실전 참고 사례가 됩니다."
   source="Docker Blog"
   severity="Medium"
 -%}
@@ -542,7 +542,7 @@ CNCF 10주년을 맞아 CTO가 클라우드 네이티브 생태계의 현재와 
   title="[DevOps] Rust, Google Summer of Code 2026 참여 발표"
   url="https://blog.rust-lang.org/2026/02/19/Rust-participates-in-GSoC-2026/"
   image="https://www.rust-lang.org/static/images/rust-social-wide.jpg"
-  summary="Rust, Google Summer of Code 2026 참여 발표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Rust 프로젝트가 3년 연속 Google Summer of Code에 참여한다고 발표했습니다. 메모리 안전성으로 주목받는 Rust의 오픈소스 기여자 저변 확대는 보안 중심 시스템 소프트웨어 생태계 성장에 긍정적인 신호입니다."
   source="Rust Blog"
   severity="Medium"
 -%}
@@ -566,7 +566,7 @@ Rust 프로젝트가 3년 연속 Google Summer of Code에 참여한다고 발표
   title="[블록체인] Bitcoin 라이트닝 네트워크, 월간 거래량 10억 달러 돌파"
   url="https://cointelegraph.com/news/bitcoin-lightning-network-1b-monthly-volume"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-02/019c77b1-52d4-779a-9396-2139521238f7.jpg"
-  summary="Bitcoin 라이트닝 네트워크, 월간 거래량 10억 달러 돌파 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin 라이트닝 네트워크의 월간 거래량이 11.7억 달러를 돌파하며 처음으로 10억 달러 벽을 넘었습니다. AI 에이전트 결제 실험 확산이 새로운 수요를 창출하고 있으며, 소액 결제 인프라로서의 입지가 빠르게 강화되고 있습니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -587,7 +587,7 @@ Bitcoin 라이트닝 네트워크의 월간 거래량이 11.7억 달러를 돌�
   title="[블록체인] CME, 5월 암호화폐 파생상품 24/7 거래 출시 목표"
   url="https://cointelegraph.com/news/cme-may-24-7-crypto-derivative-trading"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-02/019c76b7-6035-78bb-a892-da0e8b8ce4fb.jpg"
-  summary="CME, 5월 암호화폐 파생상품 24/7 거래 출시 목표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CME Group이 5월 29일부터 암호화폐 선물의 24시간 365일 거래를 시작할 예정입니다. SEC와 CFTC의 거래 시간 확대 검토와 맞물려 전통 금융과 암호화폐 시장의 경계가 빠르게 허물어지고 있는 흐름을 보여줍니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -608,7 +608,7 @@ CME Group이 5월 29일부터 암호화폐 선물의 24시간 365일 거래를 �
   title="[블록체인] SEC 리더십, 토큰화 증권과 기존 규제의 상호작용 명확화 추진"
   url="https://cointelegraph.com/news/sec-leadership-future-securities-ethdenver"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-02/019c76c0-5e44-7e39-90ed-b285dc9cde3b.jpg"
-  summary="SEC 리더십, 토큰화 증권과 기존 규제의 상호작용 명확화 추진 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="SEC 리더십이 ETHDenver에서 토큰화 증권과 기존 증권법의 상호작용을 공식적으로 명확화하겠다는 방향을 제시했습니다. 규제 불확실성 해소 움직임으로 블록체인 기반 금융 상품을 준비하는 기업에게 중요한 정책 신호입니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -629,7 +629,7 @@ SEC 리더십이 ETHDenver에서 토큰화 증권과 기존 증권법의 상호�
   title="[블록체인] Bitcoin ETF, 최근 유출에도 530억 달러 순유입 유지"
   url="https://cointelegraph.com/news/bitcoin-etfs-53b-net-inflows-after-selloff"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-01/019b92cc-d609-7af6-b3a8-9b3f85736edf.jpg"
-  summary="Bitcoin ETF, 최근 유출에도 530억 달러 순유입 유지 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin ETF가 최근 유출에도 불구하고 530억 달러의 순유입을 유지하고 있습니다. 기관 투자자의 지속적인 관심이 단기 가격 변동과 별개로 유지되는 흐름입니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -650,7 +650,7 @@ Bitcoin ETF가 최근 유출에도 불구하고 530억 달러의 순유입을 �
   title="[블록체인] UAE, 조용히 4억 5300만 달러 규모의 Bitcoin 준비금 축적"
   url="https://bitcoinmagazine.com/news/the-uae-453-million-bitcoin-reserve"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/The-UAE-Has-Quietly-Built-Up-a-453-Million-Bitcoin-Reserve-Arkham-.jpg"
-  summary="UAE, 조용히 4억 5300만 달러 규모의 Bitcoin 준비금 축적 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="UAE 왕실 연계 채굴 업체가 6,782 BTC(약 4억 5,300만 달러)를 보유하고 있음이 확인되며 국가 차원의 Bitcoin 준비금 전략이 드러났습니다. 중동 지역 기관 투자자의 암호화폐 채택이 조용하지만 의미 있는 속도로 진행되고 있음을 보여주는 사례입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -675,28 +675,24 @@ UAE 왕실 연계 채굴 업체가 6,782 BTC(약 4억 5,300만 달러)를 보유
   url="https://engineering.atspotify.com/2026/2/our-multi-agent-architecture-for-smarter-advertising/"
   source="Spotify Engineering"
   tag="Operator Signal"
-  summary="Spotify Multi-Agent Architecture for Advertising 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Discord Osprey: Open Sourcing our Rule Engine"
   url="https://discord.com/blog/osprey-open-sourcing-our-rule-engine"
   source="Discord Blog"
   tag="Operator Signal"
-  summary="Discord Osprey: Open Sourcing our Rule Engine 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Chrome CSS Zero-Day CVE-2026-2441"
   url="https://news.hada.io/topic?id=26823"
   source="GeekNews"
   tag="Tech Signals"
-  summary="Chrome CSS Zero-Day CVE-2026-2441 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="ThreatsDay Bulletin: OpenSSL RCE, Foxit 0-Days"
   url="https://thehackernews.com/2026/02/threatsday-bulletin-openssl-rce-foxit-0.html"
   source="The Hacker News"
   tag="Operator Signal"
-  summary="ThreatsDay Bulletin: OpenSSL RCE, Foxit 0-Days 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.md
+++ b/_posts/2026-02-21-Tech_Security_Weekly_Digest_Data_Rust_AI_Threat.md
@@ -92,7 +92,7 @@ redirect_from:
   title="[보안] Anthropic, AI 기반 취약점 스캔을 위한 Claude Code Security 출시"
   url="https://thehackernews.com/2026/02/anthropic-launches-claude-code-security.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhnUd8T_I-xQKNmoLh2WLznpTvsH2JGWkhRJOOcjgUxat1PSS3OKl-z5P-OYhbJssm5DqAP8B3Dye8Z298RAqvSKibFo-ISDmF0qPlOpUdUVKJRO9Gy5MxDZP4A2uUxmoqBpfK95Z4u-hvqmNqsRE42ivsIc2H-NQYubExbmPug9WbHkVpuqry9hO9nNG4y/s1700-e365/ai-code-scan.jpg"
-  summary="Anthropic, AI 기반 취약점 스캔을 위한 Claude Code Security 출시 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Anthropic의 Claude Code Security 출시는 AI가 단순한 코드 생성을 넘어 보안 감사 및 자동 패치 영역으로 진화했음을 의미합니다. DevSecOps 실무자 관점에서 분석한 결과는 다음과 같습니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -123,7 +123,7 @@ Anthropic이 공개한 'Claude Code Security'는 LLM의 문맥 이해 능력을 
   title="[보안] CISA, 실제 악용 중인 Roundcube 취약점 2건 KEV 목록에 추가"
   url="https://thehackernews.com/2026/02/cisa-adds-two-actively-exploited.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhtZg49iJDSf0QXV_lj9uqgkcevxHhncfWJrejyCIdGb2hlzcVefAWXETqflE7uEUTuAGKkqfSpa9_w1FoNTZ-67YU4H-iUio2DfhF7o2qIMIbx8BewvMG8rHsq8eh7gBwjVckasb5Qj8jsGY_3wRjBaYTh-nL10wAWFI5PbCu62cfJFk9Y8ucUBDyQNkEh/s1700-e365/roundcube.jpg"
-  summary="CISA, 실제 악용 중인 Roundcube 취약점 2건 KEV 목록에 추가 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CISA가 Roundcube 웹메일 취약점 2건을 KEV(Known Exploited Vulnerabilities) 목록에 추가했습니다. 실제 공격에 활용되고 있으며, 원격 코드 실행이 가능한 치명적 결함이 포함되어 즉각 대응이 필요합니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -152,7 +152,7 @@ CISA가 Roundcube 웹메일 취약점 2건을 KEV(Known Exploited Vulnerabilitie
   title="[보안] EC-Council AI 인증 포트폴리오 확대: 미국 AI 인력 보안 대비 강화"
   url="https://thehackernews.com/2026/02/ec-council-expands-ai-certification.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjTNtB3q8UY8WtPavGisP57bq3aRlFLsQJSfTpwuLP0E1eqcPNAtjaI2_YeTjOxEi4GGQbFUOu-sYuTLRB_WnoQNAKfiwUIJqmU5G8GrhPjsmKCx_03Ecyid-28wg-nWj4RjV8YWVXM4unbx9uhtxBz-b7crRhe03y4fH8up6O3q2k5Gdjx-r4-9Yk4QCM/s1700-e365/ec.jpg"
-  summary="EC-Council AI 인증 포트폴리오 확대: 미국 AI 인력 보안 대비 강화 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="EC-Council이 4개의 새로운 AI 인증 프로그램과 업데이트된 Certified CISO v4 프로그램을 출시했습니다. AI 채택 속도가 훈련된 인력 공급을 앞서는 구조적 격차를 해결하기 위한 조치로, 미국에서 약 70만 명의 AI 및 사이버보안 전문가 재교육이 필요한 상황입니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -186,7 +186,7 @@ EC-Council이 4개의 새로운 AI 인증 프로그램과 업데이트된 Certif
   title="[블록체인] Supreme Court가 Trump의 관세를 무효화하자 Bitcoin 급등"
   url="https://bitcoinmagazine.com/news/bitcoin-pops-after-supreme-court"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Pics-4-1.jpg"
-  summary="Supreme Court가 Trump의 관세를 무효화하자 Bitcoin 급등 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="미국 대법원이 Trump 전 대통령의 글로벌 관세 부과를 6대 3으로 무효화한 직후, 규제 불확실성 해소에 따라 Bitcoin 가격이 급등했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -208,7 +208,7 @@ EC-Council이 4개의 새로운 AI 인증 프로그램과 업데이트된 Certif
   title="[블록체인] Bitcoin 50% 급락: Quantum Scare인가 Capital Rotation인가?"
   url="https://bitcoinmagazine.com/markets/bitcoins-50-slide-quantum-scare"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Bitcoins-50-Slide-Quantum-Scare-or-Capital-Rotation.jpg"
-  summary="Bitcoin 50% 급락: Quantum Scare인가 Capital Rotation인가? 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin이 고점 대비 50% 급락하며 $67,000대로 하락했습니다. 양자 컴퓨팅의 암호화 위협에 대한 공포와 기관 자금의 자본 이동이 동시에 원인으로 거론되고 있습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -234,14 +234,12 @@ Bitcoin이 고점 대비 50% 급락하며 $67,000대로 하락했습니다. 양�
   url="https://electrek.co/2026/02/20/amazon-grows-van-fleet-solar-powered-semis-and-betterfleet-stops-by/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Amazon 배송 밴 함대 확대, 태양광 세미트럭 및 BetterFleet 방문 소식 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Kia, 대대적인 실내 개편을 통해 신형 전기 SUV 새롭게 단장"
   url="https://electrek.co/2026/02/20/kia-refreshing-new-ev-suv-major-interior-overhaul/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Kia, 대대적인 실내 개편을 통해 신형 전기 SUV 새롭게 단장 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.md
+++ b/_posts/2026-02-22-Tech_Security_Weekly_Digest_AI_Threat_Vulnerability_Security.md
@@ -93,7 +93,7 @@ summary_card:
   title="[보안] AI 활용 위협 행위자, 55개국 FortiGate 600대 이상 침해"
   url="https://thehackernews.com/2026/02/ai-assisted-threat-actor-compromises.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhJJ0OGjlNTnrjpx23D3iKXHFeEEDiGO2GRCI-o4SmtGRuXcl5S4rAcjOqOBrfuI1g8E_pj6UQjQP-R2qfAsV08Oukshw6Inq8fUK83I9sLd3LwnPyWazzaQ3yUghSA3UL0j-BNz0tn2dCEQsG3MpACZKSXoKnM6nhyphenhyphenf727_4S_f3L8EU3fxDc332_6Swkm/s1700-e365/FortiGate.jpg"
-  summary="AI 활용 위협 행위자, 55개국 FortiGate 600대 이상 침해 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="러시아어 사용 위협 행위자가 상용 생성형 AI 도구(DeepSeek, Anthropic Claude 등)를 활용하여 2026년 1~2월 사이 55개국 600대 이상의 FortiGate 장비를 침해했습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -136,7 +136,7 @@ summary_card:
   title="[보안] Anthropic, AI 기반 코드 취약점 스캐너 Claude Code Security 출시"
   url="https://thehackernews.com/2026/02/anthropic-launches-claude-code-security.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhnUd8T_I-xQKNmoLh2WLznpTvsH2JGWkhRJOOcjgUxat1PSS3OKl-z5P-OYhbJssm5DqAP8B3Dye8Z298RAqvSKibFo-ISDmF0qPlOpUdUVKJRO9Gy5MxDZP4A2uUxmoqBpfK95Z4u-hvqmNqsRE42ivsIc2H-NQYubExbmPug9WbHkVpuqry9hO9nNG4y/s1700-e365/ai-code-scan.jpg"
-  summary="Anthropic, AI 기반 코드 취약점 스캐너 Claude Code Security 출시 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Anthropic이 AI 기반 코드 보안 취약점 스캐닝 도구인 Claude Code Security를 Enterprise 및 Team 고객 대상 제한 프리뷰로 출시했습니다. 기존 규칙 기반 정적 분석 도구와 달리, 인간 연구자처럼 코드를 추론하고 데이터 흐름을 추적하여 기존 도구가 놓치는 취약점을 탐지합니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -169,7 +169,7 @@ Anthropic이 AI 기반 코드 보안 취약점 스캐닝 도구인 Claude Code S
   title="[보안] CISA, Roundcube 웹메일 취약점 2건 KEV 목록 긴급 추가"
   url="https://thehackernews.com/2026/02/cisa-adds-two-actively-exploited.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhtZg49iJDSf0QXV_lj9uqgkcevxHhncfWJrejyCIdGb2hlzcVefAWXETqflE7uEUTuAGKkqfSpa9_w1FoNTZ-67YU4H-iUio2DfhF7o2qIMIbx8BewvMG8rHsq8eh7gBwjVckasb5Qj8jsGY_3wRjBaYTh-nL10wAWFI5PbCu62cfJFk9Y8ucUBDyQNkEh/s1700-e365/roundcube.jpg"
-  summary="CISA, Roundcube 웹메일 취약점 2건 KEV 목록 긴급 추가 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="미국 CISA(사이버보안 및 인프라 보안국)가 Roundcube 웹메일의 취약점 2건을 실제 악용이 확인되어 KEV(Known Exploited Vulnerabilities) 목록에 긴급 추가했습니다. 이 취약점들은 원격 코드 실행(RCE)과 크로스 사이트 스크립팅(XSS) 공격을 가능하게 하며, 공개 후 48시간 이내에 무기화된 사례가 확인되었습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -228,7 +228,7 @@ SK쉴더스 HeadLine 11월호에서 사이버보안 특화 Vertical AI 시스템
   title="[블록체인] Bitcoin 24개월 중 50%가 상승 마감, 경제학자 연말 상승 전망"
   url="https://cointelegraph.com/news/bitcoin-price-uptrend-economist-forecast-december?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2025-03/01959c4b-5323-7b7a-85a3-e5db89e081b1"
-  summary="Bitcoin 24개월 중 50%가 상승 마감, 경제학자 연말 상승 전망 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="경제학자 Timothy Peterson은 Bitcoin의 지난 24개월 중 절반이 양의 수익률로 마감한 점을 근거로, 2026년 12월까지 가격이 상승할 확률이 88%라고 전망했습니다. 현재 Bitcoin은 약 68,173달러에 거래되고 있으며 연초 대비 약 25% 하락한 상태입니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -255,7 +255,7 @@ SK쉴더스 HeadLine 11월호에서 사이버보안 특화 Vertical AI 시스템
   title="[블록체인] 트럼프 글로벌 관세율 15%로 인상, 암호화폐 시장은 평온 유지"
   url="https://cointelegraph.com/news/trump-raises-tariff-15-crypto-unfazed?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-01/019b96a0-5e26-77e1-8fd0-b9c2dc0fe267.jpg"
-  summary="트럼프 글로벌 관세율 15%로 인상, 암호화폐 시장은 평온 유지 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="트럼프 대통령이 대법원의 이전 관세 권한 무효 판결 이후 무역확장법(1962)과 무역법(1974)을 근거로 글로벌 관세율을 10%에서 15%로 즉시 인상한다고 발표했습니다. 과거 관세 발표 시 시장이 크게 흔들렸던 것과 달리, Bitcoin과 Ethereum 등 암호화폐 자산은 이번 발표에 최소한의 반응만 보이며 1% 미만의 하락에 그쳤습니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -285,14 +285,12 @@ SK쉴더스 HeadLine 11월호에서 사이버보안 특화 Vertical AI 시스템
   url="https://electrek.co/2026/02/21/ev-driver-shares-surprising-real-world-data-after-installing-solar-panels/"
   source="Electrek"
   tag="Operator Signal"
-  summary="EV 운전자, 태양광 패널 설치 후 2년간 실제 충전 비용 데이터 공개 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="McMurtry, 136만 달러 전기 팬카 Speirling PURE 양산 개시"
   url="https://electrek.co/2026/02/21/it-begins-mcmurtry-kicks-off-production-of-1-36-million-electric-fan-car/"
   source="Electrek"
   tag="Operator Signal"
-  summary="McMurtry, 136만 달러 전기 팬카 Speirling PURE 양산 개시 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.md
+++ b/_posts/2026-02-23-Tech_Security_Weekly_Digest_AI_Ransomware_Data_Bitcoin.md
@@ -243,7 +243,7 @@ IT/OT 융합 환경의 주요 리스크:
   title="[블록체인] Bitcoin 가격 $65,000 이하로 급락"
   url="https://bitcoinmagazine.com/markets/bitcoin-price-crashes-below-65000"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Bitcoin-Price-Crashes-Below-65000-Drops-5-in-2-Hours-Amid-Six-Week-Slump.jpg"
-  summary="Bitcoin 가격 $65,000 이하로 급락 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin이 일요일 저녁 2시간 만에 5% 이상 하락하며 $65,000 선 아래로 급락했습니다. 매우 짧은 시간 내에 급격한 매도 압력이 발생하여 시장 전반에 변동성이 확대되었습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -273,7 +273,7 @@ Bitcoin이 일요일 저녁 2시간 만에 5% 이상 하락하며 $65,000 선 �
   title="[블록체인] 러시아 제재 우회를 돕는 암호화폐 거래소 네트워크 적발"
   url="https://cointelegraph.com/news/crypto-exchange-network-helping-russia-skirt-sanctions-elliptic?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2025-12/019b6f72-662b-7191-9316-5b0e1e6bbce3.jpg"
-  summary="러시아 제재 우회를 돕는 암호화폐 거래소 네트워크 적발 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="블록체인 분석 기업 Elliptic에 따르면, 5개 암호화폐 거래소(Bitpapa, ABCeX, Exmo, Rapira, Aifory Pro)가 러시아의 국제 제재 우회를 지원하고 있는 것으로 밝혀졌습니다. 이 플랫폼들은 제재 대상이었던 Garantex 폐쇄 이후 루블-암호화폐 환전 경로를 제공하며 제재 대상 자산의 국경 이동을 가능하게 하고 있습니다."
   source="Cointelegraph"
   severity="High"
 -%}
@@ -310,14 +310,12 @@ Bitcoin이 일요일 저녁 2시간 만에 5% 이상 하락하며 $65,000 선 �
   url="https://tech.worldmonitor.app/"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech World Monitor 글로벌 기술 동향 대시보드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="미 공군, 세계 최초 이동식 원자력 발전소 배치"
   url="https://electrek.co/2026/02/22/worlds-first-us-air-force-deploys-portable-nuclear-power-station/"
   source="Electrek"
   tag="Operator Signal"
-  summary="미 공군, 세계 최초 이동식 원자력 발전소 배치 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
+++ b/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
@@ -92,7 +92,7 @@ summary_card:
   title="[보안] APT28 MacroMaze 웹훅 매크로 멀웨어 캠페인"
   url="https://thehackernews.com/2026/02/apt28-targeted-european-entities-using.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjSwbKDzax_Hh_RHSU7qEInhqGvzoEncnUbB3WgxiRorJPzrvWGo2GCCC0_94YDAdaIs3gBMgO8N4iM4FoMzMiaM1icI-NX2qTf5Dflmv25XR66ni1JEcMl0HxwApTpA5W48R9KLgF5oo7uB8FAjoUrI3h7FxPgoER_FCPPgJ2gHZQyk3BR4kZkt-tU6CFG/s1700-e365/malware-attack-eu.jpg"
-  summary="APT28 MacroMaze 웹훅 매크로 멀웨어 캠페인 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="러시아 정부 지원 APT28(Fancy Bear/Forest Blizzard)이 서유럽 및 중앙유럽 정부, 외교 기관, 방산 업체를 대상으로 'MacroMaze'라는 새로운 웹훅 기반 매크로 멀웨어 캠페인을 전개하고 있습니다. 정교한 스피어피싱 이메일에 악성 매크로가 포함된 문서를 첨부하여, 실행 시 웹훅 인프라를 통해 C2 통신을 수행합니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -133,7 +133,7 @@ summary_card:
   title="[보안] XMRig BYOVD 웜 캠페인 - CVE-2020-14979 악용"
   url="https://thehackernews.com/2026/02/wormable-xmrig-campaign-uses-byovd.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiSN4m24uNLL9rLCwHv89KIT-P1ExHG8D2EAk0TBI7XClmXn4JxBe0NWurC0iazjhxVKll6ZmSfMPbfD3ohlUDAXCscVdXkLmFicuwIoz9ya4Lvx6FCcgAdu75R72rx_W1-1I5UGbtgJMkSCR1MaZAGUxzHM5uSDAhNj5FBHGpCq__7yUclLAQg7IGhUhdW/s1700-e365/miners.jpg"
-  summary="XMRig BYOVD 웜 캠페인 - CVE-2020-14979 악용 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CVE-2020-14979 취약점을 악용하는 BYOVD(Bring Your Own Vulnerable Driver) 기법과 시간 기반 논리폭탄(logic bomb), 웜 기능을 결합한 XMRig 암호화폐 채굴 캠페인이 확산 중입니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -174,7 +174,7 @@ CVE-2020-14979 취약점을 악용하는 BYOVD(Bring Your Own Vulnerable Driver)
   title="[보안] Weekly Recap: Double-Tap 스키머, PromptSpy, 30Tbps DDoS"
   url="https://thehackernews.com/2026/02/weekly-recap-double-tap-skimmers.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjD4zrmWnbbBtQZsZm7orVyVisAR_ymd6dfSG7kPtgEo-CxVEphY0ZZXuQL4IiXd3ISaSR-qhY2uALIOlVgLCCZNyBiLd-WSfzR3x7NWo0xQWpwi6kTIZaZDHzwPzulQmWzndoAd-HDhPLtEYg-OrNyl-5FjPpDKSm1hPXVBnu-p6e8wtvpOFiWRUd1-pF9/s1700-e365/cyber-recap.jpg"
-  summary="Weekly Recap: Double-Tap 스키머, PromptSpy, 30Tbps DDoS 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="이번 주 주요 사이버보안 이벤트를 종합 정리합니다. Dell RecoverPoint 제로데이 취약점, Double-Tap 결제 스키머 기법, AI 프롬프트 탈취 도구 PromptSpy, 기록적인 30Tbps DDoS 공격, Docker Hub 악성 이미지 등 다양한 위협이 보고되었습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -210,7 +210,7 @@ CVE-2020-14979 취약점을 악용하는 BYOVD(Bring Your Own Vulnerable Driver)
 {%- include news-card.html
   title="[AI/ML] OpenAI, SWE-bench Verified 벤치마크 평가 중단"
   url="https://openai.com/index/why-we-no-longer-evaluate-swe-bench-verified"
-  summary="OpenAI, SWE-bench Verified 벤치마크 평가 중단 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="OpenAI가 소프트웨어 엔지니어링 벤치마크인 SWE-bench Verified 평가를 더 이상 수행하지 않겠다고 발표했습니다. 벤치마크의 포화(saturation)와 실제 소프트웨어 엔지니어링 능력을 정확히 측정하지 못하는 한계가 주요 원인으로, AI 코딩 능력 평가 방법론의 전환점이 될 전망입니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -239,7 +239,7 @@ OpenAI가 소프트웨어 엔지니어링 벤치마크인 SWE-bench Verified 평
 {%- include news-card.html
   title="[AI/ML] OpenAI Frontier Alliance Partners 발표"
   url="https://openai.com/index/frontier-alliance-partners"
-  summary="OpenAI Frontier Alliance Partners 발표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="OpenAI가 Frontier Alliance Partners 프로그램을 발표하여, 선도적인 기업 및 연구 기관들과 AI 안전성, 보안, 정책 분야에서 협력 체계를 구축합니다. 이 프로그램은 AI 모델의 안전한 배포와 책임 있는 사용을 촉진하기 위한 다자간 협력 프레임워크입니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -269,7 +269,7 @@ OpenAI가 Frontier Alliance Partners 프로그램을 발표하여, 선도적인 
   title="[AI/ML] AWS ML: VLM 기반 데이터 주석 스케일링"
   url="https://aws.amazon.com/blogs/machine-learning/scaling-data-annotation-using-vision-language-models-to-power-physical-ai-systems/"
   image="https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/02/23/ml-20346-1120x630.png"
-  summary="AWS ML: VLM 기반 데이터 주석 스케일링 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS Machine Learning Blog에서 Vision Language Model(VLM)을 활용한 데이터 주석(annotation) 스케일링 방법론을 공개했습니다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 -%}
@@ -303,7 +303,7 @@ AWS Machine Learning Blog에서 Vision Language Model(VLM)을 활용한 데이�
   title="[클라우드] Google Cloud Firefly 시계 동기화 프로토콜"
   url="https://cloud.google.com/blog/products/networking/understanding-the-firefly-clock-synchronization-protocol/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/24_-_Networking_vCB4Wjq.max-2600x2600.jpg"
-  summary="Google Cloud Firefly 시계 동기화 프로토콜 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud가 분산 시스템을 위한 Firefly 시계 동기화 프로토콜의 기술적 세부사항을 공개했습니다. 이 프로토콜은 글로벌 분산 데이터베이스(Spanner 등)에서 나노초 수준의 시계 동기화를 달성하여, 트랜잭션 일관성과 데이터 무결성을 보장합니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -327,7 +327,7 @@ Google Cloud가 분산 시스템을 위한 Firefly 시계 동기화 프로토콜
   title="[클라우드] AWS Weekly Roundup: Claude Sonnet 4.6, Kiro GovCloud"
   url="https://aws.amazon.com/blogs/aws/aws-weekly-roundup-claude-sonnet-4-6-in-amazon-bedrock-kiro-in-govcloud-regions-new-agent-plugins-and-more-february-23-2026/"
   image="https://d2908q01vomqb2.cloudfront.net/da4b9237bacccdf19c0760cab7aec4a8359010b0/2023/08/13/AWS-WIR-default.png"
-  summary="AWS Weekly Roundup: Claude Sonnet 4.6, Kiro GovCloud 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS 주간 라운드업에서 Amazon Bedrock에 Claude Sonnet 4.6 모델 추가, AWS Kiro의 GovCloud 리전 확장, 새로운 Agent 플러그인 등 주요 업데이트를 발표했습니다."
   source="AWS Blog"
   severity="Medium"
 -%}
@@ -355,7 +355,7 @@ AWS 주간 라운드업에서 Amazon Bedrock에 Claude Sonnet 4.6 모델 추가,
   title="[DevOps] Docker Gordon AI 에이전트 업데이트"
   url="https://www.docker.com/blog/gordon-dockers-ai-agent-just-got-an-update/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="Docker Gordon AI 에이전트 업데이트 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Docker가 Gordon이라는 AI 에이전트의 주요 업데이트를 발표했습니다. Gordon은 Docker Desktop에 통합된 AI 어시스턴트로, 컨테이너 환경을 이해하고 Dockerfile 최적화, 보안 취약점 탐지, 디버깅 지원 등을 수행합니다."
   source="Docker Blog"
   severity="Medium"
 -%}
@@ -379,7 +379,7 @@ Docker가 Gordon이라는 AI 에이전트의 주요 업데이트를 발표했습
   title="[DevOps] KubeCon Europe 2026 Open Source SecurityCon"
   url="https://www.cncf.io/blog/2026/02/23/kubecon-cloudnativecon-europe-2026-co-located-event-deep-dive-open-source-securitycon/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/KubeCon-CloudNativeCon-Europe-2026-Co-located-Event-Deep-Dive-Open-Source-SecurityCon.jpg"
-  summary="KubeCon Europe 2026 Open Source SecurityCon 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CNCF가 KubeCon + CloudNativeCon Europe 2026에서 Open Source SecurityCon을 공동 개최한다고 발표했습니다. 오픈소스 소프트웨어 공급망 보안, SBOM, Sigstore 서명 검증, SLSA 프레임워크 등 클라우드 네이티브 보안의 최신 동향을 다룹니다."
   source="CNCF Blog"
   severity="Medium"
 -%}
@@ -407,7 +407,7 @@ CNCF가 KubeCon + CloudNativeCon Europe 2026에서 Open Source SecurityCon을 �
   title="[블록체인] Bitcoin Indonesia: 월 40회 밋업, 커뮤니티 부활"
   url="https://bitcoinmagazine.com/culture/from-40-meetups-a-month-to-nationwide-freedom-bitcoin-indonesias-real-life-comeback"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/TN-6.webp"
-  summary="Bitcoin Indonesia: 월 40회 밋업, 커뮤니티 부활 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="인도네시아의 Bitcoin 커뮤니티가 월 40회 이상의 밋업을 개최하며 강력한 부활세를 보이고 있습니다. 약 55,000명의 비트코이너 커뮤니티가 전국적으로 활동하며, Bitcoin 교육과 실제 결제 사용 사례를 확대하고 있습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -431,7 +431,7 @@ CNCF가 KubeCon + CloudNativeCon Europe 2026에서 Open Source SecurityCon을 �
   title="[블록체인] 프랑스 에너지 기업 Engie, 브라질 Bitcoin 채굴 검토"
   url="https://bitcoinmagazine.com/news/french-energy-engie-eyes-bitcoin-mining"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/French-Energy-Giant-Engie-Eyes-Bitcoin-Mining-at-Brazil-Mega-Solar-Project.jpg"
-  summary="프랑스 에너지 기업 Engie, 브라질 Bitcoin 채굴 검토 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="프랑스 에너지 대기업 Engie가 브라질의 895MW 태양광 발전소에서 잉여 전력을 활용한 Bitcoin 채굴을 검토 중입니다. 재생에너지와 Bitcoin 채굴의 결합은 에너지 낭비를 줄이면서 추가 수익원을 창출하는 모델로 주목받고 있습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -459,14 +459,12 @@ CNCF가 KubeCon + CloudNativeCon Europe 2026에서 Open Source SecurityCon을 �
   url="https://tech.worldmonitor.app/?lat=20.0000&lon=0.0000&zoom=1.00&view=global&timeRange=7d&layers=cables%2Cweather%2Ceconomic%2Coutages%2Cdatacenters%2Cnatural%2CstartupHubs%2CcloudRegions%2CtechHQs%2CtechEvents"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech World Monitor 글로벌 대시보드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Tesla, 캘리포니아 DMV FSD 허위광고 판결 소송"
   url="https://electrek.co/2026/02/23/tesla-sues-california-dmv-reverse-fsd-false-advertising-ruling/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Tesla, 캘리포니아 DMV FSD 허위광고 판결 소송 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
+++ b/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
@@ -94,7 +94,7 @@ summary_card:
   title="[보안] GitHub Codespaces RoguePilot: Copilot 악용 GITHUB_TOKEN 유출"
   url="https://thehackernews.com/2026/02/roguepilot-flaw-in-github-codespaces.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjCSgjd-Xezu42fOKahjOxnhqntkclItoP8FmMfyjjKTmelK3eHoUEi6_75n6ORgD650By4wESNP8yDP2WWENzqI5T9Gl-NhYPPTiAQgkFykZv1d_MsCECcu0ZgQWt29JiGmH1zCmwNWSin8AQMWmsOm6r4ZdS8EOIC9Xtdw7FrRlN8kQs7o2s_whiNtcSH/s1700-e365/github-copilot.jpg"
-  summary="GitHub Codespaces RoguePilot: Copilot 악용 GITHUB_TOKEN 유출 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="GitHub Codespaces에서 'RoguePilot'이라는 보안 취약점이 발견되었습니다. 공격자가 GitHub 이슈에 악의적인 명령어를 숨겨 GitHub Copilot을 조작하면, 민감한 GITHUB_TOKEN을 외부로 유출할 수 있습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -134,7 +134,7 @@ GitHub Codespaces에서 'RoguePilot'이라는 보안 취약점이 발견되었�
   title="[보안] UAC-0050: 유럽 금융기관 대상 RMS 멀웨어 공격"
   url="https://thehackernews.com/2026/02/uac-0050-targets-european-financial.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiMR8uMyTA6j9P1KBgNFXf7uKvuD9CpolHGiMuaTIMOc87IKSqoGXWxea4Hs3unk1kLewzUd0hyOxpk6AsnEy1WmKwQwW8QV2zFBJiCi6PLOMi5zxAD_C2_DZytczAcPCSA_JGN9Se8arByQlLzoTiDaX1qJiA0Q6IT2Sfeg7BgkeQZ2ptQcjo_RX8jMgs1/s1700-e365/bank-cyberattack.jpg"
-  summary="UAC-0050: 유럽 금융기관 대상 RMS 멀웨어 공격 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="러시아 연계 위협 행위자 UAC-0050이 우크라이나 사법부 도메인을 위조하여 유럽 금융 기관의 법무 고문을 대상으로 스피어 피싱 공격을 수행했습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -165,7 +165,7 @@ GitHub Codespaces에서 'RoguePilot'이라는 보안 취약점이 발견되었�
   title="[보안] 악성 Next.js 저장소를 통한 개발자 표적 C2 캠페인"
   url="https://www.microsoft.com/en-us/security/blog/2026/02/24/c2-developer-targeting-campaign/"
   image="https://www.microsoft.com/en-us/security/blog/wp-content/uploads/2026/02/MS_Actional-Insights_Detection-hunting.png"
-  summary="악성 Next.js 저장소를 통한 개발자 표적 C2 캠페인 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Microsoft 보안팀이 악의적인 Next.js 저장소를 이용한 개발자 표적 캠페인을 적발했습니다. 이 공격은 표준 빌드 워크플로우(npm install, npm run build) 내에서 원격 코드 실행(RCE)부터 C2(커맨드&컨트롤) 연결까지의 공격 체인을 은폐하여 실행합니다."
   source="Microsoft Security Blog"
   severity="Critical"
 -%}
@@ -200,7 +200,7 @@ Microsoft 보안팀이 악의적인 Next.js 저장소를 이용한 개발자 표
   title="[AI/ML] Apple SALAD: 텍스트-음성 LLM 성능 격차 해소 연구"
   url="https://machinelearning.apple.com/research/closing-the-gap"
   image="https://mlr.cdn-apple.com/media/Home_1200x630_48225d82e9.png"
-  summary="Apple SALAD: 텍스트-음성 LLM 성능 격차 해소 연구 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="애플 연구팀이 음성 적응 LLM이 텍스트 기반 LLM보다 성능이 저하되는 '텍스트-음성 이해 격차(text-speech understanding gap)' 문제를 체계적으로 분석했습니다."
   source="Apple Machine Learning Research"
   severity="Medium"
 -%}
@@ -230,7 +230,7 @@ Microsoft 보안팀이 악의적인 Next.js 저장소를 이용한 개발자 표
   title="[AI/ML] Meta RCCLX: AMD GPU 통신 10-50% 성능 혁신"
   url="https://engineering.fb.com/2026/02/24/data-center-engineering/rrcclx-innovating-gpu-communications-amd-platforms-meta/"
   image="https://engineering.fb.com/wp-content/uploads/2026/02/rrcclx-innovating-gpu-communications-amd-platforms-meta-HERO.png"
-  summary="Meta RCCLX: AMD GPU 통신 10-50% 성능 혁신 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Meta가 AMD 플랫폼용 GPU 통신을 개선하는 RCCLX(RCCL eXtended)를 오픈소스로 공개했습니다. Direct Data Access(DDA)와 저정밀 집합 연산 기술을 통해 AMD MI300X GPU에서 10-50%의 성능 향상을 달성했으며, Torchcomms API와 통합되어 연구자들이 쉽게 활용할 수 있습니다."
   source="Meta Engineering Blog"
   severity="Medium"
 -%}
@@ -259,7 +259,7 @@ Meta가 AMD 플랫폼용 GPU 통신을 개선하는 RCCLX(RCCL eXtended)를 오�
 {%- include news-card.html
   title="[AI/ML] OpenAI, Arvind KC를 최고인사책임자(CPO)로 임명"
   url="https://openai.com/index/arvind-kc-chief-people-officer"
-  summary="OpenAI, Arvind KC를 최고인사책임자로 임명 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="OpenAI가 Arvind KC를 최고인사책임자(Chief People Officer)로 임명했습니다. 이는 OpenAI의 급속한 조직 확장에 대응하여 인재 관리와 조직 문화 강화를 위한 전략적 임명으로, AI 산업의 인재 확보 경쟁이 심화되는 가운데 주목할 만한 인사 이동입니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -286,7 +286,7 @@ OpenAI가 Arvind KC를 최고인사책임자(Chief People Officer)로 임명했�
   title="[클라우드] AWS Elemental Inference: 라이브 비디오 모바일 최적화"
   url="https://aws.amazon.com/blogs/aws/transform-live-video-for-mobile-audiences-with-aws-elemental-inference/"
   image="https://d2908q01vomqb2.cloudfront.net/da4b9237bacccdf19c0760cab7aec4a8359010b0/2026/02/17/aws-library_illustration_data_7_2x1.jpg"
-  summary="AWS Elemental Inference: 라이브 비디오 모바일 최적화 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS가 실시간 비디오를 모바일 기기용으로 변환하는 AWS Elemental Inference 서비스를 발표했습니다. 이 서비스는 라이브 스트리밍 콘텐츠를 다양한 디바이스와 네트워크 조건에 최적화하여 전송할 수 있게 해주며, 방송사, 스트리밍 서비스 제공업체, 고품질 라이브 비디오 배포가 필요한 조직들이 활용할 수 있습니다."
   source="AWS Blog"
   severity="Medium"
 -%}
@@ -313,7 +313,7 @@ AWS가 실시간 비디오를 모바일 기기용으로 변환하는 AWS Element
   title="[DevOps] Docker Captain Kristiyan Velkov 인터뷰"
   url="https://www.docker.com/blog/from-the-captains-chair-kristiyan-velkov/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="Docker Captain Kristiyan Velkov 인터뷰 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Docker의 'Captain's Chair' 시리즈에서 프론트엔드 어드보케이트이자 기술 리더인 Kristiyan Velkov를 소개합니다. 그는 개발자들을 위한 실용적인 팁과 올해의 목표를 공유하며, Docker 기반 프론트엔드 개발 워크플로우와 커뮤니티 참여에 대한 인사이트를 제공합니다."
   source="Docker Blog"
   severity="Medium"
 -%}
@@ -336,7 +336,7 @@ Docker의 'Captain's Chair' 시리즈에서 프론트엔드 어드보케이트�
   title="[DevOps] WinForms + AI: The Dongle Died at Midnight"
   url="https://devblogs.microsoft.com/dotnet/the-dongle-died-at-midnight/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/02/the-dongle-died-at-midnight.webp"
-  summary="WinForms + AI: The Dongle Died at Midnight 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Klaus Loeffelmann이 고장난 USB 동글로 인해 독일에서 시간 연구를 수행할 수 없게 된 어머니를 돕기 위해, WinForms 전문가 에이전트와 GitHub Copilot을 활용하여 주말 동안 맞춤형 애플리케이션을 개발한 사례입니다."
   source="Microsoft .NET Blog"
   severity="Medium"
 -%}
@@ -388,7 +388,7 @@ CNCF에서 Harbor 컨테이너 레지스트리를 프로덕션 환경에서 안�
   title="[블록체인] 미국 재무부, 러시아 암호화폐 사이버 절도 네트워크 제재"
   url="https://bitcoinmagazine.com/news/us-sanctions-crypto-funded-cyber-theft"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/U.S.-Treasury-Sanctions-Russian-Exploit-Broker-Over-Crypto-Funded-Cyber-Theft.jpg"
-  summary="미국 재무부, 러시아 암호화폐 사이버 절도 네트워크 제재 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="미국 재무부가 도난당한 정부 사이버 도구를 암호화폐로 구입하여 재판매한 러시아 네트워크에 대해 제재를 부과했습니다. 이는 미국 지적재산권 보호법에 따른 첫 번째 조치로, 암호화폐를 통한 사이버 범죄 자금 조달에 대한 규제가 본격적으로 강화되고 있음을 보여줍니다."
   source="Bitcoin Magazine"
   severity="High"
 -%}
@@ -411,7 +411,7 @@ CNCF에서 Harbor 컨테이너 레지스트리를 프로덕션 환경에서 안�
   title="[블록체인] Michael Saylor, Bitcoin 2026 컨퍼런스 연사 확정"
   url="https://bitcoinmagazine.com/conference/michael-saylor-confirmed-as-a-speaker-for-bitcoin-2026"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Screenshot-2026-02-24-at-2.38.08-PM-1024x533.png"
-  summary="Michael Saylor, Bitcoin 2026 컨퍼런스 연사 확정 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="MicroStrategy 회장 Michael Saylor가 4월 27-29일 라스베이거스 베네치안에서 개최될 Bitcoin 2026 컨퍼런스의 연사로 확정되었습니다. 이 행사에는 Bitcoin, 금융, 채광, 에너지, 정책 분야의 수백 명의 글로벌 리더들이 참석할 예정입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -438,14 +438,12 @@ MicroStrategy 회장 Michael Saylor가 4월 27-29일 라스베이거스 베네�
   url="https://tech.worldmonitor.app/?lat=20.0000&lon=0.0000&zoom=1.00&view=global&timeRange=7d&layers=cables%2Cweather%2Ceconomic%2Coutages%2Cdatacenters%2Cnatural%2CstartupHubs%2CcloudRegions%2CtechHQs%2CtechEvents"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech World Monitor 글로벌 대시보드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Tesla 소송·Waymo 확장·미 공군 원자력 발전소"
   url="https://electrek.co/2026/02/24/floodgates-open-for-tesla-lawsuits-waymo-expands-and-us-goes-nuclear/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Tesla 소송·Waymo 확장·미 공군 원자력 발전소 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
+++ b/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
@@ -360,7 +360,7 @@ Klaus Loeffelmann이 고장난 USB 동글로 인해 독일에서 시간 연구�
   title="[DevOps] Harbor 프로덕션 배포: 필수 고려사항 가이드"
   url="https://www.cncf.io/blog/2026/02/24/making-harbor-production-ready-essential-considerations-for-deployment/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Akamia-Cloud-Credits-33.jpg"
-  summary="Harbor 프로덕션 배포: 필수 고려사항 가이드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CNCF에서 Harbor 컨테이너 레지스트리를 프로덕션 환경에서 안정적으로 운영하기 위한 필수 고려사항 가이드를 발표했습니다."
   source="CNCF Blog"
   severity="Medium"
 -%}

--- a/_posts/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.md
+++ b/_posts/2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.md
@@ -101,7 +101,7 @@ summary_card:
   title="[보안] Google, UNC2814 GRIDTIDE 캠페인 차단 - 42개국 53개 조직 침해"
   url="https://thehackernews.com/2026/02/google-disrupts-unc2814-gridtide.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiyrJTi6YIFc4PWNVjyVZgjQfbHNpfH-WtwcxIIEgUSin8DR8zz_VZBauDnlTA42bh7LT7nj1Y-OtoKL34tEKUKo4JrNuWgnhC1r54tIkws6OC8SWqucU0OrWysv2-pzj_YCinatv9FwUUsvADoPMVngfmR8wB2xr_lS1viUQHoK_Vom83SmBZMOBJPe6Nb/s1700-e365/google.jpg"
-  summary="Google, UNC2814 GRIDTIDE 캠페인 차단 - 42개국 53개 조직 침해 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google이 업계 파트너들과 협력하여 중국 연계 사이버 스파이 그룹 UNC2814의 인프라를 차단했습니다. 이 그룹은 42개국 53개 이상의 조직을 침해했으며, 아프리카·아시아·아메리카 전역의 정부기관과 통신사를 장기적으로 표적으로 삼아왔습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -139,7 +139,7 @@ Google이 업계 파트너들과 협력하여 중국 연계 사이버 스파이 
   title="[보안] Claude Code에서 RCE 및 API 키 유출 취약점 다수 발견"
   url="https://thehackernews.com/2026/02/claude-code-flaws-allow-remote-code.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhp3ch5lk3LqPFl0TutlBSasJaFa2bNjNdXbIePoE8y76HOmsErmRwXcYUungmePyAK_J_zclibjngwBoTNEB2whRW3-ZAjwKSu1B0VwHyHS_qtKqeivbIdC4HFmSef-lcxWkLXnMs_4HVgmiTNNQSE6UeNt4Ci6lkQaZZlrcwrEy1s4wAVb93CJup8e6r7/s1700-e365/claudecode.jpg"
-  summary="Claude Code에서 RCE 및 API 키 유출 취약점 다수 발견 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="보안 연구원들이 Anthropic의 AI 코딩 어시스턴트 Claude Code에서 원격 코드 실행(RCE) 및 API 자격증명 탈취가 가능한 다수의 취약점을 공개했습니다. Hooks, MCP(Model Context Protocol) 서버, 환경 변수 등 다양한 설정 메커니즘을 악용하여 공격이 가능합니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -169,7 +169,7 @@ Google이 업계 파트너들과 협력하여 중국 연계 사이버 스파이 
   title="[보안] SLH 해킹 그룹, IT 헬프데스크 음성 피싱에 여성 모집"
   url="https://thehackernews.com/2026/02/slh-offers-5001000-per-call-to-recruit.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEheMHWdwNTiAJVGFveDmUE-c6R5fRxcIf_ECfU1uk44EkFSWh1PAkXZhOoPtL9vJESPwrDSPgCGRsl3_nvkHawqFo8vTOk7WytOuAjfnnFTfxeGoDQFPuPoMS0fKbGfNSKAOt12sCvE5NxbCMOgzrmozgrvPTNUWeNdkz4Kz23xG2rQYPndvynXw34uD6lx/s1700-e365/vishing-attack.jpg"
-  summary="SLH 해킹 그룹, IT 헬프데스크 음성 피싱에 여성 모집 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="악명 높은 사이버 범죄 조직 Scattered LAPSUS$ Hunters(SLH)가 소셜 엔지니어링 공격을 위해 여성을 모집하고 있습니다. IT 헬프데스크를 대상으로 한 음성 피싱(Vishing) 캠페인에 투입하며, 건당 $500~$1,000의 선불 보수를 제공하는 것으로 Dataminr가 보고했습니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -203,7 +203,7 @@ Google이 업계 파트너들과 협력하여 중국 연계 사이버 스파이 
   title="[AI/ML] Google Circle to Search AI 기반 시각 검색 기능 확장"
   url="https://blog.google/products-and-platforms/products/search/circle-to-search-february-2026/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/FTL__Try_On_Social_feed.width-1300.png"
-  summary="Google Circle to Search AI 기반 시각 검색 기능 확장 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google 검색에 AI 기반 도구가 추가되었습니다. 'AI Overview'가 의상 구성 요소를 분석하고, 'Try it on' 기능으로 다양한 체형에 의류를 가상 시착할 수 있습니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -226,7 +226,7 @@ Google 검색에 AI 기반 도구가 추가되었습니다. "AI Overview"가 의
   title="[AI/ML] Samsung Galaxy S26에 탑재된 더 지능적인 Android AI"
   url="https://blog.google/products-and-platforms/platforms/android/samsung-unpacked-2026/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/Blog-social-1920x1080_withouttext.width-1300.png"
-  summary="Samsung Galaxy S26에 탑재된 더 지능적인 Android AI 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Samsung Galaxy S26 시리즈에 Google의 최신 AI 기능이 통합되었습니다. 이미지 인식 기반 검색, AI 기반 사진 편집, 실시간 통역 등 온디바이스 AI 기능이 대폭 강화되었습니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -249,7 +249,7 @@ Samsung Galaxy S26 시리즈에 Google의 최신 AI 기능이 통합되었습니
   title="[AI/ML] vLLM 기반 다중 파인튜닝 모델 효율적 서빙 (Amazon SageMaker)"
   url="https://aws.amazon.com/blogs/machine-learning/efficiently-serve-dozens-of-fine-tuned-models-with-vllm-on-amazon-sagemaker-ai-and-amazon-bedrock/"
   image="https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/02/25/ML-20205-1120x630.png"
-  summary="vLLM 기반 다중 파인튜닝 모델 효율적 서빙 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS에서 vLLM을 활용하여 MoE(Mixture of Experts) 모델에 대한 다중 LoRA 추론을 구현한 방법과 커널 수준의 최적화를 설명합니다. GPT-OSS 20B 모델을 주요 예제로 사용합니다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 -%}
@@ -276,7 +276,7 @@ AWS에서 vLLM을 활용하여 MoE(Mixture of Experts) 모델에 대한 다중 L
   title="[클라우드] 프로덕션 AI 에이전트 개발 가이드 (Google Cloud)"
   url="https://cloud.google.com/blog/products/ai-machine-learning/a-devs-guide-to-production-ready-ai-agents/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/production_ready_ai.max-2500x2500.jpg"
-  summary="프로덕션 AI 에이전트 개발 가이드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="지난 1년간 개발 커뮤니티에 큰 변화가 일어났습니다. AI 에이전트가 '흥미로운 연구 개념'에서 '팀이 실제로 구축하는 것'으로 이동했으며, Google Cloud가 프로덕션 환경에 AI 에이전트를 배포하기 위한 실무 가이드를 공개했습니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -299,7 +299,7 @@ AWS에서 vLLM을 활용하여 MoE(Mixture of Experts) 모델에 대한 다중 L
   title="[클라우드] GRIDTIDE 글로벌 사이버 스파이 캠페인 심층 분석 (Google Cloud)"
   url="https://cloud.google.com/blog/topics/threat-intelligence/disrupting-gridtide-global-espionage-campaign/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_ThreatIntelligenceWebsiteBannerIdeas_BA.max-2600x2600.png"
-  summary="GRIDTIDE 글로벌 사이버 스파이 캠페인 심층 분석 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Threat Intelligence Group(GTIG)과 Mandiant가 4개 대륙 수십 개 국가의 통신사 및 정부기관을 표적으로 한 글로벌 스파이 캠페인을 차단한 과정을 상세히 공개했습니다. UNC2814는 2017년부터 추적해온 중국(PRC) 연계 사이버 스파이 그룹입니다."
   source="Google Cloud Blog"
   severity="High"
 -%}
@@ -326,7 +326,7 @@ Google Threat Intelligence Group(GTIG)과 Mandiant가 4개 대륙 수십 개 국
   title="[DevOps] Open WebUI + Docker Model Runner: 제로 설정 셀프 호스팅 AI"
   url="https://www.docker.com/blog/openwebui-docker-model-runner/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="Open WebUI + Docker Model Runner: 제로 설정 셀프 호스팅 AI 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Docker Model Runner(DMR)와 Open WebUI 간의 원활한 통합이 공개되었습니다. Open WebUI가 localhost:12434에서 실행 중인 Docker Model Runner를 자동 감지하고 연결하여, 별도 설정 없이 셀프 호스팅 AI 모델을 바로 사용할 수 있습니다."
   source="Docker Blog"
   severity="Medium"
 -%}
@@ -349,7 +349,7 @@ Docker Model Runner(DMR)와 Open WebUI 간의 원활한 통합이 공개되었�
   title="[DevOps] 2026년 하반기 Kubernetes Community Days(KCDs) 일정 발표"
   url="https://www.cncf.io/blog/2026/02/25/announcing-h2-2026-kcds/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Announcing-H2-2026-KCDs.jpg"
-  summary="2026년 하반기 Kubernetes Community Days 일정 발표 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="CNCF가 2026년 하반기 Kubernetes Community Days(KCDs) 전체 일정을 발표했습니다. 전 세계 로컬 실무자, 도입자, 기여자들이 모여 클라우드 네이티브 지식을 공유하는 커뮤니티 주도 행사입니다."
   source="CNCF Blog"
   severity="Medium"
 -%}
@@ -376,7 +376,7 @@ CNCF가 2026년 하반기 Kubernetes Community Days(KCDs) 전체 일정을 발�
   title="[블록체인] Morgan Stanley, Bitcoin 거래·대출·수탁 사업 확대 계획"
   url="https://bitcoinmagazine.com/news/morgan-stanley-plans-for-bitcoin-trading"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Pics-7.jpg"
-  summary="Morgan Stanley, Bitcoin 거래·대출·수탁 사업 확대 계획 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Morgan Stanley가 Strategy World 행사에서 디지털 자산 서비스 확대 계획을 발표했습니다. 자체 암호화폐 수탁(Custody) 및 거래소 솔루션 출시를 포함하여, Bitcoin 거래·대출·수탁 전반에 걸친 서비스를 확장할 예정입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -399,7 +399,7 @@ Morgan Stanley가 Strategy World 행사에서 디지털 자산 서비스 확대 
   title="[블록체인] Bitcoin 7% 이상 급등, $69,000 돌파"
   url="https://bitcoinmagazine.com/markets/bitcoin-price-roars-7-to-69000"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Bitcoin-Price-Roars-8-to-69000-as-Market-Tests-Post-Capitulation-Range.jpg"
-  summary="Bitcoin 7% 이상 급등, $69,000 돌파 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin 가격이 하루 만에 8% 이상 상승하여 $69,000을 돌파했습니다. 수개월간의 매도세 이후 가장 강력한 일일 상승 중 하나이며, 항복 매도(Capitulation) 이후 가격 범위를 시험하는 중입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -426,14 +426,12 @@ Bitcoin 가격이 하루 만에 8% 이상 상승하여 $69,000을 돌파했습�
   url="https://tech.worldmonitor.app/"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech Monitor - 실시간 AI & 기술 산업 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="현대차 첫 중형 픽업 IONIQ T7 개발"
   url="https://electrek.co/2026/02/25/hyundai-new-pickup-potential-4wd-suv-in-the-works/"
   source="Electrek"
   tag="Operator Signal"
-  summary="현대차 첫 중형 픽업 IONIQ T7 개발 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
+++ b/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
@@ -97,7 +97,7 @@ summary_card:
   title="[보안] Aeternum C2 Botnet: 폴리곤 블록체인 기반 암호화 C2 봇넷"
   url="https://thehackernews.com/2026/02/aeternum-c2-botnet-stores-encrypted.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiQlH8RQUmcg8IWqV76NL0o4uRe86gJ6kxLV3DRYppBAVrfFR_gMPQBFn6GIl2jd9ZgzsuwRGAGTVUbaWCj795-XZ8I3eSBDLz6Q_0w4Alef6GNA3NtpK4po_WVC6p9o4aNVHqgCAEb3a7CqL_x7oBGWQ7N4z0IMyzOX3aZoI_TUZenfdAm0LZojDIkumG0/s1700-e365/botnet.jpg"
-  summary="Aeternum C2 Botnet: 폴리곤 블록체인 기반 암호화 C2 봇넷 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Qrator Labs가 폴리곤(Polygon) 블록체인을 C2(명령 및 제어) 인프라로 활용하는 신종 봇넷 로더 'Aeternum C2'를 공개했습니다. 기존 C2는 도메인이나 서버를 차단하는 것으로 무력화할 수 있었지만, 블록체인에 암호화된 명령을 저장하면 인프라 차단 자체가 불가능합니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -138,7 +138,7 @@ Qrator Labs가 폴리곤(Polygon) 블록체인을 C2(명령 및 제어) 인프�
   title="[보안] AWS ISO 42001 AI 관리 시스템 첫 감시 감사 통과"
   url="https://aws.amazon.com/blogs/security/aws-successfully-completed-its-first-surveillance-audit-for-iso-420012023-with-no-findings/"
   image="https://d2908q01vomqb2.cloudfront.net/22d200f8670dbdb3e253a90eee5098477c95c23d/2023/02/16/aws_bp_primarylogo_01.png"
-  summary="AWS ISO 42001 AI 관리 시스템 첫 감시 감사 통과 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS가 2024년 11월 주요 클라우드 공급자 중 최초로 ISO/IEC 42001 AI 관리 시스템 인증을 획득한 데 이어, 2025년 11월 첫 번째 감시 감사를 무결점(no findings)으로 통과했습니다. 인증 범위는 Amazon Bedrock, Amazon Q Business, Textract, Transcribe를 포함합니다."
   source="AWS Security Blog"
   severity="Medium"
 -%}
@@ -168,7 +168,7 @@ AWS가 2024년 11월 주요 클라우드 공급자 중 최초로 ISO/IEC 42001 A
   title="[보안] AWS Security Agent: 자동화 침투 테스트를 위한 멀티 에이전트 아키텍처"
   url="https://aws.amazon.com/blogs/security/inside-aws-security-agent-a-multi-agent-architecture-for-automated-penetration-testing/"
   image="https://d2908q01vomqb2.cloudfront.net/22d200f8670dbdb3e253a90eee5098477c95c23d/2026/02/25/security-agent-image-998x630.jpg"
-  summary="AWS Security Agent: 자동화 침투 테스트를 위한 멀티 에이전트 아키텍처 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="AWS가 자사 내부에서 운영 중인 'AWS Security Agent'의 아키텍처를 공개했습니다. 이 시스템은 수시간~수일 단위로 자율 실행되는 '프론티어 에이전트(frontier agents)' 개념을 도입하여, 복잡한 추론·다단계 계획·자율 실행을 통해 침투 테스트를 자동화합니다."
   source="AWS Security Blog"
   severity="High"
 -%}
@@ -203,7 +203,7 @@ AWS가 자사 내부에서 운영 중인 'AWS Security Agent'의 아키텍처를
   title="[AI/ML] Google x Massachusetts AI Hub: 무료 AI 교육 파트너십"
   url="https://blog.google/company-news/outreach-and-initiatives/grow-with-google/google-ai-training-massachusetts-residents/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/691A1377_1920x1080.max-1440x810.png"
-  summary="Google x Massachusetts AI Hub: 무료 AI 교육 파트너십 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google이 매사추세츠 AI Hub와 파트너십을 맺고 매사추세츠 주민 전원에게 Google의 AI 교육 과정을 무료로 제공합니다. AI 리터러시 격차 해소를 목표로 하는 이 이니셔티브는 기업 내 AI 역량 내재화를 검토 중인 DevSecOps 팀에도 실질적인 무료 학습 경로를 제공합니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -227,7 +227,7 @@ Google이 매사추세츠 AI Hub와 파트너십을 맺고 매사추세츠 주�
   title="[AI/ML] Google 번역: AI 기반 번역 컨텍스트 이해 기능 추가"
   url="https://blog.google/products-and-platforms/products/translate/translation-context-ai-update/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/Translate_TextTranslate_1920x1080_Still_01.max-1440x810.png"
-  summary="Google 번역: AI 기반 번역 컨텍스트 이해 기능 추가 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google 번역에 'understand'와 'ask' 두 가지 신규 버튼이 추가되었습니다. 단순 직역을 넘어 번역된 표현의 뉘앙스, 문화적 맥락, 관용구 배경을 AI가 설명하는 기능입니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -251,7 +251,7 @@ Google 번역에 'understand'와 'ask' 두 가지 신규 버튼이 추가되었�
   title="[AI/ML] Google Nano Banana 2: 차세대 이미지 생성 모델"
   url="https://blog.google/innovation-and-ai/technology/developers-tools/build-with-nano-banana-2/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/BuildWith_SocialShare.width-1300.png"
-  summary="Google Nano Banana 2: 차세대 이미지 생성 모델 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google이 Imagen 계열의 차세대 이미지 생성 모델 'Nano Banana 2'를 개발자에게 공개했습니다. 전작 대비 디테일 표현력과 프롬프트 이해도가 향상되었으며, API를 통해 애플리케이션에 통합할 수 있습니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -279,7 +279,7 @@ Google이 Imagen 계열의 차세대 이미지 생성 모델 'Nano Banana 2'를 
   title="[클라우드] PayPal 역대 최대 규모 데이터 마이그레이션: Gen AI 혁신의 기반"
   url="https://cloud.google.com/blog/products/databases/paypals-historic-data-migration-is-the-foundation-for-its-gen-ai-innovation/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/paypal-historic-teradata-migration.max-2600x2600.png"
-  summary="PayPal 역대 최대 규모 데이터 마이그레이션: Gen AI 혁신의 기반 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="PayPal이 25년간 누적된 복잡한 데이터 인프라를 Google Cloud로 이전하는 대규모 마이그레이션 작업을 완료했습니다. 단순한 클라우드 이전이 아니라 Gen AI 시대에 맞는 데이터 기반을 재구축하는 것이 목표였으며, 수억 명의 고객 데이터를 처리하면서 서비스 연속성을 유지한 점이 핵심 성과입니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -303,7 +303,7 @@ PayPal이 25년간 누적된 복잡한 데이터 인프라를 Google Cloud로 �
   title="[클라우드] Spanner Columnar Engine: Iceberg 레이크하우스 실시간 데이터 서빙"
   url="https://cloud.google.com/blog/products/databases/spanner-columnar-engine-in-preview/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/1_GGexgWX.max-2500x2500.jpg"
-  summary="Spanner Columnar Engine: Iceberg 레이크하우스 실시간 데이터 서빙 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud Spanner에 컬럼형 스토리지 엔진(Columnar Engine)이 프리뷰로 추가되었습니다. 이를 통해 Apache Iceberg 레이크하우스에 저장된 데이터를 ETL 없이 저지연으로 서빙할 수 있게 됩니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -327,7 +327,7 @@ Google Cloud Spanner에 컬럼형 스토리지 엔진(Columnar Engine)이 프리
   title="[클라우드] Google Data Cloud 업데이트: MCP 지원 확대"
   url="https://cloud.google.com/blog/products/data-analytics/whats-new-with-google-data-cloud/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/whats_new_data_cloud_fWg4bKK.max-2500x2500.png"
-  summary="Google Data Cloud 업데이트: MCP 지원 확대 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud가 AlloyDB, Spanner, Cloud SQL, Bigtable, Firestore 등 주요 데이터베이스에 관리형(managed) 및 원격(remote) MCP(Model Context Protocol) 지원을 추가했습니다. AI 모델이 데이터베이스 도구에 직접 연결하여 복잡한 문제를 계획·해결할 수 있는 기반이 마련됩니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -355,7 +355,7 @@ Google Cloud가 AlloyDB, Spanner, Cloud SQL, Bigtable, Firestore 등 주요 데�
   title="[DevOps] Docker Model Runner: macOS Apple Silicon에서 vLLM 지원"
   url="https://www.docker.com/blog/docker-model-runner-vllm-metal-macos/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
-  summary="Docker Model Runner: macOS Apple Silicon에서 vLLM 지원 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Docker Model Runner가 Apple Silicon macOS 환경에서 Metal 백엔드를 통한 vLLM 추론을 공식 지원합니다. 기존에는 NVIDIA GPU(Linux) 및 WSL2(Windows)에서만 가능했던 고처리량 LLM 서빙을 이제 M1/M2/M3 Mac에서도 Docker 컨테이너 내에서 실행할 수 있습니다."
   source="Docker Blog"
   severity="Medium"
 -%}
@@ -379,7 +379,7 @@ Docker Model Runner가 Apple Silicon macOS 환경에서 Metal 백엔드를 통�
   title="[DevOps] Safari Technology Preview 238 릴리스"
   url="https://webkit.org/blog/17848/release-notes-for-safari-technology-preview-238/"
   image="https://webkit.org/wp-content/themes/webkit/images/preview-card.jpg"
-  summary="Safari Technology Preview 238 릴리스 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Apple이 macOS Tahoe 및 Sequoia 대상으로 Safari Technology Preview 238을 공개했습니다. 최신 웹 표준 실험적 지원이 포함되어 있으며, 웹 앱 개발팀은 Safari 호환성 이슈를 사전에 파악하는 데 활용할 수 있습니다."
   source="WebKit Blog"
   severity="Medium"
 -%}
@@ -402,7 +402,7 @@ Apple이 macOS Tahoe 및 Sequoia 대상으로 Safari Technology Preview 238을 �
   title="[DevOps] .NET Vector Data: AI 시맨틱 검색 통합 인터페이스"
   url="https://devblogs.microsoft.com/dotnet/vector-data-in-dotnet-building-blocks-for-ai-part-2/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/02/mevd-scaled.webp"
-  summary=".NET Vector Data: AI 시맨틱 검색 통합 인터페이스 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Microsoft가 Microsoft.Extensions.VectorData 라이브러리를 통해 .NET 애플리케이션에서 다양한 벡터 데이터베이스에 단일 인터페이스로 접근하는 방법을 소개했습니다."
   source="Microsoft .NET Blog"
   severity="Medium"
 -%}
@@ -430,7 +430,7 @@ Microsoft가 `Microsoft.Extensions.VectorData` 라이브러리를 통해 .NET �
   title="[블록체인] SEC 의장 Paul Atkins, Bitcoin 2026 컨퍼런스 연사 확정"
   url="https://bitcoinmagazine.com/conference/paul-atkins-confirmed-as-a-bitcoin-2026-speaker"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/B26-Green-VIP-Paul-Atkins.png"
-  summary="SEC 의장 Paul Atkins, Bitcoin 2026 컨퍼런스 연사 확정 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="현직 미국 SEC(증권거래위원회) 의장 Paul Atkins가 Bitcoin 2026 컨퍼런스 연사로 공식 확정되었습니다. 현직 SEC 의장이 Bitcoin 컨퍼런스에 연사로 초청된 것은 역사상 처음으로, 미국 디지털 자산 규제 방향의 변화를 상징하는 사건입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -454,7 +454,7 @@ Microsoft가 `Microsoft.Extensions.VectorData` 라이브러리를 통해 .NET �
   title="[블록체인] libsecp256k1: Bitcoin의 암호화 핵심 라이브러리 분석"
   url="https://bitcoinmagazine.com/print/the-core-issue-libsecp256k1-bitcoins-cryptographic-heart"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Core-Issue-Article-Header-2400x1256-Falbesoner-fotor-20260226143313.webp"
-  summary="libsecp256k1: Bitcoin의 암호화 핵심 라이브러리 분석 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Bitcoin의 모든 서명 검증과 키 생성을 담당하는 암호화 라이브러리 libsecp256k1의 역사와 설계 철학을 심층 분석한 글이 공개되었습니다. 취미 프로젝트로 시작해 수조 달러 규모 자산을 보호하는 가장 보안 집약적인 코드 경로 중 하나로 발전한 과정은 오픈소스 보안 크리티컬 라이브러리 유지 관리의 중요성을 잘 보여줍니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -478,7 +478,7 @@ Bitcoin의 모든 서명 검증과 키 생성을 담당하는 암호화 라이�
   title="[블록체인] Citi, Bitcoin-전통 금융 통합 및 수탁 서비스 출시 예정"
   url="https://bitcoinmagazine.com/news/citi-to-integrate-bitcoin-with-finance"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Citi-to-Integrate-Bitcoin-with-Traditional-Finance-Launch-Custody-Services.jpg"
-  summary="Citi, Bitcoin-전통 금융 통합 및 수탁 서비스 출시 예정 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Citi 경영진이 Bitcoin을 자사 뱅킹 시스템에 통합하고 수탁(custody) 서비스를 출시할 계획을 공개했습니다. 글로벌 대형 은행의 Bitcoin 수탁 서비스 진입은 기관 투자자의 암호화폐 노출을 확대하는 동시에, 디지털 자산 보관 보안에 대한 금융권 표준을 높이는 계기가 됩니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -506,21 +506,18 @@ Citi 경영진이 Bitcoin을 자사 뱅킹 시스템에 통합하고 수탁(cust
   url="https://tech.worldmonitor.app/?lat=20.0000&lon=0.0000&zoom=1.00&view=global&timeRange=7d&layers=cables%2Cweather%2Ceconomic%2Coutages%2Cdatacenters%2Cnatural%2CstartupHubs%2CcloudRegions%2CtechHQs%2CtechEvents"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech Monitor - Real-Time AI & Tech Industry 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Rivian has a new performance division but for"
   url="https://electrek.co/2026/02/26/rivian-has-a-new-performance-division-but-for-crazy-off-road-adventures/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Rivian has a new performance division but for 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="Donut solid-state batteries tested, Tesla"
   url="https://electrek.co/2026/02/26/donut-solid-state-batteries-tested-tesla-engineer-quits-and-solar-value/"
   source="Electrek"
   tag="Operator Signal"
-  summary="Donut solid-state batteries tested, Tesla 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
+++ b/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
@@ -383,7 +383,7 @@ Google Cloud의 2026년 2월 두 번째 Cloud CISO Perspectives가 발행되었�
   title="[DevOps] KubeCon Europe 2026: BackstageCon 및 플랫폼 엔지니어링 동향"
   url="https://www.cncf.io/blog/2026/02/27/kubecon-cloudnativecon-europe-2026-co-located-event-deep-dive-backstagecon/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Co-Lo-Blog-KubeCon-AMS-2026.jpg"
-  summary="KubeCon Europe 2026: BackstageCon 및 플랫폼 엔지니어링 동향 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="KubeCon + CloudNativeCon Europe 2026의 공동 개최 이벤트인 BackstageCon에 대한 심층 분석이 공개되었다."
   source="CNCF Blog"
   severity="Medium"
 -%}

--- a/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
+++ b/_posts/2026-02-28-Tech_Security_Weekly_Digest_Go_AI_Malware.md
@@ -95,7 +95,7 @@ summary_card:
   title="[보안] 미국 법무부, Pig Butchering 사기 연루 USDT $6,100만 압수"
   url="https://thehackernews.com/2026/02/doj-seizes-61-million-in-tether-linked.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEglF1nudH44Lr269ed-E49qDWqg7t-GFuybhyQ8-6oDnBn-CcFh7o21w44Cjxxw0cuZQDBXdHQCxuOrR_vOLEvON4DyGSPWbr-7l3XaHXInETTZLxm-BAfCxUCFZ-Wxek-TnFI8t1rJ3gew5p3BnztZeIXY0ePy6DUFqL5R9QlKHZaUOVPwdIuDLkCju83c/s1700-e365/tether-scam.jpg"
-  summary="미국 법무부, Pig Butchering 사기 연루 USDT $6,100만 압수 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="미국 법무부(DoJ)가 '돼지 도살(Pig Butchering)' 암호화폐 사기와 연관된 6,100만 달러 상당의 Tether(USDT)를 압수했다. 압수된 자금은 피해자들로부터 탈취한 범죄 수익을 세탁하는 데 사용된 암호화폐 주소에서 추적되었으며, 이번 조치는 암호화폐 기반 투자 사기에 대한 미국 정부의 적극적인 단속 의지를 보여준다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -138,7 +138,7 @@ summary_card:
   title="[보안] FreePBX 900개 이상 인스턴스, 웹 셸 공격으로 대규모 침해"
   url="https://thehackernews.com/2026/02/900-sangoma-freepbx-instances.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgVfnqoWodxrya2TOd7lDLrZ23Bvo_FZhrnRLTnOO-Y4zvouKylIpkT7KE_LKo8lQGBCwMo3GCldGiyqSJobUKHLxmKx6hja0EBG6K3DCtQG-bmDDapu2el8CnQMMs971cJ3dICyw4-T1I8o0W7-XNHKzRBO8U48USZlO8MmtJkKKaOkweEzgKZF2PyaUt9/s1700-e365/freepbx.jpg"
-  summary="FreePBX 900개 이상 인스턴스, 웹 셸 공격으로 대규모 침해 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Shadowserver Foundation에 따르면 900개 이상의 Sangoma FreePBX 인스턴스가 2025년 12월부터 시작된 커맨드 인젝션 취약점을 악용한 공격으로 웹 셸에 감염된 상태로 남아 있다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -191,7 +191,7 @@ index=web sourcetype=access_combined (SELECT OR UNION OR script OR "\x" OR "%27"
   title="[보안] 악성 Go Crypto 모듈, 비밀번호 탈취 및 Rekoobe 백도어 배포"
   url="https://thehackernews.com/2026/02/malicious-go-crypto-module-steals.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjdXNmYRKw13_BHE7B7MMtqTTpJXBkgDzl2sH31t0L0_VCl9uJbWPS2yg0j0jz0XJovSYryM4NcSCAZdtTDsoRa2d6y3U84K9TDQYJSObLgaJXXh8juWmP6liqj_uirhZvKjR0dqYZ-J2mwTnmEIYIKfAoC9BY3yL2xhfLD_NbwVKzekKwoI3u4iSzU44Xn/s1700-e365/hackers.jpg"
-  summary="악성 Go Crypto 모듈, 비밀번호 탈취 및 Rekoobe 백도어 배포 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="악성 Go 모듈(github[.]com/xinfeisoft/crypto)이 정상적인 golang.org/x/crypto 패키지를 사칭하여 비밀번호 탈취, SSH를 통한 지속적 접근 권한 확보, Linux 백도어(Rekoobe) 배포를 수행하는 것으로 확인되었다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -239,7 +239,7 @@ index=web sourcetype=access_combined (SELECT OR UNION OR script OR "\x" OR "%27"
 {%- include news-card.html
   title="[AI/ML] OpenAI-Microsoft 파트너십 강화 공동 성명"
   url="https://openai.com/index/continuing-microsoft-partnership"
-  summary="OpenAI-Microsoft 파트너십 강화 공동 성명 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Microsoft와 OpenAI가 연구, 엔지니어링, 제품 개발 전반에 걸친 긴밀한 파트너십을 지속한다는 공동 성명을 발표했다. 양사의 협력 관계 재확인은 Azure OpenAI Service를 포함한 엔터프라이즈 AI 서비스의 안정적 운영과 향후 모델 접근 방식에 영향을 미칠 수 있다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -261,7 +261,7 @@ Microsoft와 OpenAI가 연구, 엔지니어링, 제품 개발 전반에 걸친 �
 {%- include news-card.html
   title="[AI/ML] Amazon Bedrock, AI 에이전트용 Stateful Runtime 환경 도입"
   url="https://openai.com/index/introducing-the-stateful-runtime-environment-for-agents-in-amazon-bedrock"
-  summary="Amazon Bedrock, AI 에이전트용 Stateful Runtime 환경 도입 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Amazon Bedrock에 Stateful Runtime 환경이 도입되어, AI 에이전트의 다단계 워크플로우에서 지속적 오케스트레이션, 메모리 유지, 보안 실행 환경을 제공한다. OpenAI 모델 기반의 에이전트가 세션 간 상태를 유지하면서 복잡한 작업을 수행할 수 있게 되어, 엔터프라이즈 AI 에이전트 운영의 안정성과 보안성이 향상된다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -283,7 +283,7 @@ Amazon Bedrock에 Stateful Runtime 환경이 도입되어, AI 에이전트의 �
 {%- include news-card.html
   title="[AI/ML] OpenAI, $1,100억 투자 유치 — AI 인프라 대규모 확장"
   url="https://openai.com/index/scaling-ai-for-everyone"
-  summary="OpenAI, $1,100억 투자 유치 — AI 인프라 대규모 확장 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="OpenAI가 기업가치 7,300억 달러 기준 1,100억 달러 규모의 신규 투자를 발표했다. SoftBank 300억, NVIDIA 300억, Amazon 500억 달러가 포함되며, 이는 AI 인프라 확장과 모델 개발 가속화에 사용될 예정이다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -310,7 +310,7 @@ OpenAI가 기업가치 7,300억 달러 기준 1,100억 달러 규모의 신규 �
   title="[클라우드] AI 에이전트 품질 보증: &quot;Vibe Check&quot;에서 지속적 평가 체계로"
   url="https://cloud.google.com/blog/topics/developers-practitioners/from-vibe-checks-to-continuous-evaluation-engineering-reliable-ai-agents/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/vibe-check-hero.max-2500x2500.jpg"
-  summary="AI 에이전트 품질 보증: &quot;Vibe Check&quot;에서 지속적 평가 체계로 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud Blog에서 AI 에이전트의 품질 보증 방법론을 다룬 글이 발표되었다. 초기 테스트에서 잘 작동하던 AI 에이전트가 프로덕션 환경에서 예상치 못한 질문에 실패하는 문제를 지적하며, '감 검증(Vibe Check)'을 넘어서 체계적인 지속적 평가(Continuous Evaluation) 파이프라인 구축의 필요성을 강조한다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -333,7 +333,7 @@ Google Cloud Blog에서 AI 에이전트의 품질 보증 방법론을 다룬 글
   title="[클라우드] Google Cloud Eventarc Advanced: 중앙 정책 + 분산 이벤트 아키텍처"
   url="https://cloud.google.com/blog/products/application-modernization/getting-to-know-eventarc-advanced/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/0_zjIbf2O.max-2500x2500.jpg"
-  summary="Google Cloud Eventarc Advanced: 중앙 정책 + 분산 이벤트 아키텍처 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud의 Eventarc Advanced가 소개되었다. 엔터프라이즈 환경에서 개발 민첩성과 조직 통제 사이의 딜레마를 해결하기 위해, 중앙화된 정책 관리와 분산된 마이크로서비스 로직을 결합하는 이벤트 기반 아키텍처를 제공한다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -356,7 +356,7 @@ Google Cloud의 Eventarc Advanced가 소개되었다. 엔터프라이즈 환경�
   title="[클라우드] Google Cloud CISO Perspectives: 핵심 보안 과제에 대한 Google의 접근법"
   url="https://cloud.google.com/blog/products/identity-security/cloud-ciso-perspectives-how-google-approaches-critical-security-topics-fundamentals-to-ai/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/Cloud_CISO_Perspectives_header_4_Blue.max-2500x2500.png"
-  summary="Google Cloud CISO Perspectives: 핵심 보안 과제에 대한 Google의 접근법 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Google Cloud의 2026년 2월 두 번째 Cloud CISO Perspectives가 발행되었다. Google 엔지니어링 부사장 Royal Hansen이 오늘날 가장 복잡한 사이버보안 과제에 대한 Google의 접근 방식을 설명하며, AI 보안부터 기본 보안 원칙까지 폭넓은 주제를 다룬다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -405,7 +405,7 @@ KubeCon + CloudNativeCon Europe 2026의 공동 개최 이벤트인 BackstageCon�
 {%- include news-card.html
   title="[DevOps] Ingress-NGINX 폐지 전 반드시 알아야 할 5가지 동작 특성"
   url="https://kubernetes.io/blog/2026/02/27/ingress-nginx-before-you-migrate/"
-  summary="Ingress-NGINX 폐지 전 반드시 알아야 할 5가지 동작 특성 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="2025년 11월 발표된 대로 Kubernetes는 2026년 3월에 Ingress-NGINX를 공식 폐지(retire)한다. 광범위하게 사용되고 있음에도 Ingress-NGINX에는 예상치 못한 기본 설정과 부작용이 다수 존재하며, 이 글은 안전한 마이그레이션을 위해 반드시 알아야 할 5가지 동작 특성을 정리한다."
   source="Kubernetes Blog"
   severity="Medium"
 -%}
@@ -432,7 +432,7 @@ KubeCon + CloudNativeCon Europe 2026의 공동 개최 이벤트인 BackstageCon�
   title="[블록체인] 밴쿠버 DCTRL: 12년 역사의 Bitcoin 해커스페이스 다운타운 폐쇄"
   url="https://bitcoinmagazine.com/culture/dctrl-vancouver-iconic-bitcoin-hackerspace-closes-downtown-location-after-12-years-due-to-zoning-changes"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/screenshot-2026-02-27_15-34-50.png"
-  summary="밴쿠버 DCTRL: 12년 역사의 Bitcoin 해커스페이스 다운타운 폐쇄 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="밴쿠버의 상징적인 Bitcoin 해커스페이스 DCTRL이 12년간 운영해온 다운타운 물리적 공간을 용도지역 변경으로 인해 폐쇄한다. 자원봉사자 운영 기반으로 Bitcoin 혁신 이벤트, Bepsi 머신 운영, 커뮤니티 기부를 통해 유지되어 온 DCTRL은 새로운 장소를 준비 중이다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -455,7 +455,7 @@ KubeCon + CloudNativeCon Europe 2026의 공동 개최 이벤트인 BackstageCon�
   title="[블록체인] 미국 민주당, Binance에 대한 DOJ·재무부 조사 촉구"
   url="https://bitcoinmagazine.com/news/senate-democrats-press-doj-over-binance"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Senate-Democrats-Press-DOJ-Treasury-to-Probe-Binance-Over-Trump-Ties-Iran-Sanctions-Allegations.jpg"
-  summary="미국 민주당, Binance에 대한 DOJ·재무부 조사 촉구 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="미국 민주당 상원의원들이 법무부(DOJ)와 재무부에 Binance에 대한 조사를 촉구하고 있다. 이란 제재 위반 혐의 및 정치적 유착 의혹이 제기되며, 세계 최대 암호화폐 거래소의 규제 리스크가 다시 부각되고 있다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -478,7 +478,7 @@ KubeCon + CloudNativeCon Europe 2026의 공동 개최 이벤트인 BackstageCon�
   title="[블록체인] 한국 상장사 Bitplanet, BTC 300개 보유로 아시아 기업 Top 20 진입"
   url="https://bitcoinmagazine.com/news/sora-backed-bitplanet-reaches-300"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Pics-8.jpg"
-  summary="한국 상장사 Bitplanet, BTC 300개 보유로 아시아 기업 Top 20 진입 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
+  summary="Sora Ventures가 투자한 한국 상장사 Bitplanet이 체계적 매입 프로그램을 통해 Bitcoin 300개를 보유하며 아시아 기업 Bitcoin 보유량 상위 20위권에 진입했다. 한국 기업의 Bitcoin 자산 전략이 본격화되고 있음을 보여주는 사례다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}
@@ -505,21 +505,18 @@ Sora Ventures가 투자한 한국 상장사 Bitplanet이 체계적 매입 프로
   url="https://tech.worldmonitor.app/"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech Monitor - 실시간 AI & 기술 산업 대시보드 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="멀티모달 Post-Training 엔지니어링"
   url="https://devblogs.microsoft.com/engineering-at-microsoft/engineering-and-algorithmic-interventions-for-multimodal-post-training-at-microsoft-scale/"
   source="Microsoft Engineering"
   tag="Operator Signal"
-  summary="멀티모달 Post-Training 엔지니어링 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% include news-spotlight-item.html
   title="신입 디자이너가 꼭 알아야 할 실험 설계 팁"
   url="https://toss.tech/article/45391"
   source="토스 기술 블로그"
   tag="Operator Signal"
-  summary="신입 디자이너가 꼭 알아야 할 실험 설계 팁 이슈를 기준으로 기술적으로는 공격 경로·영향 자산·탐지 포인트를 정리하고, 경영진 관점에서는 서비스 영향·우선순위·의사결정 체크포인트를 함께 제시했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
+++ b/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
@@ -194,7 +194,7 @@ SIEM 탐지 쿼리 (Splunk)
   title="[AI/ML] NVIDIA, Agentic AI 기반 통신 자율 네트워크 추진"
   url="https://blogs.nvidia.com/blog/nvidia-agentic-ai-blueprints-telco-reasoning-models/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/02/Autonomous-Networks-Blog-Image-1280x720.png"
-  summary="NVIDIA, Agentic AI 기반 통신 자율 네트워크 추진 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="NVIDIA가 통신 사업자를 위한 Agentic AI 자율 네트워크 솔루션을 공개했습니다. 핵심은 300억 파라미터 규모의 오픈소스 Nemotron LTM(Large Telco Model)으로, 통신 전문 용어와 추론 워크플로를 이해하도록 파인튜닝된 모델입니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 -%}
@@ -228,7 +228,7 @@ Agentic AI가 네트워크 인프라에 자율 제어권을 가지면서 새로�
   title="[AI/ML] NVIDIA, 소프트웨어 정의 AI-RAN 상용화 실증 성공"
   url="https://blogs.nvidia.com/blog/software-defined-ai-ran/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/02/AI-RAN-Commercialization-Blog-Image.jpg"
-  summary="NVIDIA, 소프트웨어 정의 AI-RAN 상용화 실증 성공 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="NVIDIA와 T-Mobile, SoftBank, Indosat 등 글로벌 통신사가 소프트웨어 정의 AI-RAN을 실증에서 상용 배포 단계로 전환하는 데 성공했습니다. MWC에서 20건 이상의 시연을 통해, GPU 기반 소프트웨어 방식이 기존 하드웨어 의존 방식을 대체할 수 있음을 증명했습니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 -%}
@@ -278,7 +278,7 @@ Amazon Bedrock의 에이전트 기능과 통합되며, Kiro, Claude Code, Linear
   title="[블록체인] 토큰화 금(Tokenized Gold), 주말 가격 발견의 100%를 주도"
   url="https://cointelegraph.com/news/tokenized-gold-weekend-price-discovery-cme-closed?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-01/019bbc62-fe05-760e-b9f5-f8e1ab342acd.jpg"
-  summary="토큰화 금, 주말 가격 발견의 100%를 주도 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="PAX Gold(PAXG)와 Tether Gold(XAUt) 등 토큰화 금 자산이 CME 선물 시장이 마감되는 주말(금요일 17시~일요일 18시 ET) 동안 사실상 100%의 가격 발견(Price Discovery) 역할을 수행하고 있습니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -308,7 +308,7 @@ PAX Gold(PAXG)와 Tether Gold(XAUt) 등 토큰화 금 자산이 CME 선물 시�
   title="[블록체인] Polymarket 거래자 6명, 미-이란 공습 예측으로 $1M 수익 — 내부자 거래 의혹"
   url="https://cointelegraph.com/news/polymarket-traders-1m-us-iran-strike-insider-trading-concerns?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-03/019ca84b-b61b-7697-8ab7-dcd84b4f31da.jpg"
-  summary="Polymarket 거래자 6명, 미-이란 공습 예측으로 $1M 수익 — 내부자 거래 의혹 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="신규 생성된 Polymarket 지갑 6개가 테헤란 폭발 보도 수 시간 전에 미국의 이란 공습 예측 계약을 약 $0.10에 매수하여 총 약 100만 달러의 수익을 올렸습니다. 의심스러운 거래 타이밍으로 인해 내부자 거래 조사가 촉발되었으며, 미국 의회에서는 정부 관계자의 비공개 정보를 이용한 예측 시장 거래를 제한하는 법안을 검토 중입니다."
   source="Cointelegraph"
   severity="High"
 -%}
@@ -325,7 +325,7 @@ PAX Gold(PAXG)와 Tether Gold(XAUt) 등 토큰화 금 자산이 CME 선물 시�
   title="[블록체인] Bitcoin, 이란 최고지도자 사망 후 $68K로 회복"
   url="https://cointelegraph.com/news/bitcoin-recovers-to-68k-following-reported-death-of-iranian-supreme-leader?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-03/019ca7ab-9219-72a5-8214-96388e93d1fa.jpeg"
-  summary="Bitcoin, 이란 최고지도자 사망 후 $68K로 회복 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="이란 최고지도자 하메네이가 미-이스라엘 공습으로 사망한 후, Bitcoin은 $63,000 저점에서 24시간 내에 $68,200까지 $5,000 반등했습니다. 시장은 하메네이 사망을 미-이란 긴장 완화 신호로 해석했습니다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -346,21 +346,18 @@ PAX Gold(PAXG)와 Tether Gold(XAUt) 등 토큰화 금 자산이 CME 선물 시�
   url="https://tech.worldmonitor.app/"
   source="Tech World Monitor"
   tag="Operator Signal"
-  summary="Tech Monitor - 실시간 AI & Tech 산업 대시보드 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Guido van Rossum이 전하는 Python의 구술 역사"
   url="https://news.hada.io/topic?id=27107"
   source="GeekNews"
   tag="Tech Signals"
-  summary="Guido van Rossum이 전하는 Python의 구술 역사 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="인지 부채: 속도가 이해를 초과할 때"
   url="https://news.hada.io/topic?id=27106"
   source="GeekNews"
   tag="Tech Signals"
-  summary="인지 부채: 속도가 이해를 초과할 때 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
+++ b/_posts/2026-03-01-Tech_Security_Weekly_Digest_AI_Agent_Ransomware.md
@@ -251,7 +251,7 @@ NVIDIA와 T-Mobile, SoftBank, Indosat 등 글로벌 통신사가 소프트웨어
   title="[클라우드] AWS: Agentic AI 플랫폼 Part 2 — AgentCore Gateway와 MCP Registry 구현"
   url="https://aws.amazon.com/ko/blogs/tech/agentic-ai-platform-part2-agentcore-gateway-identity-making-mcp-registry/"
   image="https://d2908q01vomqb2.cloudfront.net/2a459380709e2fe4ac2dae5733c73225ff6cfee1/2026/02/26/feature-main-1118x630.png"
-  summary="AWS: Agentic AI 플랫폼 Part 2 — AgentCore Gateway와 MCP Registry 구현 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="AWS Korea Blog의 시리즈 2편으로, 2명의 Solutions Architect가 7주 만에 구축한 Agentic AI 플랫폼의 핵심 인프라를 다룹니다."
   source="AWS Korea Blog"
   severity="Medium"
 -%}

--- a/_posts/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.md
+++ b/_posts/2026-03-02-Tech_Security_Weekly_Digest_Ransomware_AI_Agent.md
@@ -198,7 +198,7 @@ IBM QRadar (AQL) — East-West 트래픽 이상 탐지:
   title="[블록체인] Trump Media, 암호화폐 사업 확대 속 Truth Social 분사 검토"
   url="https://cointelegraph.com/news/trump-media-considers-truth-social-spinout?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-03/019cabfa-c3a2-72da-b194-fab729b24e80.jpg"
-  summary="Trump Media, 암호화폐 사업 확대 속 Truth Social 분사 검토 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Trump Media & Technology Group(DJT)이 소셜 미디어 플랫폼 Truth Social의 분사(Spin-out)를 검토 중이라고 밝혔다. 배경에는 그룹 차원의 암호화폐·핀테크 사업 확대 전략이 있다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -235,7 +235,7 @@ Trump Media & Technology Group(DJT)이 소셜 미디어 플랫폼 Truth Social�
   title="[블록체인] X(트위터), 유료 프로모션 라벨링 도입 및 암호화폐 광고 정책 변경"
   url="https://cointelegraph.com/news/x-lifts-crypto-promo-ban-for-paid-partnerships?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-03/019cabf9-6fcc-7133-8d32-5f8019e82cae.jpg"
-  summary="X, 유료 프로모션 라벨링 도입 및 암호화폐 광고 정책 변경 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="X(구 트위터)가 유료 파트너십 콘텐츠에 'Paid Partnership' 라벨을 의무적으로 표시하는 정책을 도입한다. 주목할 점은 암호화폐 관련 프로모션을 유료 파트너십 프레임워크 하에서 허용하되, 별도 규정을 적용한다는 것이다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -276,7 +276,7 @@ X 플랫폼 내 암호화폐 마케팅 적법 요건 (2026년 3월 기준):
   title="[블록체인] Kalshi 창업자, 이란 하메네이 관련 예측 시장 carve-out 발표"
   url="https://cointelegraph.com/news/kalshi-founder-khamenei-market-carveout?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/cdn-cgi/image/f=auto,onerror=redirect,w=1200/https://s3.cointelegraph.com/uploads/2026-02/019c30f6-7921-75e0-a1b0-230012cf2270.jpg"
-  summary="Kalshi 창업자, 이란 하메네이 관련 예측 시장 carve-out 발표 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="미국 CFTC 승인을 받은 예측 시장 플랫폼 Kalshi의 창업자 Tarek Mansour가 이란 최고지도자 하메네이 관련 예측 시장에 대해 'carve-out(예외 적용)' 방침을 발표했다. Kalshi는 '이 특정 마켓은 플랫폼에서 운영하지 않겠다'는 입장을 명확히 했다."
   source="Cointelegraph"
   severity="Medium"
 -%}
@@ -314,7 +314,7 @@ Kalshi의 carve-out 결정은 단순한 개별 사례를 넘어, 예측 시장 �
   title="[AI/ML] 광고 기반 무료 AI 채팅 데모 — &quot;무료&quot; AI의 미래를 풍자한 실험"
   url="https://news.hada.io/topic?id=27119"
   image="https://social.news.hada.io/topic/27119"
-  summary="광고 기반 무료 AI 채팅 데모 — &quot;무료&quot; AI의 미래를 풍자한 실험 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="한 개발자가 광고 수익으로 운영되는 무료 AI 채팅 서비스의 미래를 풍자적으로 구현한 실시간 데모를 공개했다. 실제 작동하는 언어 모델에 다양한 광고 형식을 통합하여, AI 서비스의 지속 가능한 수익화 모델에 대한 질문을 던진다."
   source="GeekNews"
   severity="Medium"
 -%}
@@ -341,7 +341,7 @@ Kalshi의 carve-out 결정은 단순한 개별 사례를 넘어, 예측 시장 �
   title="[AI/ML] Anthropic Courses — 무료 온라인 강의 공개"
   url="https://news.hada.io/topic?id=27118"
   image="https://social.news.hada.io/topic/27118"
-  summary="Anthropic Courses — 무료 온라인 강의 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Anthropic이 개발자를 위한 무료 온라인 교육 과정 'Anthropic Courses'를 공개했다. Claude 기본 사용법부터 시작하여 API 심화 활용, Claude Code 개발 워크플로, MCP(Model Context Protocol) 서버 구축, Agent Skills 개발까지 실무 중심 커리큘럼으로 구성되어 있다."
   source="GeekNews"
   severity="Medium"
 -%}

--- a/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
+++ b/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
@@ -94,7 +94,7 @@ summary_card:
 {%- include news-card.html
   title="[보안] JWT 서명키 유출: 전체 인증 체계 침해"
   url="https://www.skshieldus.com/download/files/download.do?o_fname=Research%20Technique%201%EC%9B%94%ED%98%B8_JWT%20%EC%84%9C%EB%AA%85%ED%82%A4%20%EC%9C%A0%EC%B6%9C%EC%9D%B4%20%EC%B4%88%EB%9E%98%ED%95%98%EB%8A%94%20%EC%9D%B8%EC%A6%9D%20%EC%9C%84%ED%98%91%EA%B3%BC%20%EB%A6%AC%EC%8A%A4%ED%81%AC%20%EB%8C%80%EC%9D%91%20%EC%A0%84%EB%9E%B5.pdf&r_fname=20260129161142327.pdf"
-  summary="JWT 서명키 유출: 전체 인증 체계 침해 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="SK쉴더스 Research Technique (1월호)에서 JWT 서명키 노출과 그로 인한 인증 위협에 대한 심층 분석을 발표했습니다."
   source="SK쉴더스 Research Technique — JWT 서명키 위협 분석 (PDF)"
   severity="High"
 -%}
@@ -144,7 +144,7 @@ source.ip NOT IN known_admin_ips
 {%- include news-card.html
   title="[보안] 금융 AI 7대 원칙 및 글로벌 정책 분석"
   url="https://www.skshieldus.com/download/files/download.do?o_fname=HeadLine_2%EC%9B%94%ED%98%B8_%EA%B8%88%EC%9C%B5%EB%B6%84%EC%95%BC%20AI%207%EB%8C%80%20%EC%9B%90%EC%B9%99%EA%B3%BC%20%EA%B5%AD%EB%82%B4%EC%99%B8%20%EC%A0%95%EC%B1%85%EC%82%AC%EB%A1%80%20%EB%B6%84%EC%84%9D.pdf&r_fname=20260225185655664.pdf"
-  summary="금융 AI 7대 원칙 및 글로벌 정책 분석 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="SK쉴더스 HeadLine (2월호)에서 금융 서비스 분야 AI를 위한 7대 핵심 원칙과 국내외 정책 사례 연구를 분석했습니다."
   source="SK쉴더스 HeadLine — 금융 AI 7대 원칙 (PDF)"
   severity="Medium"
 -%}
@@ -201,7 +201,7 @@ SK쉴더스 HeadLine (2월호)에서 금융 서비스 분야 AI를 위한 7대 �
   title="[블록체인] 이란 암호화폐 유출: 미-이스라엘 공습 후 BTC $1,030만 유출"
   url="https://www.chainalysis.com/blog/iranian-crypto-outflows-spike-after-airstrikes/"
   image="https://www.chainalysis.com/wp-content/uploads/2026/03/2026-03-iran.jpg"
-  summary="이란 암호화폐 유출: 미-이스라엘 공습 후 BTC $1,030만 유출 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Chainalysis 및 Bitcoin Magazine의 온체인 분석에 따르면, 2월 28일 미-이스라엘의 테헤란 공습 이후 이란 거래소에서 대규모 암호화폐 유출이 발생했습니다."
   source="Chainalysis Blog"
   severity="High"
 -%}
@@ -239,7 +239,7 @@ AML/컴플라이언스 시사점:
   title="[블록체인] American Bitcoin (ABTC) 채굴 장비 대규모 확장"
   url="https://bitcoinmagazine.com/news/trump-linked-american-bitcoin-abtc-2"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/Trump-Linked-American-Bitcoin-ABTC-Expands-Mining-Fleet-Bitcoin-Production-Capacity.jpg"
-  summary="American Bitcoin 채굴 장비 대규모 확장 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="트럼프 가문과 연관된 기업 American Bitcoin(ABTC)이 11,000대 이상의 신규 고효율 채굴 장비를 투입하며 채굴 사업을 대폭 확장하고 있습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 -%}

--- a/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
+++ b/_posts/2026-03-04-Tech_Security_Weekly_Digest_AI_Ransomware_Bitcoin.md
@@ -177,7 +177,7 @@ SK쉴더스 HeadLine (2월호)에서 금융 서비스 분야 AI를 위한 7대 �
 {%- include news-card.html
   title="[보안] SK쉴더스 EQST Insight 및 랜섬웨어 트렌드"
   url="https://www.skshieldus.com/download/files/download.do?o_fname=SK%EC%89%B4%EB%8D%94%EC%8A%A4%20EQST%20insight%20%ED%86%B5%ED%95%A9%20(%EB%AA%A9%EC%B0%A8"
-  summary="SK쉴더스 EQST Insight 및 랜섬웨어 트렌드 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="이번 기간 SK쉴더스 추가 발간물 2종입니다. EQST Insight (1월호)는 신규 공격 벡터를 다루는 통합 위협 인텔리전스 다이제스트, 글로벌 랜섬웨어 트렌드 보고서 (2월)는 랜섬웨어 진화, 신규 변종, 업종별 타겟팅 패턴 분석을 다룹니다."
   source="SK쉴더스 EQST Insight (PDF)"
   severity="High"
 -%}

--- a/_posts/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.md
+++ b/_posts/2026-03-05-Tech_Security_Weekly_Digest_iOS_Exploit_Hacktivist_DDoS.md
@@ -99,7 +99,7 @@ summary_card:
   title="[보안] Coruna iOS 익스플로잇 킷 — 23개 취약점 체인 발견"
   url="https://thehackernews.com/2026/03/coruna-ios-exploit-kit-uses-23-exploits.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEijM5GpGGT0LP6vQkv_yu-1sEWzgjTfk9OIdbMaYKiXdAVgK5DbybegA7hVb_XEgaAPPNAAXJNMh7K2jsH1uHltLp-6L_gOS5xWudR5Z4I76PI3Zv0h2tfvWgCUsq5LoiLMm4x_XXomAeWKVZJ_uNOmCL4cK8TlwNL_SxwwNX0XEr7I9D-ZK-JE1iwHsvM1/s1700-e365/ios.jpg"
-  summary="Coruna iOS 익스플로잇 킷 — 23개 취약점 체인 발견 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Threat Intelligence Group(GTIG)이 Coruna(일명 CryptoWaters)라는 강력한 iOS 익스플로잇 킷을 발견했습니다. 이 킷은 iOS 13.0부터 17.2.1까지를 타겟으로 하며, 5개의 완전한 iOS 익스플로잇 체인과 총 23개 익스플로잇을 포함하고 있습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -137,7 +137,7 @@ WIRED가 최초 보도했으며, 최신 iOS 버전에서는 작동하지 않는 
   title="[보안] 핵티비스트 DDoS 149건 — 중동 분쟁 후 보복 공격 급증"
   url="https://thehackernews.com/2026/03/149-hacktivist-ddos-attacks-hit-110.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjabhLtgN_k3Zm7rY2cHxMPh9Py-QdY1pESzIEtJbo45w5Y744g5nEtkc9z6tmPaXh_wB0pgzxbFwTzM7C0whbwEbbSopd-CZy98ANNcLF5k7orHTEMlkLSN5JegxMAMPEyeXPE2VXurPv4npqtKkvuay4ZltoPMk47uR-eqP6LsFHp3SqxAeu8tthDyZMa/s1700-e365/ddos.jpg"
-  summary="핵티비스트 DDoS 149건 — 중동 분쟁 후 보복 공격 급증 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="미국-이스라엘의 이란 대상 군사 작전(코드명: Epic Fury, Roaring Lion) 이후, 보복성 핵티비스트 활동이 급증했습니다. Radware 보고서에 따르면, 2월 28일~3월 2일 사이 16개국 110개 기관을 대상으로 149건의 DDoS 공격이 발생했습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -169,7 +169,7 @@ index=network sourcetype=firewall ("DDoS" OR "flood" OR "amplification")
   title="[보안] 엔터프라이즈 AI 거버넌스를 위한 RFP 템플릿 공개"
   url="https://thehackernews.com/2026/03/new-rfp-template-for-ai-usage-control.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhrvS_eE1grWPn8hXdb-s4EpPUtevfmC487K-kpFLYJOHCw0vZ1A81bBjhZflx5zj8qY4KrWG3FbQ2dbSFOatzswmBbFxZJkX5vqJOpzyaCefDzEiOfca4ayNkY1ERY95TefFgfRj01keLjzjK_8NKr4OSO3B5vM4k9yY_J9dNtmc1Z7lXdqjawA22F2Zc/s1700-e365/main-ai.jpg"
-  summary="엔터프라이즈 AI 거버넌스를 위한 RFP 템플릿 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="AI가 엔터프라이즈 생산성의 핵심 엔진이 되면서, 보안 리더들이 AI 보안 예산을 확보하고 있지만 실질적인 AI 거버넌스 요구사항을 정의하지 못하는 문제가 발생하고 있습니다. 많은 조직이 'AI 거버넌스가 필요하다'는 것은 알지만, 구체적으로 무엇을 요구해야 하는지 파악하지 못한 상태입니다."
   source="The Hacker News"
   severity="Medium"
 -%}
@@ -191,7 +191,7 @@ AI가 엔터프라이즈 생산성의 핵심 엔진이 되면서, 보안 리더�
   title="[보안] AWS IAM 접근 거부 오류에 정책 ARN 추가"
   url="https://aws.amazon.com/blogs/security/enhanced-access-denied-error-messages-with-policy-arns/"
   image="https://d2908q01vomqb2.cloudfront.net/22d200f8670dbdb3e253a90eee5098477c95c23d/2026/03/04/Slide1.jpeg"
-  summary="AWS IAM 접근 거부 오류에 정책 ARN 추가 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="AWS가 IAM 접근 거부 오류 메시지에 거부 정책의 ARN(Amazon Resource Name)을 포함하도록 개선했습니다. 2021년에 정책 유형 표시를 추가한 것에 이어, 이번에는 구체적인 정책 식별자를 제공하여 트러블슈팅을 크게 단순화합니다."
   source="AWS Security Blog"
   severity="Medium"
 -%}
@@ -208,7 +208,7 @@ AWS가 IAM 접근 거부 오류 메시지에 거부 정책의 ARN(Amazon Resourc
   title="[보안] AWS 2025 ISO/CSA STAR 인증 갱신 완료"
   url="https://aws.amazon.com/blogs/security/2025-iso-and-csa-star-certificates-are-now-available-with-one-additional-service-and-one-new-region/"
   image="https://d2908q01vomqb2.cloudfront.net/22d200f8670dbdb3e253a90eee5098477c95c23d/2023/02/16/aws_bp_primarylogo_01.png"
-  summary="AWS 2025 ISO/CSA STAR 인증 갱신 완료 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="AWS가 ISO 9001, 27001, 27017, 27018, 27701, 20000-1, 22301 및 CSA STAR CCM v4.0 인증 감사를 무결점(no findings)으로 통과했습니다. 새로운 리전 1개와 서비스 1개가 인증 범위에 추가되었습니다."
   source="AWS Security Blog"
   severity="Medium"
 -%}
@@ -227,7 +227,7 @@ AWS가 ISO 9001, 27001, 27017, 27018, 27701, 20000-1, 22301 및 CSA STAR CCM v4.
   title="[AI/ML] Google AI Mode Canvas — 검색에서 바로 문서 작성·코딩"
   url="https://blog.google/products-and-platforms/products/search/ai-mode-canvas-writing-coding/"
   image="https://storage.googleapis.com/gweb-uniblog-publish-prod/images/AIMMode_Social.max-1440x810.png"
-  summary="Google AI Mode Canvas — 검색에서 바로 문서 작성·코딩 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google이 검색의 AI Mode에 Canvas 기능을 추가했습니다. 미국 전체 사용자에게 제공되며, 검색 화면에서 바로 문서 초안 작성이나 인터랙티브 도구를 빌드할 수 있습니다."
   source="Google AI Blog"
   severity="Medium"
 -%}
@@ -243,7 +243,7 @@ AI 기반 검색이 단순 정보 검색에서 생산성 도구로 진화하는 
 {%- include news-card.html
   title="[AI/ML] OpenAI GPT-5.2 Pro — 양자중력 중력자 진폭 검증"
   url="https://openai.com/index/extending-single-minus-amplitudes-to-gravitons/"
-  summary="OpenAI GPT-5.2 Pro — 양자중력 중력자 진폭 검증 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="OpenAI가 GPT-5.2 Pro를 활용하여 양자중력에서 비영(nonzero) 중력자 트리 진폭을 유도하고 검증하는 데 성공한 새로운 프리프린트를 공개했습니다. 단일-마이너스(single-minus) 진폭을 중력자로 확장한 연구로, AI가 이론물리학 연구에서 실질적인 기여를 한 주목할 만한 사례입니다."
   source="OpenAI Blog"
   severity="Medium"
 -%}
@@ -258,7 +258,7 @@ OpenAI가 GPT-5.2 Pro를 활용하여 양자중력에서 비영(nonzero) 중력�
   title="[AI/ML] AWS Amazon Nova 기반 콜센터 분석"
   url="https://aws.amazon.com/blogs/machine-learning/unlock-powerful-call-center-analytics-with-amazon-nova-foundation-models/"
   image="https://d2908q01vomqb2.cloudfront.net/f1f836cb4ea6efb2a0b1b99f41ad8b103eff4b59/2026/03/04/ml-18030-1120x630.png"
-  summary="AWS Amazon Nova 기반 콜센터 분석 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="AWS가 Amazon Nova 파운데이션 모델을 활용한 강력한 콜센터 분석 기능을 소개했습니다. 대화 분석, 통화 분류 등 컨택센터 관련 유즈케이스에서 Nova 모델의 역량을 검증한 내용입니다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 -%}
@@ -276,7 +276,7 @@ AWS가 Amazon Nova 파운데이션 모델을 활용한 강력한 콜센터 분�
 {%- include news-card.html
   title="[클라우드] GKE 기반 AI-네이티브 통신망 아키텍처"
   url="https://cloud.google.com/blog/products/networking/gke-for-telco-building-a-highly-resilient-network-architecture/"
-  summary="GKE 기반 AI-네이티브 통신망 아키텍처 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Cloud가 Google Kubernetes Engine(GKE)을 활용한 고가용성 통신망 아키텍처를 발표했습니다. 전통적인 온프레미스 데이터센터 모델의 한계를 넘어서, 클라우드 네이티브 방식으로 통신 인프라를 현대화하는 전략입니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -291,7 +291,7 @@ Google Cloud가 Google Kubernetes Engine(GKE)을 활용한 고가용성 통신�
   title="[클라우드] Google Cloud H4D VM 정식 출시 (GA)"
   url="https://cloud.google.com/blog/products/compute/h4d-vms-now-ga/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/05_-_Compute.max-2600x2600.jpg"
-  summary="Google Cloud H4D VM 정식 출시 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Cloud가 5세대 AMD EPYC 프로세서 기반 H4D VM을 정식 출시했습니다. HPC(고성능 컴퓨팅) 워크로드에 최적화된 VM으로, 뛰어난 성능과 스케일링을 제공합니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -305,7 +305,7 @@ Google Cloud가 5세대 AMD EPYC 프로세서 기반 H4D VM을 정식 출시했�
 {%- include news-card.html
   title="[클라우드] BMW의 도메인 특화 소형 언어 모델 실험"
   url="https://cloud.google.com/blog/topics/manufacturing/how-bmw-is-testing-slms-not-llms-for-natural-language-voice-commands/"
-  summary="BMW의 도메인 특화 소형 언어 모델 실험 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
+  summary="Google Cloud와 BMW가 협업하여 대형 모델 대신 도메인 특화 소형 언어 모델(SLM)을 평가한 실험 결과를 공개했습니다. 자동차 음성 명령의 자연어 처리 품질을 향상시키면서도 비용과 레이턴시를 줄이는 접근입니다."
   source="Google Cloud Blog"
   severity="Medium"
 -%}
@@ -324,42 +324,36 @@ Google Cloud와 BMW가 협업하여 대형 모델 대신 도메인 특화 소형
   url="https://news.hada.io/topic?id=27207"
   source="GeekNews"
   tag="Tech Signals"
-  summary="Qwen의 땅에서 무언가 일어나고 있다 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="에이전틱 엔지니어링 패턴"
   url="https://news.hada.io/topic?id=27206"
   source="GeekNews"
   tag="Tech Signals"
-  summary="에이전틱 엔지니어링 패턴 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="모토로라 GrapheneOS 기기, 부트로더 지원"
   url="https://news.hada.io/topic?id=27203"
   source="GeekNews"
   tag="Tech Signals"
-  summary="모토로라 GrapheneOS 기기, 부트로더 지원 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="OpenAI Codex 앱 Windows용 공개"
   url="https://news.hada.io/topic?id=27201"
   source="GeekNews"
   tag="AI / Product"
-  summary="OpenAI Codex 앱 Windows용 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="Apple, MacBook Neo 공개"
   url="https://news.hada.io/topic?id=27200"
   source="GeekNews"
   tag="Tech Signals"
-  summary="Apple, MacBook Neo 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% include news-spotlight-item.html
   title="클로드 코드 가이드 (전자책) 공개"
   url="https://news.hada.io/topic?id=27190"
   source="GeekNews"
   tag="Tech Signals"
-  summary="클로드 코드 가이드 공개 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, 탐지·차단·복구 관점의 우선 대응 항목을 실무 기준으로 정리했습니다."
 %}
 {% endcapture %}
 {% include news-spotlight-section.html

--- a/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
+++ b/_posts/2026-03-07-Tech_Security_Weekly_Digest_Android_Zero_Day_DevSecOps.md
@@ -111,7 +111,7 @@ summary_card:
   title="[보안] Google Android 3월 보안 업데이트: 129개 취약점 패치"
   url="https://thehackernews.com/2026/03/google-confirms-cve-2026-21385-in.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjR_pPCmiYZpBkIhumuW9B55rXBX7U9PZto5xPxHsLBbx5EstbqXgUI-XLZkQQV8OCsdaOi5RuSapl0V4LPKX9B_8MDBqSteyX83vXpj7G8-87BBhyphenhyphen75Os_0RhTFWBL_yxr7JVwXXtZ-qdbbugAlw9MoC5mFEx0hfQMncgnDRR8tLlEMXsLiPmim2sTjzNO/s1700-e365/android-exploit.jpg"
-  summary="Google Android 3월 보안 업데이트: 129개 취약점 패치를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Google이 Android 역사상 최대 규모의 보안 업데이트를 배포했습니다. 총 129개 취약점이 수정되었으며, 이 중 10개는 Critical 등급입니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -155,7 +155,7 @@ Google이 Android 역사상 최대 규모의 보안 업데이트를 배포했습
   title="[보안] VMware Aria Operations 명령 주입 취약점 활성 공격"
   url="https://thehackernews.com/2026/03/cisa-adds-actively-exploited-vmware.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjwSnIflppBRH5X_FxN5pZcibA3-KyhW9iDiNGlD76L9B8dFwzLtP5i7FHFzf73XpTAhCLtmQn0JD_fUqgXceUlrCwPgJqbmlkPXi2e_IDggrIHDyJ5HoDzr191LxAbe08arokXZ4FXH5k9NxErepVgiaEkGVfWDWQ2ZWJ8h3mGjySQ-QqTzo02oBdh01Up/s1700-e365/vmware.jpg"
-  summary="VMware Aria Operations 명령 주입 취약점 활성 공격를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="CISA가 VMware Aria Operations의 명령 주입 취약점 CVE-2026-22719(CVSS 8.1)를 KEV(Known Exploited Vulnerabilities) 카탈로그에 등재했습니다. 이 취약점은 인증되지 않은 공격자가 임의의 운영 체제 명령을 실행할 수 있게 합니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -183,7 +183,7 @@ Aria Operations는 VMware 가상화 인프라의 성능 및 용량 관리 핵심
 {%- include news-card.html
   title="[보안] Cisco SD-WAN 인증 우회 제로데이 (CVE-2026-20127)"
   url="https://www.tenable.com/blog/cve-2026-20127-cisco-catalyst-sd-wan-controllermanager-zero-day-authentication-bypass"
-  summary="Cisco SD-WAN 인증 우회 제로데이를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Cisco Catalyst SD-WAN Controller/Manager에서 인증 우회 취약점이 발견되어 실제 공격에 활용되고 있습니다. 원격의 인증되지 않은 공격자가 조작된 요청을 보내 고권한 사용자로 로그인할 수 있습니다."
   source="Tenable"
   severity="Critical"
 -%}
@@ -218,7 +218,7 @@ CISA는 긴급 지시문 ED 26-03을 발령하여 Cisco SD-WAN 시스템의 즉�
   title="[보안] APT28 MSHTML 제로데이 악용 확인 (CVE-2026-21513)"
   url="https://thehackernews.com/2026/03/apt28-tied-to-cve-2026-21513-mshtml-0.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgGmBYExYY-MdqirvtI7-k2gWDf2rCE5AX4J246DywytJU0hWklJfAxRUKUa6AhU-VFWf2jazsAR1DkpPBHUqv2LsGckfxhVUebrMsnAccaYYmp2L9VJDz4rHaRLxKRgXaYM-UPcFS_ZoyveJxkLu1RunwaIuCBckILFDzMo1mCZtg9zaOmXrOSEEWU7RSg/s1700-e365/windows.jpg"
-  summary="APT28 MSHTML 제로데이 악용 확인를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="러시아 연계 APT28(Fancy Bear)이 Microsoft MSHTML 프레임워크의 보안 기능 우회 취약점 CVE-2026-21513(CVSS 8.8)을 2월 패치 전부터 제로데이로 악용한 것이 확인되었습니다."
   source="The Hacker News"
   severity="Critical"
 -%}
@@ -241,7 +241,7 @@ CISA는 긴급 지시문 ED 26-03을 발령하여 Cisco SD-WAN 시스템의 즉�
 {%- include news-card.html
   title="[보안] Google, 중국 사이버 첩보 캠페인 GridTide 차단"
   url="https://www.cybersecurity-review.com/news-march-2026/"
-  summary="Google, 중국 사이버 첩보 캠페인 GridTide 차단를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Google이 42개국 53개 조직을 표적으로 한 대규모 중국 사이버 첩보 캠페인을 차단했습니다. GridTide 악성코드를 사용한 이 캠페인은 정부, 국방, 기술 분야를 주로 공격했습니다."
   source="Cybersecurity News"
   severity="High"
 -%}
@@ -263,7 +263,7 @@ Google이 42개국 53개 조직을 표적으로 한 대규모 중국 사이버 �
   title="[보안] 악성 PHP 패키지: 크로스 플랫폼 RAT 배포"
   url="https://thehackernews.com/"
   image="https://thehackernews.com/images/-AaptImXE5Y4/WzjvqBS8HtI/AAAAAAAAxSs/BcCIwpWJszILkuEbDfKZhxQJwOAD7qV6ACLcBGAs/s728-e365/the-hacker-news.jpg"
-  summary="악성 PHP 패키지: 크로스 플랫폼 RAT 배포를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Packagist PHP 패키지 레지스트리에서 Laravel 유틸리티로 위장한 악성 패키지가 발견되었습니다. Windows, macOS, Linux 모두에서 작동하는 크로스 플랫폼 RAT(원격 접근 트로이목마)를 배포하며, 발견 시점에도 여전히 다운로드 가능했습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -285,7 +285,7 @@ Packagist PHP 패키지 레지스트리에서 Laravel 유틸리티로 위장한 
   title="[보안] Microsoft OAuth 스캠: 정부 기관 표적 공격"
   url="https://www.microsoft.com/en-us/security/blog/"
   image="https://www.microsoft.com/en-us/security/blog/wp-content/uploads/2018/08/cropped-microsoft_logo_element.png"
-  summary="Microsoft OAuth 스캠: 정부 기관 표적 공격를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Microsoft가 OAuth 남용 스캠에 대해 경고했습니다. 피싱 이메일과 URL 리디렉트를 활용하여 피해자의 시스템에 악성코드를 설치하며, 주로 정부 및 공공 부문 조직을 표적으로 합니다."
   source="Microsoft Security"
   severity="High"
 -%}
@@ -307,7 +307,7 @@ Microsoft가 OAuth 남용 스캠에 대해 경고했습니다. 피싱 이메일�
   title="[보안] 보복성 핵티비스트 공격 급증: Epic Fury 이후"
   url="https://thehackernews.com/"
   image="https://thehackernews.com/images/-AaptImXE5Y4/WzjvqBS8HtI/AAAAAAAAxSs/BcCIwpWJszILkuEbDfKZhxQJwOAD7qV6ACLcBGAs/s728-e365/the-hacker-news.jpg"
-  summary="보복성 핵티비스트 공격 급증: Epic Fury 이후를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="미국-이스라엘 합동 군사 작전(Epic Fury/Roaring Lion) 이후 보복성 핵티비스트 활동이 급증했습니다. Radware에 따르면, Keymous+와 DieNet 두 그룹이 2월 28일-3월 2일 사이 전체 공격의 약 70%를 수행했습니다."
   source="The Hacker News"
   severity="High"
 -%}
@@ -333,7 +333,7 @@ Microsoft가 OAuth 남용 스캠에 대해 경고했습니다. 피싱 이메일�
   title="Datadog DevSecOps 2026 보고서: 87% 조직이 공격 가능 취약점 보유"
   url="https://www.helpnetsecurity.com/2026/03/02/devsecops-supply-chain-risk-security-debt/"
   image="https://img.helpnetsecurity.com/wp-content/uploads/2024/01/19155548/devsecops-1400.jpg"
-  summary="Datadog DevSecOps 2026 보고서: 87% 조직이 공격 가능 취약점 보유를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Datadog의 State of DevSecOps 2026 보고서가 발표되었습니다. 조사 대상 조직의 87%가 운영 환경에서 하나 이상의 공격 가능한 취약점을 실행하고 있으며, 서비스의 40%가 영향을 받습니다."
   source="Help Net Security"
   severity="High"
 -%}
@@ -362,7 +362,7 @@ Datadog의 State of DevSecOps 2026 보고서가 발표되었습니다. 조사 �
   title="CI/CD 파이프라인 자동 공격 캠페인"
   url="https://www.helpnetsecurity.com/2026/03/02/devsecops-supply-chain-risk-security-debt/"
   image="https://img.helpnetsecurity.com/wp-content/uploads/2024/01/19155548/devsecops-1400.jpg"
-  summary="CI/CD 파이프라인 자동 공격 캠페인를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="주요 오픈소스 리포지토리를 대상으로 한 1주일간의 자동화된 CI/CD 파이프라인 공격이 보고되었습니다. hackerbot-claw라는 자율 봇이 5가지 익스플로잇 기법을 사용하여 GitHub에서 가장 인기 있는 리포지토리 중 하나에서 쓰기 권한이 있는 GitHub 토큰을 유출하는 데 성공했습니다."
   source="Help Net Security"
   severity="High"
 -%}
@@ -385,7 +385,7 @@ Datadog의 State of DevSecOps 2026 보고서가 발표되었습니다. 조사 �
   title="코드 서명 인증서 유효기간 460일로 제한"
   url="https://devops.com/three-encryption-resolutions-for-devsecops-in-2026/"
   image="https://devops.com/wp-content/uploads/2020/08/Overheard-at-CloudBees-Connect-The-Reality-of-Delivering-Modern-Software.jpg"
-  summary="코드 서명 인증서 유효기간 460일로 제한를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="2026년 3월 1일부터 CA/B Forum 규정에 따라 코드 서명 인증서의 최대 유효기간이 460일로 제한됩니다. 공급망 공격이 증가하고 AI 기반 위협이 확대되면서, DevSecOps 팀은 CI/CD 보안을 강화하고 인증서 갱신 자동화가 필수가 되었습니다."
   source="DevOps.com"
   severity="Medium"
 -%}
@@ -411,7 +411,7 @@ Datadog의 State of DevSecOps 2026 보고서가 발표되었습니다. 조사 �
   title="[AI/ML] AI 기반 사이버 공격 89% 증가"
   url="https://www.securityweek.com/cyber-insights-2026-malware-and-cyberattacks-in-the-age-of-ai/"
   image="https://www.securityweek.com/wp-content/uploads/2026/02/malware-cyber-insights-2026.jpg"
-  summary="AI 기반 사이버 공격 89% 증가를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="2026년 3월 기준, AI 기반 사이버 공격이 89% 증가했습니다. 피싱, 딥페이크 캠페인, 자격 증명 탈취에 AI가 적극적으로 활용되고 있으며, 아이덴티티 위협(API 자격 증명 남용, 내부자 위협)이 대부분의 데이터 유출 원인을 차지합니다."
   source="SecurityWeek"
   severity="High"
 -%}
@@ -435,7 +435,7 @@ Datadog의 State of DevSecOps 2026 보고서가 발표되었습니다. 조사 �
   title="[AI/ML] AI가 DevSecOps를 재편: PR 병합 98% 증가"
   url="https://www.computerweekly.com/news/366639364/How-AI-code-generation-is-pushing-DevSecOps-to-machine-speed"
   image="https://www.computerweekly.com/visuals/ComputerWeekly/HeroImages/security-code-encryption-gonin-adobe.jpg"
-  summary="AI가 DevSecOps를 재편: PR 병합 98% 증가를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AI를 활용하는 개발자는 98% 더 많은 PR을 병합하고 있습니다. 보안 팀에게 이 속도는 복합적인 문제를 만듭니다."
   source="Computer Weekly"
   severity="Medium"
 -%}
@@ -458,7 +458,7 @@ JFrog은 AI 모델을 소프트웨어 아티팩트와 동일한 수준으로 관
 {%- include news-card.html
   title="[AI/ML] 랜섬웨어 생태계의 구조적 변화"
   url="https://www.recordedfuture.com/blog/ransomware-tactics-2026"
-  summary="랜섬웨어 생태계의 구조적 변화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="랜섬웨어 공격은 2025년 7,200건으로 전년 대비 47% 증가했지만, 수익은 감소했습니다. LockBit과 RansomHub가 사라진 후 Akira(16%), Qilin(16%), DragonForce(5%)가 부상했습니다."
   source="Recorded Future"
   severity="High"
 -%}
@@ -485,7 +485,7 @@ Recorded Future는 2026년을 러시아 외 지역 랜섬웨어 조직이 러시
 {%- include news-card.html
   title="[클라우드] VoidLink: AI로 제작된 K8s 인식형 악성코드"
   url="https://blogs.cisco.com/security/voidlink-ai-built-malware-and-the-future-of-workload-security"
-  summary="VoidLink: AI로 제작된 K8s 인식형 악성코드를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Check Point Research가 공개한 VoidLink는 클라우드 네이티브 환경에 특화된 악성코드 프레임워크입니다. AWS, GCP, Azure, Alibaba, Tencent 환경을 탐지하고, Docker 컨테이너와 Kubernetes 포드 내부에서 동작하는지 판별하여 행위를 자동으로 조정합니다."
   source="Cisco Security Blog"
   severity="High"
 -%}
@@ -515,7 +515,7 @@ Check Point Research가 공개한 VoidLink는 클라우드 네이티브 환경�
   title="[클라우드] Kubernetes 공격 도구 급증"
   url="https://dev.to/deepseax/kubernetes-cluster-attacks-surge-in-2026-how-to-harden-your-k8s-foo"
   image="https://media2.dev.to/dynamic/image/width=1200,height=627,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Farticles%2Fh0yfzebupy5doeul7v02.png"
-  summary="Kubernetes 공격 도구 급증를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="CSO Online은 2026년 3월 Kubernetes 전용 공격 도구의 급격한 증가를 보고했습니다. 노출된 API 서버를 통한 권한 상승, 탈취된 Pod를 이용한 크립토마이너 배포 등 점점 정교한 공격이 이루어지고 있습니다."
   source="DEV Community"
   severity="High"
 -%}
@@ -540,7 +540,7 @@ Kubernetes는 전 세계 컨테이너화된 워크로드의 60% 이상을 관리
   title="[클라우드] 서비스 메시 복귀: 제로 트러스트 보안 강화"
   url="https://cloudnativenow.com/contributed-content/why-service-mesh-is-poised-for-a-dramatic-comeback-in-2026/"
   image="https://cloudnativenow.com/wp-content/uploads/2019/06/Service-Mesh-Pattern.jpg"
-  summary="서비스 메시 복귀: 제로 트러스트 보안 강화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="2026년 서비스 메시가 제로 트러스트 보안의 핵심 인프라로 재부상하고 있습니다. 기존 사이드카 기반 메시의 채택은 50%에서 42%로 감소했지만, Ambient Mode(사이드카리스) 아키텍처가 새로운 관심을 끌고 있습니다."
   source="Cloud Native Now"
   severity="Medium"
 -%}
@@ -567,7 +567,7 @@ AI 기반 워크로드의 증가로 보안 연결, 워크로드 아이덴티티,
 {%- include news-card.html
   title="[블록체인] GENIUS Act: 미국 스테이블코인 규제 프레임워크 구체화"
   url="https://www.clearygottlieb.com/news-and-insights/publication-listing/2026-digital-assets-regulatory-update-a-landmark-2025-but-more-developments-on-the-horizon"
-  summary="GENIUS Act: 미국 스테이블코인 규제 프레임워크 구체화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="2025년 7월 초당적으로 통과된 GENIUS Act의 구현 타임라인이 구체화되고 있습니다. 감독 기관은 2026년 7월 18일까지 미국 달러 기반 스테이블코인 발행사에 대한 시행 규칙을 발표해야 하며, 규정은 2027년 1월 18일까지 발효됩니다."
   source="Cleary Gottlieb"
   severity="Medium"
 -%}
@@ -590,7 +590,7 @@ SEC와 CFTC도 Project Crypto 공동 프로젝트를 발표하며 디지털 자�
   title="[블록체인] 일본 암호화폐 세율 55%에서 20%로 인하 예정"
   url="https://sumsub.com/blog/global-crypto-regulations/"
   image="https://sumsub.com/wp/wp-content/uploads/2025/12/opengraph_crypto-regulation-around-the-world-2026_-what-changed-and-whats-ahead.png"
-  summary="일본 암호화폐 세율 55%에서 20%로 인하 예정를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="일본이 2026년 암호화폐 세율을 55%에서 20%로 인하할 예정입니다. 기존 잡소득으로 분류되던 암호화폐 수익을 전통적인 자본 이득세율과 동일하게 적용하여, 암호화폐 투자 환경을 크게 개선합니다."
   source="Sumsub"
   severity="Medium"
 -%}
@@ -607,7 +607,7 @@ SEC와 CFTC도 Project Crypto 공동 프로젝트를 발표하며 디지털 자�
   title="[블록체인] EU MiCA 전면 시행: 세계 최초 포괄적 암호화폐 규제"
   url="https://www.elliptic.co/blog/regulatory-and-policy-crypto-trends-to-except-in-2026"
   image="https://www.elliptic.co/hubfs/2026-Regulatory-outlook-blog_R%26A-Image.png"
-  summary="EU MiCA 전면 시행: 세계 최초 포괄적 암호화폐 규제를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="EU의 MiCA(Markets in Crypto-Assets Regulation)가 전면 시행에 들어갔습니다. 세계 최초의 포괄적 암호화폐 규제 프레임워크로, 엄격한 요구사항으로 인해 일부 시장 참여자에게는 상당한 혼란이 발생하고 있습니다."
   source="Elliptic"
   severity="Medium"
 -%}

--- a/_posts/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.md
+++ b/_posts/2026-03-08-Tech_Security_Weekly_Digest_AI_Security.md
@@ -221,7 +221,7 @@ OpenAI Codex Security와의 시너지:
   title="AI 에이전트 도입의 가장 큰 병목은 성능보다 신뢰(feat. 시간)"
   url="https://news.hada.io/topic?id=27301"
   image="https://social.news.hada.io/topic/27301"
-  summary="AI 에이전트 도입의 가장 큰 병목은 성능보다 신뢰를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Anthropic이 수백만 건의 Claude Code 상호작용 데이터를 분석한 결과, AI 에이전트 도입의 핵심 병목은 모델 성능이 아니라 사용자가 에이전트를 신뢰하기까지 걸리는 시간이라는 사실을 확인했습니다. 사용자들은 처음에 단순 작업만 맡기다가, 에이전트가 일관되게 올바른 결과를 제공하는 것을 확인한 후에야 점차 복잡한 작업을 위임합니다."
   source="GeekNews"
   severity="Medium"
 %}
@@ -243,7 +243,7 @@ DevSecOps 시사점:
   title="Autoresearch - Karpathy의 자동 연구 프레임워크"
   url="https://news.hada.io/topic?id=27300"
   image="https://social.news.hada.io/topic/27300"
-  summary="Autoresearch - Karpathy의 자동 연구 프레임워크를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Andrej Karpathy가 공개한 Autoresearch는 LLM 학습의 핵심을 단일 GPU·단일 파일 630줄로 압축한 자기완결형 연구 프레임워크입니다. AI 에이전트가 밤새 실험을 반복하고 인간은 프롬프트만 수정하는 방식으로, 연구 자동화의 새로운 패러다임을 제시합니다."
   source="GeekNews"
   severity="Medium"
 %}
@@ -266,7 +266,7 @@ Andrej Karpathy가 공개한 Autoresearch는 LLM 학습의 핵심을 단일 GPU�
   title="Go 표준 라이브러리에 UUID 패키지 추가 제안"
   url="https://news.hada.io/topic?id=27299"
   image="https://social.news.hada.io/topic/27299"
-  summary="Go 표준 라이브러리에 UUID 패키지 추가 제안를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Go 언어에 UUID 생성·파싱 기능을 표준 라이브러리(unique/uuid)로 추가하자는 제안이 논의 중입니다. 현재 대부분의 Go 프로젝트가 google/uuid나 gofrs/uuid 같은 외부 패키지에 의존하고 있어, 표준화가 공급망 보안 측면에서도 긍정적입니다."
   source="GeekNews"
   severity="Medium"
 %}

--- a/_posts/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.md
+++ b/_posts/2026-03-09-Tech_Security_Weekly_Digest_AI_Security_Go_Bitcoin.md
@@ -97,7 +97,7 @@ summary_card:
   title="[보안] AI 어시스턴트가 보안 기준을 바꾸고 있다"
   url="https://krebsonsecurity.com/2026/03/how-ai-assistants-are-moving-the-security-goalposts/"
   image="https://krebsonsecurity.com/wp-content/uploads/2026/03/lethaltrifecta.png"
-  summary="AI 어시스턴트가 보안 기준을 바꾸고 있다를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AI 기반 자율 에이전트가 사용자의 컴퓨터·파일·온라인 서비스에 완전한 접근권을 가지면서 심각한 보안 문제를 야기하고 있습니다. Krebs on Security는 실제 발생한 사건들을 바탕으로, AI 에이전트가 기존 보안 경계를 근본적으로 재정의하고 있음을 상세히 분석했습니다."
   source="Krebs on Security"
   severity="High"
 %}
@@ -177,7 +177,7 @@ MCP 서버가 새로운 공격 표면을 생성하며, 악성 MCP 서버에 연�
   title="[블록체인] 은행에게 암호화폐 규제 명확성이 더 중요 — 전 CFTC 위원장"
   url="https://cointelegraph.com/news/us-banks-need-crypto-regulatory-clarity-giancarlo-cftc?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjA0NTctN2FkYy03MTdlLWIyOWUtNjk5MjkwYzQ3NTc3.jpg"
-  summary="은행에게 암호화폐 규제 명확성이 더 중요 — 전 CFTC 위원장를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="전 CFTC 의장 크리스 지앙카를로(Chris Giancarlo)는 암호화폐 규제 명확성이 암호화폐 산업 자체보다 미국 은행들에게 더 긴급한 과제라고 강조했습니다. 그는 '은행들은 규제 불확실성을 감당할 수 없으며, 수십억 달러를 투자하려면 규제 확실성이 필요하다'고 지적했습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -215,7 +215,7 @@ SEC/CFTC 역할 분담의 핵심:
   title="[블록체인] Saylor, BTC $66K 근처에서 추가 매수 신호"
   url="https://cointelegraph.com/news/saylor-signals-bitcoin-buy-btc-near-66k?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YWZmOTctOTNhYS03YTA1LTg1NGQtZjVmNmVmNTQ5OGNm.jpg"
-  summary="Saylor, BTC $66K 근처에서 추가 매수 신호를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Michael Saylor가 이끄는 Strategy(구 MicroStrategy)는 720,737 BTC(시장가 기준 약 $481억)를 보유한 전 세계 최대 Bitcoin 보유 상장기업입니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -250,7 +250,7 @@ Strategy의 매수 신호가 뉴스를 장식할 때마다, 이를 악용한 피
   title="[블록체인] 브라질 Pix 즉시결제 시스템, 아르헨티나로 확장"
   url="https://cointelegraph.com/news/brazil-pix-payments-expand-argentina?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2NlYjEtZTMwZC03M2ZkLWI1NTItNjkzYzczNjY4MzEzLmpwZw==.jpg"
-  summary="브라질 Pix 즉시결제 시스템, 아르헨티나로 확장를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="브라질 중앙은행이 Pix 디지털 즉시결제 시스템을 아르헨티나 거주 브라질인들로 확장했습니다. 이들은 이제 양국에서 상품·서비스 구매 및 송금이 가능합니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -293,7 +293,7 @@ Pix의 국경간 확장은 새로운 보안 과제를 수반합니다.
   title="엔터프라이즈 LLM 서비스 구축기 2: 에이전트 엔지니어링"
   url="https://techblog.lycorp.co.jp/ko/building-an-llm-service-for-enterprise-2-agent-engineering"
   image="https://techblog.lycorp.co.jp/static/6566a0509ecea313ec484dccc2d6293e/7d66e/40c7b64033ec406fa055af3f2fbe65c3.png"
-  summary="엔터프라이즈 LLM 서비스 구축기 2: 에이전트 엔지니어링를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="LINE Engineering(LY Corporation)이 발행한 이 기술 블로그 시리즈 2편은, 수백 명의 직원이 사용하는 엔터프라이즈급 LLM 서비스를 실제 운영하면서 터득한 에이전트 엔지니어링의 핵심 노하우를 공개합니다."
   source="LINE Engineering Blog"
   severity="Medium"
 %}
@@ -326,7 +326,7 @@ DevSecOps 관점에서의 인사이트:
   title="전쟁은 AI 기업의 윤리 원칙을 어디까지 밀어붙였나?"
   url="https://news.hada.io/topic?id=27330"
   image="https://social.news.hada.io/topic/27330"
-  summary="전쟁은 AI 기업의 윤리 원칙을 어디까지 밀어붙였나?를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Anthropic의 Claude가 Palantir의 Maven Smart System을 통해 미군의 정보분석·표적 식별·시뮬레이션에 활용되고 있다는 사실이 알려지며 AI 업계에 큰 파장을 일으켰습니다. 이 사건의 핵심은 평시의 윤리 원칙이 전시에는 얼마나 쉽게 흔들리는가를 보여준다는 것입니다."
   source="GeekNews"
   severity="Medium"
 %}
@@ -360,7 +360,7 @@ Anthropic의 Claude가 Palantir의 Maven Smart System을 통해 미군의 정보
   title="Agent Safehouse — macOS용 로컬 에이전트 샌드박싱 도구"
   url="https://news.hada.io/topic?id=27329"
   image="https://social.news.hada.io/topic/27329"
-  summary="Agent Safehouse — macOS용 로컬 에이전트 샌드박싱 도구를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Agent Safehouse는 본 포스트 1.1절에서 다룬 AI 에이전트 보안 위협에 대한 실질적인 대응 도구입니다. LLM의 확률적 특성으로 인한 예기치 못한 명령 실행을 차단하여 시스템 파일 손상을 방지하며, macOS 커널 수준에서 민감한 파일 접근을 차단합니다."
   source="GeekNews"
   severity="Medium"
 %}

--- a/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
+++ b/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
@@ -100,7 +100,7 @@ summary_card:
   title="[보안] UNC4899, 개발자가 에어드롭한 트로이목마 파일로 암호화폐 기업 침해"
   url="https://thehackernews.com/2026/03/unc4899-used-airdrop-file-transfer-and.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgu3lqP8aiEKLJA-l7TChGGULVqWhyphenhyphenMc67vwAHHEK4LkpR5ZlZuFIYWFmmPqdA8VQpGbFPvjwGvDHxkhXmC9xhTWlRCccD9PyU3A08-ahTc87j__u6g7RvgkwNo85LmbffhVRly_r4Sd9iiVdEvjtVvpcw0NiwOM1NfjNFQXx5xquwbd9E1zUUr09SYv_-A/s1600/crypto.jpg"
-  summary="UNC4899, 개발자가 에어드롭한 트로이목마 파일로 암호화폐 기업 침해를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="UNC4899로 알려진 북한 위협 행위자가 2025년 암호화폐 조직을 표적으로 한 정교한 클라우드 침해 캠페인의 배후로 지목되고 있으며, 수백만 달러 규모의 암호화폐 탈취를 시도한 것으로 의심받고 있습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -133,7 +133,7 @@ UNC4899로 알려진 북한 위협 행위자가 2025년 암호화폐 조직을 �
   title="[보안] ⚡ 주간 요약: Qualcomm 제로데이, iOS 익스플로잇 체인, AirSnitch 공격 &"
   url="https://thehackernews.com/2026/03/weekly-recap-qualcomm-0-day-ios-exploit.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjoDPwegKSRDQPO8CYuOJ9gg-wqvYfrwW1Ne0kApS2regCVz9BAJVhPeGCxT8oMd8gnIfNm4-QdgqCXs6VHUDEoS4i66bGo7R52oYjURwGCyG5gPaM-MeWqgTrM5fmKSHJh42NYkPDYQX9v2x97Q2XP1l816qk17OL8ncXwGpRj3AQ-BTjjDZlG1WnbFKDz/s1600/recap-march.jpg"
-  summary="⚡ 주간 요약: Qualcomm 제로데이, iOS 익스플로잇 체인, AirSnitch 공격을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="또 한 주가 지나갔습니다. 사이버보안 업계에서는 '이게 말이 되냐'는 한숨이 절로 나오는 한 주였습니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -170,7 +170,7 @@ UNC4899로 알려진 북한 위협 행위자가 2025년 암호화폐 조직을 �
   title="[보안] 보안 플랫폼이 마침내 중견기업 시장에서 성과를 낼 수 있을까?"
   url="https://thehackernews.com/2026/03/can-security-platform-finally-deliver.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEh1VI1qz4KwHldnHqAJcopF23x8Jtybzn4Obme0AQPvuP_SDx-vwFks8V70CSb-Gn_BBlONDV7BoK3IrxzxGfUd_3va58XjeoXX81Ix1E7JkcgC2kikZ-nWAawWhE0uU8bURJs1ggtbIG1N_F8VsYIYyjDe5NuF3SAholWy_u6Evu5ROpWGAaIShHZMNiA/s1600/bit.jpg"
-  summary="보안 플랫폼이 마침내 중견기업 시장에서 성과를 낼 수 있을까?를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="중견 기업들은 대기업 수준의 보안을 달성하기 위해 끊임없이 노력하고 있습니다. 공급망 공격에 대한 인식이 높아진 가운데, 고객과 비즈니스 파트너들이 요구하는 보안 수준이 점점 더 높아지고 있습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -211,7 +211,7 @@ UNC4899로 알려진 북한 위협 행위자가 2025년 암호화폐 조직을 �
   title="[AI] Messenger의 고급 브라우징 보호 기능 동작 원리"
   url="https://engineering.fb.com/2026/03/09/security/how-advanced-browsing-protection-works-in-messenger/"
   image="https://engineering.fb.com/wp-content/uploads/2026/03/Advanced-Browsing-Protection-Messenger.png"
-  summary="Messenger의 고급 브라우징 보호 기능 동작 원리를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Messenger의 고급 브라우징 보호(ABP) 기능이 채팅 내 클릭된 링크의 개인정보를 보호하면서도 악성 링크에 대한 경고를 제공하는 방법에 대한 기술적 세부 사항을 공개합니다. 이 기능을 사용자에게 제공하기 위해 수반되는 엔지니어링 과제와 인프라 구성 요소를 이 글을 통해 명확히 설명하고자 합니다."
   source="Meta Engineering Blog"
   severity="Medium"
 %}
@@ -228,7 +228,7 @@ Messenger의 고급 브라우징 보호(ABP) 기능이 채팅 내 클릭된 링�
   title="[AI] ABB 로보틱스, NVIDIA Omniverse 도입으로 산업용 물리 AI 구현"
   url="https://blogs.nvidia.com/blog/abb-robotics-omniverse/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/03/2.24-842x450.jpg"
-  summary="ABB 로보틱스, NVIDIA Omniverse 도입으로 산업용 물리 AI 구현을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="ABB 로보틱스와 NVIDIA가 산업용 물리 AI를 공장 현장에 구현하는 획기적인 파트너십을 발표했습니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -245,7 +245,7 @@ ABB 로보틱스와 NVIDIA가 산업용 물리 AI를 공장 현장에 구현하�
   title="[AI] AI가 매출을 견인하고 비용을 절감하며 생산성을 높이는 방법"
   url="https://blogs.nvidia.com/blog/state-of-ai-report-2026/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/03/industry-press-state-of-the-ai-report-overreaching-blog-1920x1080-2-842x450.png"
-  summary="AI가 매출을 견인하고 비용을 절감하며 생산성을 높이는 방법을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AI는 모든 곳에서 모든 것을 가속화하고 있으며, 모든 산업을 발전시킬 인텔리전스를 창출하는 핵심 인프라로 자리 잡고 있습니다. 이에 따라 기업들은 AI의 투자 대비 수익률(ROI)과 자사 유스케이스에 AI를 가장 효과적으로 적용하는 방법에 더욱 집중하고 있습니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -266,7 +266,7 @@ AI는 모든 곳에서 모든 것을 가속화하고 있으며, 모든 산업을
   title="[클라우드] Google, IDC MarketScape 미국 주·지방정부 보안 서비스 부문 리더 선정"
   url="https://cloud.google.com/blog/topics/public-sector/google-named-a-leader-in-idc-marketscape-us-state-and-local-government-professional-security-services-20252026-vendor-assessment/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/US53891025tabfig_1.max-1000x1000.png"
-  summary="Google, IDC MarketScape 미국 주·지방정부 보안 서비스 부문 리더 선정을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="오늘날의 사이버 위협 환경에서 미국 주·지방 정부는 AI를 활용해 더욱 빠르고 정교해진 공격자들로부터 지속적인 공격을 받고 있습니다. 미션 크리티컬 워크로드를 보호해야 할 필요성이 그 어느 때보다 높아진 상황입니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -283,7 +283,7 @@ AI는 모든 곳에서 모든 것을 가속화하고 있으며, 모든 산업을
   title="[클라우드] Spanner로 게임 온: PlayStation의 글로벌 스케일 달성 방법"
   url="https://cloud.google.com/blog/products/gaming/sony-interactive-playstation-games-library-spanner-heroes/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/sony-interactive-playstation-games-library.max-2500x2500.jpg"
-  summary="Spanner로 게임 온: PlayStation의 글로벌 스케일 달성 방법을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="PlayStation을 켜고 게임 라이브러리가 로드될 때마다 — Final Fantasy 시리즈, Crash Bandicoot 리마스터, 새벽 2시에 충동구매한 인디 게임까지 — 사용자가 소유한 게임을 확인하는 시스템이 백그라운드에서 작동합니다. Sony Interactive Entertainment는 이를 '엔타이틀먼트 서비스'라고 부릅니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -300,7 +300,7 @@ PlayStation을 켜고 게임 라이브러리가 로드될 때마다 — Final Fa
   title="[클라우드] AWS 주간 요약: Amazon Connect Health, Bedrock"
   url="https://aws.amazon.com/blogs/aws/aws-weekly-roundup-amazon-connect-health-bedrock-agentcore-policy-gameday-europe-and-more-march-9-2026/"
   image="https://d2908q01vomqb2.cloudfront.net/da4b9237bacccdf19c0760cab7aec4a8359010b0/2023/08/13/AWS-WIR-default.png"
-  summary="AWS 주간 요약: Amazon Connect Health, Bedrock을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AWS 학생 커뮤니티 케냐를 환영합니다! 지난주는 믿기 힘들 정도로 바쁜 한 주였습니다."
   source="AWS Blog"
   severity="Medium"
 %}
@@ -321,7 +321,7 @@ AWS 학생 커뮤니티 케냐를 환영합니다! 지난주는 믿기 힘들 �
   title="[DevOps] .NET Skills로 코딩 에이전트 기능 확장하기"
   url="https://devblogs.microsoft.com/dotnet/extend-your-coding-agent-with-dotnet-skills/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/03/skills-preview.webp"
-  summary=".NET Skills로 코딩 에이전트 기능 확장하기를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="dotnet/skills 저장소 소개 및 .NET 에이전트 스킬이 코딩 에이전트 워크플로우를 어떻게 개선할 수 있는지 설명합니다."
   source="Microsoft .NET Blog"
   severity="Medium"
 %}
@@ -338,7 +338,7 @@ dotnet/skills 저장소 소개 및 .NET 에이전트 스킬이 코딩 에이전�
   title="[DevOps] KubeCon + CloudNativeCon Europe 2026 코로케이티드 이벤트 심층 분석"
   url="https://www.cncf.io/blog/2026/03/09/kubecon-cloudnativecon-europe-2026-co-located-event-deep-dive-opentofu-day/"
   image="https://www.cncf.io/wp-content/uploads/2026/03/Co-Lo-OpenTofu-Day.jpg"
-  summary="KubeCon + CloudNativeCon Europe 2026 코로케이티드 이벤트 심층 분석을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="OpenTofu Day는 2024년 파리에서 열린 KubeCon Europe에서 처음 개최된 이후 매 KubeCon마다 진행되어 왔습니다. 최근 라이선스 변경, 업계 통합, 상용화 방향의 변화로 인해 인프라스트럭처 애즈 코드(IaC) 생태계가 명확한 변곡점을 맞이하고 있습니다."
   source="CNCF Blog"
   severity="High"
 %}
@@ -355,7 +355,7 @@ OpenTofu Day는 2024년 파리에서 열린 KubeCon Europe에서 처음 개최�
   title="[DevOps] Kubernetes 시크릿을 활용한 레지스트리 미러 인증"
   url="https://www.cncf.io/blog/2026/03/09/registry-mirror-authentication-with-kubernetes-secrets/"
   image="https://www.cncf.io/wp-content/uploads/2026/03/Co-Lo-K8s-on-Edge-Day-EU-2026-5-1.png"
-  summary="Kubernetes 시크릿을 활용한 레지스트리 미러 인증을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="1부: 아키텍처 및 구현 - 프로덕션 Kubernetes 클러스터에서는 하루에도 수천 번씩 프라이빗 레지스트리로부터 컨테이너 이미지를 가져옵니다. 주요 클라우드 벤더의 Kubernetes 배포판은 AWS 등 각자의 레지스트리를 위한 크리덴셜 프로바이더를 제공합니다."
   source="CNCF Blog"
   severity="High"
 %}
@@ -393,7 +393,7 @@ Bitcoin은 에이전트 결제 세계에서 마침내 실질적인 결제 우위
   title="[블록체인] Coinbase, 유럽 전역에 규제 준수 Bitcoin 및 암호화폐 선물 출시"
   url="https://bitcoinmagazine.com/news/coinbase-regulated-bitcoin-futures"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/Coinbase-Launches-Regulated-Bitcoin-and-Crypto-Futures-Across-Europe.jpg"
-  summary="Coinbase, 유럽 전역에 규제 준수 Bitcoin 및 암호화폐 선물 출시를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Coinbase가 독일, 프랑스, 네덜란드 등 유럽 26개국 트레이더를 대상으로 선물 계약을 출시했습니다. 이는 유럽 지역에서의 첫 직접 파생상품 서비스 제공으로, 규제 준수 기반의 암호화폐 파생상품 시장 진출을 의미합니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}
@@ -410,7 +410,7 @@ Coinbase가 독일, 프랑스, 네덜란드 등 유럽 26개국 트레이더를 
   title="[블록체인] Nasdaq, 암호화폐 거래소 Kraken과 파트너십으로 토큰화 증권 도입"
   url="https://bitcoinmagazine.com/news/nasdaq-and-crypto-exchange-kraken-partner"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/Nasdaq-and-Crypto-Exchange-Kraken-Partner-to-Bring-Tokenized-Stocks-to-Global-Markets.jpg"
-  summary="Nasdaq, 암호화폐 거래소 Kraken과 파트너십으로 토큰화 증권 도입을 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Nasdaq이 암호화폐 거래소 Kraken의 모회사 Payward와 파트너십을 체결하여 전통 주식 시장과 블록체인 네트워크를 연결하는 게이트웨이를 구축합니다. 이번 협력은 토큰화 증권의 글로벌 시장 접근성을 높이는 중요한 이정표가 될 전망입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
+++ b/_posts/2026-03-10-Tech_Security_Weekly_Digest_AI_Malware_Security_Data.md
@@ -376,7 +376,7 @@ OpenTofu Day는 2024년 파리에서 열린 KubeCon Europe에서 처음 개최�
   title="[블록체인] Bitcoin과 AI 에이전트의 황금 기회, 지금이 구축할 때"
   url="https://bitcoinmagazine.com/technical/bitcoin-has-a-golden-opportunity-with-ai-agents-its-time-to-build"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/AIAgentBItcoinPayments-fotor-20260309153310.webp"
-  summary="Bitcoin과 AI 에이전트의 황금 기회, 지금이 구축할 때를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Bitcoin은 에이전트 결제 세계에서 마침내 실질적인 결제 우위를 갖게 되었습니다. 이 기회를 살리기 위해 모두가 힘을 합쳐야 할 때입니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
+++ b/_posts/2026-03-12-Tech_Security_Weekly_Digest_AI_Malware_AWS_Patch.md
@@ -103,7 +103,7 @@ summary_card:
   title="Jito Foundation, SolanaFloor 인수로 Solana 생태계 저널리즘 재건"
   url="https://cointelegraph.com/news/jito-foundation-acquires-solanafloor-to-revive-solana-ecosystem-journalism?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjI2Y2EtMDM2NC03ZTAxLTgxZjYtOTAxZGJhN2FhZTI1LmpwZw==.jpg"
-  summary="Jito Foundation, SolanaFloor 인수로 Solana 생태계 저널리즘 재건를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Jito Foundation이 Solana 생태계의 데이터 분석 미디어 플랫폼 SolanaFloor를 인수했습니다. Jito는 Solana 네트워크의 MEV(Maximal Extractable Value) 프로토콜을 운영하는 재단으로, 이번 인수를 통해 생태계 데이터 분석과 저널리즘 기능을 자체적으로 갖추게 됩니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -122,7 +122,7 @@ Jito Foundation이 Solana 생태계의 데이터 분석 미디어 플랫폼 Sola
   title="Trust Wallet, 32개 EVM 체인에서 주소 오염 방지 기능 확대"
   url="https://cointelegraph.com/news/trust-wallet-address-poisoning-protection-32-evm-chains?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMTIvMDE5YjI3NTQtNWVlNy03MzRkLTg3MmUtZDg5OTEwNmMxMTY3LmpwZw==.jpg"
-  summary="Trust Wallet, 32개 EVM 체인에서 주소 오염 방지 기능 확대를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Trust Wallet이 주소 오염(Address Poisoning) 공격 탐지 기능을 Ethereum, Polygon, BNB Chain, Avalanche 등 32개 EVM 호환 체인으로 확대했습니다."
   source="Cointelegraph"
   severity="High"
 %}
@@ -141,7 +141,7 @@ Trust Wallet이 32개 체인에 걸쳐 탐지 기능을 배포한 것은 이 공
   title="CFTC 의장, 블록체인 예측시장을 '진실 기계'로 지지"
   url="https://cointelegraph.com/news/cftc-chair-backs-blockchain-prediction-markets-truth-machines?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2Q3ZGItNGM3ZC03MGVkLWJhNGItZDJjMDg5YTNkZWMzLmpwZw==.jpg"
-  summary="CFTC 의장, 블록체인 예측시장을 '진실 기계'로 지지를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="CFTC(미국 상품선물거래위원회) 의장이 블록체인 기반 예측시장을 '진실 기계(Truth Machine)'로 공개 지지했습니다. Polymarket, Kalshi 등 블록체인 예측시장은 집단 지성을 활용해 미래 사건의 발생 확률을 거래하는 플랫폼으로, 스마트 컨트랙트를 통해 결과 정산이 자동화됩니다."
   source="Cointelegraph"
   severity="Medium"
 %}

--- a/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
+++ b/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
@@ -103,7 +103,7 @@ summary_card:
   title="GlassWorm Supply-Chain Attack Abuses 72 Open VSX Extensions to Target Developers"
   url="https://thehackernews.com/2026/03/glassworm-supply-chain-attack-abuses-72.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg4d-2XpiCS0UYnMWh32sQEJP9LnlN_m7m2hok9CnY_vu05XXwWn4INodYCvrEdweEzpho7XqcuOFvEPnnEWlHCRa_q3HY3V5O_ii35MVWAimRwsgrpNQrvGqeUchhZ48FRUl91zTpYQdLMRxVvRjV_T8GEm-J9mnMesefzlgeaoE_EU7Ba32liTr63SsQq/s1600/open.jpg"
-  summary="GlassWorm Supply-Chain Attack Abuses 72 Open VSX Extensions to Target Developers를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="GlassWorm은 VSCodium, Eclipse Che 등 오픈소스 IDE가 의존하는 Open VSX 레지스트리를 표적으로 삼았습니다. 공격 방식은 인기 있는 정상 확장을 복제한 뒤 이름을 유사하게 변조(typosquatting)하거나, 기존 확장 유지관리자 계정을 탈취해 악성 업데이트를 배포하는 두 가지입니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -167,7 +167,7 @@ NOT (Image="code.exe" OR Image="codium" OR Image="node")
   title="OpenClaw AI Agent Flaws Could Enable Prompt Injection and Data Exfiltration"
   url="https://thehackernews.com/2026/03/openclaw-ai-agent-flaws-could-enable.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg2mVucJhli25A25joXcap-ewfeMT1Vh-95wQKQfGOue7PwZJ1_55YsG8OQ1DQF7WVOU8tsOy73kGDzgfpTLLeqTYQ1k9LqrFWTNavDmfvCV-9IIER9PfrRsdg1wA5UzpIMrer3xC1mBClBzKkaT6pfczDbppMjZM7afcWu-RURquDGrEfjq3vVBsmlltLm/s1600/open-clawss.jpg"
-  summary="OpenClaw AI Agent Flaws Could Enable Prompt Injection and Data Exfiltration를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="이번에 공개된 취약점은 특정 제품의 버그가 아니라 AI 에이전트 설계 패턴 자체의 구조적 문제입니다. 대부분의 LLM 에이전트는 사용자 입력, 도구 호출 결과, 웹 검색 결과를 구분 없이 하나의 컨텍스트로 처리합니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -245,7 +245,7 @@ def validate_agent_input(text: str, max_length: int = 4096) -> Optional[str]:
 {% include news-card.html
   title="Deploy AWS applications and access AWS accounts across multiple Regions with IAM Identity Center"
   url="https://aws.amazon.com/blogs/security/deploy-aws-applications-and-access-aws-accounts-across-multiple-regions-with-iam-identity-center/"
-  summary="Deploy AWS applications and access AWS accounts across multiple Regions with IAM Identity Center를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AWS IAM Identity Center(구 AWS SSO)의 멀티리전 지원이 확장됐습니다. 기존에는 특정 리전을 홈 리전으로 설정하고, 그 리전에서만 Identity Center 콘솔을 관리했습니다."
   source="AWS Security Blog"
   severity="Medium"
 %}
@@ -338,7 +338,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
   title="Changing Basel rules could unlock 'huge' liquidity for BTC"
   url="https://cointelegraph.com/news/changing-basel-rules-huge-liquidity-btc?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDEvMDE5YmU2M2MtNWYyMy03N2MyLWIwNTItODQ3ODEwY2E0MjIwLmpwZw==.jpg"
-  summary="Changing Basel rules could unlock 'huge' liquidity for BTC를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="현행 Basel III 체계에서 Bitcoin은 Group 2b 자산으로 분류돼 1,250%의 위험 가중치가 적용됩니다. 이는 은행이 BTC 1달러를 보유하려면 자기자본 12.5달러를 적립해야 한다는 의미로, 사실상 은행의 BTC 직접 보유를 금지하는 수준입니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -357,7 +357,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
   title="Boris Johnson linked to BTC Ponzi scheme allegations"
   url="https://cointelegraph.com/news/boris-johnson-btc-ponzi-scheme?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2VkNzAtNzk3ZC03ZWE5LTk5MTItMjAwOGM4YjY1ZTczLmpwZw==.jpg"
-  summary="Boris Johnson linked to BTC Ponzi scheme allegations를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="이번 사례는 기술적 취약점이 아닌 사회공학적 신뢰 조작의 전형입니다. 전직 국가 지도자 수준의 유명인을 내세워 투자자들의 경계심을 낮추는 이 수법은 딥페이크 광고와 결합해 더 정교해지고 있습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -376,7 +376,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
   title="Bitcoin beats stocks as Strategy eyes $776M BTC buying potential"
   url="https://cointelegraph.com/news/bitcoin-beats-stocks-strategy-strc-776m-btc-buying-potential?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDIvMDE5Yzk5ODMtZWRmNS03NjU2LTlmOWQtNjgwM2FlOWI4ZTg0LmpwZw==.jpg"
-  summary="Bitcoin beats stocks as Strategy eyes $776M BTC buying potential를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Strategy의 Michael Saylor 모델(채권 발행 → BTC 매수)이 기관 투자자들의 레퍼런스 케이스로 자리 잡으면서, 유사 전략을 채택하는 상장사가 늘고 있습니다. 이번 $776M 매수 계획은 STRC라는 수익 공유형 채권 상품을 통해 조달하며, BTC 가격 상승 시 채권 이자를 BTC로 지급하는 구조입니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -397,7 +397,6 @@ Strategy의 Michael Saylor 모델(채권 발행 → BTC 매수)이 기관 투자
   url="https://news.hada.io/topic?id=27513"
   source="GeekNews"
   tag="AI Engineering"
-  summary="진짜 내 일을 위한 Agentic Workflow를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
   note="<strong>보안 관점</strong>: 130억 토큰 규모의 에이전트 코딩 워크플로우는 코드 생성 과정에서 시크릿이 포함된 프롬프트가 LLM 제공사로 전송될 위험이 있습니다. 에이전트 코딩 도입 시 코드베이스 내 시크릿 사전 제거(git-secrets, truffleHog)와 프롬프트 필터링 정책이 필요합니다."
 %}
 {% include news-spotlight-item.html
@@ -405,7 +404,6 @@ Strategy의 Michael Saylor 모델(채권 발행 → BTC 매수)이 기관 투자
   url="https://news.hada.io/topic?id=27512"
   source="GeekNews"
   tag="Hardware"
-  summary="MacBook Neo에서 Parallels 가상 머신으로 윈도우 실행 가능 확인를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
   note="<strong>운영 관점</strong>: MacBook Neo 환경에서 Windows VM을 사용하는 개발자가 생긴다면, VM 내 Windows 환경의 보안 패치 관리와 호스트-게스트 간 클립보드 공유 범위 정책을 사전에 수립하세요."
 %}
 {% include news-spotlight-item.html
@@ -413,7 +411,6 @@ Strategy의 Michael Saylor 모델(채권 발행 → BTC 매수)이 기관 투자
   url="https://news.hada.io/topic?id=27511"
   source="GeekNews"
   tag="Developer Tools"
-  summary="Hammerspoon - Lua로 구현된 강력한 macOS 데스크톱 자동화 도구를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
   note="<strong>보안 관점</strong>: Hammerspoon은 macOS 접근성 API에 광범위한 권한을 요구합니다. 조직에서 사용을 허용할 경우 MDM 정책으로 허용 스크립트 범위를 제한하고, 자동화 스크립트가 자격증명이나 민감 데이터에 접근하지 않도록 코드 리뷰 절차를 두세요."
 %}
 {% endcapture %}

--- a/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
+++ b/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
@@ -147,7 +147,7 @@ index=security sourcetype=ai_agent_logs
   title="Amazon Bedrock과 Claude Agent SDK로 서버리스 멀티 에이전트 구현하기"
   url="https://aws.amazon.com/ko/blogs/tech/implement-serverless-multiagent-bedrock-claude-agent-sdk/"
   image="https://d2908q01vomqb2.cloudfront.net/2a459380709e2fe4ac2dae5733c73225ff6cfee1/2026/03/15/feature-1118x630.png"
-  summary="Amazon Bedrock과 Claude Agent SDK로 서버리스 멀티 에이전트 구현하기를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Kiro CLI나 Claude Code 같은 AI 코딩 에이전트를 사용하다 보면, 코드를 분석하고 수정하고 테스트까지 실행하는 이 에이전트의 동작 방식을 자신의 애플리케이션 백엔드에도 적용할 수 있으면 좋겠다고 생각해 본 적이 있을 것입니다."
   source="AWS Korea Blog"
   severity="Medium"
 %}

--- a/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
+++ b/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Agent_Open-Source_Update.md
@@ -96,7 +96,7 @@ summary_card:
   title="Show HN: 악용 코드가 공개된 AI 에이전트를 레드팀할 수 있는 오픈소스 플레이그라운드"
   url="https://github.com/fabraix/playground"
   image="https://opengraph.githubassets.com/1/fabraix/playground"
-  summary="Show HN: 악용 코드가 공개된 AI 에이전트를 레드팀할 수 있는 오픈소스 플레이그라운드를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AI 에이전트 보안을 위한 오픈소스 레드팀링 플레이그라운드가 공개되었습니다. 이 도구는 실제 도구와 시스템 프롬프트를 가진 라이브 에이전트를 대상으로 취약점을 테스트하며, 각 챌린지가 끝나면 우승한 대화 기록과 가드레일 로그가 공개됩니다."
   source="Hacker News"
   severity="Critical"
 %}
@@ -166,7 +166,7 @@ Kiro CLI나 Claude Code 같은 AI 코딩 에이전트를 사용하다 보면, �
   title="Aave, 5000만 달러 토큰 스왑 사고 후 'Aave Shield' 출시 예정"
   url="https://cointelegraph.com/news/aave-roll-out-aave-shield-after-50m-user-loss?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2YzODgtNGJiMi03NzI3LTg0MzgtMmY2YzE3MzVjNzAyLmpwZw==.jpg"
-  summary="Aave, 5000만 달러 토큰 스왑 사고 후 'Aave Shield' 출시 예정를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Aave는 거래자가 USDT를 AAVE로 스왑하는 과정에서 5천만 달러 이상 손실이 발생한 원인이 슬리피지가 아닌 유동성 부족 시장 때문이라고 사후 분석을 통해 밝혔습니다. 이에 따라 Aave는 'Aave Shield' 출시를 준비하고 있습니다."
   source="Cointelegraph"
   severity="High"
 %}
@@ -183,7 +183,7 @@ Aave는 거래자가 USDT를 AAVE로 스왑하는 과정에서 5천만 달러 �
   title="CLARITY 법안은 암호화폐를 중앙화된 기업에 넘길 위험이 있다: Gnosis 임원"
   url="https://cointelegraph.com/news/clarity-act-hand-crypto-centralized-player?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2YzNGUtMGMwZi03MDkzLTg2ZDktOWM2OWNjNWQwYjVmLmpwZw==.jpg"
-  summary="CLARITY 법안은 암호화폐를 중앙화된 기업에 넘길 위험이 있다: Gnosis 임원를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Gnosis 공동 창립자는 CLARITY Act가 모든 암호화폐 활동이 미국 정부가 허가한 금융 중개자를 통과해야 한다고 가정한다고 경고합니다. 이 법안은 암호화폐 산업을 중앙화된 기업에 넘길 위험이 있습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -200,7 +200,7 @@ Gnosis 공동 창립자는 CLARITY Act가 모든 암호화폐 활동이 미국 �
   title="Venus Protocol, '공급 한도' 공격으로 370만 달러 피해"
   url="https://cointelegraph.com/news/venus-protocol-3-7-million-supply-cap-attack?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2YyY2EtNTk1NC03YTBkLTkxYTgtMTFhN2VlMzkwMmUzLmpwZw==.jpg"
-  summary="Venus Protocol, '공급 한도' 공격으로 370만 달러 피해를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Venus Protocol이 'supply cap' 공격으로 약 370만 달러의 피해를 입었습니다. 공격자는 Thena 토큰을 이용해 최대 공급 한도를 우회하고 여러 디지털 자산을 빌려냈습니다."
   source="Cointelegraph"
   severity="High"
 %}

--- a/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.md
+++ b/_posts/2026-03-16-Tech_Security_Weekly_Digest_AI_Bitcoin.md
@@ -90,7 +90,7 @@ summary_card:
   title="아르헨티나 대통령 Libra 토큰 홍보 관련 $5M 거래 포렌식 분석"
   url="https://cointelegraph.com/news/milei-libra-promotion-5m-draft-deal-found-novelli-phone?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjUtMDgvMDE5OGU4NGYtNzI5OC03NTdmLWFmZWUtOWYyYjllYmYzNTky.jpg"
-  summary="아르헨티나 대통령 Libra 토큰 홍보 관련 $5M 거래 포렌식 분석를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="아르헨티나 로비스트 Mauricio Novelli의 휴대폰 포렌식 분석에서 대통령의 Libra 토큰 홍보와 연결된 $5M 거래 계약서 초안이 발견되었습니다. 이 사건은 정치인이 특정 암호화폐 프로젝트를 홍보하는 행위의 법적·윤리적 리스크를 재확인시킵니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -107,7 +107,7 @@ summary_card:
   title="스테이블코인 규제 불확실성, 은행에 더 큰 타격 전망"
   url="https://cointelegraph.com/news/stablecoin-uncertainty-could-hurt-banks-more-than-crypto-firms-expert?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDIvMDE5YzhmMDUtNmFjYi03YmY1LThhMWEtODkxMDA1ZGZkZWJiLmpwZw==.jpg"
-  summary="스테이블코인 규제 불확실성, 은행에 더 큰 타격 전망를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="스테이블코인에 대한 규제 불확실성이 크립토 기업보다 전통 금융 기관에 더 큰 타격을 줄 수 있다는 분석입니다. 크립토 기업은 규제 공백 속에서도 확장을 계속하는 반면, 은행은 명확한 규칙이 나올 때까지 디지털 자산 서비스 출시를 보류하고 있습니다."
   source="Cointelegraph"
   severity="Medium"
 %}
@@ -124,7 +124,7 @@ summary_card:
   title="암호화폐 시장 일일 동향 종합"
   url="https://cointelegraph.com/news/what-happened-in-crypto-today?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDIvMDE5YzY2NjktN2UxNi03ZmI0LTlmNjItOTIxNWU3YTcwZmIwLmpwZw==.jpg"
-  summary="암호화폐 시장 일일 동향 종합를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Bitcoin 가격, DeFi, NFT, Web3, 규제 동향을 포함한 암호화폐 시장 일일 종합 리포트입니다. 최근 시장 변동성이 높아지면서 피싱·스캠 활동도 증가하는 추세입니다."
   source="Cointelegraph"
   severity="Medium"
 %}

--- a/_posts/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.md
+++ b/_posts/2026-03-17-Tech_Security_Weekly_Digest_Malware_AI_AWS_Botnet.md
@@ -98,7 +98,7 @@ summary_card:
   title="GlassWorm 공격, 탈취된 GitHub 토큰으로 Python 저장소에 악성코드 강제 푸시"
   url="https://thehackernews.com/2026/03/glassworm-attack-uses-stolen-github.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhm7L4zUQpR3yqvBYQOLElALmeqWJoxMkXDZVmvs0LgAMwPCH6yuBMCeP_IJwLfkM_4SFI5mXmBQKNWu8JgME_4yZ271ZLEeJe_l-mZ-H4gsw2XaZecZoUhvlaaxdWjcDnn3zrl4boAnxhfXUNogrGpM83ucMCez0IN1A9xKn2XlrUEfVcBgFdFuC7pWdsX/s1600/githun-malware.jpg"
-  summary="GlassWorm 공격, 탈취된 GitHub 토큰으로 Python 저장소에 악성코드 강제 푸시를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="이 공격은 GitHub 토큰 탈취를 통해 Python 생태계를 표적으로 하는 지속적 위협입니다. 공격자는 합법적인 저장소 접근 권한을 획득하여 setup.py, main.py, app.py와 같은 핵심 파일에 난독화된 악성 코드를 force-push 방식으로 주입합니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -126,7 +126,7 @@ DevSecOps 실무자에게 이 공격은 **소스 코드 무결성**과 **빌드 
   title="주간 보안 뉴스 요약: Chrome 제로데이, 라우터 봇넷, AWS 침해, 악성 AI 에이전트 등"
   url="https://thehackernews.com/2026/03/weekly-recap-chrome-0-days-router.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg_H0YAbH9M9ZJEpNND8ld-a6PMbK_iC6MTl5KYp4PZ5cagUKRCuqsIsILZabA2CSAgcmKqr7xth_SL23l17zM8ANvYNa6LdvZc8xz_R08FfTek2V8rVtMBte0ubUnBlZ8IbZi0GBs-W4J9R7TCaVOCK9NYXWDPIAuFGTHyCOybC1PQqQKRKnTI6r9BZVaO/s1600/cyberrecap.jpg"
-  summary="주간 보안 뉴스 요약: Chrome 제로데이, 라우터 봇넷, AWS 침해, 악성 AI 에이전트 등를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="본 주간 뉴스는 Chrome 0-day 취약점, 라우터 봇넷, AWS 침해 사고, 악성 AI 에이전트 등 다양한 위협을 다루고 있습니다. Chrome 0-day는 공급망 신뢰를 악용한 대표적 사례로, 패치 전 공격 가능한 취약점이 실시간으로 악용되고 있음을 보여줍니다."
   source="The Hacker News"
   severity="Critical"
 %}
@@ -154,7 +154,7 @@ DevSecOps 실무자에게 이번 주간 이슈는 **자동화된 패치 관리**
   title="보안 검증이 에이전트 기반으로 진화하는 이유"
   url="https://thehackernews.com/2026/03/why-security-validation-is-becoming.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgLVOZFyD6pBH1804jnpyTOScRJO3CnlHA2m3B-L1ML1B5l2iP70OHF_rUwtdHARpNsVh5WxdCXX7fO9NfpjPaH0jwJYCmWgGa2Eo5x9RPkl8PEl9e7tq2-T5sbv6KI7GnyzCr3PhSUSpweRRMlR0pGC4lO_3m1gVgLfrjt6sulJRo4yJKPlNSn_VyM8oo/s1600/picus.jpg"
-  summary="보안 검증이 에이전트 기반으로 진화하는 이유를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="현대 조직의 보안 검증 스택은 BAS(Breach and Attack Simulation), 자동화된 침투 테스트, 취약점 스캐너, 공격 표면 관리(ASM) 플랫폼 등이 단절적으로 운영되는 경우가 많습니다. 각 도구는 고유한 데이터와 인사이트를 제공하지만, 상호 연동되지 않아 보안 팀이 종합적인 위협 상황을 실시간으로 파악하기 어렵습니다."
   source="The Hacker News"
   severity="High"
 %}
@@ -183,7 +183,7 @@ DevSecOps 실무자에게 이 변화는 단순한 도구 통합을 넘어 **자�
   title="Roche, 전 세계적으로 NVIDIA AI 팩토리 확장으로 신약 개발·진단 솔루션·제조 혁신 가속화"
   url="https://blogs.nvidia.com/blog/roche-ai-factories-omniverse/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/03/hc-press-roche-gtcsj26-4853250-1920x1080-1-842x450.jpg"
-  summary="Roche, 전 세계적으로 NVIDIA AI 팩토리 확장으로 신약 개발·진단 솔루션·제조 혁신 가속화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="로슈는 전 세계 운영 전반에 걸쳐 3,500개 이상의 NVIDIA Blackwell GPU를 배치해 R&D 생산성, 차세대 진단 솔루션 및 제조 효율을 대폭 확장하고 있습니다. 이는 AI 기반 신약 개발과 제조 혁신을 가속화하기 위한 전략적 조치입니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -200,7 +200,7 @@ DevSecOps 실무자에게 이 변화는 단순한 도구 통합을 넘어 **자�
   title="NVIDIA DSX Air, AI 팩토리 시뮬레이션 가속화로 토큰 생성 시간 단축"
   url="https://blogs.nvidia.com/blog/dsx-air-simulation-ai-factories/"
   image="https://blogs.nvidia.com/wp-content/uploads/2026/03/ethernet-corp-blog-dsx-air-1280x680-4855450-842x450.png"
-  summary="NVIDIA DSX Air, AI 팩토리 시뮬레이션 가속화로 토큰 생성 시간 단축를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="NVIDIA 창립자 겸 CEO 젠슨 황이 GTC 2026에서 NVIDIA DSX Air를 공개했습니다. 이는 DSX 플랫폼 내 NVIDIA DSX Sim의 일부로, AI 팩토리 구축을 시뮬레이션하여 배포 시간을 단축합니다."
   source="NVIDIA AI Blog"
   severity="Medium"
 %}
@@ -216,7 +216,7 @@ NVIDIA 창립자 겸 CEO 젠슨 황이 GTC 2026에서 NVIDIA DSX Air를 공개�
 {% include news-card.html
   title="AWS와 NVIDIA, 파일럿부터 프로덕션까지 AI 가속화를 위한 전략적 협력 강화"
   url="https://aws.amazon.com/blogs/machine-learning/aws-and-nvidia-deepen-strategic-collaboration-to-accelerate-ai-from-pilot-to-production/"
-  summary="AWS와 NVIDIA, 파일럿부터 프로덕션까지 AI 가속화를 위한 전략적 협력 강화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="AWS와 NVIDIA가 NVIDIA GTC 2026에서 전략적 협력을 확대했습니다. 양사는 AI 컴퓨팅 수요 증가를 지원하고 프로덕션 레디 AI 솔루션 구축 및 운영을 돕기 위한 새로운 기술 통합을 발표했습니다."
   source="AWS Machine Learning Blog"
   severity="Medium"
 %}
@@ -235,7 +235,7 @@ AWS와 NVIDIA가 NVIDIA GTC 2026에서 전략적 협력을 확대했습니다. �
   title="BigQuery Studio, 개선된 Gemini 어시스턴트로 그 어느 때보다 유용해졌습니다."
   url="https://cloud.google.com/blog/products/data-analytics/gemini-supercharges-the-bigquery-studio-assistant/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/original_images/1_ESdCZq3.gif"
-  summary="BigQuery Studio, 개선된 Gemini 어시스턴트로 그 어느 때보다 유용해졌습니다.를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="BigQuery Studio는 향상된 Gemini assistant를 통해 데이터 분석가들의 운영 부담을 줄여줍니다. 이 도구는 사용자의 데이터와 작업 맥락을 이해하는 어시스턴트 기능을 제공하여 분석에 더 많은 시간을 할당할 수 있게 합니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -251,7 +251,7 @@ BigQuery Studio는 향상된 Gemini assistant를 통해 데이터 분석가들�
 {% include news-card.html
   title="Google Cloud와 NVIDIA, GTC 2026에서 산업 전반의 AI 혁신 확대"
   url="https://cloud.google.com/blog/products/compute/google-cloud-ai-infrastructure-at-nvidia-gtc-2026/"
-  summary="Google Cloud와 NVIDIA, GTC 2026에서 산업 전반의 AI 혁신 확대를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Google Cloud와 NVIDIA가 GTC 2026에서 산업 전반의 AI 혁신을 확대하고 있습니다. 에이전트형 AI 시대가 기업 인프라 요구를 근본적으로 바꾸면서, 동적 추론과 자율 실행이 가능한 시스템 구축을 위한 최적화된 공동 설계 스택이 필요해졌습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -268,7 +268,7 @@ Google Cloud와 NVIDIA가 GTC 2026에서 산업 전반의 AI 혁신을 확대하
   title="랜섬웨어 압박: 변화하는 위협 환경에서의 전술, 기법 및 절차"
   url="https://cloud.google.com/blog/topics/threat-intelligence/ransomware-ttps-shifting-threat-landscape/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/2025-ransomware-trends-fig1.max-1000x1000.png"
-  summary="랜섬웨어 압박: 변화하는 위협 환경에서의 전술, 기법 및 절차를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="2018년 이후 금전적 동기를 가진 위협 행위자들이 사후 침해 랜섬웨어 배포로 전략을 전환하면서, 랜섬웨어는 거의 모든 산업과 지역의 조직에게 가장 만연한 위협 중 하나가 되었습니다. 이에 따라 위협 환경이 변화함에 따라 랜섬웨어의 전술, 기법 및 절차(TTPs)도 진화하고 있습니다."
   source="Google Cloud Blog"
   severity="Medium"
 %}
@@ -287,7 +287,7 @@ Google Cloud와 NVIDIA가 GTC 2026에서 산업 전반의 AI 혁신을 확대하
   title="KubeCon + CloudNativeCon Europe 2026 공동 개최 이벤트 심층 분석: Open Sovereign Cloud Day"
   url="https://www.cncf.io/blog/2026/03/16/kubecon-cloudnativecon-europe-2026-co-located-event-deep-dive-open-sovereign-cloud-day/"
   image="https://www.cncf.io/wp-content/uploads/2026/03/Co-Lo-Open-Sovereign-Cloud-Day.png"
-  summary="KubeCon + CloudNativeCon Europe 2026 공동 개최 이벤트 심층 분석: Open Sovereign Cloud Day를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Open Sovereign Cloud Day는 디지털 주권이 추상적 논의에서 실질적 엔지니어링 우선순위로 부상한 가운데 KubeCon + CloudNativeCon Europe 2026과 함께 개최됩니다. 이 행사는 특히 유럽을 중심으로 클라우드 네이티브 기반의 현대 인프라에서 주권 문제를 집중 논의합니다."
   source="CNCF Blog"
   severity="High"
 %}
@@ -304,7 +304,7 @@ Open Sovereign Cloud Day는 디지털 주권이 추상적 논의에서 실질적
   title="Kubernetes Secrets를 사용한 레지스트리 미러 인증"
   url="https://www.cncf.io/blog/2026/03/16/registry-mirror-authentication-with-kubernetes-secrets-2/"
   image="https://www.cncf.io/wp-content/uploads/2026/03/Co-Lo-K8s-on-Edge-Day-EU-2026-6.png"
-  summary="Kubernetes Secrets를 사용한 레지스트리 미러 인증를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="CRI-O credential provider의 Part II에서는 OpenShift와 같은 플랫폼에서 Kubernetes Secrets를 활용한 Registry Mirror 인증 통합 예시를 다룹니다."
   source="CNCF Blog"
   severity="High"
 %}
@@ -320,7 +320,7 @@ CRI-O credential provider의 Part II에서는 OpenShift와 같은 플랫폼에�
 {% include news-card.html
   title="보이지 않는 재작성: Kubernetes 이미지 프로모터 현대화"
   url="https://kubernetes.io/blog/2026/03/17/image-promoter-rewrite/"
-  summary="보이지 않는 재작성: Kubernetes 이미지 프로모터 현대화를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Kubernetes 이미지 프로모터인 kpromo의 핵심을 재작성하여 코드베이스를 20% 삭제하고 성능을 대폭 개선했습니다. 이 도구는 registry.k8s.io의 컨테이너 이미지를 스테이징에서 프로덕션으로 복사하고 cosign 서명 및 SLSA 프로비넌스 어테스테이션을 생성하는 중요한 역할을 합니다."
   source="Kubernetes Blog"
   severity="Medium"
 %}
@@ -339,7 +339,7 @@ Kubernetes 이미지 프로모터인 kpromo의 핵심을 재작성하여 코드�
   title="Bitcoin이 주요 지지선에 도달 — Jack Mallers가 지금 DCA를 시작해야 한다고 말하는 이유"
   url="https://bitcoinmagazine.com/markets/bitcoin-at-key-support-levels-why-jack-mallers-says-turn-on-dca-now"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/unnamed-file.webp"
-  summary="Bitcoin이 주요 지지선에 도달 — Jack Mallers가 지금 DCA를 시작해야 한다고 말하는 이유를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Bitcoin이 고점 대비 50% 하락하며 주간 RSI가 과매도권에 진입하는 등 주요 지지선을 테스트하고 있습니다. Jack Mallers는 바닥이 형성되고 있다고 분석하며 이 시점이 DCA(Dollar-Cost Averaging)를 시작하기에 적합하다고 강조했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}
@@ -356,7 +356,7 @@ Bitcoin이 고점 대비 50% 하락하며 주간 RSI가 과매도권에 진입�
   title="에릭 트럼프, Bitcoin 2026 컨퍼런스 연사로 확정"
   url="https://bitcoinmagazine.com/news/eric-trump-confirmed-speaker-bitcoin-2026"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/B26-Blue-VIP-1.jpg"
-  summary="에릭 트럼프, Bitcoin 2026 컨퍼런스 연사로 확정를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Eric Trump가 Bitcoin 2026 컨퍼런스의 연사로 확정되었습니다. 이 행사는 Michael Saylor를 포함한 글로벌 리더들이 참여하며 4월 27일부터 29일까지 라스베이거스 The Venetian에서 개최됩니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}
@@ -373,7 +373,7 @@ Eric Trump가 Bitcoin 2026 컨퍼런스의 연사로 확정되었습니다. 이 
   title="Bitcoin 보유 기반이 성숙해지며 소매 투자자 의존도 감소: 분석가들"
   url="https://bitcoinmagazine.com/markets/bitcoins-ownership-base-is-maturing"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/03/Bitcoins-Ownership-Base-is-Maturing-Reducing-Reliance-on-Retail-Analysts.jpg"
-  summary="Bitcoin 보유 기반이 성숙해지며 소매 투자자 의존도 감소: 분석가들를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 운영 측면에서는 우선 대응 순서와 의사결정 체크포인트를 함께 정리했습니다."
+  summary="Bitcoin Magazine에 따르면, Bitcoin의 소유 기반이 성숙해지고 있어 시장의 소매 투자자 의존도가 감소하고 있다. 기관 투자자와 장기 보유자들의 축적이 지속되며 시장의 회복탄력성을 보여주고 장기적 전망을 강화하고 있다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}

--- a/scripts/rewrite_template_echo_summaries.py
+++ b/scripts/rewrite_template_echo_summaries.py
@@ -245,20 +245,21 @@ def _to_liquid_safe(text: str) -> str:
     return text.replace("‘", "'").replace("’", "'")
 
 
-def summarise(prose: str, max_sentences: int = 2):
-    """First one or two sentences of ``prose``, or None if it is not a summary."""
-    text = _clean_markdown(prose)
-    if len(text) < MIN_PROSE_LEN:
-        return None
-    if not text.endswith(("다.", "요.", ".")):
-        return None
-    if "{%" in text or "{{" in text:
+def _quote(candidate: str):
+    """One candidate quotation, validated, or None.
+
+    Every rule that decides whether text may be lifted lives here, so the
+    narrowing loop in ``summarise`` cannot weaken a check by retrying: a shorter
+    candidate faces exactly the same bar as the longer one it replaces.
+    """
+    # Applied to the CANDIDATE, not to the whole paragraph. A paragraph often
+    # trails into something that is not a sentence — a byline "(작성: …)", a
+    # colon lead-in for the bullet list below it, or, in 2026-03-16, a
+    # generator truncation that stops mid-word. None of those are quoted, and
+    # none of them are evidence against the finished sentences above them.
+    if not candidate.endswith(("다.", "요.", ".")):
         return None
 
-    sentences = [s for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
-    if not sentences:
-        return None
-    candidate = " ".join(sentences[:max_sentences]).strip()
     clipped = _truncate_korean_sentence(candidate, MAX_SUMMARY_LEN)
     # The helper's word-boundary fallback can APPEND "… 등이 확인되었습니다." That is
     # fine for a generator writing new text and wrong here: every character of a
@@ -275,6 +276,30 @@ def summarise(prose: str, max_sentences: int = 2):
     if _is_template_echo(value):
         return None
     return value
+
+
+def summarise(prose: str, max_sentences: int = 2):
+    """First one or two sentences of ``prose``, or None if it is not a summary.
+
+    Two sentences are preferred; when they cannot be quoted the first alone is
+    tried before giving up. Narrowing the quote never loosens a rule — it only
+    stops one unusable trailing sentence from discarding a usable leading one,
+    which is the whole difference between 6 and 1 unrepairable cards.
+    """
+    text = _clean_markdown(prose)
+    if len(text) < MIN_PROSE_LEN:
+        return None
+    if "{%" in text or "{{" in text:
+        return None
+
+    sentences = [s for s in _SENTENCE_SPLIT_RE.split(text) if s.strip()]
+    if not sentences:
+        return None
+    for count in range(max_sentences, 0, -1):
+        value = _quote(" ".join(sentences[:count]).strip())
+        if value is not None:
+            return value
+    return None
 
 
 # --- transform: replace ------------------------------------------------------

--- a/scripts/tests/fixtures/quality_baseline.json
+++ b/scripts/tests/fixtures/quality_baseline.json
@@ -1376,7 +1376,7 @@
     }
   },
   "2026-02-26-Tech_Security_Weekly_Digest_AI_Go_AWS_API.md": {
-    "total": 95,
+    "total": 94,
     "scores": {
       "front_matter": 15,
       "ai_summary": 10,
@@ -1387,7 +1387,7 @@
       "tables": 10,
       "code_blocks": 10,
       "cross_refs": 0,
-      "length": 5
+      "length": 4
     }
   },
   "2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md": {

--- a/scripts/tests/test_rewrite_template_echo_summaries.py
+++ b/scripts/tests/test_rewrite_template_echo_summaries.py
@@ -220,6 +220,62 @@ def test_prose_that_is_not_a_finished_sentence_is_skipped():
     assert rw.replace_echo_summaries(src) == src
 
 
+# --- narrowing the quote: two sentences, else one ----------------------------
+#
+# A whole paragraph is judged as one unit only in the happy case. When the
+# two-sentence candidate is unusable — too long to cut without the helper
+# padding it, or trailing into something that is not a finished sentence — the
+# first sentence alone is still evidence the post carries, so it is quoted
+# instead of abandoning the card to its template echo. Measured: this is the
+# entire difference between 6 and 1 unrepairable cards in the corpus.
+
+
+def test_two_sentence_overflow_falls_back_to_one_sentence():
+    """Sentence 1 fits the cap, sentences 1+2 do not. Quote sentence 1."""
+    first = "CNCF에서 Harbor 컨테이너 레지스트리를 프로덕션 환경에서 운영하기 위한 가이드를 발표했습니다."
+    second = "고가용성과 보안, 스토리지, 모니터링, 네트워크 구성 등 " + "다섯 가지 핵심 영역을 중심으로 정리한 " * 6 + "실무 권장사항입니다."
+    assert len(first) <= rw.MAX_SUMMARY_LEN < len(first + " " + second)
+    value = _summary_of(rw.replace_echo_summaries(_post(_card() + "\n" + first + " " + second + "\n")))
+    assert value == first
+
+
+def test_paragraph_trailing_into_a_byline_still_yields_its_sentences():
+    """A trailing "(작성: …)" is not a sentence; it must not veto the two above it."""
+    prose = _PROSE + " (작성: Matt Corallo)"
+    value = _summary_of(rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n")))
+    assert value in _PROSE
+    assert "Matt Corallo" not in value
+
+
+def test_paragraph_trailing_into_a_colon_lead_in_falls_back_to_one_sentence():
+    first = "AWS Korea Blog의 시리즈 2편으로, 7주 만에 구축한 Agentic AI 플랫폼의 핵심 인프라를 다룹니다."
+    prose = first + " 이번 글의 주제는 엔터프라이즈급 에이전트 시스템의 세 가지 핵심 구성요소입니다:"
+    value = _summary_of(rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n")))
+    assert value == first
+
+
+def test_paragraph_cut_off_mid_sentence_still_yields_its_finished_first():
+    """2026-03-16 ships a paragraph the generator truncated mid-word. The first
+    sentence survived intact and is the only thing quoted."""
+    first = "AI 코딩 에이전트의 동작 방식을 자신의 애플리케이션 백엔드에도 적용할 수 있습니다."
+    prose = first + " 하나의 에이전트에게 코드 리뷰와 테스트 작성을 모두 맡기면 컨텍스트가 길어지면서 자신이 작성한"
+    value = _summary_of(rw.replace_echo_summaries(_post(_card() + "\n" + prose + "\n")))
+    assert value == first
+
+
+def test_fallback_still_refuses_to_invent_when_one_sentence_also_overflows():
+    """The narrowing is a second attempt, not a licence to pad. When neither
+    candidate survives the no-invented-text check the card is left alone."""
+    prose = ("첫 문장은 아주 길게 이어지는 설명으로 " * 12).strip() + "입니다."
+    src = _post(_card() + "\n" + prose + "\n")
+    assert rw.replace_echo_summaries(src) == src
+
+
+def test_fallback_does_not_rescue_a_paragraph_with_no_finished_sentence():
+    src = _post(_card() + "\n주요 구성요소는 다음 세 가지 항목으로 충분히 길게 구성되어 있습니다:\n")
+    assert rw.replace_echo_summaries(src) == src
+
+
 # --- Liquid attribute safety -------------------------------------------------
 
 


### PR DESCRIPTION
## 무엇을

파일럿 #521 에서 검증한 `rewrite_template_echo_summaries.py` 를 남은 코퍼스 전체에 확산하고,
자동 교체가 기각한 잔여 6건까지 해소한다. **코퍼스 template-echo 잔여 0건.**

| 커밋 | 범위 | replace | drop | 개별 |
|------|------|---------|------|------|
| `8216408f` | 2월 9포스트 | 97 | 22 | — |
| `952535fc` | 3월 13포스트 | 100 | 12 | — |
| `53eff391` | 잔여 6건 (5파일 + 1) | 5 | — | 1 |
| **합계** | **23포스트** | **202** | **34** | **1** |

`_posts/` 변경은 전부 `summary=` 속성 한 곳뿐이다(개별 수정 1건 포함). 교체 텍스트는
같은 포스트의 바로 아래 산문에서 복사된다 — 네트워크 호출도 LLM도 없다.

## 왜 6건이 남았었나 (실측이 전제를 뒤집음)

착수 전 가설은 "카드 뒤에 산문이 없다"였으나, 실제 사유는 `summarise()` 가 **문단 전체를
한 덩어리로 판정**한 것이었다.

| 포스트 | 실제 기각 사유 |
|--------|----------------|
| 02-25, 02-28 | 두 문장이 200자를 넘어 `_truncate_korean_sentence` 가 꼬리를 창작 |
| 03-01 | 문단이 `:` 로 끝남 (아래 불릿의 리드인) |
| 03-10 | 문단이 `(작성: Matt Corallo)` 바이라인으로 끝남 |
| 03-16 | 문단 자체가 생성 시점에 어절 중간에서 잘려 있음 |
| 03-04 | 카드 뒤가 산문이 아니라 불릿 목록 — 유일한 진짜 자동 불가 |

그래서 종결어미 검사를 문단이 아니라 **인용 후보**에 적용하고, 두 문장이 인용 불가면
첫 문장으로 한 번 좁혀 재시도한다.

**좁히기는 규칙을 완화하지 않는다.** 모든 검사를 `_quote()` 한 곳에 모아 두 후보가 동일한
기준을 받으므로, 재시도가 검사를 우회할 수 없다. "교체 텍스트의 모든 글자는 포스트에서
온다"는 불변식은 그대로이며, 꼬리 창작 방지 테스트
(`test_no_text_is_invented_when_the_helper_would_pad`)는 **수정 없이** 통과한다.

폭발 반경은 추정이 아니라 실측이다 — 코퍼스 전체 dry-run 결과 정확히 5파일 5건, 부수 변경 0.

03-04 는 `_includes/news-card.html:33` 이 `summary` 가 비면 제목을 잘라 넣으므로 삭제가
개선이 아니다. 목록 두 항목을 그대로 펼쳐 손으로 채웠다(실질 어휘는 전부 본문에서 온다).

## 두 모드는 각자의 런타임 계약으로 검증된다

- `replace` — 카드 `summary=` **값** 외 바이트 불변
- `drop` — `news-spotlight-item` 의 `summary="…"` **줄 삭제** 외 불변 (카드 수·속성 순서 별도 감사)

계약 위반 시 실행 전체가 ABORT 된다. 23포스트 전부 통과.

## quality_baseline 변동 1건

02-26 이 500줄 → 498줄이 되며 `validate_length` 의 500줄 경계를 넘어 total 95 → 94.
줄 수 프록시 점수이고, 삭제된 2줄은 근거 없는 템플릿 문장이므로 회귀가 아니다.
`regen_quality_baseline.py` 로 갱신했다.

## 검증

```
pytest scripts/tests/                    3905 passed, 5 skipped  (신규 테스트 6건 포함)
ruff check                               All checks passed
.githooks/pre-commit                     exit 0 (구조/고유명사/체크리스트/품질/맨URL/KST)
bundle exec jekyll build                 성공 9.3s
코퍼스 잔여 스캔                          template-echo 0건
_posts/ raw grep (카드 밖 본문 포함)      고정 문구 3종 0건
렌더된 사이트 전체 grep                   0 파일
렌더 재확인 (2월 9 + 3월 15 포스트)       news-card__summary 정상, news-spotlight-summary 0
```

렌더 확인 시 02-21 은 KST 드리프트로 canonical 이 `/posts/2026/02/20/` 이다(`/02/21/` 는 리다이렉트 스텁).