### PR TITLE
feat(gate): template-echo 카드 요약 재발 방지 게이트 (pre-commit + CI + blogwatcher)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -241,3 +241,22 @@ if [ -n "$STAGED_ANY_POSTS" ]; then
   fi
   echo "[pre-commit] Bare-URL check: passed."
 fi
+
+# 13. Template-echo card summary gate — a summary that repeats the headline and
+#     bolts on one of three fixed clauses describes no article. 490 were repaired
+#     in PRs #521/#525 and the corpus is at 0 across all 259 posts, so there is
+#     no ratchet: any hit is new drift. Runs on every staged post, not just
+#     digests — the markers only occur inside a news-item include, so a
+#     hand-written post cannot false-positive.
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for template-echo card summaries..."
+  python3 "$REPO_ROOT/scripts/check_template_echo.py" --staged --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Template-echo summary found — it describes no article."
+    echo "             Repair from the post's own prose (no network, no LLM):"
+    echo "               python3 scripts/rewrite_template_echo_summaries.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Template-echo check: passed."
+fi

--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -377,6 +377,33 @@ jobs:
           fi
           python3 scripts/check_digest_checklist_heading.py "$POST_FILE"
 
+      - name: Template-echo summary pre-flight (self-heal, then block)
+        if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'
+        run: |
+          # A template-echo summary repeats the headline and bolts on one of
+          # three fixed clauses; it describes no article. 490 accumulated
+          # unnoticed before PRs #521/#525 cleared them, because nothing failed
+          # when one landed. The pre-commit gate cannot see this post: the
+          # Actions commit below runs with no local hooks.
+          #
+          # Self-heal first — rewrite_template_echo_summaries lifts the first
+          # sentences of the prose paragraph the post already carries under each
+          # card. No network, no LLM, and each mode enforces its own runtime
+          # contract (REPLACE may change nothing but a summary= VALUE; DROP may
+          # only delete whole summary= lines from spotlight items), aborting
+          # rather than writing a violation.
+          #
+          # Then re-verify and BLOCK. Unlike the lone-adjective warn above this
+          # is not a judgement call: the clause is either there or it is not,
+          # and a survivor means the post has no prose to ground the summary in,
+          # which needs a human.
+          POST_FILE="${{ steps.check_post.outputs.post_file }}"
+          if ! python3 scripts/check_template_echo.py "$POST_FILE" --quiet; then
+            echo "::warning::Template-echo summary in ${POST_FILE} — attempting rewrite_template_echo_summaries self-heal."
+            python3 scripts/rewrite_template_echo_summaries.py "$POST_FILE" || true
+          fi
+          python3 scripts/check_template_echo.py "$POST_FILE" --quiet
+
       - name: Commit and publish
         if: steps.check_post.outputs.post_created == 'true' && env.DRY_RUN != 'true'
         env:

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -39,6 +39,8 @@ on:
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/linkify_bare_urls.py'
+      - 'scripts/check_template_echo.py'
+      - 'scripts/rewrite_template_echo_summaries.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -84,6 +86,8 @@ on:
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/linkify_bare_urls.py'
+      - 'scripts/check_template_echo.py'
+      - 'scripts/rewrite_template_echo_summaries.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
       - '_includes/head.html'
@@ -301,6 +305,16 @@ jobs:
         # after PR #509, so any hit is fresh. Guides, not cron digests, are the
         # recurrence path, so there is deliberately no blogwatcher step.
         run: python3 scripts/linkify_bare_urls.py --check --all
+
+      - name: Template-echo card summary gate
+        id: template_echo_gate
+        # --all: PRs #521/#525 took the corpus from 490 template-echo summaries
+        # to 0 across all 259 posts, so there is no legacy debt to scope around
+        # and any hit is fresh drift — including one arriving via a cron push
+        # that never ran the pre-commit hook. The clauses no longer exist
+        # anywhere in scripts/, which is precisely the state where a regression
+        # would otherwise be silent.
+        run: python3 scripts/check_template_echo.py --all --quiet
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,7 +523,7 @@ the 9 historical posts affected before the rule was introduced. The 7
 posts that still violated the rule were fixed in commit `b4ff35c4`
 (2026-05-28).
 
-### Active automation gates (9 enforcing)
+### Active automation gates (10 enforcing)
 
 | # | Script | Scope | Wired to |
 |---|--------|-------|----------|
@@ -536,6 +536,7 @@ posts that still violated the rule were fixed in commit `b4ff35c4`
 | 7 | `check_kst_midnight.py` | KST 00-09 post URL drift | pre-commit + svg-lint CI |
 | 8 | blogwatcher raster auto-emit | cron-side raster generation | `.github/workflows/ai-blogwatcher.yml` |
 | 9 | `check_digest_checklist_heading.py` | exactly one canonical `## 실무 체크리스트` H2 | pre-commit (9d) + svg-lint CI (`--all`) + blogwatcher publish (self-heal, then block) |
+| 10 | `check_template_echo.py` | card `summary=` that only echoes the headline + a fixed clause | pre-commit (13, `--staged`) + svg-lint CI (`--all`) + blogwatcher publish (self-heal via `rewrite_template_echo_summaries.py`, then block) |
 
 ### Code Blocks
 - **Always** include language tags: ```python, ```bash, ```yaml

--- a/scripts/check_template_echo.py
+++ b/scripts/check_template_echo.py
@@ -1,0 +1,194 @@
+"""Template-echo card summary guard.
+
+A "template echo" summary says nothing about the article it sits on: it repeats
+the headline and bolts on one of three fixed clauses.
+
+    "<제목>를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, …"
+    "<제목> 이슈를 중심으로 공격 벡터와 영향 범위를 점검하고, …"
+    "… 공격 경로·영향 자산·탐지 포인트를 정리하고, …"
+
+490 of them were replaced with body-grounded prose across PRs #521/#525
+(2026-08-07 … 08). The corpus is now at **0** — measured over all 259 posts, not
+just digests — so this gate has no ratchet and no baseline: any hit is new drift.
+
+Why a gate rather than trusting the fix
+---------------------------------------
+The clauses no longer appear anywhere in ``scripts/`` — the generator path that
+emitted them is gone. That is exactly the state in which a regression is
+invisible: nothing fails, the corpus just quietly re-acquires them, and it is
+found by hand weeks later (which is how the 490 accumulated). Three enforcement
+points, because the corpus has three separate write paths:
+
+* **pre-commit** (``--staged``) — human authoring and repair PRs.
+* **CI** (``--all``) — catches anything that reached a branch by another route,
+  including a cron push that bypassed local hooks.
+* **blogwatcher publish** (explicit path) — the cron's GitHub-Actions commit runs
+  with no local hooks at all, so pre-commit never sees the post it writes. There
+  the gate runs self-heal-then-block: ``rewrite_template_echo_summaries.py``
+  rewrites from the post's own prose (no network, no LLM, contract-enforced), and
+  only a defect that survives that blocks the publish.
+
+Detection is deliberately narrow: the three literal clauses, inside a
+``summary=`` attribute of a news-item include. Not a similarity heuristic — the
+markers are the measured defect class, and a fuzzy "summary resembles title"
+rule has no corpus evidence behind it and would fire on legitimately short
+summaries.
+
+Exit 1 if any checked post carries a template-echo summary.
+
+Usage:
+    python3 scripts/check_template_echo.py --all
+    python3 scripts/check_template_echo.py --staged
+    python3 scripts/check_template_echo.py --changed origin/main
+    python3 scripts/check_template_echo.py _posts/2026-08-08-*Weekly_Digest*.md
+"""
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO / "_posts"
+sys.path.insert(0, str(REPO))
+
+# Imported, never re-declared (contract C8): the gate and the repair tool must
+# agree on what a defect IS, and the card patterns must agree on what a card is.
+# A re-spelled ``\{%\s*include`` here would silently skip every ``{%- include``
+# card — the miss that made PRs #512/#513 under-fixes.
+from scripts.news_card_patterns import CARD_RE, SUMMARY_RE  # noqa: E402
+from scripts.rewrite_template_echo_summaries import (  # noqa: E402
+    TEMPLATE_MARKERS,
+    _is_template_echo,
+)
+
+_POST_PATH_RE_PREFIX = "_posts/"
+
+
+def _line_of(text: str, pos: int) -> int:
+    return text.count("\n", 0, pos) + 1
+
+
+def check_text(text: str) -> list:
+    """Return ``(line, marker, excerpt)`` for every template-echo summary."""
+    found = []
+    for card in CARD_RE.finditer(text):
+        match = SUMMARY_RE.search(card.group(0))
+        if not match:
+            continue
+        value = match.group(2)
+        if not _is_template_echo(value):
+            continue
+        marker = next(m for m in TEMPLATE_MARKERS if m in value)
+        line = _line_of(text, card.start() + match.start(2))
+        excerpt = value if len(value) <= 90 else value[:87] + "…"
+        found.append((line, marker, excerpt))
+    return found
+
+
+def check_post(path) -> list:
+    return check_text(Path(path).read_text(encoding="utf-8"))
+
+
+def _all_paths() -> list:
+    return sorted(POSTS_DIR.glob("*.md"))
+
+
+def _git_paths(cmd: list) -> list:
+    try:
+        out = subprocess.check_output(
+            cmd, cwd=str(REPO), stderr=subprocess.DEVNULL, text=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    paths = []
+    for line in out.splitlines():
+        rel = line.strip()
+        if not rel.startswith(_POST_PATH_RE_PREFIX) or not rel.endswith(".md"):
+            continue
+        if "/" in rel[len(_POST_PATH_RE_PREFIX):]:
+            continue
+        full = REPO / rel
+        if full.exists():
+            paths.append(full)
+    return sorted(paths)
+
+
+def _explicit(args_paths: list) -> list:
+    paths = []
+    for arg in args_paths:
+        p = Path(arg)
+        if not p.is_absolute():
+            cwd_p = Path.cwd() / p
+            p = cwd_p if cwd_p.exists() else REPO / arg
+        if p.exists():
+            paths.append(p)
+    return paths
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag posts whose news-card summary= only echoes the headline plus "
+            "one of three fixed template clauses."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--staged", action="store_true")
+    mode.add_argument("--all", action="store_true")
+    mode.add_argument("--changed", metavar="BASE", default=None)
+    parser.add_argument("paths", nargs="*")
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="print only failures and the final summary line",
+    )
+    args = parser.parse_args(argv)
+
+    if args.staged:
+        files = _git_paths(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"]
+        )
+    elif args.changed:
+        files = _git_paths(
+            ["git", "diff", "--name-only", f"{args.changed}...HEAD", "--diff-filter=ACM"]
+        )
+    elif args.paths:
+        files = _explicit(args.paths)
+    else:
+        files = _all_paths()
+
+    if not files:
+        print("[template-echo] No post files to check.")
+        return 0
+
+    rc = 0
+    defects = 0
+    for path in files:
+        rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+        hits = check_post(path)
+        if hits:
+            rc = 1
+            defects += len(hits)
+            print(f"FAIL {rel}")
+            for line, marker, excerpt in hits:
+                print(f"  {rel}:{line}: template clause {marker!r}")
+                print(f"    summary=\"{excerpt}\"")
+        elif not args.quiet:
+            print(f"OK   {rel}")
+
+    if rc:
+        print(
+            f"\n[template-echo] FAIL — {defects} template-echo summary(ies). "
+            "These describe no article. Repair them from the post's own prose:\n"
+            "    python3 scripts/rewrite_template_echo_summaries.py <post>\n"
+            "Spotlight items have no prose to lift, so they are handled by "
+            "`--mode drop` (the attribute is deleted rather than kept lying).",
+            file=sys.stderr,
+        )
+    else:
+        print(f"[template-echo] OK — {len(files)} post(s), 0 template-echo summaries.")
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -281,6 +281,25 @@ if [ -n "$STAGED_ANY_POSTS" ]; then
   fi
   echo "[pre-commit] Bare-URL check: passed."
 fi
+
+# 13. Template-echo card summary gate — a summary that repeats the headline and
+#     bolts on one of three fixed clauses describes no article. 490 were repaired
+#     in PRs #521/#525 and the corpus is at 0 across all 259 posts, so there is
+#     no ratchet: any hit is new drift. Runs on every staged post, not just
+#     digests — the markers only occur inside a news-item include, so a
+#     hand-written post cannot false-positive.
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for template-echo card summaries..."
+  python3 "$REPO_ROOT/scripts/check_template_echo.py" --staged --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Template-echo summary found — it describes no article."
+    echo "             Repair from the post's own prose (no network, no LLM):"
+    echo "               python3 scripts/rewrite_template_echo_summaries.py <post>"
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Template-echo check: passed."
+fi
 HOOK
 
 chmod +x "$HOOK_FILE"

--- a/scripts/tests/test_check_template_echo.py
+++ b/scripts/tests/test_check_template_echo.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_template_echo.py and its three wiring points.
+
+Two halves:
+
+* **Detector** — the gate must catch every shape the corpus actually produced
+  (both include kinds, both whitespace-control forms) and must not fire on prose
+  that merely discusses attack vectors.
+* **Wiring guard** — a detector nobody runs is not a gate. The three enforcement
+  points exist because the corpus has three write paths, and the cron path in
+  particular runs with no local hooks; dropping any one of them silently
+  restores the condition in which 490 defects accumulated unnoticed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.check_template_echo import check_text, main  # noqa: E402
+from scripts.rewrite_template_echo_summaries import TEMPLATE_MARKERS  # noqa: E402
+
+HOOK_SRC = REPO_ROOT / "scripts" / "install-hooks.sh"
+HOOK_FILE = REPO_ROOT / ".githooks" / "pre-commit"
+SVG_LINT = REPO_ROOT / ".github" / "workflows" / "svg-lint.yml"
+BLOGWATCHER = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+
+FRONT_MATTER = '---\nlayout: post\ntitle: "t"\n---\n\n'
+
+
+def _card(summary: str, kind: str = "news-card", dash: str = "-") -> str:
+    return (
+        f"{{%{dash} include {kind}.html\n"
+        '  title="Acme breach"\n'
+        '  url="https://example.org/a"\n'
+        f'  summary="{summary}"\n'
+        '  source="Acme"\n'
+        '  severity="high"\n'
+        f"{dash}%}}\n"
+    )
+
+
+ECHO = "Acme breach를 기준으로 기술적으로는 공격 벡터·영향 범위·탐지 지표를 요약하고, 대응 우선순위를 정리합니다."
+REAL = "Acme는 고객 인증 토큰 12만 건이 유출됐다고 8월 6일 공시했다. 토큰 회전이 진행 중이다."
+
+
+class TestDetector:
+    def test_clean_summary_passes(self):
+        assert check_text(FRONT_MATTER + _card(REAL)) == []
+
+    @pytest.mark.parametrize("marker", TEMPLATE_MARKERS)
+    def test_every_marker_is_caught(self, marker):
+        hits = check_text(FRONT_MATTER + _card(f"Acme breach {marker}, 대응합니다."))
+        assert len(hits) == 1
+        assert hits[0][1] == marker
+
+    @pytest.mark.parametrize("dash", ["", "-"])
+    def test_both_whitespace_control_forms(self, dash):
+        """``\\s`` does not match ``-``.
+
+        A gate spelled ``\\{%\\s*include`` skips every ``{%- include`` card —
+        282 of 2117 on 2026-08-07 — and reports a clean corpus. That miss is why
+        the patterns are imported from news_card_patterns rather than re-spelled
+        here (contract C8/C11).
+        """
+        assert len(check_text(FRONT_MATTER + _card(ECHO, dash=dash))) == 1
+
+    def test_spotlight_items_are_covered(self):
+        """45 of the 490 defects lived in news-spotlight-item, not news-card."""
+        text = FRONT_MATTER + _card(ECHO, kind="news-spotlight-item")
+        assert len(check_text(text)) == 1
+
+    def test_reports_the_line_of_the_summary(self):
+        text = FRONT_MATTER + "\n\n\n" + _card(ECHO)
+        line = check_text(text)[0][0]
+        assert text.split("\n")[line - 1].strip().startswith('summary="')
+
+    def test_prose_outside_a_card_is_not_flagged(self):
+        """The gate is about a card attribute, not about the words.
+
+        A post may legitimately write these phrases in its body — that is
+        analysis, not a summary that claims to describe an article.
+        """
+        body = FRONT_MATTER + f"이 절에서는 {TEMPLATE_MARKERS[0]}, 배포 순서를 다룬다.\n"
+        assert check_text(body) == []
+
+    def test_multiple_defects_counted_separately(self):
+        text = FRONT_MATTER + _card(ECHO) + "\n" + _card(ECHO, dash="")
+        assert len(check_text(text)) == 2
+
+    def test_card_without_summary_attribute(self):
+        text = FRONT_MATTER + (
+            "{%- include news-card.html\n"
+            '  title="Acme breach"\n'
+            '  url="https://example.org/a"\n'
+            "-%}\n"
+        )
+        assert check_text(text) == []
+
+
+class TestCli:
+    def test_exit_code_and_output(self, tmp_path, capsys):
+        bad = tmp_path / "2026-08-08-Bad_Weekly_Digest.md"
+        bad.write_text(FRONT_MATTER + _card(ECHO), encoding="utf-8")
+        assert main([str(bad)]) == 1
+        out = capsys.readouterr()
+        assert "FAIL" in out.out
+        assert "rewrite_template_echo_summaries.py" in out.err
+
+    def test_clean_file_exits_zero(self, tmp_path, capsys):
+        good = tmp_path / "2026-08-08-Good_Weekly_Digest.md"
+        good.write_text(FRONT_MATTER + _card(REAL), encoding="utf-8")
+        assert main([str(good)]) == 0
+
+    def test_corpus_is_at_zero(self):
+        """No ratchet, no baseline — the gate only works from a clean corpus.
+
+        If this ever fails, either a defect landed or the campaign regressed;
+        do not add a baseline to make it green.
+        """
+        result = subprocess.run(
+            [sys.executable, "scripts/check_template_echo.py", "--all", "--quiet"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            "the corpus re-acquired template-echo summaries:\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+
+
+class TestWiring:
+    """A detector nobody runs is not a gate."""
+
+    def test_precommit_source_and_generated_hook_agree(self):
+        """``.githooks/pre-commit`` is generated by ``install-hooks.sh``.
+
+        Editing only the generated file works until the next
+        ``bash scripts/install-hooks.sh`` silently reverts it.
+        """
+        for path in (HOOK_SRC, HOOK_FILE):
+            text = path.read_text(encoding="utf-8")
+            assert "check_template_echo.py" in text, (
+                f"{path.name} no longer runs the template-echo gate. Human "
+                "authoring and repair PRs are one of the three write paths into "
+                "the corpus."
+            )
+            assert "--staged" in text.split("check_template_echo.py")[1][:40], (
+                f"{path.name} runs the gate without --staged; a pre-commit hook "
+                "must scope to what is being committed."
+            )
+
+    def test_ci_runs_the_gate_over_the_whole_corpus(self):
+        text = SVG_LINT.read_text(encoding="utf-8")
+        assert "check_template_echo.py --all" in text, (
+            "svg-lint no longer runs the template-echo gate with --all. The "
+            "corpus is at 0 with no baseline, and --all is what catches a defect "
+            "that reached a branch without passing pre-commit (a cron push runs "
+            "with no local hooks)."
+        )
+        assert "'scripts/check_template_echo.py'" in text, (
+            "the workflow's paths filter does not include the gate script, so a "
+            "change to the gate itself would not run it."
+        )
+
+    def test_blogwatcher_self_heals_then_blocks(self):
+        text = BLOGWATCHER.read_text(encoding="utf-8")
+        assert "check_template_echo.py" in text, (
+            "the blogwatcher publish path no longer checks for template-echo "
+            "summaries. That path is why the gate exists: its GitHub-Actions "
+            "commit runs with no local hooks, so pre-commit never sees the post "
+            "the cron writes."
+        )
+        assert "rewrite_template_echo_summaries.py" in text, (
+            "the self-heal step is gone. The repair is deterministic (it lifts "
+            "prose the post already carries, no network and no LLM), so a "
+            "fixable defect should not block the weekly publish."
+        )
+        # The check must run AFTER the self-heal, or the heal proves nothing.
+        heal = text.index("rewrite_template_echo_summaries.py")
+        checks = [
+            i for i in range(len(text))
+            if text.startswith("check_template_echo.py", i)
+        ]
+        assert any(i > heal for i in checks), (
+            "every check_template_echo.py call precedes the self-heal, so a "
+            "defect that survives the rewrite would still publish."
+        )


### PR DESCRIPTION
## 왜 지금인가

PR #521/#525 가 template-echo 요약 **490건**을 본문 근거로 교체해 코퍼스는 **전체 259 포스트 기준 0**이다.

그런데 세 개의 고정 문구는 이제 `scripts/` 어디에도 없다 — 즉 **회귀가 완전히 무증상이 되는 상태**다. 아무것도 실패하지 않고, 코퍼스가 조용히 다시 오염되고, 몇 주 뒤 사람이 손으로 발견한다. 490건이 쌓인 경로가 정확히 이것이다.

## 배선이 셋인 이유

코퍼스 쓰기 경로가 셋이라서다.

| 경로 | 게이트 | 동작 |
|---|---|---|
| 사람이 쓰는 포스트 / 수리 PR | pre-commit step 13 | `--staged`, 차단 |
| 훅을 안 거친 브랜치 | svg-lint CI | `--all`, 차단 (베이스라인·래칫 없음 — 코퍼스가 0이므로) |
| 크론 발행 | blogwatcher publish | **self-heal 후 차단** |

크론 경로가 핵심이다. blogwatcher 의 Actions 커밋은 **로컬 훅이 아예 없어서** pre-commit 이 그 포스트를 절대 보지 못한다. 거기서는 `rewrite_template_echo_summaries.py` 로 먼저 자가치유한다 — 네트워크·LLM 없이 포스트가 이미 들고 있는 카드 아래 산문에서 문장을 끌어오고, 모드별 런타임 계약(REPLACE 는 card `summary=` **값**만, DROP 은 spotlight 의 `summary=` **줄 전체**만)을 위반하면 abort 한다. 그 뒤 재검증해서 살아남은 결함만 발행을 막는다. `check_digest_checklist_heading` 와 같은 패턴.

## 탐지 범위 (의도적으로 좁음)

세 개의 **리터럴 문구**가 뉴스 include 의 `summary=` 안에 있을 때만.

- "제목과 비슷하다" 류 유사도 휴리스틱은 코퍼스 근거가 없고 정상적으로 짧은 요약을 오탐한다.
- 본문 산문이 같은 문구를 쓰는 건 분석이지 결함이 아니므로 플래그하지 않는다 (테스트로 고정).
- 패턴은 `news_card_patterns` 에서 **import** (계약 C8). `\s` 는 `-` 를 매치하지 않아 재선언하면 `{%- include` 카드 **282/2117** 을 통째로 놓치고 "코퍼스 깨끗함"을 보고한다 — #512/#513 이 과소수정이 된 원인.

## 검증

- `--all` 전 코퍼스: **259 포스트 / 0건**
- **실제 커밋 차단 확인**: 실제 08-08 digest 의 `summary=` 에 문구를 주입 → `git add` → `git commit` → step 13 에서 차단, `HEAD` 불변, 작업 트리 복원 확인
- **자가치유 e2e**: 결함 주입 → `rewrite_template_echo_summaries.py` → 재검증 0건, 요약이 실제 본문 문장으로 교체됨
- **배선 가드 비어있지 않음**: 8가지 변조 각각에서 실패 확인 — 훅 소스/생성본 각각에서 게이트 제거, `--staged` 상실, CI `--all` → `--changed` 완화, CI `paths` 필터 누락, blogwatcher 검사 제거, 자가치유 제거, 검사가 치유보다 **앞서도록** 순서 뒤집기
- `pytest scripts/tests/` — **3926 passed, 5 skipped** (main 기준 3909 → +17, 정확히 새 테스트 수)
- `.githooks/pre-commit` 는 `scripts/install-hooks.sh` 재생성으로 갱신 (생성본만 편집하면 다음 `install-hooks.sh` 실행에 조용히 되돌아감). 재생성 diff 는 이번 추가분 19줄뿐 — 기존 드리프트 없음.

**미검증**: CI 스텝과 blogwatcher 스텝은 각 워크플로가 실제로 돌기 전까지 실행된 적 없다 (이 PR 이 svg-lint 를 트리거하므로 CI 스텝은 여기서 1회 실행된다).

🤖 Generated with [Claude Code](https://claude.com/claude-code)