### PR TITLE
ci: 조용히 통과하던 게이트 5건 fail-closed 전환 + 뮤테이션 검증 가드

### DIFF
--- a/.github/workflows/check-svg.yml
+++ b/.github/workflows/check-svg.yml
@@ -81,10 +81,18 @@ jobs:
           echo "Validating SVG XML well-formedness via xmllint..."
           python3 scripts/verify_images_unified.py --svg-validate
 
-      - name: Auto-fix and check SVG quality
+      # No --fix here, deliberately. Until 2026-08-10 this step ran
+      # `--fix --ci`, which repaired missing width/height in the CI workspace and
+      # only then asserted. Nothing commits that repair, so every run re-fixed the
+      # same files, passed, and the "SVG missing dimensions" regression class could
+      # never surface — the gate was reporting on output it had just rewritten.
+      # Verified before removing: `--ci` alone gives 307 PASS / 0 WARNING / 0 FAIL
+      # on the current corpus, so this is not deferring a backlog.
+      # To repair locally: python3 scripts/check_svg_quality.py --fix assets/images/
+      - name: Check SVG quality
         run: |
-          echo "Auto-fixing missing width/height and checking SVG quality..."
-          python3 scripts/check_svg_quality.py --fix --ci assets/images/
+          echo "Checking SVG quality (read-only; use --fix locally to repair)..."
+          python3 scripts/check_svg_quality.py --ci assets/images/
           echo "SVG quality check passed"
 
       - name: Check cover QR URLs match canonical post permalink
@@ -93,9 +101,20 @@ jobs:
           python3 scripts/check_cover_qr_urls.py
           echo "Cover QR URL check passed"
 
+      # The `|| true` that used to wrap check_posts.py is gone. Detection here rests
+      # on grepping two literal strings out of the script's stdout, so a traceback,
+      # an import error, or a renamed message produced TOTAL=0 and this step passed
+      # under the name "zero SVG warnings" while having verified nothing. The
+      # script's own exit code is now the first gate; the grep is the second.
+      # Verified before removing: check_posts.py exits 0 on the current corpus.
       - name: Check posts quality (zero SVG warnings)
         run: |
-          OUTPUT=$(python3 scripts/check_posts.py 2>&1 || true)
+          set -o pipefail
+          if ! OUTPUT=$(python3 scripts/check_posts.py 2>&1); then
+            echo "$OUTPUT" | tail -30
+            echo "::error::check_posts.py exited non-zero. The SVG-warning grep below cannot be trusted when the script itself failed."
+            exit 1
+          fi
           TRUNCATED=$(echo "$OUTPUT" | grep -c "truncated" || true)
           DENSE=$(echo "$OUTPUT" | grep -c "text too dense" || true)
           TOTAL=$((TRUNCATED + DENSE))

--- a/.github/workflows/font-drift-gate.yml
+++ b/.github/workflows/font-drift-gate.yml
@@ -19,6 +19,20 @@ env:
 jobs:
   font-drift:
     name: woff2 drift check
+    # The override is a JOB-level condition, not a step-level one. Until 2026-08-10
+    # the bypass lived in an in-job step and gated the two real steps on
+    # `skip == 'false'`, so an overridden run reported SUCCESS having checked
+    # nothing — a green tick indistinguishable from a genuine pass. Skipping the job
+    # instead renders grey, which is what lighthouse-ci.yml already does with its
+    # perf-regression-allowed label.
+    #
+    # `contains(...)` is an exact element match over the label-name array. The old
+    # implementation piped the label JSON through `grep -q 'font-drift-allowed'`,
+    # which is an unanchored substring match: any label CONTAINING that text (e.g.
+    # `not-font-drift-allowed`) silently disabled the gate.
+    if: >
+      github.event_name != 'pull_request' ||
+      !contains(github.event.pull_request.labels.*.name, 'font-drift-allowed')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -27,24 +41,8 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Check for override label
-        id: label-check
-        # Pass PR-controlled label JSON via env, not inline ${{ }} in the shell,
-        # so a label with shell metacharacters cannot break out. (Security fix M-02, 2026-07-13 audit.)
-        env:
-          LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-        run: |
-          echo "labels=$LABELS_JSON"
-          if echo "$LABELS_JSON" | grep -q 'font-drift-allowed'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Label 'font-drift-allowed' is set — skipping font drift gate."
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Compute changed files
         id: diff
-        if: steps.label-check.outputs.skip == 'false'
         run: |
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
@@ -57,7 +55,6 @@ jobs:
           echo "Changed files: $CHANGED"
 
       - name: Run font drift gate
-        if: steps.label-check.outputs.skip == 'false'
         # Pass the diff-derived file list via env, not inline ${{ }} in the
         # shell, so a PR-controlled filename with shell metacharacters cannot
         # break out of the argument. (Security fix M-01, 2026-06-30 audit.)

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -303,11 +303,25 @@ jobs:
       - name: Compare LCP head vs base
         id: compare
         run: |
+          # --require-comparable is passed ONLY when both Jekyll builds succeeded.
+          # In that case an empty comparison means URL resolution broke, which is a
+          # real defect and must fail. When a build failed the run legitimately
+          # degrades to the GH Pages fallback (which writes head-side LHRs only), so
+          # the flag is withheld and the script exits 0 after printing a ::warning::
+          # that the PR was not actually measured. Before 2026-08-10 the degraded run
+          # was indistinguishable from a clean pass at a glance.
+          REQUIRE=""
+          if [ "${{ steps.build-head.outcome }}" = "success" ] \
+             && [ "${{ steps.build-base.outcome }}" = "success" ]; then
+            REQUIRE="--require-comparable"
+          fi
+          echo "[compare] build-head=${{ steps.build-head.outcome }} build-base=${{ steps.build-base.outcome }} require_comparable=${REQUIRE:-no}"
           python3 scripts/dev/compare_lighthouse_runs.py \
             --base-dir lhci-base \
             --head-dir lhci-head \
             --threshold-lcp-ms 200 \
-            --output-md lighthouse-comparison.md
+            --output-md lighthouse-comparison.md \
+            $REQUIRE
           # The script's exit code IS the gate, and it is fail-safe by design:
           # compare() returns 1 ONLY when a URL measured on BOTH sides regresses
           # past the +200ms threshold; a missing/incomparable base (e.g. the

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -191,15 +191,53 @@ jobs:
     permissions:
       contents: read
     steps:
+      # This job used to compare needs.*.result against "failure" only and then
+      # print "✅ Security audit clean (or skipped — no dependency changes)".
+      # Measured 2026-08-10: across the 30 most recent merged PRs both audit jobs
+      # reported `skipped` on 100% of appearances (correct — they are gated on
+      # package.json / package-lock.json / Gemfile / Gemfile.lock changing), while
+      # this job reported success on all 30. "clean" and "did not run" therefore
+      # rendered identically, and any consumer treating this name as coverage was
+      # reading a guaranteed green.
+      #
+      # Skipped stays a pass — failing every PR that does not touch a manifest would
+      # be noise, and the Monday cron runs both audits unconditionally (25 schedule
+      # runs verified). What changes: skipped is now labelled NOT RUN rather than
+      # clean, and any conclusion that is neither success nor skipped (cancelled,
+      # timed_out, a future value) fails instead of falling through the equality test.
       - name: Evaluate audit results
         run: |
           NPM="${{ needs.npm-audit.result }}"
           BUNDLE="${{ needs.bundle-audit.result }}"
           echo "## Security Audit Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- npm audit: $NPM" >> $GITHUB_STEP_SUMMARY
-          echo "- bundle audit: $BUNDLE" >> $GITHUB_STEP_SUMMARY
-          if [ "$NPM" = "failure" ] || [ "$BUNDLE" = "failure" ]; then
-            echo "❌ One or more audits failed"
+
+          label() {
+            case "$1" in
+              success) echo "✅ ran, no high/critical findings reported" ;;
+              skipped) echo "⏭️ NOT RUN — no dependency manifest changed in this event" ;;
+              *)       echo "❌ $1" ;;
+            esac
+          }
+          echo "- npm audit: $(label "$NPM")" >> $GITHUB_STEP_SUMMARY
+          echo "- bundle audit: $(label "$BUNDLE")" >> $GITHUB_STEP_SUMMARY
+
+          bad=""
+          for r in "$NPM" "$BUNDLE"; do
+            case "$r" in
+              success|skipped) ;;
+              *) bad="$bad $r" ;;
+            esac
+          done
+          if [ -n "$bad" ]; then
+            echo "::error::Security audit job(s) ended in an unexpected state:$bad"
             exit 1
           fi
-          echo "✅ Security audit clean (or skipped — no dependency changes)"
+
+          if [ "$NPM" = "skipped" ] && [ "$BUNDLE" = "skipped" ]; then
+            echo "⏭️ Neither audit ran (no dependency manifest changed)." >> $GITHUB_STEP_SUMMARY
+            echo "This check passing does NOT mean dependencies were audited." >> $GITHUB_STEP_SUMMARY
+            echo "Coverage comes from the Monday cron, which audits unconditionally." >> $GITHUB_STEP_SUMMARY
+            echo "⏭️ Neither audit ran — not a clean bill of health."
+            exit 0
+          fi
+          echo "✅ Audits that ran reported no high/critical findings"

--- a/scripts/dev/compare_lighthouse_runs.py
+++ b/scripts/dev/compare_lighthouse_runs.py
@@ -211,6 +211,15 @@ def main() -> int:
     )
     parser.add_argument("--output-md", type=Path, default=None, help="Optional Markdown output path")
     parser.add_argument("--quiet", action="store_true", help="Suppress stdout summary")
+    parser.add_argument(
+        "--require-comparable",
+        action="store_true",
+        help=(
+            "Fail when no URL is comparable on both sides. Pass this only when both "
+            "builds succeeded: zero comparable rows then means URL resolution broke, "
+            "not that the run degraded to the GH Pages fallback."
+        ),
+    )
     args = parser.parse_args()
 
     rows, exit_code = compare(args.base_dir, args.head_dir, args.threshold_lcp_ms)
@@ -220,6 +229,33 @@ def main() -> int:
         args.output_md.write_text(md, encoding="utf-8")
     if not args.quiet:
         print(md)
+
+    # Zero comparable rows is the gate's soft-degrade path: the GH Pages fallback
+    # writes only head-side LHRs, so the intersection is empty and nothing can be
+    # judged. Exiting 0 there is deliberate (see the workflow header, security fix
+    # C-H1) — a Vercel block or a flaky build must not hold a PR hostage.
+    #
+    # What was NOT deliberate is that the degraded run is indistinguishable from a
+    # clean pass at a glance: the job goes green and only the artifact says
+    # "(no comparable URLs found)". So the empty case is always announced, and with
+    # --require-comparable (passed by the workflow only when both builds succeeded)
+    # it becomes a failure, because then the emptiness is a defect in URL
+    # resolution rather than an expected degrade.
+    if not rows:
+        if args.require_comparable:
+            print(
+                "::error::Lighthouse perf gate measured NOTHING: both builds succeeded "
+                "yet no URL was comparable on both sides. Check resolve_lighthouse_urls.py "
+                "and the per-side build-id probes.",
+                file=sys.stderr,
+            )
+            return 1
+        print(
+            "::warning::Lighthouse perf gate did not measure this PR — no URL was "
+            "comparable on both sides (expected when a build failed and the run fell "
+            "back to GH Pages). This check passing does NOT mean performance was verified.",
+            file=sys.stderr,
+        )
     return exit_code
 
 

--- a/scripts/tests/test_ci_silent_pass_guard.py
+++ b/scripts/tests/test_ci_silent_pass_guard.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""CI regression guard: five gates that used to pass without checking anything.
+
+Found by the 2026-08-10 CI gate audit. Each of these reported a green tick while
+verifying nothing, which is worse than a missing gate — a missing gate is visible.
+
+D1  lighthouse-ci.yml — when either Jekyll build fails the run falls back to GH Pages,
+    which writes head-side LHRs only. The intersection in compare() is then empty,
+    no row is judged, and the script exits 0. That soft degrade is deliberate
+    (security fix C-H1: a Vercel block must not hold a PR hostage) and stays. What
+    was not deliberate is that it looked identical to a clean pass. The empty case is
+    now always announced, and --require-comparable (passed only when BOTH builds
+    succeeded) turns it into a failure, because then emptiness means URL resolution
+    broke rather than the run degraded.
+
+D2  check-svg.yml — ran `check_svg_quality.py --fix --ci`, repairing missing
+    width/height in the CI workspace and only then asserting. Nothing commits the
+    repair, so the regression class could never surface.
+
+D3  check-svg.yml — `check_posts.py 2>&1 || true` then grepped two literal strings. A
+    traceback or a renamed message yielded TOTAL=0 under a step named "zero SVG
+    warnings".
+
+D5  security-audit.yml — the summary compared needs.*.result to "failure" only and
+    printed "clean (or skipped)". Measured: both audits `skipped` on 100% of the last
+    30 PRs while this job reported success on all 30. Skipped still passes (the Monday
+    cron audits unconditionally), but it must not read as clean.
+
+D18 font-drift-gate.yml — the override label was matched with an unanchored
+    `grep -q`, so any label containing the text bypassed the gate, and because the
+    bypass gated steps rather than the job, an overridden run reported SUCCESS.
+
+Direction: these assert the ABSENCE of the old shapes and the PRESENCE of the new
+ones. Reintroducing `--fix` in CI, `|| true` around the script, the substring label
+match, or the failure-only comparison trips this guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+CHECK_SVG = WORKFLOWS / "check-svg.yml"
+SECURITY_AUDIT = WORKFLOWS / "security-audit.yml"
+FONT_DRIFT = WORKFLOWS / "font-drift-gate.yml"
+LIGHTHOUSE_CI = WORKFLOWS / "lighthouse-ci.yml"
+COMPARE_SCRIPT = REPO_ROOT / "scripts" / "dev" / "compare_lighthouse_runs.py"
+
+
+def _body(path: Path) -> str:
+    """File text with comment-only lines dropped.
+
+    Every file below documents the anti-pattern it removed, naming `--fix`,
+    `|| true` and `grep -q 'font-drift-allowed'` in prose. Matching that commentary
+    would keep this guard green after the real YAML came back.
+    """
+    return "\n".join(
+        ln for ln in path.read_text(encoding="utf-8").splitlines() if not ln.lstrip().startswith("#")
+    )
+
+
+# ---------------------------------------------------------------------------
+# D1 — the perf gate must not render "measured nothing" as a plain pass
+# ---------------------------------------------------------------------------
+
+
+def test_compare_script_supports_require_comparable():
+    src = COMPARE_SCRIPT.read_text(encoding="utf-8")
+    assert "--require-comparable" in src, "compare_lighthouse_runs.py lost the --require-comparable flag"
+    assert "require_comparable" in src
+
+
+def test_empty_comparison_is_always_announced():
+    """Silent green was the defect; the annotation is the fix."""
+    src = COMPARE_SCRIPT.read_text(encoding="utf-8")
+    assert "::warning::" in src, (
+        "the degraded (no comparable URLs) path no longer emits a ::warning::, so a run "
+        "that measured nothing is again indistinguishable from a clean pass"
+    )
+    assert "::error::" in src, "the --require-comparable failure path lost its ::error:: annotation"
+
+
+def test_workflow_passes_require_comparable_only_when_both_builds_succeeded():
+    body = _body(LIGHTHOUSE_CI)
+    assert "--require-comparable" in body or "$REQUIRE" in body, (
+        "lighthouse-ci.yml no longer wires --require-comparable; an empty comparison "
+        "with two healthy builds would pass again"
+    )
+    assert "steps.build-head.outcome" in body and "steps.build-base.outcome" in body, (
+        "the flag must be conditioned on both build outcomes — passing it "
+        "unconditionally would fail every legitimate GH Pages fallback run"
+    )
+
+
+def test_compare_exit_codes_for_empty_input(tmp_path):
+    """Behavioural check, not a text match: run the script on empty dirs both ways."""
+    import subprocess
+    import sys
+
+    base = tmp_path / "base"
+    head = tmp_path / "head"
+    base.mkdir()
+    head.mkdir()
+
+    lenient = subprocess.run(
+        [sys.executable, str(COMPARE_SCRIPT), "--base-dir", str(base), "--head-dir", str(head), "--quiet"],
+        capture_output=True,
+        text=True,
+    )
+    assert lenient.returncode == 0, "the soft-degrade path must stay exit 0 (security fix C-H1)"
+    assert "::warning::" in lenient.stderr, "soft degrade must still be announced"
+
+    strict = subprocess.run(
+        [
+            sys.executable, str(COMPARE_SCRIPT),
+            "--base-dir", str(base), "--head-dir", str(head),
+            "--quiet", "--require-comparable",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert strict.returncode == 1, "--require-comparable must fail when nothing is comparable"
+    assert "::error::" in strict.stderr
+
+
+# ---------------------------------------------------------------------------
+# D2 / D3 — check-svg must not repair its own input, nor swallow a crash
+# ---------------------------------------------------------------------------
+
+
+def test_svg_quality_gate_does_not_self_repair_in_ci():
+    body = _body(CHECK_SVG)
+    assert not re.search(r"check_svg_quality\.py\s+--fix", body), (
+        "check-svg.yml runs check_svg_quality.py with --fix again. In CI that rewrites "
+        "the files before asserting on them, so the missing-dimensions regression class "
+        "can never fail. Repair locally instead."
+    )
+    assert re.search(r"check_svg_quality\.py\s+--ci\s+assets/images/", body), (
+        "the read-only corpus check is gone from check-svg.yml"
+    )
+
+
+def test_check_posts_exit_code_is_not_swallowed():
+    body = _body(CHECK_SVG)
+    assert not re.search(r"check_posts\.py[^\n]*\|\|\s*true", body), (
+        "check_posts.py is wrapped in '|| true' again — a traceback would then yield "
+        "TOTAL=0 and pass under the step name 'zero SVG warnings'"
+    )
+    assert "check_posts.py" in body, "the check_posts.py step disappeared entirely"
+
+
+def test_check_posts_step_fails_on_nonzero_exit():
+    body = _body(CHECK_SVG)
+    step = body[body.index("Check posts quality") :]
+    step = step[: step.find("\n      - name:") if "\n      - name:" in step else len(step)]
+    assert "if ! OUTPUT=$(python3 scripts/check_posts.py 2>&1); then" in step, (
+        "the step must branch on check_posts.py's own exit code before trusting its stdout"
+    )
+    assert "exit 1" in step
+
+
+# ---------------------------------------------------------------------------
+# D5 — "skipped" must not print as "clean"
+# ---------------------------------------------------------------------------
+
+
+def test_security_summary_does_not_call_skipped_clean():
+    body = _body(SECURITY_AUDIT)
+    assert "Security audit clean (or skipped" not in body, (
+        "the summary again prints 'clean (or skipped)'. Both audits are skipped on "
+        "every PR that does not touch a dependency manifest (30/30 measured), so this "
+        "wording made a never-executed audit read as a clean bill of health."
+    )
+    assert "NOT RUN" in body, "the skipped case must be labelled as not-run"
+
+
+def test_security_summary_rejects_unexpected_conclusions():
+    """A failure-only equality test lets cancelled/timed_out fall through as success."""
+    body = _body(SECURITY_AUDIT)
+    assert not re.search(r'if\s+\[\s+"\$NPM"\s+=\s+"failure"\s+\]\s+\|\|\s+\[\s+"\$BUNDLE"\s+=\s+"failure"\s+\]', body), (
+        "the summary is back to comparing only against 'failure'; cancelled and "
+        "timed_out would pass"
+    )
+    assert "success|skipped)" in body, (
+        "expected an allow-list of acceptable conclusions rather than a deny-list of one"
+    )
+
+
+@pytest.mark.parametrize("manifest", ["package.json", "package-lock.json", "Gemfile", "Gemfile.lock"])
+def test_audit_trigger_manifests_still_filtered(manifest: str):
+    """Canary on the premise of D5: the audits really are manifest-gated."""
+    assert f"'{manifest}'" in _body(SECURITY_AUDIT), (
+        f"{manifest} is no longer in the should-audit filter; if the audits now run on "
+        "every PR, the skipped-vs-clean distinction this guard protects is moot and the "
+        "guard should be revisited."
+    )
+
+
+# ---------------------------------------------------------------------------
+# D18 — the font-drift bypass must be exact and must render as a skip
+# ---------------------------------------------------------------------------
+
+
+def test_font_drift_override_is_not_a_substring_match():
+    body = _body(FONT_DRIFT)
+    assert "grep -q 'font-drift-allowed'" not in body, (
+        "the override is matched with an unanchored grep again: any label containing "
+        "'font-drift-allowed' (e.g. 'not-font-drift-allowed') would disable the gate"
+    )
+    assert "contains(github.event.pull_request.labels.*.name, 'font-drift-allowed')" in body, (
+        "expected an exact element match over the label array"
+    )
+
+
+def test_font_drift_override_skips_the_job_not_the_steps():
+    """A step-gated bypass reports SUCCESS; a job-level `if` renders grey."""
+    import yaml
+
+    parsed = yaml.safe_load(FONT_DRIFT.read_text(encoding="utf-8"))
+    job = parsed["jobs"]["font-drift"]
+    assert "if" in job, (
+        "font-drift has no job-level 'if'. With the bypass at step level an overridden "
+        "run reports SUCCESS having checked nothing — a green tick that looks like a pass."
+    )
+    assert "font-drift-allowed" in job["if"]
+
+    body = _body(FONT_DRIFT)
+    assert "label-check" not in body, (
+        "the old in-job label-check step is back; the bypass belongs in the job's 'if'"
+    )
+    assert "steps.label-check.outputs.skip" not in body
+
+
+def test_font_drift_still_runs_the_gate_script():
+    body = _body(FONT_DRIFT)
+    assert "scripts/dev/check_font_drift.py" in body, "the gate no longer invokes its own script"
+    assert "CHANGED_FILES" in body, "the env-passing hardening (security fix M-01) was dropped"

--- a/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
+++ b/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
@@ -102,19 +102,31 @@ def test_manual_dispatch_still_available():
 
 
 def test_corpus_scan_still_covers_whole_directory():
-    """The gate's value is the full-corpus verdict; narrowing it hides regressions."""
+    """The gate's value is the full-corpus verdict; narrowing it hides regressions.
+
+    This originally pinned the literal ``--fix --ci assets/images/``. The ``--fix``
+    was incidental to what the assertion is about — and actively harmful, because in
+    CI it rewrote the files before asserting on them, so the missing-dimensions
+    regression class could never fail (audit finding D2, removed 2026-08-10). The
+    corpus path is what must not narrow; the flags are checked separately, by
+    ``test_ci_silent_pass_guard.py::test_svg_quality_gate_does_not_self_repair_in_ci``.
+    """
     body = _body()
     # Anchored at end-of-line: 'assets/images/one.svg' must NOT satisfy this, or the
     # assertion would pass while the scan had been narrowed to a single file.
     assert re.search(
-        rf"{re.escape(CORE_SCRIPT)}\s+--fix\s+--ci\s+assets/images/\s*$",
+        rf"{re.escape(CORE_SCRIPT)}(?:\s+--[a-z-]+)*\s+--ci\s+assets/images/\s*$",
         body,
         re.MULTILINE,
     ), (
-        f"check-svg.yml no longer runs '{CORE_SCRIPT} --fix --ci assets/images/'. "
+        f"check-svg.yml no longer runs '{CORE_SCRIPT} --ci assets/images/'. "
         "If the scan was narrowed to changed files only, that is a legitimate "
         "alternative fix for the trigger/scan mismatch — but then say so and update "
         "this guard (and test_schedule_trigger_present) in the same PR."
+    )
+    assert not re.search(rf"{re.escape(CORE_SCRIPT)}\s+--fix", body), (
+        "--fix is back in the CI invocation: the gate would repair its own input "
+        "before asserting, which is how this regression class stayed invisible."
     )
 
 


### PR DESCRIPTION
CI 게이트 감사(2026-08-10) 후속 2/3. 각 항목은 **green 틱을 내면서 아무것도 검증하지 않던** 것들입니다 — 없는 게이트보다 나쁩니다(없는 건 눈에 보입니다).

## 요청 항목 중 2건은 재해석했습니다

**D1은 "교집합 공집합 시 fail"이 아닙니다.** 구현 전에 읽어보니 그 exit 0은 **의도된 설계**였습니다 — `lighthouse-ci.yml` 헤더 36-40행이 "no row is comparable and the compare step returns 'skip' — **a soft degrade, by design**"이라 명시하고, 보안 수정 C-H1(2026-06-30 감사)에 귀속돼 있습니다. Vercel 차단이나 빌드 플레이크가 PR을 인질로 잡지 않게 하려는 것입니다. 그대로 fail로 바꾸면 그 결정을 되돌리게 됩니다.

의도되지 않은 것은 **그 실행이 깨끗한 통과와 구별되지 않았다**는 점입니다. 그래서 이렇게 고쳤습니다:
- 빈 비교는 **항상** `::warning::`으로 알린다 ("this check passing does NOT mean performance was verified")
- `--require-comparable`은 **양쪽 빌드가 성공했을 때만** 워크플로가 전달한다. 그 경우의 공집합은 degrade가 아니라 **URL 해석 결함**이므로 실패시킨다.

**D5의 "skipped를 clean으로 보지 않기"는 skipped→fail이 아닙니다.** 두 감사는 `package.json`/`Gemfile` 계열이 바뀔 때만 도는 게 맞는 설계이므로, skipped를 실패시키면 **모든 일반 PR이 red**가 됩니다. 커버리지는 월요일 cron이 담당합니다(schedule 실행 25회 확인). 그래서 skipped는 계속 통과시키되 **표기를 `NOT RUN`으로** 바꾸고, `success`/`skipped` 외의 결론은 allow-list로 실패시킵니다.

## 5건 변경

| # | 파일 | 문제 | 수정 |
|---|---|---|---|
| D1 | `lighthouse-ci.yml`, `compare_lighthouse_runs.py` | 폴백 시 exit 0이 깨끗한 통과와 구별 불가 | 빈 비교 항상 `::warning::`, 양쪽 빌드 성공 시 `--require-comparable`로 fail |
| D2 | `check-svg.yml:87` | `--fix --ci`가 CI에서 파일을 **고친 뒤 검사** → 회귀 영구 미표면화 | `--fix` 제거 (read-only) |
| D3 | `check-svg.yml:98` | `check_posts.py … \|\| true` + 리터럴 2개 grep → 트레이스백이면 TOTAL=0 통과 | 스크립트 exit code를 1차 게이트로 승격 |
| D5 | `security-audit.yml:201` | `"failure"`와만 비교, `"clean (or skipped)"` 출력 | `NOT RUN` 표기 + allow-list(cancelled/timed_out 실패) |
| D18 | `font-drift-gate.yml:38` | 무앵커 `grep -q` 부분일치 우회 + 스텝 단위라 잡이 **SUCCESS** | `contains()` 정확 일치 + **잡 레벨 `if`** → 우회 시 회색 스킵 |

D18은 `lighthouse-ci.yml:81`이 `perf-regression-allowed`로 이미 쓰는 방식과 같아졌습니다.

## 사전 실측 (naive 수정이 깨뜨리지 않는지)

D2·D3는 제거하면 red가 될 수 있어 먼저 확인했습니다:

```
python3 scripts/check_svg_quality.py --ci assets/images/   → exit 0
   Summary: 307 PASS, 0 WARNING, 0 FAIL / 307 files checked
python3 scripts/check_posts.py                             → exit 0
   (truncated / text too dense 매칭 0줄)
```

즉 백로그를 이연시키는 변경이 아닙니다.

## 회귀 가드 — 가드 자체를 뮤테이션으로 검증

`scripts/tests/test_ci_silent_pass_guard.py` 신규 **16건**. 이 감사의 주제가 "안 돌던 게이트는 검증된 적 없다"였으므로, 새 가드를 믿기 전에 각 수정을 되돌려 실제로 잡히는지 확인했습니다:

| 뮤테이션 | 결과 |
|---|---|
| D2 `--fix` 복구 | caught |
| D3 `\|\| true` 복구 | caught (2건) |
| D5 `clean (or skipped)` 문구 복구 | caught |
| D5 failure-only 비교 복구 | caught |
| D18 무앵커 grep + 스텝 우회 복구 | caught (2건) |
| D1 플래그 배선 제거 | caught |

D1은 텍스트 매칭이 아니라 **실제 실행**으로 검증합니다 — 빈 디렉토리 2개를 주고 `--require-comparable` 없이는 exit 0 + `::warning::`, 붙이면 exit 1 + `::error::`임을 subprocess로 확인합니다(`test_compare_exit_codes_for_empty_input`).

## 기존 가드 1건 정정

`test_corpus_scan_still_covers_whole_directory`의 정규식이 `--fix --ci assets/images/`를 리터럴로 못박고 있어 D2 수정과 충돌했습니다. 그 단정의 취지는 **"스캔 범위가 좁아지지 않았는가"**이고 `--fix`는 부수적입니다 — 게다가 CI에서는 유해했습니다. 가드 메시지 자체가 "대안 수정이라면 같은 PR에서 갱신하라"고 지시하고 있어 그대로 따랐고, 축소 / `--fix` 복구 / 스텝 삭제 3종 뮤테이션으로 재검증했습니다.

## 검증

- `pytest scripts/tests/` — **4,017 passed** / 5 skipped
- 뮤테이션 10종 전부 caught
- `ruff check` clean, `.githooks/pre-commit` exit 0
- YAML 파싱 + 잡 키 검증: 4개 워크플로 모두 unknown job key 없음

## 남은 열화 항목 (이 PR 범위 밖)

감사에서 18건이 나왔고 이 PR은 🔴 5건을 다룹니다. 나머지 🟠 13건 중 눈에 띄는 것:
`jekyll.yml`의 `continue-on-error` + `|| true` 이중 연성 4곳(D7·D8·D9·D11 — 특히 D8은 "Validate"라는 이름의 스텝), 시크릿 부재 시 "green + 무작업" 7개 워크플로(D14), `ai-blogwatcher.yml:426` proper-nouns `--fix || true` **재검증 없음**(D16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
