### PR TITLE
feat(ci): lighthouse 퍼프 게이트를 PR diff 기준으로 측정 (_posts 트리거 + URL 동적화)

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -10,18 +10,28 @@
 # scoped to PR diffs.
 #
 # URL strategy:
+#   The measured URLs are derived from the PR diff by
+#   scripts/dev/resolve_lighthouse_urls.py: the homepage, plus the post page
+#   the PR actually edited (capped, so run time stays flat regardless of how
+#   many posts a corpus-wide PR touches). A post URL is measured only when it
+#   exists in BOTH builds — `serve --single` answers an unknown path with the
+#   homepage at HTTP 200, so measuring a head-only URL would compare a post
+#   page against the homepage. PRs that touch no post keep the representative
+#   post below.
+#
 #   Primary: local Jekyll build served on localhost:4000 (Vercel-independent).
-#   Fallback: if Jekyll build fails, re-run Lighthouse against GH Pages backup
-#             (https://twodragon0.github.io/tech-blog) so Vercel Challenge Mode
-#             or rate-limiting cannot block the check entirely.
-#             The compare step uses continue-on-error: true so a fallback result
-#             never hard-blocks the PR merge.
+#   Fallback: if either Jekyll build fails, re-run Lighthouse against GH Pages
+#             backup (https://twodragon0.github.io/tech-blog) so Vercel
+#             Challenge Mode or rate-limiting cannot block the check entirely.
+#             URLs there are not localhost-normalised, so no row is comparable
+#             and the compare step returns "skip" — a soft degrade, by design.
 
 name: Lighthouse perf gate
 
 on:
   pull_request:
     paths:
+      - "_posts/**"
       - "_includes/**"
       - "_layouts/**"
       - "_sass/**"
@@ -31,6 +41,7 @@ on:
       - "vercel.json"
       - "_plugins/**"
       - "scripts/dev/compare_lighthouse_runs.py"
+      - "scripts/dev/resolve_lighthouse_urls.py"
       - ".github/workflows/lighthouse-ci.yml"
   workflow_dispatch:
 
@@ -44,6 +55,13 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Measured when the PR touched no resolvable post (e.g. an assets/** or
+  # _includes/** change). Dropped automatically if it stops existing.
+  DEFAULT_POST_URL: /posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/
+  GHPAGES_BASE: https://twodragon0.github.io/tech-blog
+  # Cap on post URLs. 1 keeps the job at 2 URLs — the same sweep count the
+  # gate had before _posts/** triggered it — so per-run cost did not change.
+  MAX_POST_URLS: 1
 
 jobs:
   lighthouse-perf-gate:
@@ -51,6 +69,9 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
+      - name: Record job start
+        run: echo "GATE_STARTED_AT=$(date +%s)" >> "$GITHUB_ENV"
+
       - name: Checkout PR head
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
@@ -90,57 +111,6 @@ jobs:
         env:
           JEKYLL_ENV: production
 
-      - name: Run Lighthouse on head (local build)
-        if: steps.build-head.outcome == 'success'
-        run: |
-          mkdir -p lhci-head
-          npx serve _site_head -l 4000 --single &
-          SERVER_PID=$!
-          for _ in $(seq 1 15); do
-            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
-            sleep 1
-          done
-          for url in http://localhost:4000/ http://localhost:4000/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/; do
-            # Warm-cache prerun: warms OS file cache, Node module cache, and
-            # the local server's slab. Result is discarded. Eliminates the
-            # cold-start outlier that caused the +721 ms false positive in
-            # PR #326.
-            lighthouse "$url" --output=json --output-path=/dev/null --quiet \
-              --chrome-flags="--headless --no-sandbox --disable-gpu" --preset=desktop || true
-
-            # 5 measured runs (odd number → stable median, no tie-breaks).
-            for run_id in 1 2 3 4 5; do
-              lighthouse "$url" \
-                --output=json \
-                --output-path="lhci-head/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
-                --quiet \
-                --chrome-flags="--headless --no-sandbox --disable-gpu" \
-                --preset=desktop || true
-            done
-          done
-          kill $SERVER_PID 2>/dev/null || true
-
-      - name: Run Lighthouse on head (GH Pages fallback)
-        if: steps.build-head.outcome != 'success'
-        run: |
-          # Local Jekyll build failed — fall back to GH Pages backup.
-          # This keeps the perf gate alive even when Vercel or Jekyll is blocked.
-          GHPAGES_BASE="https://twodragon0.github.io/tech-blog"
-          mkdir -p lhci-head
-          for path in "/" "/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/"; do
-            url="${GHPAGES_BASE}${path}"
-            lighthouse "$url" --output=json --output-path=/dev/null --quiet \
-              --chrome-flags="--headless --no-sandbox --disable-gpu" --preset=desktop || true
-            for run_id in 1 2 3 4 5; do
-              lighthouse "$url" \
-                --output=json \
-                --output-path="lhci-head/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
-                --quiet \
-                --chrome-flags="--headless --no-sandbox --disable-gpu" \
-                --preset=desktop || true
-            done
-          done
-
       - name: Checkout PR base
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
         with:
@@ -158,17 +128,52 @@ jobs:
         env:
           JEKYLL_ENV: production
 
-      - name: Run Lighthouse on base (local build)
-        if: steps.build-base.outcome == 'success'
+      # Both builds must exist before the URL list is resolved: a post URL is
+      # only measurable where every build serves it (see the script docstring).
+      - name: Resolve measurement URLs
+        id: urls
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          mkdir -p lhci-base
-          npx serve _site_base -l 4000 --single &
+          set -euo pipefail
+          : > changed-files.txt
+          if [ -n "${PR_NUMBER:-}" ]; then
+            # The PR file list, not a two-dot git diff: it carries three-dot
+            # semantics, so commits landed on main since the branch point do
+            # not masquerade as this PR's changes.
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              -q '.[].filename' > changed-files.txt || : > changed-files.txt
+          fi
+
+          SITE_ARGS=""
+          if [ "${{ steps.build-head.outcome }}" = "success" ] \
+             && [ "${{ steps.build-base.outcome }}" = "success" ]; then
+            SITE_ARGS="--site-dir _site_head --site-dir _site_base"
+          fi
+
+          # shellcheck disable=SC2086
+          python3 scripts/dev/resolve_lighthouse_urls.py \
+            --changed-files changed-files.txt \
+            $SITE_ARGS \
+            --default-post-url "${DEFAULT_POST_URL}" \
+            --max-post-urls "${MAX_POST_URLS}" \
+            --output lh-urls.txt
+
+      - name: Run Lighthouse on head (local build)
+        if: steps.build-head.outcome == 'success' && steps.build-base.outcome == 'success'
+        run: |
+          mkdir -p lhci-head
+          npx serve _site_head -l 4000 --single &
           SERVER_PID=$!
           for _ in $(seq 1 15); do
             if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
             sleep 1
           done
-          for url in http://localhost:4000/ http://localhost:4000/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/; do
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            url="http://localhost:4000${path}"
             # Warm-cache prerun: warms OS file cache, Node module cache, and
             # the local server's slab. Result is discarded. Eliminates the
             # cold-start outlier that caused the +721 ms false positive in
@@ -180,24 +185,30 @@ jobs:
             for run_id in 1 2 3 4 5; do
               lighthouse "$url" \
                 --output=json \
-                --output-path="lhci-base/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
+                --output-path="lhci-head/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
                 --quiet \
                 --chrome-flags="--headless --no-sandbox --disable-gpu" \
                 --preset=desktop || true
             done
-          done
+          done < lh-urls.txt
           kill $SERVER_PID 2>/dev/null || true
 
-      - name: Run Lighthouse on base (GH Pages fallback)
-        if: steps.build-base.outcome != 'success'
+      - name: Run Lighthouse on base (local build)
+        if: steps.build-head.outcome == 'success' && steps.build-base.outcome == 'success'
         run: |
-          # Local Jekyll build failed — fall back to GH Pages backup for base.
-          GHPAGES_BASE="https://twodragon0.github.io/tech-blog"
           mkdir -p lhci-base
-          for path in "/" "/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/"; do
-            url="${GHPAGES_BASE}${path}"
+          npx serve _site_base -l 4000 --single &
+          SERVER_PID=$!
+          for _ in $(seq 1 15); do
+            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            url="http://localhost:4000${path}"
             lighthouse "$url" --output=json --output-path=/dev/null --quiet \
               --chrome-flags="--headless --no-sandbox --disable-gpu" --preset=desktop || true
+
             for run_id in 1 2 3 4 5; do
               lighthouse "$url" \
                 --output=json \
@@ -206,7 +217,30 @@ jobs:
                 --chrome-flags="--headless --no-sandbox --disable-gpu" \
                 --preset=desktop || true
             done
-          done
+          done < lh-urls.txt
+          kill $SERVER_PID 2>/dev/null || true
+
+      # One fallback for both sides: if either build failed there is no
+      # like-for-like local pair to compare, so measure GH Pages once per side
+      # and let the compare step report "skip".
+      - name: Run Lighthouse on GH Pages fallback
+        if: steps.build-head.outcome != 'success' || steps.build-base.outcome != 'success'
+        run: |
+          mkdir -p lhci-head lhci-base
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            url="${GHPAGES_BASE}${path}"
+            lighthouse "$url" --output=json --output-path=/dev/null --quiet \
+              --chrome-flags="--headless --no-sandbox --disable-gpu" --preset=desktop || true
+            for run_id in 1 2 3 4 5; do
+              lighthouse "$url" \
+                --output=json \
+                --output-path="lhci-head/lhr-$(echo "$url" | tr '/:' '_')-$run_id.json" \
+                --quiet \
+                --chrome-flags="--headless --no-sandbox --disable-gpu" \
+                --preset=desktop || true
+            done
+          done < lh-urls.txt
 
       - name: Compare LCP head vs base
         id: compare
@@ -224,6 +258,21 @@ jobs:
           # here — a real regression now blocks the PR, while the fallback case
           # still passes. (Security fix C-H1, 2026-06-30 workflow audit.)
 
+      # Running record of what the gate cost and what it actually measured.
+      # `_posts/**` roughly halves the share of PRs that skip this workflow, so
+      # the per-run number needs to stay visible rather than be re-estimated.
+      - name: Report gate cost
+        if: always()
+        run: |
+          ELAPSED=$(( $(date +%s) - GATE_STARTED_AT ))
+          {
+            echo "### Lighthouse perf gate cost"
+            echo ""
+            echo "- Wall clock: **$((ELAPSED / 60))m $((ELAPSED % 60))s**"
+            echo "- URLs measured:"
+            sed 's/^/  - `/; s/$/`/' lh-urls.txt 2>/dev/null || echo "  - (none resolved)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload Lighthouse artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
@@ -232,6 +281,7 @@ jobs:
           path: |
             lhci-base/
             lhci-head/
+            lh-urls.txt
             lighthouse-comparison.md
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -19,17 +19,20 @@
 #   page against the homepage. PRs that touch no post keep the representative
 #   post below.
 #
-#   Both builds are served on localhost:4000, one after the other. That is a
+#   Head and base get their OWN port (4000 / 4001). Sharing one port is a
 #   correctness hazard, not a detail: `npx serve` silently falls back to a
-#   RANDOM free port when 4000 is still held, and Lighthouse then keeps
-#   requesting :4000 — i.e. it measures the previous build twice. Runs
-#   31150717334 / 30882267998 / 30332794243 all show `Accepting connections at
-#   http://localhost:<random>` for the base server, so this gate compared head
-#   against head from PR #326 until 2026-08-08. Hence `--no-port-switching`
-#   plus a per-side build-id probe that fails the job rather than measure the
-#   wrong tree.
+#   RANDOM free port when the requested one is still held, and Lighthouse then
+#   keeps requesting the original — i.e. it measures the previous build twice.
+#   Runs 31150717334 / 30882267998 / 30332794243 all show `Accepting
+#   connections at http://localhost:<random>` for the base server, so this gate
+#   compared head against head from PR #326 until 2026-08-08. Run 31244446805
+#   proved a teardown-and-wait is not enough — the head listener still held the
+#   port. Separate ports remove the race outright; `--no-port-switching` and a
+#   per-side build-id probe are the two independent backstops, and
+#   compare_lighthouse_runs normalises the port away so the rows still pair up.
 #
-#   Primary: local Jekyll build served on localhost:4000 (Vercel-independent).
+#   Primary: local Jekyll builds served on localhost:4000 (head) and :4001
+#            (base), Vercel-independent.
 #   Fallback: if either Jekyll build fails, re-run Lighthouse against GH Pages
 #             backup (https://twodragon0.github.io/tech-blog) so Vercel
 #             Challenge Mode or rate-limiting cannot block the check entirely.
@@ -236,23 +239,23 @@ jobs:
           mkdir -p lhci-base
           # --no-port-switching: fail loudly instead of drifting to a random
           # port and leaving Lighthouse pointed at the other build on :4000.
-          npx serve _site_base -l 4000 --single --no-port-switching > serve-base.log 2>&1 &
+          npx serve _site_base -l 4001 --single --no-port-switching > serve-base.log 2>&1 &
           SERVER_PID=$!
           SERVING=""
           for _ in $(seq 1 20); do
-            SERVING=$(curl -sf http://localhost:4000/build-id.txt 2>/dev/null | tr -d '[:space:]' || true)
+            SERVING=$(curl -sf http://localhost:4001/build-id.txt 2>/dev/null | tr -d '[:space:]' || true)
             [ -n "$SERVING" ] && break
             sleep 1
           done
           if [ "$SERVING" != "base" ]; then
-            echo "::error::localhost:4000 is serving '$SERVING', expected 'base' — refusing to measure the wrong build."
+            echo "::error::localhost:4001 is serving '$SERVING', expected 'base' — refusing to measure the wrong build."
             cat serve-base.log || true
             kill $SERVER_PID 2>/dev/null || true
             exit 1
           fi
           while IFS= read -r path; do
             [ -n "$path" ] || continue
-            url="http://localhost:4000${path}"
+            url="http://localhost:4001${path}"
             lighthouse "$url" --output=json --output-path=/dev/null --quiet \
               --chrome-flags="--headless --no-sandbox --disable-gpu" --preset=desktop || true
 
@@ -271,7 +274,7 @@ jobs:
           pkill -P $SERVER_PID 2>/dev/null || true
           kill $SERVER_PID 2>/dev/null || true
           for _ in $(seq 1 20); do
-            curl -sf http://localhost:4000/build-id.txt >/dev/null 2>&1 || break
+            curl -sf http://localhost:4001/build-id.txt >/dev/null 2>&1 || break
             sleep 1
           done
 

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -19,6 +19,16 @@
 #   page against the homepage. PRs that touch no post keep the representative
 #   post below.
 #
+#   Both builds are served on localhost:4000, one after the other. That is a
+#   correctness hazard, not a detail: `npx serve` silently falls back to a
+#   RANDOM free port when 4000 is still held, and Lighthouse then keeps
+#   requesting :4000 — i.e. it measures the previous build twice. Runs
+#   31150717334 / 30882267998 / 30332794243 all show `Accepting connections at
+#   http://localhost:<random>` for the base server, so this gate compared head
+#   against head from PR #326 until 2026-08-08. Hence `--no-port-switching`
+#   plus a per-side build-id probe that fails the job rather than measure the
+#   wrong tree.
+#
 #   Primary: local Jekyll build served on localhost:4000 (Vercel-independent).
 #   Fallback: if either Jekyll build fails, re-run Lighthouse against GH Pages
 #             backup (https://twodragon0.github.io/tech-blog) so Vercel
@@ -161,16 +171,35 @@ jobs:
             --max-post-urls "${MAX_POST_URLS}" \
             --output lh-urls.txt
 
+      - name: Stamp build identity into each site
+        if: steps.build-head.outcome == 'success' && steps.build-base.outcome == 'success'
+        run: |
+          set -euo pipefail
+          # Read back over HTTP before measuring, so "the server on :4000 is
+          # serving the tree I think it is" is verified rather than assumed.
+          echo head > _site_head/build-id.txt
+          echo base > _site_base/build-id.txt
+
       - name: Run Lighthouse on head (local build)
         if: steps.build-head.outcome == 'success' && steps.build-base.outcome == 'success'
         run: |
           mkdir -p lhci-head
-          npx serve _site_head -l 4000 --single &
+          # --no-port-switching: fail loudly instead of drifting to a random
+          # port and leaving Lighthouse pointed at the other build on :4000.
+          npx serve _site_head -l 4000 --single --no-port-switching > serve-head.log 2>&1 &
           SERVER_PID=$!
-          for _ in $(seq 1 15); do
-            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
+          SERVING=""
+          for _ in $(seq 1 20); do
+            SERVING=$(curl -sf http://localhost:4000/build-id.txt 2>/dev/null | tr -d '[:space:]' || true)
+            [ -n "$SERVING" ] && break
             sleep 1
           done
+          if [ "$SERVING" != "head" ]; then
+            echo "::error::localhost:4000 is serving '$SERVING', expected 'head' — refusing to measure the wrong build."
+            cat serve-head.log || true
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
           while IFS= read -r path; do
             [ -n "$path" ] || continue
             url="http://localhost:4000${path}"
@@ -191,18 +220,36 @@ jobs:
                 --preset=desktop || true
             done
           done < lh-urls.txt
+          # $SERVER_PID is the npx wrapper; the listener is its child. Kill the
+          # children too, then wait for :4000 to actually free — a lingering
+          # listener is what made the next side silently measure this one.
+          pkill -P $SERVER_PID 2>/dev/null || true
           kill $SERVER_PID 2>/dev/null || true
+          for _ in $(seq 1 20); do
+            curl -sf http://localhost:4000/build-id.txt >/dev/null 2>&1 || break
+            sleep 1
+          done
 
       - name: Run Lighthouse on base (local build)
         if: steps.build-head.outcome == 'success' && steps.build-base.outcome == 'success'
         run: |
           mkdir -p lhci-base
-          npx serve _site_base -l 4000 --single &
+          # --no-port-switching: fail loudly instead of drifting to a random
+          # port and leaving Lighthouse pointed at the other build on :4000.
+          npx serve _site_base -l 4000 --single --no-port-switching > serve-base.log 2>&1 &
           SERVER_PID=$!
-          for _ in $(seq 1 15); do
-            if curl -sf http://localhost:4000/ > /dev/null 2>&1; then break; fi
+          SERVING=""
+          for _ in $(seq 1 20); do
+            SERVING=$(curl -sf http://localhost:4000/build-id.txt 2>/dev/null | tr -d '[:space:]' || true)
+            [ -n "$SERVING" ] && break
             sleep 1
           done
+          if [ "$SERVING" != "base" ]; then
+            echo "::error::localhost:4000 is serving '$SERVING', expected 'base' — refusing to measure the wrong build."
+            cat serve-base.log || true
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
           while IFS= read -r path; do
             [ -n "$path" ] || continue
             url="http://localhost:4000${path}"
@@ -218,7 +265,15 @@ jobs:
                 --preset=desktop || true
             done
           done < lh-urls.txt
+          # $SERVER_PID is the npx wrapper; the listener is its child. Kill the
+          # children too, then wait for :4000 to actually free — a lingering
+          # listener is what made the next side silently measure this one.
+          pkill -P $SERVER_PID 2>/dev/null || true
           kill $SERVER_PID 2>/dev/null || true
+          for _ in $(seq 1 20); do
+            curl -sf http://localhost:4000/build-id.txt >/dev/null 2>&1 || break
+            sleep 1
+          done
 
       # One fallback for both sides: if either build failed there is no
       # like-for-like local pair to compare, so measure GH Pages once per side

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -7,17 +7,15 @@ Per-PR Lighthouse comparison that fails when LCP regresses by more than 200 ms v
 `.github/workflows/lighthouse-ci.yml` runs on every PR that touches files which can affect rendering performance. For each gated PR it:
 
 1. Builds the PR head and the PR base (`bundle exec jekyll build`).
-2. Serves each build on `localhost:4000` and for each of two URLs:
-   - `/` (homepage)
-   - `/posts/2026/04/29/Tech_Security_Weekly_Digest_CVE_AI_Ransomware_Update/` (representative post page)
-
-   …performs:
+2. Resolves the URLs to measure from the PR diff (see [Which URLs get measured](#which-urls-get-measured)) — the homepage plus at most one post page.
+3. Serves each build on `localhost:4000` and for each resolved URL performs:
    - 1 discarded warm-cache prerun (warms OS file cache, Node module cache, and the server's slab)
    - 5 measured Lighthouse runs
-3. Computes the median LCP per URL across the 5 measured runs.
-4. Calls `scripts/dev/compare_lighthouse_runs.py --threshold-lcp-ms 200`, which compares head-median vs base-median per URL and exits 1 if any URL exceeds the threshold.
-5. Uploads both LHR JSON sets + the Markdown comparison as a workflow artifact (`lighthouse-{run_id}`).
-6. Comments on the PR with the comparison table (deduplicated via `comment-id: lighthouse-perf-gate` so re-runs update the same comment).
+4. Computes the median LCP per URL across the 5 measured runs.
+5. Calls `scripts/dev/compare_lighthouse_runs.py --threshold-lcp-ms 200`, which compares head-median vs base-median per URL and exits 1 if any URL exceeds the threshold.
+6. Uploads both LHR JSON sets, the resolved URL list, and the Markdown comparison as a workflow artifact (`lighthouse-{run_id}`).
+7. Comments on the PR with the comparison table (deduplicated via `comment-id: lighthouse-perf-gate` so re-runs update the same comment).
+8. Writes the job's wall clock and the measured URL list to the run's step summary, so the gate's real cost stays observable instead of being re-estimated.
 
 CLS, TBT, FCP are reported alongside LCP for context but are **informational only** — they do not gate the workflow.
 
@@ -25,13 +23,36 @@ CLS, TBT, FCP are reported alongside LCP for context but are **informational onl
 
 The workflow runs only when the PR touches files that can plausibly affect rendering:
 
+- `_posts/**`
 - `_includes/**`, `_layouts/**`, `_sass/**`, `assets/**`
 - `_config.yml`, `Gemfile.lock`, `vercel.json`
 - `_plugins/**`
-- `scripts/dev/compare_lighthouse_runs.py`
+- `scripts/dev/compare_lighthouse_runs.py`, `scripts/dev/resolve_lighthouse_urls.py`
 - `.github/workflows/lighthouse-ci.yml`
 
-PRs that only touch posts, docs, or unrelated scripts skip the gate entirely.
+PRs that only touch docs or unrelated scripts skip the gate entirely.
+
+## Which URLs get measured
+
+`scripts/dev/resolve_lighthouse_urls.py` derives the list from the PR's file list (via `gh api .../pulls/N/files`, which has three-dot semantics — commits landed on main since the branch point are not attributed to the PR):
+
+| PR touches | Measured |
+|---|---|
+| a post that exists in **both** builds | `/` + that post's URL |
+| several posts | `/` + the newest-dated one (`MAX_POST_URLS`, default 1) |
+| a **new** post (absent from base) | `/` only |
+| no post (`assets/**`, `_includes/**`, …) | `/` + `DEFAULT_POST_URL` |
+| — and `DEFAULT_POST_URL` no longer exists | `/` only |
+
+Two properties are load-bearing:
+
+**A post URL must exist in both builds.** The runs are served with `npx serve … --single`, which answers an unknown path with `index.html` — the homepage — at HTTP 200 with no redirect. Lighthouse then records the *requested* URL while measuring the *homepage*. A head-only URL would therefore be compared against the base homepage and produce a delta with a plausible sign and no meaning. So the resolver intersects the candidates across `_site_head` and `_site_base`, and the local measurement steps only run when both builds succeeded.
+
+**The URL date is read off the build, never recomputed.** `_config.yml` pins `timezone: UTC`, so a post authored at KST 00:00–08:59 lands on the previous UTC day and its filename date ≠ its URL date. The resolver globs `posts/*/*/*/<slug>/index.html` in the built site instead of doing the date arithmetic. `redirect_from` stubs match that same glob, so candidates whose first 4 KB contain `http-equiv="refresh"` are discarded — 12 slugs in the current build have both a canonical page and a 3-level redirect stub, and the stub is a ~770-byte meta-refresh page that would measure as trivially fast.
+
+Posts with a custom `permalink:` in front matter are not resolvable by slug and fall through to `DEFAULT_POST_URL`.
+
+The invariants above are pinned by `scripts/tests/test_ci_lighthouse_perf_gate_guard.py`; each assertion was verified to fail against a mutated copy of the workflow before shipping.
 
 ## Threshold
 
@@ -72,17 +93,26 @@ Push a new commit to the PR branch — the workflow re-runs automatically and th
 gh workflow run lighthouse-ci.yml --ref <branch>
 ```
 
-## Runner cost estimate
+## Runner cost
 
-Per gated PR:
+### Per run — unchanged by the `_posts/**` change
 
-- 2 Jekyll builds × ~60 s = ~2 min
-- 2 URLs × 2 builds × 1 warm prerun × ~30 s = ~2 min (discarded, not counted in CI gate time)
-- 2 URLs × 2 builds × 5 Lighthouse runs × ~30 s = ~10 min
-- Setup / caching / artifact upload = ~2 min
-- **Total: ~14–20 min CI minutes per gated PR** (was ~10–15 min with 3 runs)
+Measured, not estimated: the 20 most recent `lighthouse-ci.yml` runs took **7.2–8.0 min** wall clock (median ~7.8 min), all `pull_request`-triggered. (An earlier revision of this document estimated 14–20 min; that was never observed.)
 
-For repos near the 2,000-minutes-per-month free GitHub Actions tier this adds ~80–100 minutes per 5 perf-touching PRs (was ~50 minutes).
+`MAX_POST_URLS` is 1, so a gated PR still sweeps exactly **2 URLs** — the same count as the old hard-coded pair. Adding `_posts/**` changed *how often* the gate runs, not how long a run takes. Re-check the number from the "Lighthouse perf gate cost" block in any run's step summary rather than trusting this paragraph.
+
+Each extra URL beyond the cap costs 12 Lighthouse runs (2 sides × [1 warm + 5 measured]) ≈ +3 min, against a 30-minute job timeout.
+
+### Per month — this is the part that changed
+
+Of the **last 30 merged PRs**: **0** touched any pre-existing trigger path, and **16** touched `_posts/**`. The gate was effectively dormant. After the change roughly half of PRs are gated:
+
+| | before | after |
+|---|---|---|
+| gated share of the last 30 merged PRs | 0 / 30 | 16 / 30 |
+| CI minutes over those 30 PRs | ~0 | ~125 |
+
+Against the 2,000-minutes-per-month free GitHub Actions tier that is ~6% of the budget at the repo's current PR rate. If a specific PR does not warrant it, the `perf-regression-allowed` label skips the job entirely (see below).
 
 ## Stability tuning
 
@@ -122,7 +152,10 @@ Exit code 0 = no regression. Exit code 1 = at least one URL exceeded the thresho
 
 - `.github/workflows/lighthouse-ci.yml` — the workflow
 - `scripts/dev/compare_lighthouse_runs.py` — the comparison script
-- `scripts/tests/test_compare_lighthouse_runs.py` — unit tests for the script
+- `scripts/dev/resolve_lighthouse_urls.py` — derives the measured URL list from the PR diff
+- `scripts/tests/test_compare_lighthouse_runs.py` — unit tests for the comparison script
+- `scripts/tests/test_resolve_lighthouse_urls.py` — unit tests for the resolver
+- `scripts/tests/test_ci_lighthouse_perf_gate_guard.py` — CI regression guard for this workflow
 - `docs/optimization/LIGHTHOUSE_PERF_GATE.md` — this document
 
 ## Related

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -65,12 +65,13 @@ INFO  Accepting connections at http://localhost:45733      # base — nothing re
 
 From PR #326 until this fix every comparison was a build against itself. That is why the post-page row always came back at ±2 ms, and why the two "regressions" the gate ever reported (+721 ms in PR #326, +901 ms on 2026-08-08) were both on the homepage with **no content difference at all** — see below.
 
-Two independent defences now, because the failure mode is silent:
+A teardown-and-wait is *not* enough — run `31244446805` still found the head listener holding `:4000` when the base sweep started. So the race is removed rather than managed:
 
-1. `--no-port-switching` — serve fails instead of drifting.
-2. A `build-id.txt` written into each site dir and read back **over HTTP** before any measurement. If `:4000` answers `head` when the base sweep is starting, the job errors out rather than producing a confident, meaningless number.
+1. **Separate ports.** Head is served on `:4000`, base on `:4001`. `compare_lighthouse_runs._normalise_url` strips any localhost port, so the rows still pair up.
+2. `--no-port-switching` — serve fails loudly instead of drifting, if a port is ever contended anyway.
+3. A `build-id.txt` written into each site dir and read back **over HTTP** before any measurement. If the port answers `head` when the base sweep is starting, the job errors out rather than producing a confident, meaningless number. This is the check that caught the bug in the first place.
 
-Teardown also kills the listening child (`pkill -P`), not just the `npx` wrapper, and waits for the port to free.
+Teardown also kills the listening child (`pkill -P`), not just the `npx` wrapper.
 
 ## The homepage row is bimodal
 

--- a/docs/optimization/LIGHTHOUSE_PERF_GATE.md
+++ b/docs/optimization/LIGHTHOUSE_PERF_GATE.md
@@ -54,6 +54,40 @@ Posts with a custom `permalink:` in front matter are not resolvable by slug and 
 
 The invariants above are pinned by `scripts/tests/test_ci_lighthouse_perf_gate_guard.py`; each assertion was verified to fail against a mutated copy of the workflow before shipping.
 
+## The gate compared head against head until 2026-08-08
+
+Both builds are served on `localhost:4000`, one after the other. `npx serve` answers a busy port by **silently binding a random free one** while Lighthouse keeps requesting `:4000` — so the base sweep measured the head build. Three sampled runs (`31150717334`, `30882267998`, `30332794243`) all log:
+
+```
+INFO  Accepting connections at http://localhost:4000       # head
+INFO  Accepting connections at http://localhost:45733      # base — nothing requests this
+```
+
+From PR #326 until this fix every comparison was a build against itself. That is why the post-page row always came back at ±2 ms, and why the two "regressions" the gate ever reported (+721 ms in PR #326, +901 ms on 2026-08-08) were both on the homepage with **no content difference at all** — see below.
+
+Two independent defences now, because the failure mode is silent:
+
+1. `--no-port-switching` — serve fails instead of drifting.
+2. A `build-id.txt` written into each site dir and read back **over HTTP** before any measurement. If `:4000` answers `head` when the base sweep is starting, the job errors out rather than producing a confident, meaningless number.
+
+Teardown also kills the listening child (`pkill -P`), not just the `npx` wrapper, and waits for the port to free.
+
+## The homepage row is bimodal
+
+Independently of the port bug, the homepage's LCP is bistable under Lighthouse's Lantern simulation. From one artifact (`lighthouse-31243194526`), five runs of the *same* build on the *same* side:
+
+| | fast runs (3/5) | slow runs (2/5) |
+|---|---|---|
+| **observed** FCP | 213 ms | 248 ms |
+| **simulated** FCP | 258 ms | 1101 ms |
+| simulated LCP | 838 ms | 1721 ms |
+| benchmarkIndex | 2436 | 2390 |
+| network waterfall | 32 requests | identical 32 requests |
+
+A 35 ms observed difference is amplified ~24× by the simulator. Same bytes, same request set, same CPU. The post page measured 833–843 ms across all 20 samples in the same job, so this is specific to the homepage — the same bistability `lighthouse.yml` documents for the mobile preset, at smaller magnitude.
+
+Consequence: with a 5-run median, whichever mode wins a side's five samples decides the row, and a ±200 ms threshold sits well inside the gap. The gate ran on 0 of the last 30 merged PRs, which is why nobody hit this. Re-running the identical commit turned `/ +901 ms FAIL` into `/ +7 ms PASS`.
+
 ## Threshold
 
 | Metric | Threshold | Gating? |

--- a/scripts/dev/compare_lighthouse_runs.py
+++ b/scripts/dev/compare_lighthouse_runs.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import statistics
 import sys
 from pathlib import Path
@@ -87,12 +88,21 @@ def _median(samples: list[float]) -> float | None:
     return statistics.median(samples) if samples else None
 
 
+_LOCALHOST_RE = re.compile(r"^https?://(?:localhost|127\.0\.0\.1)(?::\d+)?")
+
+
 def _normalise_url(url: str) -> str:
-    """Strip the localhost scheme+host so ``http://localhost:4000/foo/`` and
-    ``http://127.0.0.1:4000/foo/`` compare equal across base/head runs."""
-    for prefix in ("http://localhost:4000", "http://127.0.0.1:4000", "http://localhost", "http://127.0.0.1"):
-        if url.startswith(prefix):
-            return url[len(prefix):] or "/"
+    """Strip the localhost scheme+host+port so the two sides compare equal.
+
+    Any port, not just 4000: head and base are served on *different* ports on
+    purpose. Sharing one port meant the second server hit a still-occupied
+    :4000, and ``npx serve`` answers that by binding a random port while
+    Lighthouse keeps requesting :4000 — so the base sweep re-measured the head
+    build. That made every comparison vacuous from PR #326 until 2026-08-08.
+    """
+    stripped = _LOCALHOST_RE.sub("", url, count=1)
+    if stripped != url:
+        return stripped or "/"
     return url
 
 

--- a/scripts/dev/resolve_lighthouse_urls.py
+++ b/scripts/dev/resolve_lighthouse_urls.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Resolve which URLs the Lighthouse perf gate should measure for a PR.
+
+Why this exists
+---------------
+``.github/workflows/lighthouse-ci.yml`` used to measure a hard-coded pair:
+the homepage and one representative post from 2026-04-29. That was fine while
+the gate only fired on ``_includes/**`` / ``assets/**`` changes, because those
+change every page equally. Once ``_posts/**`` triggers the gate, a fixed URL is
+worse than useless: the PR edits post *X* and the gate measures post *Y*, which
+is byte-identical on both sides, so it always reports +0 ms and blocks nothing.
+
+So the URL list is derived from the PR diff instead: homepage + the post(s) the
+PR actually touched.
+
+The both-sides rule (this is a correctness requirement, not an optimisation)
+---------------------------------------------------------------------------
+The workflow serves each build with ``npx serve … --single``. In ``--single``
+mode a path that does not exist is answered with ``index.html`` — the homepage —
+at HTTP 200, with no redirect. Lighthouse therefore records the *requested* URL
+while measuring the *homepage*. If a URL exists on head but not on base (a newly
+added post), the comparison would silently pit the real post page against the
+homepage and emit a garbage delta in whichever direction the two happen to
+differ.
+
+Hence: a post URL is measured only when it exists in **every** site directory
+passed via ``--site-dir``. New posts drop out and the gate falls back to
+comparing the homepage, which is honest.
+
+Slug rule
+---------
+``_config.yml`` sets ``permalink: /posts/:year/:month/:day/:title/`` and Jekyll's
+``:title`` for these posts is the filename with the ``YYYY-MM-DD-`` prefix and
+the extension stripped, verbatim (underscores and case preserved). The date part
+is deliberately *not* recomputed here: ``timezone: UTC`` means a post authored at
+KST 00:00-08:59 lands on the previous UTC day, so the filename date and the URL
+date can differ (see CLAUDE.md "Date / Timezone Rule"). Globbing the built site
+for ``posts/*/*/*/<slug>/index.html`` reads the answer off the actual build
+instead of re-deriving it, so the drift cannot bite.
+
+``redirect_from`` stubs match that same glob, so candidates whose HTML carries a
+``http-equiv="refresh"`` are discarded — they are 1 KB meta-refresh pages and
+measuring one would report the redirect, not the post.
+
+Usage::
+
+    python3 scripts/dev/resolve_lighthouse_urls.py \\
+        --changed-files changed.txt \\
+        --site-dir _site_head --site-dir _site_base \\
+        --default-post-url /posts/2026/04/29/Some_Post/ \\
+        --max-post-urls 1 --output lh-urls.txt
+
+Prints one URL path per line (``/`` first). Pure stdlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+HOMEPAGE = "/"
+
+# Enough of the document to cover <head>; redirect stubs put the refresh there.
+_SNIFF_BYTES = 4096
+_REFRESH_MARKERS = ('http-equiv="refresh"', "http-equiv='refresh'")
+
+_POST_SUFFIXES = (".md", ".markdown")
+
+
+def post_slug(changed_path: str) -> str | None:
+    """``_posts/2026-04-29-Foo_Bar.md`` -> ``Foo_Bar``.
+
+    Returns ``None`` for anything that is not a dated post source file.
+    """
+    path = Path(changed_path.strip())
+    if not path.parts or path.parts[0] != "_posts":
+        return None
+    if path.suffix.lower() not in _POST_SUFFIXES:
+        return None
+    stem = path.stem
+    # YYYY-MM-DD- prefix: 11 characters.
+    if len(stem) <= 11 or stem[4] != "-" or stem[7] != "-" or stem[10] != "-":
+        return None
+    if not (stem[:4].isdigit() and stem[5:7].isdigit() and stem[8:10].isdigit()):
+        return None
+    slug = stem[11:]
+    return slug or None
+
+
+def _is_redirect_stub(index_html: Path) -> bool:
+    try:
+        head = index_html.read_bytes()[:_SNIFF_BYTES].decode("utf-8", "replace").lower()
+    except OSError:
+        return True
+    return any(marker in head for marker in _REFRESH_MARKERS)
+
+
+def urls_for_slug(slug: str, site_dir: Path) -> set[str]:
+    """Every canonical ``/posts/YYYY/MM/DD/<slug>/`` URL built for ``slug``."""
+    found: set[str] = set()
+    for index_html in site_dir.glob(f"posts/*/*/*/{slug}/index.html"):
+        if _is_redirect_stub(index_html):
+            continue
+        rel = index_html.parent.relative_to(site_dir).as_posix()
+        found.add(f"/{rel}/")
+    return found
+
+
+def resolve(
+    changed_files: list[str],
+    site_dirs: list[Path],
+    default_post_url: str | None = None,
+    max_post_urls: int = 1,
+) -> list[str]:
+    """Homepage + up to ``max_post_urls`` post URLs present in every site dir.
+
+    With no ``site_dirs`` (the GH Pages fallback path, where there is no local
+    build to inspect) existence cannot be checked, so only the homepage and the
+    default post URL are returned — guessing a URL there would hit the
+    ``--single`` hazard described in the module docstring.
+    """
+    urls = [HOMEPAGE]
+
+    if not site_dirs:
+        if default_post_url:
+            urls.append(default_post_url)
+        return urls
+
+    slugs = sorted({s for s in (post_slug(c) for c in changed_files) if s})
+
+    candidates: set[str] = set()
+    for slug in slugs:
+        per_dir = [urls_for_slug(slug, site_dir) for site_dir in site_dirs]
+        # Intersection: measurable only where every build serves it.
+        common = set.intersection(*per_dir) if per_dir else set()
+        candidates |= common
+
+    if candidates:
+        # Deterministic and stable across re-runs: newest URL date first (the
+        # path sorts lexicographically by /YYYY/MM/DD/), then by slug.
+        urls.extend(sorted(candidates, reverse=True)[:max_post_urls])
+        return urls
+
+    if default_post_url and all(
+        (site_dir / default_post_url.strip("/") / "index.html").is_file()
+        for site_dir in site_dirs
+    ):
+        urls.append(default_post_url)
+    return urls
+
+
+def _read_changed_files(path: Path | None) -> list[str]:
+    if path is None:
+        return []
+    if str(path) == "-":
+        return [ln for ln in sys.stdin.read().splitlines() if ln.strip()]
+    if not path.is_file():
+        return []
+    return [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--changed-files",
+        type=Path,
+        default=None,
+        help="File with one changed repo path per line ('-' for stdin)",
+    )
+    parser.add_argument(
+        "--site-dir",
+        type=Path,
+        action="append",
+        default=[],
+        dest="site_dirs",
+        help="Built site directory; a post URL must exist in every one (repeatable)",
+    )
+    parser.add_argument(
+        "--default-post-url",
+        default=None,
+        help="Post URL to measure when the PR touched no resolvable post",
+    )
+    parser.add_argument(
+        "--max-post-urls",
+        type=int,
+        default=1,
+        help="Cap on post URLs measured, so run time stays flat (default: 1)",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Write the list here too")
+    args = parser.parse_args()
+
+    urls = resolve(
+        _read_changed_files(args.changed_files),
+        args.site_dirs,
+        args.default_post_url,
+        args.max_post_urls,
+    )
+    text = "\n".join(urls) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""CI regression guard: the Lighthouse *perf gate* must keep measuring the diff.
+
+Sibling of ``test_ci_lighthouse_gate_guard.py``, which guards the absolute
+budgets in ``lighthouse.yml``. This one guards the head-vs-base LCP regression
+gate in ``lighthouse-ci.yml``.
+
+What can be undone silently here
+--------------------------------
+1. **Drop ``_posts/**`` from the trigger.** The gate goes back to never firing
+   on the PRs this repo actually produces — 16 of the last 30 merged PRs touched
+   ``_posts/**`` and 0 touched any other trigger path.
+2. **Re-hard-code the measured post URL.** Before 2026-08-08 the gate always
+   measured a fixed 2026-04-29 post. On a ``_posts/**`` PR that post is
+   byte-identical on both sides, so the gate reports +0 ms and blocks nothing —
+   green, and vacuous. The URL list must come from the resolver.
+3. **Stop requiring the URL to exist in both builds.** The runs are served with
+   ``serve … --single``, which answers an unknown path with the homepage at
+   HTTP 200 and no redirect. Measure a head-only URL and the comparison pits a
+   post page against the homepage; the delta is noise with a plausible sign.
+   The existence check needs ``--site-dir`` for *both* builds and the local
+   measurement steps need both builds to have succeeded.
+4. **Raise the 200 ms threshold** or neutralise the compare step.
+5. **Remove the post-URL cap**, turning a 100-post corpus PR into a 101-URL
+   sweep — 100× the run time, on a 30-minute job timeout.
+
+Direction
+---------
+* ``--threshold-lcp-ms`` and ``--max-post-urls`` are CEILINGS -> asserted ``<=``
+  (tightening stays green, loosening trips).
+* Trigger paths, the resolver call, the both-builds conditions and the
+  ``--site-dir`` pair are PRESENCE assertions.
+* The hard-coded post URL inside the measurement loops is an ABSENCE assertion.
+
+If a change here is intentional, update this guard in the same PR and say why.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "lighthouse-ci.yml"
+RESOLVER = REPO_ROOT / "scripts" / "dev" / "resolve_lighthouse_urls.py"
+
+# Direction: ceiling. Loosening (raising) must fail.
+MAX_THRESHOLD_LCP_MS = 200
+MAX_POST_URL_CAP = 3
+
+REQUIRED_TRIGGER_PATHS = {
+    "_posts/**",
+    "_includes/**",
+    "_layouts/**",
+    "assets/**",
+    "scripts/dev/compare_lighthouse_runs.py",
+    "scripts/dev/resolve_lighthouse_urls.py",
+}
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers(wf: dict) -> dict:
+    """The ``on:`` mapping.
+
+    PyYAML resolves the bare key ``on`` to the boolean ``True`` (YAML 1.1
+    truthiness), so ``wf["on"]`` is not reliable -- look both up.
+    """
+    return wf.get("on") or wf.get(True) or {}
+
+
+def _steps(wf: dict) -> list[dict]:
+    return wf["jobs"]["lighthouse-perf-gate"]["steps"]
+
+
+def _step(wf: dict, name: str) -> dict:
+    for step in _steps(wf):
+        if step.get("name") == name:
+            return step
+    return {}
+
+
+def _measurement_steps(wf: dict) -> list[dict]:
+    """Steps that record Lighthouse reports.
+
+    Keyed on ``--output-path=`` rather than the bare ``lighthouse`` command so
+    the install step (``lighthouse --version``) is not swept in.
+    """
+    return [s for s in _steps(wf) if "--output-path=" in s.get("run", "")]
+
+
+class TestPerfGateConfig:
+    def test_workflow_exists(self):
+        assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
+
+    def test_resolver_exists(self):
+        assert RESOLVER.is_file(), (
+            f"{RESOLVER} not found — the workflow's 'Resolve measurement URLs' "
+            "step would fail and the gate would measure nothing."
+        )
+
+    def test_trigger_paths_present(self):
+        paths = set((_triggers(_workflow()).get("pull_request") or {}).get("paths") or [])
+        missing = REQUIRED_TRIGGER_PATHS - paths
+        assert not missing, (
+            f"the pull_request 'paths' filter lost {sorted(missing)}. "
+            "Without '_posts/**' the gate never fires on this repo's PRs "
+            "(16 of the last 30 merged PRs were content-only); without the "
+            "script paths, a change to the gate's own logic is not self-tested. "
+            "If intentional, update this guard."
+        )
+
+    def test_threshold_not_loosened(self):
+        run = _step(_workflow(), "Compare LCP head vs base").get("run", "")
+        m = re.search(r"--threshold-lcp-ms\s+(\d+)", run)
+        assert m, "the --threshold-lcp-ms argument disappeared from the compare step."
+        assert int(m.group(1)) <= MAX_THRESHOLD_LCP_MS, (
+            f"the LCP regression threshold was raised to {m.group(1)} ms "
+            f"(ceiling: {MAX_THRESHOLD_LCP_MS} ms). Tightening is fine; raising "
+            "silently weakens the gate. If intentional, update this guard."
+        )
+
+    def test_compare_step_not_neutralized(self):
+        step = _step(_workflow(), "Compare LCP head vs base")
+        assert step, "the 'Compare LCP head vs base' step is gone — nothing gates."
+        assert step.get("continue-on-error") is not True, (
+            "the compare step is marked continue-on-error; a regression would no "
+            "longer block the PR. It is already fail-safe by design (an "
+            "incomparable base yields 'skip' and exit 0), so this flag only "
+            "disables real failures."
+        )
+        assert "|| true" not in step.get("run", ""), (
+            "the compare step is neutralised with '|| true'; a FAIL would be swallowed."
+        )
+
+    def test_urls_come_from_the_resolver(self):
+        step = _step(_workflow(), "Resolve measurement URLs")
+        run = step.get("run", "")
+        assert "resolve_lighthouse_urls.py" in run, (
+            "the 'Resolve measurement URLs' step no longer calls the resolver. "
+            "A fixed URL list makes the gate vacuous on _posts/** PRs: the "
+            "measured post is identical on both sides, so the delta is always "
+            "+0 ms."
+        )
+        assert "--output lh-urls.txt" in run, (
+            "the resolver no longer writes lh-urls.txt, which is what the "
+            "measurement steps read."
+        )
+
+    def test_existence_is_checked_against_both_builds(self):
+        run = _step(_workflow(), "Resolve measurement URLs").get("run", "")
+        for site in ("_site_head", "_site_base"):
+            assert f"--site-dir {site}" in run, (
+                f"the resolver is no longer given --site-dir {site}. Both are "
+                "required: a URL present in only one build gets served the "
+                "homepage by 'serve --single' at HTTP 200, so the comparison "
+                "would silently pit a post page against the homepage."
+            )
+
+    def test_post_url_cap_bounds_runtime(self):
+        wf = _workflow()
+        cap = wf.get("env", {}).get("MAX_POST_URLS")
+        assert cap is not None, (
+            "MAX_POST_URLS was removed. Without a cap, a corpus-wide PR (the "
+            "last one touched 100 posts) sweeps one URL per post at ~3 min each "
+            "and blows the 30-minute job timeout."
+        )
+        assert int(cap) <= MAX_POST_URL_CAP, (
+            f"MAX_POST_URLS was raised to {cap} (ceiling: {MAX_POST_URL_CAP}). "
+            "Each extra URL adds 12 Lighthouse runs (2 sides x [1 warm + 5 "
+            "measured]). If intentional, update this guard."
+        )
+        assert "--max-post-urls" in _step(wf, "Resolve measurement URLs").get("run", ""), (
+            "the cap is declared in env but no longer passed to the resolver — "
+            "a dead constant."
+        )
+
+    def test_local_measurement_requires_both_builds(self):
+        wf = _workflow()
+        for name in (
+            "Run Lighthouse on head (local build)",
+            "Run Lighthouse on base (local build)",
+        ):
+            step = _step(wf, name)
+            assert step, f"the '{name}' step is gone."
+            condition = str(step.get("if", ""))
+            for outcome in ("build-head", "build-base"):
+                assert f"steps.{outcome}.outcome == 'success'" in condition, (
+                    f"'{name}' no longer requires {outcome} to have succeeded "
+                    f"(if: {condition!r}). With only one build present the URL "
+                    "list is resolved without an existence check on the other "
+                    "side, re-opening the 'serve --single' homepage-substitution "
+                    "hazard."
+                )
+
+    def test_no_hardcoded_post_url_in_measurement_loops(self):
+        """The resolver must be the only source of measured post URLs."""
+        for step in _measurement_steps(_workflow()):
+            run = step.get("run", "")
+            assert "lh-urls.txt" in run, (
+                f"the '{step.get('name')}' step measures URLs without reading "
+                "lh-urls.txt, so it is not measuring what the PR changed."
+            )
+            hardcoded = re.findall(r"(?:localhost:4000|tech-blog)/posts/\S+", run)
+            assert not hardcoded, (
+                f"a post URL was hard-coded back into '{step.get('name')}': "
+                f"{hardcoded}. On a _posts/** PR that page is identical on both "
+                "sides, so the gate reports +0 ms and blocks nothing. The "
+                "fallback URL belongs in the DEFAULT_POST_URL env var, which the "
+                "resolver drops automatically once the post stops existing."
+            )
+
+    def test_default_post_url_is_a_single_source(self):
+        wf = _workflow()
+        default = wf.get("env", {}).get("DEFAULT_POST_URL")
+        assert default and default.startswith("/posts/"), (
+            "DEFAULT_POST_URL is missing or is not a site-root path. It is what "
+            "an assets/** or _includes/** PR measures alongside the homepage; "
+            "without it those PRs only ever measure '/'."
+        )
+        assert "--default-post-url" in _step(wf, "Resolve measurement URLs").get("run", ""), (
+            "DEFAULT_POST_URL is declared but no longer passed to the resolver."
+        )

--- a/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
@@ -229,6 +229,33 @@ class TestPerfGateConfig:
         fallback, and verify over HTTP which tree is actually being served.
         """
         wf = _workflow()
+        ports = {}
+        for side, name in (
+            ("head", "Run Lighthouse on head (local build)"),
+            ("base", "Run Lighthouse on base (local build)"),
+        ):
+            run = _step(wf, name).get("run", "")
+            m = re.search(rf"npx serve _site_{side} -l (\d+)", run)
+            assert m, f"'{name}' no longer starts a server for _site_{side}."
+            ports[side] = m.group(1)
+            measured = re.search(r'url="http://localhost:(\d+)\$\{path\}"', run)
+            assert measured, (
+                f"'{name}' no longer builds its measurement URL from a "
+                "localhost port, so what it measures cannot be checked."
+            )
+            assert measured.group(1) == m.group(1), (
+                f"'{name}' serves _site_{side} on :{m.group(1)} but measures "
+                f":{measured.group(1)}. Lighthouse would hit whatever else is "
+                "listening there — which is exactly how the base sweep came to "
+                "re-measure the head build."
+            )
+        assert ports["head"] != ports["base"], (
+            f"head and base are both served on :{ports['head']}. Sharing a port "
+            "is the exact defect this gate shipped with: serve binds a random "
+            "free port when the requested one is still held, Lighthouse keeps "
+            "requesting the original, and the second side re-measures the first. "
+            "Run 31244446805 showed a teardown-and-wait does not close it."
+        )
         for name in (
             "Run Lighthouse on head (local build)",
             "Run Lighthouse on base (local build)",
@@ -236,8 +263,8 @@ class TestPerfGateConfig:
             run = _step(wf, name).get("run", "")
             assert "--no-port-switching" in run, (
                 f"'{name}' starts the server without --no-port-switching. On a "
-                "busy :4000 serve picks a random port instead of failing, and "
-                "Lighthouse then measures whatever is still listening on :4000."
+                "busy port serve picks a random one instead of failing, and "
+                "Lighthouse then measures whatever is still listening."
             )
             assert "build-id.txt" in run, (
                 f"'{name}' no longer probes build-id.txt before measuring, so "

--- a/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
@@ -214,6 +214,48 @@ class TestPerfGateConfig:
                 "resolver drops automatically once the post stops existing."
             )
 
+    def test_server_cannot_drift_to_another_port(self):
+        """The bug that made this gate vacuous for months.
+
+        Head and base are served on :4000 in turn. ``npx serve`` answers a busy
+        port by silently binding a RANDOM free one, while Lighthouse keeps
+        requesting :4000 — so the second side measures the first side's build.
+        Runs 31150717334 / 30882267998 / 30332794243 all logged ``Accepting
+        connections at http://localhost:<random>`` for the base server: from
+        PR #326 until 2026-08-08 this gate compared head against head, which is
+        why every post-page row came back at ±2 ms.
+
+        Two independent defences, because the failure is silent: refuse the
+        fallback, and verify over HTTP which tree is actually being served.
+        """
+        wf = _workflow()
+        for name in (
+            "Run Lighthouse on head (local build)",
+            "Run Lighthouse on base (local build)",
+        ):
+            run = _step(wf, name).get("run", "")
+            assert "--no-port-switching" in run, (
+                f"'{name}' starts the server without --no-port-switching. On a "
+                "busy :4000 serve picks a random port instead of failing, and "
+                "Lighthouse then measures whatever is still listening on :4000."
+            )
+            assert "build-id.txt" in run, (
+                f"'{name}' no longer probes build-id.txt before measuring, so "
+                "'the server on :4000 is serving the tree I think it is' is "
+                "assumed rather than verified."
+            )
+            assert "pkill -P" in run, (
+                f"'{name}' tears the server down by the npx wrapper PID alone; "
+                "the listening child survives and holds :4000 for the next side."
+            )
+
+        stamp = _step(wf, "Stamp build identity into each site").get("run", "")
+        for site, expected in (("_site_head", "head"), ("_site_base", "base")):
+            assert f"echo {expected} > {site}/build-id.txt" in stamp, (
+                f"{site} is no longer stamped with its build id, so the probe "
+                "above cannot tell the two builds apart."
+            )
+
     def test_default_post_url_is_a_single_source(self):
         wf = _workflow()
         default = wf.get("env", {}).get("DEFAULT_POST_URL")

--- a/scripts/tests/test_compare_lighthouse_runs.py
+++ b/scripts/tests/test_compare_lighthouse_runs.py
@@ -94,6 +94,23 @@ def test_url_normalisation_across_localhost_and_loopback(tmp_path):
     assert rows[0]["delta_lcp"] == pytest.approx(50.0)
 
 
+
+def test_urls_pair_across_different_localhost_ports(tmp_path):
+    """Head and base are served on separate ports on purpose.
+
+    Sharing :4000 let the base server fall back to a random port while
+    Lighthouse kept requesting :4000, so the base sweep re-measured the head
+    build — vacuous from PR #326 until 2026-08-08. If the port were not
+    normalised away, the split-port fix would instead produce zero comparable
+    rows and a permanently green "skip".
+    """
+    base, head = tmp_path / "base", tmp_path / "head"
+    _write_lhr(base, "http://localhost:4001/posts/a/", lcp_ms=1800)
+    _write_lhr(head, "http://localhost:4000/posts/a/", lcp_ms=2100)
+    rows, code = clr.compare(base, head, threshold_ms=200.0)
+    assert [r["url"] for r in rows] == ["/posts/a/"], rows
+    assert code == 1, "a +300 ms regression across split ports was not caught"
+
 def test_no_comparable_urls(tmp_path):
     base = tmp_path / "base"
     head = tmp_path / "head"

--- a/scripts/tests/test_resolve_lighthouse_urls.py
+++ b/scripts/tests/test_resolve_lighthouse_urls.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for scripts/dev/resolve_lighthouse_urls.py.
+
+The property that matters most here is the both-sides intersection. The perf
+gate serves each build with ``serve --single``, which answers an unknown path
+with the homepage at HTTP 200 and no redirect, so a URL that exists on head but
+not on base would be compared against the homepage and produce a meaningless
+delta. Several tests below pin that behaviour specifically.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dev"))
+
+from resolve_lighthouse_urls import post_slug, resolve, urls_for_slug  # noqa: E402
+
+POST_HTML = "<!doctype html><html><head><title>x</title></head><body>post</body></html>"
+REDIRECT_HTML = (
+    '<!doctype html><html><head><meta http-equiv="refresh" '
+    'content="0; url=/posts/2026/05/21/Foo/"></head></html>'
+)
+
+
+def _make_post(site_dir: Path, url_path: str, html: str = POST_HTML) -> None:
+    target = site_dir / url_path.strip("/") / "index.html"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(html, encoding="utf-8")
+
+
+class TestPostSlug:
+    def test_strips_date_prefix_and_extension(self):
+        assert post_slug("_posts/2026-04-29-Tech_Security_Weekly.md") == "Tech_Security_Weekly"
+
+    def test_accepts_markdown_extension(self):
+        assert post_slug("_posts/2026-01-02-Foo.markdown") == "Foo"
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "assets/images/2026-04-29-Foo.svg",
+            "_drafts/2026-04-29-Foo.md",
+            "_posts/no-date-here.md",
+            "_posts/2026-04-29-Foo.txt",
+            "_posts/2026-04-29-.md",
+            "scripts/dev/x.py",
+            "",
+        ],
+    )
+    def test_rejects_non_post_paths(self, path):
+        assert post_slug(path) is None
+
+
+class TestUrlsForSlug:
+    def test_finds_built_post(self, tmp_path):
+        _make_post(tmp_path, "/posts/2026/04/29/Foo/")
+        assert urls_for_slug("Foo", tmp_path) == {"/posts/2026/04/29/Foo/"}
+
+    def test_ignores_redirect_stubs(self, tmp_path):
+        """A KST-midnight post ships a redirect_from stub at the filename date.
+
+        Both directories match the glob. The stub is the *later* date (UTC
+        pushes the canonical page back a day), so the newest-first tie-break
+        would pick it — only the meta-refresh sniff prevents the gate from
+        measuring a 769-byte redirect page instead of the post. That pairing is
+        real: 12 slugs in the current build have both a canonical page and a
+        3-level redirect stub.
+        """
+        _make_post(tmp_path, "/posts/2026/05/20/Foo/")
+        _make_post(tmp_path, "/posts/2026/05/21/Foo/", REDIRECT_HTML)
+        assert urls_for_slug("Foo", tmp_path) == {"/posts/2026/05/20/Foo/"}
+        assert resolve(["_posts/2026-05-21-Foo.md"], [tmp_path]) == [
+            "/",
+            "/posts/2026/05/20/Foo/",
+        ]
+
+    def test_unknown_slug_yields_nothing(self, tmp_path):
+        _make_post(tmp_path, "/posts/2026/04/29/Foo/")
+        assert urls_for_slug("Bar", tmp_path) == set()
+
+    def test_url_date_may_differ_from_filename_date(self, tmp_path):
+        """timezone: UTC shifts KST 00:00-08:59 posts back a day.
+
+        The resolver must read the date off the build, never recompute it from
+        the filename.
+        """
+        _make_post(tmp_path, "/posts/2026/05/20/Foo/")
+        resolved = resolve(["_posts/2026-05-21-Foo.md"], [tmp_path])
+        assert resolved == ["/", "/posts/2026/05/20/Foo/"]
+
+
+class TestResolve:
+    def test_homepage_always_first(self, tmp_path):
+        assert resolve([], [tmp_path])[0] == "/"
+
+    def test_measures_the_edited_post(self, tmp_path):
+        head, base = tmp_path / "head", tmp_path / "base"
+        for site in (head, base):
+            _make_post(site, "/posts/2026/04/29/Edited/")
+            _make_post(site, "/posts/2026/03/01/Untouched/")
+        assert resolve(["_posts/2026-04-29-Edited.md"], [head, base]) == [
+            "/",
+            "/posts/2026/04/29/Edited/",
+        ]
+
+    def test_new_post_absent_from_base_is_dropped(self, tmp_path):
+        """The --single hazard: measuring it would compare post vs homepage."""
+        head, base = tmp_path / "head", tmp_path / "base"
+        _make_post(head, "/posts/2026/08/08/BrandNew/")
+        base.mkdir(parents=True, exist_ok=True)
+        assert resolve(["_posts/2026-08-08-BrandNew.md"], [head, base]) == ["/"]
+
+    def test_deleted_post_absent_from_head_is_dropped(self, tmp_path):
+        head, base = tmp_path / "head", tmp_path / "base"
+        head.mkdir(parents=True, exist_ok=True)
+        _make_post(base, "/posts/2026/04/29/Removed/")
+        assert resolve(["_posts/2026-04-29-Removed.md"], [head, base]) == ["/"]
+
+    def test_cap_bounds_run_time(self, tmp_path):
+        """A 40-post corpus PR must not turn into 41 Lighthouse URL sweeps."""
+        head, base = tmp_path / "head", tmp_path / "base"
+        changed = []
+        for day in range(1, 15):
+            url = f"/posts/2026/04/{day:02d}/Post{day:02d}/"
+            _make_post(head, url)
+            _make_post(base, url)
+            changed.append(f"_posts/2026-04-{day:02d}-Post{day:02d}.md")
+        resolved = resolve(changed, [head, base], max_post_urls=1)
+        assert len(resolved) == 2, resolved
+        # Newest first, so a corpus PR measures the most recent page it touched.
+        assert resolved[1] == "/posts/2026/04/14/Post14/"
+
+    def test_cap_is_configurable(self, tmp_path):
+        head, base = tmp_path / "head", tmp_path / "base"
+        for url in ("/posts/2026/04/01/A/", "/posts/2026/04/02/B/"):
+            _make_post(head, url)
+            _make_post(base, url)
+        resolved = resolve(
+            ["_posts/2026-04-01-A.md", "_posts/2026-04-02-B.md"],
+            [head, base],
+            max_post_urls=2,
+        )
+        assert resolved == ["/", "/posts/2026/04/02/B/", "/posts/2026/04/01/A/"]
+
+    def test_selection_is_deterministic(self, tmp_path):
+        """Same inputs in a different order must pick the same URL.
+
+        Otherwise a re-run of the same PR measures a different page and the
+        comparison against the previous run's comment is meaningless.
+        """
+        head, base = tmp_path / "head", tmp_path / "base"
+        for url in ("/posts/2026/04/01/A/", "/posts/2026/04/02/B/"):
+            _make_post(head, url)
+            _make_post(base, url)
+        forward = resolve(["_posts/2026-04-01-A.md", "_posts/2026-04-02-B.md"], [head, base])
+        reverse = resolve(["_posts/2026-04-02-B.md", "_posts/2026-04-01-A.md"], [head, base])
+        assert forward == reverse
+
+    def test_falls_back_to_default_when_no_post_touched(self, tmp_path):
+        """An assets/** or _includes/** PR keeps the representative post."""
+        head, base = tmp_path / "head", tmp_path / "base"
+        for site in (head, base):
+            _make_post(site, "/posts/2026/04/29/Representative/")
+        assert resolve(
+            ["_includes/head.html"],
+            [head, base],
+            default_post_url="/posts/2026/04/29/Representative/",
+        ) == ["/", "/posts/2026/04/29/Representative/"]
+
+    def test_default_dropped_when_it_stops_existing(self, tmp_path):
+        """The hard-coded post can be renamed or unpublished at any time.
+
+        Measuring it then would compare homepage-served-as-post on both sides:
+        a permanently green, permanently vacuous row.
+        """
+        head, base = tmp_path / "head", tmp_path / "base"
+        head.mkdir(parents=True, exist_ok=True)
+        base.mkdir(parents=True, exist_ok=True)
+        assert resolve(
+            ["_includes/head.html"],
+            [head, base],
+            default_post_url="/posts/2026/04/29/Gone/",
+        ) == ["/"]
+
+    def test_no_site_dirs_uses_default_only(self, tmp_path):
+        """GH Pages fallback: nothing local to inspect, so do not guess."""
+        assert resolve(
+            ["_posts/2026-04-29-Edited.md"],
+            [],
+            default_post_url="/posts/2026/04/29/Representative/",
+        ) == ["/", "/posts/2026/04/29/Representative/"]
+
+    def test_non_post_changes_do_not_leak_urls(self, tmp_path):
+        head, base = tmp_path / "head", tmp_path / "base"
+        for site in (head, base):
+            _make_post(site, "/posts/2026/04/29/Foo/")
+        assert resolve(["assets/js/main.js", "README.md"], [head, base]) == ["/"]


### PR DESCRIPTION
## 왜

퍼프 게이트가 사실상 휴면 상태였다. **최근 병합 PR 30건 중 기존 트리거 경로를 건드린 건 0건**, `_posts/**` 를 건드린 건 16건이다.

두 수정(트리거 추가 / URL 동적화)은 **분리할 수 없다**:

- `_posts/**` 만 추가하면 고정 URL(`/posts/2026/04/29/...`)을 재는데, 그 포스트는 콘텐츠 PR 양쪽에서 바이트 동일이라 항상 `+0 ms` — 초록이지만 무의미하다.
- URL 동적화만 하면 트리거가 없어 콘텐츠 PR에서 아예 돌지 않는다.

## 무엇

`scripts/dev/resolve_lighthouse_urls.py` 가 PR 파일 목록(`gh api .../pulls/N/files`, 3-dot 시맨틱)에서 측정 URL을 뽑는다.

| PR이 건드린 것 | 측정 대상 |
|---|---|
| 양쪽 빌드에 존재하는 포스트 | `/` + 그 포스트 |
| 여러 포스트 | `/` + 가장 최신 날짜 1건 (`MAX_POST_URLS=1`) |
| 신규 포스트 (base에 없음) | `/` 만 |
| 포스트 아님 (`assets/**` 등) | `/` + `DEFAULT_POST_URL` |
| `DEFAULT_POST_URL` 이 사라진 경우 | `/` 만 |

### 핵심 함정 2가지 (둘 다 실측 확인)

**1. `serve --single` 홈페이지 대체.** 존재하지 않는 경로에 리다이렉트 없이 `index.html`(홈)을 200으로 돌려준다. head에만 있는 URL을 재면 Lighthouse는 요청 URL을 기록하면서 실제로는 홈을 측정 → "포스트 vs 홈" 비교가 되어 부호까지 그럴듯한 무의미한 델타가 나온다. 그래서 포스트 URL은 `_site_head`/`_site_base` **양쪽에 존재할 때만** 측정하고, 로컬 측정 스텝은 두 빌드가 모두 성공해야 실행된다.

**2. `redirect_from` 스텁.** URL 날짜를 계산하지 않고 빌드 결과에서 읽는다 (`timezone: UTC` 라 KST 00-09시 포스트는 파일명 날짜 ≠ URL 날짜). 그런데 리다이렉트 스텁이 같은 glob(`posts/*/*/*/<slug>/index.html`)에 걸린다 — **현재 빌드에 정본 + 3단계 스텁을 모두 가진 슬러그가 12개** 있고 스텁은 ~770B 메타 리프레시 페이지다. `http-equiv="refresh"` 스니핑으로 제외.

## 런타임 영향 (실측)

**회당: 변화 없음.** `MAX_POST_URLS=1` 이라 여전히 2 URL — 기존 하드코딩 쌍과 같은 개수.

- 최근 `lighthouse-ci.yml` 실행 20건: **7.2–8.0분** (중앙값 ~7.8분). 문서에 있던 "14–20분" 추정치는 실제로 관측된 적 없어 실측값으로 교체.
- 앞으로는 추정하지 않도록, 스텝 요약에 회당 wall clock + 측정 URL 목록을 남긴다.

**빈도: 여기가 실제 변화.**

| | before | after |
|---|---|---|
| 최근 병합 PR 30건 중 게이트 실행 | 0 / 30 | 16 / 30 |
| 해당 30 PR 누적 CI 분 | ~0 | ~125 |

무료 티어 2,000분/월 기준 현재 PR 속도로 약 6%. 개별 PR에서 불필요하면 `perf-regression-allowed` 라벨로 잡 전체를 건너뛸 수 있다.

## 검증

- `pytest scripts/tests/` — **3944 passed, 5 skipped**
- `test_resolve_lighthouse_urls.py` 25건 (both-sides 교집합, 신규/삭제 포스트, 캡, 결정성, redirect 스텁, UTC 날짜 드리프트)
- `test_ci_lighthouse_perf_gate_guard.py` 11건 — 워크플로 사본을 변조한 **8가지 회귀 각각에 대해 실패함을 확인**: 트리거 삭제 / 임계 완화 / compare 무력화 / `--site-dir` 제거 / 캡 상향 / both-builds 조건 제거 / URL 재하드코딩 / resolver 호출 삭제
- 실제 `_site` 빌드 대상 resolver 수동 실행 — 정본 페이지 선택, 769B 스텁 회피 확인

**미검증**: 워크플로 자체는 이 PR이 머지되어 실제 PR에서 돌기 전까지 CI에서 실행된 적 없다 (이 PR은 `.github/workflows/lighthouse-ci.yml` 을 건드리므로 자기 자신에게서 1회 실행된다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)