### PR TITLE
ci: 크론 봇 push를 못 보던 게이트 2개 트리거 수정 + 회귀 가드

### DIFF
--- a/.github/workflows/check-svg.yml
+++ b/.github/workflows/check-svg.yml
@@ -14,12 +14,19 @@ name: SVG Quality Check
 # Two-part fix: (1) the daily `schedule:` scans main regardless of paths, so a
 # corpus regression surfaces within 24h; (2) `paths` lists every script the steps
 # invoke plus this workflow file, so editing the gate runs the gate.
+#
+# 2026-08-10 follow-up: the SVG glob was `assets/images/*.svg`, which in Actions
+# path filters does not cross `/`. verify_images_unified.py:267 scans with
+# `IMAGES_DIR.rglob("*.svg")` — measured 307 SVGs at depth 1 and 156 at depth >= 2
+# (diagrams/, mermaid/, _unused_archive/). Those 156 were inside the scan and
+# outside the trigger: the same trigger-narrower-than-scan shape described above,
+# one directory level down. Widened to `**.svg`, matching svg-lint.yml's glob.
 on:
   push:
     branches:
       - main
     paths:
-      - 'assets/images/*.svg'
+      - 'assets/images/**.svg'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
       - 'scripts/check_svg_quality.py'
@@ -29,7 +36,7 @@ on:
     branches:
       - main
     paths:
-      - 'assets/images/*.svg'
+      - 'assets/images/**.svg'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
       - 'scripts/check_svg_quality.py'

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -1,5 +1,24 @@
 name: SVG Compliance Lint
 
+# This workflow carries 15 corpus-wide gates (`--all`): cover drift for four
+# generator families, the honesty scorer, title-ASCII, spec-slug consistency,
+# KST-midnight URLs, checklist headings, bare URLs, template-echo. They scan the
+# WHOLE corpus, so the same trigger-narrower-than-scan hazard that hid a
+# three-week regression in check-svg.yml applies here — see that file's header.
+#
+# Until 2026-08-10 this workflow had `push` + `pull_request` and no `schedule`,
+# i.e. exactly the pre-#489 shape. That mattered more than it looks: the blogwatcher
+# cron publishes digests and covers by pushing DIRECTLY to main with GITHUB_TOKEN,
+# and such a push triggers no workflow at all (GitHub's recursion prevention — the
+# same mechanism documented in deploy-pages.yml). Measured: 35 of the last 40
+# commits touching assets/images/*.svg are github-actions[bot] direct pushes, and
+# the bot cover commit 685ca468 carried 12 workflow runs, every one of them
+# `schedule` and not a single `push` or `pull_request` event.
+#
+# So the dominant producer of the artifacts these 15 gates exist to check was
+# invisible to both triggers. The daily `schedule` below closes that: it scans main
+# regardless of paths, exactly as check-svg.yml does. All 15 gates were verified
+# green against the current corpus before this was added, so it is not born red.
 on:
   push:
     paths:
@@ -95,6 +114,17 @@ on:
       - 'vercel.json'
       - 'assets/js/mermaid-init.js'
       - 'scripts/tests/check_mermaid_csp_render.mjs'
+  schedule:
+    # 03:45 UTC = 12:45 KST. Deliberately after check-svg.yml's 03:15 slot so the
+    # two corpus sweeps do not contend, and well after the blogwatcher digest
+    # (00:00) has published the covers this sweep is meant to inspect.
+    # On a schedule run the four diff-scoped steps (size-gate, digest-structure,
+    # untranslated, proper-nouns) fall back to BASE=HEAD~1 — the branch already
+    # present in each step — so they check the most recent commit, typically the
+    # bot's. The 15 `--all` gates are the point of this trigger and are unaffected
+    # by the diff base.
+    - cron: '45 3 * * *'
+  workflow_dispatch: {}
 
 concurrency:
   group: svg-lint-${{ github.ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,12 +531,23 @@ posts that still violated the rule were fixed in commit `b4ff35c4`
 | 2 | `check_spec_slug_consistency.py` | spec slug ↔ post `image:` field | pre-commit + svg-lint CI |
 | 3 | `check_svg_size_gate.py` | SVG size band (std/hq/rollup) | pre-commit (warn) + svg-lint CI |
 | 4 | `validate-svg.sh` | SVG XML well-formed + no Hangul | PreToolUse hook (per-edit) |
-| 5 | `tests/visual-baselines/` | PNG visual regression baselines | visual-regression CI (PR only) |
+| 5 | `reports/l20-visual-regression/run.py` | phash sweep over a **hardcoded** Jan–Mar 2026 date set | visual-regression CI (PR only) |
 | 6 | `check_svg_precommit.sh` | NUL-delimited path-safety wrapper | pre-commit |
 | 7 | `check_kst_midnight.py` | KST 00-09 post URL drift | pre-commit + svg-lint CI |
 | 8 | blogwatcher raster auto-emit | cron-side raster generation | `.github/workflows/ai-blogwatcher.yml` |
 | 9 | `check_digest_checklist_heading.py` | exactly one canonical `## 실무 체크리스트` H2 | pre-commit (9d) + svg-lint CI (`--all`) + blogwatcher publish (self-heal, then block) |
 | 10 | `check_template_echo.py` | card `summary=` that only echoes the headline + a fixed clause | pre-commit (13, `--staged`) + svg-lint CI (`--all`) + blogwatcher publish (self-heal via `rewrite_template_echo_summaries.py`, then block) |
+
+#### Two different visual systems — do not conflate them
+
+Row 5 used to read "`tests/visual-baselines/` — PNG visual regression baselines — visual-regression CI". That was wrong, and the confusion is easy to repeat:
+
+| System | Captured by | Verified by |
+|---|---|---|
+| `reports/l20-visual-regression/run.py` (phash, Hamming > 25) | n/a — compares against one hardcoded `REFERENCE_NAME` | `visual-regression.yml` on PRs. Only inspects dates in `ALL_TARGET_DATES` (Jan–Mar 2026), so it is a **frozen historical sweep** and cannot see a new cover. |
+| `tests/visual-baselines/` + `scripts/svg_visual_baseline.py` (pixel-diff) | `visual-baseline-refresh.yml` (`--capture`, push to main) | **nothing** — `--verify` is not wired into any workflow as of 2026-08-10 |
+
+Consequences to keep in mind: adding a `schedule` to `visual-regression.yml` buys nothing (it would re-run the same fixed date set daily), and the 58 baselines under `tests/visual-baselines/` are re-captured but never compared. `--verify` also cannot be validated locally on macOS — baselines are captured on `ubuntu-22.04`, and a local run shows a uniform ~1.5 % diff with an identical `max_block=1134px` across all 30 files, i.e. a platform rendering delta rather than drift.
 
 ### Code Blocks
 - **Always** include language tags: ```python, ```bash, ```yaml

--- a/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
+++ b/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
@@ -158,3 +158,43 @@ def test_scripts_referenced_by_paths_exist():
         f"these trigger paths point at files that no longer exist: {dead}. A dead "
         "path filter matches nothing, so the gate stops running for that dependency."
     )
+
+
+def test_svg_trigger_glob_is_recursive():
+    """The SVG path filter must cross directories, because the scan does.
+
+    ``assets/images/*.svg`` does not match a subdirectory in Actions path filters,
+    but ``verify_images_unified.py:267`` scans with ``rglob("*.svg")``. Measured
+    2026-08-10: 307 SVGs at depth 1, 156 at depth >= 2 (diagrams/, mermaid/,
+    _unused_archive/) — all inside the scan, none reachable by the trigger. That is
+    the same hazard this file documents, one directory level down.
+    """
+    body = _body()
+    assert "'assets/images/*.svg'" not in body, (
+        "check-svg.yml uses the depth-1 glob 'assets/images/*.svg'. Actions path "
+        "filters do not cross '/', so every SVG in a subdirectory is scanned but "
+        "cannot trigger the scan. Use 'assets/images/**.svg'."
+    )
+    assert "'assets/images/**.svg'" in body, "check-svg.yml must filter on 'assets/images/**.svg'"
+
+
+def test_svg_trigger_glob_present_on_both_events():
+    """push and pull_request must both carry the recursive glob, not just one."""
+    assert _body().count("'assets/images/**.svg'") >= 2, (
+        "expected the recursive SVG glob under both the push and pull_request "
+        "triggers; a one-sided filter leaves the other event blind."
+    )
+
+
+def test_recursive_glob_would_actually_reach_nested_svgs():
+    """Canary on the premise: nested SVGs exist, so the widened glob is not cosmetic.
+
+    If the corpus ever flattens to depth 1 this stops proving anything, which is
+    the signal to revisit the guard rather than trust it.
+    """
+    images = REPO_ROOT / "assets" / "images"
+    nested = [p for p in images.rglob("*.svg") if p.parent != images]
+    assert nested, (
+        "no SVGs below assets/images/ any more — re-check whether the recursive "
+        "trigger glob still corresponds to the scan scope."
+    )

--- a/scripts/tests/test_ci_svg_lint_schedule_guard.py
+++ b/scripts/tests/test_ci_svg_lint_schedule_guard.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""CI regression guard: svg-lint.yml must keep a schedule, because its producer bypasses PRs.
+
+Why this guard exists
+---------------------
+``svg-lint.yml`` carries 15 corpus-wide (``--all``) gates: cover drift for four
+generator families, the honesty scorer, title-ASCII, spec-slug consistency,
+KST-midnight URLs, checklist headings, bare URLs, template-echo. They scan the whole
+corpus, so a narrow trigger produces the same trigger-narrower-than-scan hazard that
+hid a three-week regression in ``check-svg.yml`` (see that file's header and
+``test_ci_svg_gate_no_conceal_guard.py``).
+
+Until 2026-08-10 this workflow had ``push`` + ``pull_request`` and no ``schedule`` —
+exactly the pre-#489 shape. Measured that day:
+
+- ``git log --format='%an' -40 -- 'assets/images/*.svg'`` -> **35 github-actions[bot]**
+  direct pushes to main, 5 human commits. The blogwatcher cron is the dominant
+  producer of the covers these gates check.
+- A GITHUB_TOKEN push triggers no workflow (GitHub's recursion prevention, the same
+  mechanism ``deploy-pages.yml`` documents and works around with its own cron).
+- Bot cover commit ``685ca468`` carried 12 workflow runs, **every one ``schedule``**
+  and not a single ``push`` or ``pull_request`` event.
+
+So the artifacts these 15 gates exist to check arrived through the one path neither
+trigger could see. A ``schedule`` is the only trigger that observes bot pushes, which
+makes it load-bearing here rather than a nice-to-have.
+
+Direction: presence assertions. Dropping the schedule or shrinking the corpus-wide
+gate set trips this; adding triggers or gates stays green. If svg-lint is ever
+reworked so every gate is diff-scoped (no ``--all``), the mismatch disappears and
+this guard should be updated in the same PR with the reasoning.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "svg-lint.yml"
+
+# A representative slice of the corpus-wide gates. Not the full 15: this guard
+# should fail when the *category* is gutted, not churn on every gate addition.
+CORPUS_WIDE_GATES = (
+    "score_cover_honesty.py",
+    "check_svg_title_ascii.py",
+    "check_template_echo.py",
+    "check_digest_checklist_heading.py",
+)
+
+
+def _noncomment_lines(text: str) -> str:
+    """Workflow text with comment-only lines dropped.
+
+    The header prose above names ``schedule``, ``cron`` and several gate scripts.
+    Matching that commentary would keep this guard green after the real YAML was
+    deleted, so comment-only lines are removed. Inline trailing comments survive
+    because those lines are not comment-only.
+    """
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _body() -> str:
+    return _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _triggers() -> set[str]:
+    import yaml
+
+    parsed = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    # PyYAML resolves the bare key `on:` to the boolean True.
+    section = parsed[True] if True in parsed else parsed["on"]
+    return set(section)
+
+
+def test_workflow_exists():
+    assert WORKFLOW.is_file(), f"missing {WORKFLOW}"
+
+
+def test_schedule_trigger_present():
+    assert "schedule" in _triggers(), (
+        "svg-lint.yml has no 'schedule' trigger. Its 15 corpus-wide gates would then "
+        "never see a blogwatcher cron push (GITHUB_TOKEN pushes fire no workflow), so "
+        "a cover or digest regression published by the bot could sit on main "
+        "indefinitely — the pre-#489 check-svg failure mode."
+    )
+
+
+def test_schedule_has_a_cron_expression():
+    body = _body()
+    schedule_at = body.find("schedule:")
+    assert schedule_at != -1, "schedule: key missing from the YAML body"
+    assert "cron:" in body[schedule_at:], "schedule: present but carries no cron entry"
+
+
+def test_schedule_does_not_collide_with_check_svg_sweep():
+    """Two full-corpus sweeps in the same minute contend for the runner pool."""
+    import yaml
+
+    def crons(path: Path) -> list[str]:
+        parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+        section = parsed[True] if True in parsed else parsed["on"]
+        entries = section.get("schedule") or []
+        return [e["cron"] for e in entries if isinstance(e, dict) and "cron" in e]
+
+    ours = crons(WORKFLOW)
+    theirs = crons(REPO_ROOT / ".github" / "workflows" / "check-svg.yml")
+    assert ours, "svg-lint.yml must declare at least one cron"
+    overlap = sorted(set(ours) & set(theirs))
+    assert not overlap, (
+        f"svg-lint.yml and check-svg.yml share cron slot(s) {overlap}; stagger them so "
+        "the two corpus sweeps do not run simultaneously."
+    )
+
+
+def test_manual_dispatch_available():
+    """Without dispatch, verifying a schedule-only change means waiting a day."""
+    assert "workflow_dispatch" in _triggers(), (
+        "svg-lint.yml should keep workflow_dispatch so the sweep can be run on demand "
+        "after changing it, instead of trusting it until the next cron."
+    )
+
+
+def test_corpus_wide_gates_still_present():
+    """The schedule only matters while corpus-wide gates justify it."""
+    body = _body()
+    missing = [g for g in CORPUS_WIDE_GATES if g not in body]
+    assert not missing, (
+        f"corpus-wide gate(s) gone from svg-lint.yml: {missing}. If every gate here is "
+        "now diff-scoped, the trigger/scan mismatch this guard protects against no "
+        "longer exists — update the guard deliberately rather than leaving it stale."
+    )
+
+
+def test_diff_scoped_steps_have_a_non_pull_request_base():
+    """On a schedule run there is no pull_request context; the fallback must exist.
+
+    The four diff-scoped steps branch on ``github.event_name`` and fall back to
+    ``HEAD~1``. Without that fallback, ``origin/`` + an empty base ref would make the
+    scheduled run fail on every diff-scoped gate — turning the new trigger into daily
+    noise that gets muted.
+    """
+    body = _body()
+    pr_branches = body.count("github.event_name }}\" = \"pull_request\"")
+    assert pr_branches >= 4, (
+        f"expected the 4 diff-scoped steps to branch on event_name, found {pr_branches}"
+    )
+    assert body.count('BASE="HEAD~1"') >= pr_branches, (
+        "a diff-scoped step branches on event_name without a HEAD~1 fallback; the "
+        "scheduled sweep would fail there instead of checking the latest commit."
+    )


### PR DESCRIPTION
CI 게이트 감사(2026-08-10)의 최우선 후속. **범위 정정이 하나 있어 먼저 밝힙니다.**

## 원래 계획과 달라진 점

요청받은 항목은 "`visual-regression.yml`에 schedule + push: main 추가"였습니다.
구현 전에 실제 동작을 읽어보니 **그 변경은 효과가 없습니다.** `visual-regression.yml`은
`reports/l20-visual-regression/run.py --strict --threshold 25`를 실행하고, 그 스크립트의
`collect_files()`는 `date in ALL_TARGET_DATES` — **하드코딩된 2026년 1~3월 날짜 집합** —
으로 필터링합니다. 즉 오늘자 커버는 트리거와 무관하게 구조적으로 대상이 아니며,
schedule을 붙이면 변하지 않는 파일 30개를 매일 재검사하는 소음이 됩니다.

그래서 이 PR은 **실제로 효과가 있는 2개**만 담고, visual 계열은 별도 후속으로 분리했습니다
(아래 "후속 과제" 참조).

## 근본 원인 (실측)

블로그워처 크론은 디제스트/커버를 GITHUB_TOKEN으로 main에 **직접 push**하고, 그런 push는
어떤 워크플로도 트리거하지 않습니다(GitHub 재귀 방지 — `deploy-pages.yml`이 이미 같은 문제를
겪고 cron으로 우회한 그 메커니즘입니다).

```
git log --format='%an' -40 -- 'assets/images/*.svg'
  35  github-actions[bot]      ← main 직접 push
   5  Twodragon

봇 커버 커밋 685ca468에 붙은 워크플로 실행 12건 → 전부 schedule, push/PR 이벤트 0건
```

즉 커버 SVG의 **지배적 생산자가 push·PR 두 트리거 모두를 빠져나갑니다.**

## 변경 1 — `svg-lint.yml`에 schedule 추가

이 워크플로는 코퍼스 전체(`--all`) 게이트를 **15개** 갖고 있으면서 `schedule`이 없었습니다
(pre-#489 `check-svg`와 정확히 같은 형태). 봇이 발행한 커버·디제스트는 이 15개 게이트에
한 번도 걸리지 않았습니다.

`schedule: '45 3 * * *'` + `workflow_dispatch`를 추가했습니다. `check-svg`의 03:15 슬롯과
겹치지 않게 배치했고, 블로그워처 발행(00:00) 이후입니다.

**red로 태어나지 않는지 사전 확인** — 15개 게이트를 현재 코퍼스에 전부 실행:

```
upgrade_digest_cover --all --check              PASS
upgrade_rollup_cover --all --check              PASS
upgrade_l25_cover --all --check                 PASS
check_l22_visual_variety --all                  PASS
check_svg_title_ascii --all                     PASS
check_spec_slug_consistency --all               PASS
check_kst_midnight --all                        PASS
score_cover_honesty --all --baseline --strict   PASS
upgrade_l20_cover --all --check --baseline      PASS
check_digest_checklist_heading --all            PASS
linkify_bare_urls --check --all                 PASS
check_template_echo --all --quiet               PASS
check_l20_sidecard_advisory                     PASS
check_l20_generic_hero                          PASS
check_orphan_cover_rasters                      PASS
```

diff-scoped 4개 스텝(size-gate / digest-structure / untranslated / proper-nouns)은 이미
비-PR 이벤트에서 `BASE="HEAD~1"`로 폴백하므로 schedule에서도 깨지지 않고, 가장 최근 커밋
(보통 봇의 것)을 검사합니다.

## 변경 2 — `check-svg.yml` 트리거를 `**.svg`로

Actions path 필터의 `*`는 `/`를 넘지 않는데, `verify_images_unified.py:267`은
`IMAGES_DIR.rglob("*.svg")`로 스캔합니다.

```
depth-1 SVG 307 / 전체 463 → 156개가 스캔 안·트리거 밖
(diagrams/, mermaid/, _unused_archive/)
```

#489가 고친 "트리거가 스캔보다 좁다" 함정이 **한 디렉토리 아래에 그대로 남아 있었습니다.**
`svg-lint.yml`이 이미 쓰는 글롭과 동일하게 맞췄습니다.

## 회귀 가드 (뮤테이션 검증 포함)

`scripts/tests/test_ci_svg_lint_schedule_guard.py` 신규 7건 + 기존
`test_ci_svg_gate_no_conceal_guard.py`에 3건 추가. 이 감사의 주제가 "안 돌던 게이트는
검증된 적 없다"였으므로, **새 가드 자체를 뮤테이션으로 검증**했습니다:

| 뮤테이션 | 결과 |
|---|---|
| schedule 블록 제거 | caught (2건) |
| cron을 check-svg와 동일 슬롯으로 충돌 | caught |
| 코퍼스 전체 게이트 1개 제거 | caught |
| `BASE="HEAD~1"` 폴백 제거 | caught |
| `workflow_dispatch` 제거 | caught |
| `**.svg` → `*.svg` 회귀 | caught (2건) |
| 한쪽 이벤트만 넓힘 | caught |

## CLAUDE.md 정정

활성 게이트 표 5행이 **두 개의 별개 시각 시스템을 혼동**하고 있었습니다
("`tests/visual-baselines/` — PNG visual regression baselines — visual-regression CI").

| 시스템 | 캡처 | 검증 |
|---|---|---|
| `run.py` (phash, Hamming>25) | 하드코딩 단일 reference | `visual-regression.yml` (PR). **1~3월 날짜만** = 동결 스윕 |
| `tests/visual-baselines/` (pixel-diff) | `visual-baseline-refresh.yml` `--capture` (push:main) | **없음** — `--verify`가 어떤 워크플로에도 배선되지 않음 |

## 후속 과제 (이 PR 범위 밖, 명시)

`svg_visual_baseline.py --verify`를 배선해야 58개 베이스라인이 실제로 검증됩니다. 이 PR에
넣지 않은 이유는 **로컬로 검증이 불가능**하기 때문입니다 — 베이스라인은 `ubuntu-22.04`에서
캡처되고, macOS 로컬 실행은 30/30 실패하는데 전부 균일한 ~1.5% diff에 `max_block=1134px`가
동일합니다(실제 드리프트가 아닌 플랫폼 렌더링 차이, 스크립트 자체가 문서화한 함정).
따라서 CI가 첫 시험대여야 하며, `pull_request` 트리거를 함께 걸어 그 PR에서 첫 실측을 얻는
방식으로 별도 진행하는 것이 맞습니다.

## 검증

- `pytest scripts/tests/` — 4,001 passed / 5 skipped
- 뮤테이션 7종 전부 caught
- YAML 파싱 확인: 두 워크플로 모두 `['pull_request', 'push', 'schedule', 'workflow_dispatch']`
- `.githooks/pre-commit` exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
