### PR TITLE
ci(jekyll): 연성으로 무력화된 검증 스텝 4곳을 fail-closed 로 + 근거 실측

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -140,7 +140,13 @@ jobs:
         run: |
           echo "📋 Running Digest quality report..."
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            CHANGED=$(git diff --name-only origin/main...HEAD -- '_posts/*Digest*.md' || true)
+            # No `|| true`: an unresolvable origin/main used to yield an empty list and
+            # print "No Digest posts changed, skipping" — a shallow or broken checkout
+            # therefore skipped the gate while reporting success.
+            if ! CHANGED=$(git diff --name-only origin/main...HEAD -- '_posts/*Digest*.md'); then
+              echo "::error::could not diff against origin/main; refusing to skip the Digest gate"
+              exit 1
+            fi
             if [ -n "$CHANGED" ]; then
               python3 scripts/digest_quality_report.py --files $CHANGED --ci
             else
@@ -183,9 +189,11 @@ jobs:
             --jq '.[] | select(.body | contains("Test Coverage Report")) | .id' 2>/dev/null | head -1 || true)
 
           if [ -n "$EXISTING" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" -X PATCH -f body="$BODY" || true
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING}" -X PATCH -f body="$BODY" \
+              || echo "::warning::could not update the coverage comment (comment posting is non-blocking)"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" || true
+            gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY" \
+              || echo "::warning::could not post the coverage comment (comment posting is non-blocking)"
           fi
           echo "✅ Coverage comment posted"
 
@@ -206,7 +214,19 @@ jobs:
             # Read changed paths into an array (newline-delimited) and pass them
             # quoted, so a post filename containing shell metacharacters can't be
             # word-split or injected. (Security fix M-02, 2026-06-30 audit.)
-            mapfile -t CHANGED < <(git diff --name-only origin/main...HEAD -- '_posts/*.md' 2>/dev/null || true)
+            # The diff is computed BEFORE mapfile, not inside process substitution:
+            # a failure inside <(...) is invisible to mapfile, so an unresolvable
+            # origin/main used to produce an empty array and skip this gate while
+            # reporting success. Same shape as the Digest gate above.
+            if ! DIFF_OUT=$(git diff --name-only origin/main...HEAD -- '_posts/*.md'); then
+              echo "::error::could not diff against origin/main; refusing to skip the quote gate"
+              exit 1
+            fi
+            mapfile -t CHANGED <<< "$(printf '%s' "$DIFF_OUT")"
+            # mapfile on empty input still yields one empty element; drop it.
+            if [ "${#CHANGED[@]}" -eq 1 ] && [ -z "${CHANGED[0]}" ]; then
+              CHANGED=()
+            fi
             if [ "${#CHANGED[@]}" -gt 0 ]; then
               python3 scripts/validators/check_frontmatter_quotes.py "${CHANGED[@]}"
             else
@@ -224,12 +244,25 @@ jobs:
           python3 scripts/check_posts.py --changed
           echo "✅ Post validation passed"
 
+      # The 60-point floor is now actually enforced here.
+      #
+      # validate_post_quality.py has `--fail-below` defaulting to 60, so this step
+      # always had a real gate in it — and it was disabled twice over:
+      # `continue-on-error: true` on the step plus `|| true` on the command, under a
+      # step named "Validate" that printed "warnings only, non-blocking". The floor
+      # therefore only existed in the pre-commit hook, which `--no-verify` skips.
+      #
+      # Measured before enabling (261 posts): minimum score 80, mean 90.6, and ZERO
+      # posts below 60. So this is a 20-point margin on the worst existing post, not
+      # a backlog being deferred onto the next contributor.
       - name: Validate post quality (PR only)
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         run: |
           echo "📊 Checking post quality for changed files..."
-          CHANGED_POSTS=$(git diff --name-only origin/main...HEAD -- '_posts/*.md' 2>/dev/null || echo "")
+          if ! CHANGED_POSTS=$(git diff --name-only origin/main...HEAD -- '_posts/*.md'); then
+            echo "::error::could not diff against origin/main; refusing to report 'no changes'"
+            exit 1
+          fi
           if [ -z "$CHANGED_POSTS" ]; then
             echo "✅ No post changes detected"
             exit 0
@@ -237,38 +270,25 @@ jobs:
           echo "Changed posts:"
           echo "$CHANGED_POSTS"
           echo ""
-          # Check front matter size
-          python3 scripts/validate_post_quality.py $CHANGED_POSTS || true
+          # Exits 1 below --fail-below (default 60). No `|| true`: a score under the
+          # floor, or a crash in the scorer, must both surface.
+          python3 scripts/validate_post_quality.py $CHANGED_POSTS
           echo ""
-          echo "✅ Post quality check completed (warnings only, non-blocking)"
+          echo "✅ Post quality at or above the 60-point floor"
 
-      - name: Check front matter size (PR only)
+      # Ratchet, not an absolute limit. The old inline snippet warned above 1,000
+      # chars — measured 2026-08-10, 261 of 261 posts exceed that, and the snippet
+      # could not exit non-zero anyway (plus `continue-on-error: true`). A threshold
+      # every file violates is noise that trains people to ignore warnings.
+      #
+      # check_front_matter_growth.py asserts two things that are true today: an
+      # existing post's front matter must not GROW, and nothing may exceed a 3,000-char
+      # ceiling (measured max: 2,749). Legacy size is grandfathered; new bloat fails.
+      # Moved out of inline YAML into a script so it can have tests — being untestable
+      # is part of how the old check rotted unnoticed.
+      - name: Check front matter growth (PR only)
         if: github.event_name == 'pull_request'
-        continue-on-error: true
-        run: |
-          echo "📏 Checking front matter size..."
-          CHANGED_POSTS=$(git diff --name-only origin/main...HEAD -- '_posts/*.md' 2>/dev/null || echo "")
-          if [ -z "$CHANGED_POSTS" ]; then
-            echo "✅ No post changes detected"
-            exit 0
-          fi
-          python3 -c "
-          import sys, re
-          warnings = 0
-          for f in sys.argv[1:]:
-              with open(f) as fh:
-                  content = fh.read()
-              match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
-              if match:
-                  fm_len = len(match.group(1))
-                  if fm_len > 1000:
-                      print(f'⚠️  {f}: front matter {fm_len} chars (limit: 1000)')
-                      warnings += 1
-          if warnings:
-              print(f'\n⚠️  {warnings} post(s) exceed 1000-char front matter limit')
-          else:
-              print('✅ All front matter within size limit')
-          " $CHANGED_POSTS
+        run: python3 scripts/check_front_matter_growth.py --changed origin/main
 
       - name: Post quality dashboard comment (PR only)
         if: github.event_name == 'pull_request'
@@ -333,10 +353,12 @@ jobs:
 
           if [ -n "$EXISTING_COMMENT" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT}" \
-              -X PATCH -f body="$(cat /tmp/pr-quality-comment.md)" || true
+              -X PATCH -f body="$(cat /tmp/pr-quality-comment.md)" \
+              || echo "::warning::could not update the quality dashboard comment (comment posting is non-blocking)"
             echo "Updated existing quality dashboard comment"
           else
-            gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/pr-quality-comment.md || true
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/pr-quality-comment.md \
+              || echo "::warning::could not post the quality dashboard comment (comment posting is non-blocking)"
             echo "Posted quality dashboard comment"
           fi
 

--- a/scripts/check_front_matter_growth.py
+++ b/scripts/check_front_matter_growth.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Front-matter size gate — a growth ratchet, not an absolute limit.
+
+Why this replaced the old check
+-------------------------------
+`jekyll.yml` used to run an inline Python snippet that warned when a post's front
+matter exceeded 1,000 characters. Measured 2026-08-10: **261 of 261 posts exceed
+it**, and the snippet could not exit non-zero anyway (the step was additionally
+`continue-on-error: true`). A threshold every single file violates carries no
+information — it prints a warning on every post-touching PR, which is how people
+learn to scroll past warnings.
+
+So the absolute number is replaced by two claims that are actually true today:
+
+1. **Ratchet** — a post that already exists must not grow its front matter. The
+   corpus is where it is; what matters is that it stops getting worse. This is the
+   same shape as `check_digest_structure.py --ratchet` and the cover honesty
+   baseline: legacy debt is grandfathered, new debt fails.
+2. **Absolute cap** — nothing, new or old, may exceed `--max-chars` (default 3000).
+   Measured maximum at the time of writing is 2,749, so the cap is a ceiling on
+   unbounded growth rather than a retroactive judgement. New posts have no baseline
+   to ratchet against, and this is what bounds them.
+
+Usage
+-----
+    # PR mode: compare every changed post against its version in <base>
+    python3 scripts/check_front_matter_growth.py --changed origin/main
+
+    # Explicit files (still ratcheted against <base>)
+    python3 scripts/check_front_matter_growth.py --changed origin/main _posts/a.md
+
+    # Corpus-wide cap check only (no baseline available)
+    python3 scripts/check_front_matter_growth.py --all
+
+Exit codes: 0 clean, 1 violation, 2 usage/environment error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POSTS_DIR = REPO_ROOT / "_posts"
+
+# Measured max across 261 posts on 2026-08-10 was 2,749 chars. 3,000 is a ceiling on
+# further growth, deliberately not a retroactive verdict on the corpus.
+DEFAULT_MAX_CHARS = 3000
+
+_FRONT_MATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+
+def front_matter_len(text: str) -> int | None:
+    """Length of the YAML front matter block, or None when there is none."""
+    match = _FRONT_MATTER_RE.match(text)
+    return len(match.group(1)) if match else None
+
+
+def _git(args: list[str]) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True, check=False
+    )
+    return proc.returncode, proc.stdout
+
+
+def changed_posts(base: str) -> list[str]:
+    """Repo-relative paths of _posts/*.md that differ from `base`.
+
+    Raises RuntimeError when the diff cannot be computed. An unresolvable base must
+    not silently look like "nothing changed" — that is exactly how the old digest
+    gate reported "No Digest posts changed, skipping" on a broken checkout.
+    """
+    code, out = _git(["diff", "--name-only", f"{base}...HEAD", "--", "_posts/*.md"])
+    if code != 0:
+        raise RuntimeError(
+            f"git diff against {base!r} failed (exit {code}). Refusing to report "
+            "'no changes' on an unresolvable base — deepen the checkout or fix the ref."
+        )
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def baseline_len(base: str, rel_path: str) -> int | None:
+    """Front-matter length of `rel_path` at `base`, or None when it did not exist."""
+    code, out = _git(["show", f"{base}:{rel_path}"])
+    if code != 0:
+        return None
+    return front_matter_len(out)
+
+
+def check(base: str | None, paths: list[str], max_chars: int) -> tuple[list[str], list[str]]:
+    """Return (violations, notes)."""
+    violations: list[str] = []
+    notes: list[str] = []
+
+    for rel in paths:
+        path = REPO_ROOT / rel
+        if not path.is_file():
+            notes.append(f"{rel}: deleted or moved — skipped")
+            continue
+        current = front_matter_len(path.read_text(encoding="utf-8", errors="replace"))
+        if current is None:
+            violations.append(f"{rel}: no front matter block found")
+            continue
+
+        if current > max_chars:
+            violations.append(
+                f"{rel}: front matter {current} chars exceeds the {max_chars}-char cap"
+            )
+            continue
+
+        if base is None:
+            continue
+
+        previous = baseline_len(base, rel)
+        if previous is None:
+            notes.append(f"{rel}: new post ({current} chars, under the {max_chars} cap)")
+            continue
+        if current > previous:
+            violations.append(
+                f"{rel}: front matter grew {previous} -> {current} chars "
+                f"(+{current - previous}). Trim it, or move the content into the body."
+            )
+        elif current < previous:
+            notes.append(f"{rel}: front matter shrank {previous} -> {current} chars")
+
+    return violations, notes
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--changed", metavar="BASE", help="Ratchet changed posts against BASE")
+    group.add_argument("--all", action="store_true", help="Cap check over every post (no ratchet)")
+    parser.add_argument("files", nargs="*", help="Optional explicit post paths")
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=DEFAULT_MAX_CHARS,
+        help=f"Absolute front-matter ceiling (default: {DEFAULT_MAX_CHARS})",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if args.all:
+        base = None
+        paths = sorted(str(p.relative_to(REPO_ROOT)) for p in POSTS_DIR.glob("*.md"))
+    else:
+        base = args.changed
+        if args.files:
+            paths = [str(Path(f)) for f in args.files]
+        else:
+            try:
+                paths = changed_posts(base)
+            except RuntimeError as exc:
+                print(f"ERROR: {exc}", file=sys.stderr)
+                return 2
+
+    if not paths:
+        print("No posts to check.")
+        return 0
+
+    violations, notes = check(base, paths, args.max_chars)
+
+    for note in notes:
+        print(f"  note: {note}")
+    if violations:
+        print()
+        for violation in violations:
+            print(f"::error::front matter: {violation}")
+        print(f"\n{len(violations)} front-matter violation(s) across {len(paths)} post(s).")
+        return 1
+
+    print(f"Front matter OK across {len(paths)} post(s) (cap {args.max_chars}, no growth).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_front_matter_growth.py
+++ b/scripts/tests/test_check_front_matter_growth.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check_front_matter_growth.py.
+
+The gate this replaced was an inline YAML snippet warning above 1,000 chars — a
+threshold 261 of 261 posts violated, in a step that could not exit non-zero. Being
+untestable inline is part of how it rotted unnoticed, so the replacement lives in a
+script and these tests cover both directions: it must FAIL on growth and on breaching
+the cap, and it must PASS on legacy size, shrinkage, and new posts under the cap.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_front_matter_growth import (  # noqa: E402
+    DEFAULT_MAX_CHARS,
+    check,
+    front_matter_len,
+    main,
+)
+
+SCRIPT = REPO_ROOT / "scripts" / "check_front_matter_growth.py"
+
+
+# ---------------------------------------------------------------------------
+# front_matter_len
+# ---------------------------------------------------------------------------
+
+
+def test_front_matter_len_counts_inner_block_only():
+    text = "---\ntitle: hi\n---\nbody text here"
+    assert front_matter_len(text) == len("title: hi")
+
+
+def test_front_matter_len_none_when_absent():
+    assert front_matter_len("no front matter at all") is None
+
+
+def test_front_matter_len_ignores_later_triple_dashes():
+    text = "---\na: 1\n---\nbody\n---\nnot front matter\n---\n"
+    assert front_matter_len(text) == len("a: 1")
+
+
+# ---------------------------------------------------------------------------
+# check() — the pure decision function
+# ---------------------------------------------------------------------------
+
+
+def _write(tmp_path: Path, name: str, fm_chars: int) -> str:
+    """Create a post whose front matter is exactly `fm_chars` long."""
+    posts = tmp_path / "_posts"
+    posts.mkdir(exist_ok=True)
+    filler = "x" * max(0, fm_chars - len("t: "))
+    body = f"---\nt: {filler}\n---\nbody\n"
+    (posts / name).write_text(body, encoding="utf-8")
+    return str((posts / name).relative_to(tmp_path))
+
+
+def test_check_flags_missing_front_matter(tmp_path, monkeypatch):
+    import check_front_matter_growth as mod
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    posts = tmp_path / "_posts"
+    posts.mkdir()
+    (posts / "a.md").write_text("no front matter", encoding="utf-8")
+    violations, _ = mod.check(None, ["_posts/a.md"], DEFAULT_MAX_CHARS)
+    assert any("no front matter block" in v for v in violations)
+
+
+def test_check_flags_cap_breach(tmp_path, monkeypatch):
+    import check_front_matter_growth as mod
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    rel = _write(tmp_path, "a.md", 500)
+    violations, _ = mod.check(None, [rel], 100)
+    assert any("exceeds the 100-char cap" in v for v in violations)
+
+
+def test_check_passes_under_cap_without_baseline(tmp_path, monkeypatch):
+    import check_front_matter_growth as mod
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    rel = _write(tmp_path, "a.md", 50)
+    violations, _ = mod.check(None, [rel], 100)
+    assert violations == []
+
+
+def test_check_notes_deleted_file_without_failing(tmp_path, monkeypatch):
+    import check_front_matter_growth as mod
+
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)
+    violations, notes = mod.check(None, ["_posts/gone.md"], DEFAULT_MAX_CHARS)
+    assert violations == []
+    assert any("deleted or moved" in n for n in notes)
+
+
+# ---------------------------------------------------------------------------
+# Ratchet behaviour against a real git baseline
+# ---------------------------------------------------------------------------
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture()
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    (repo / "_posts").mkdir(parents=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "t")
+    return repo
+
+
+def _commit_post(repo: Path, name: str, fm_chars: int, message: str) -> None:
+    filler = "x" * max(0, fm_chars - len("t: "))
+    (repo / "_posts" / name).write_text(f"---\nt: {filler}\n---\nbody\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", message)
+
+
+@pytest.fixture()
+def script_in_repo(git_repo: Path) -> Path:
+    """Copy the script in so its REPO_ROOT resolves to the temp repo."""
+    dest = git_repo / "scripts"
+    dest.mkdir(exist_ok=True)
+    (dest / SCRIPT.name).write_text(SCRIPT.read_text(encoding="utf-8"), encoding="utf-8")
+    return dest / SCRIPT.name
+
+
+def test_growth_fails(git_repo: Path, script_in_repo: Path):
+    _commit_post(git_repo, "a.md", 200, "base")
+    _git(git_repo, "branch", "-M", "base")
+    _git(git_repo, "checkout", "-qb", "topic")
+    _commit_post(git_repo, "a.md", 400, "grow")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "base"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "grew 200 -> 400" in proc.stdout
+
+
+def test_shrinkage_passes(git_repo: Path, script_in_repo: Path):
+    _commit_post(git_repo, "a.md", 400, "base")
+    _git(git_repo, "branch", "-M", "base")
+    _git(git_repo, "checkout", "-qb", "topic")
+    _commit_post(git_repo, "a.md", 200, "shrink")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "base"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "shrank 400 -> 200" in proc.stdout
+
+
+def test_legacy_size_is_grandfathered(git_repo: Path, script_in_repo: Path):
+    """An oversized post that does not change must not fail — that is the ratchet."""
+    _commit_post(git_repo, "a.md", 2500, "base")
+    _git(git_repo, "branch", "-M", "base")
+    _git(git_repo, "checkout", "-qb", "topic")
+    # touch the body only
+    path = git_repo / "_posts" / "a.md"
+    path.write_text(path.read_text(encoding="utf-8") + "\nmore body\n", encoding="utf-8")
+    _git(git_repo, "add", "-A")
+    _git(git_repo, "commit", "-qm", "body edit")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "base"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+def test_new_post_is_noted_not_failed(git_repo: Path, script_in_repo: Path):
+    _commit_post(git_repo, "a.md", 200, "base")
+    _git(git_repo, "branch", "-M", "base")
+    _git(git_repo, "checkout", "-qb", "topic")
+    _commit_post(git_repo, "b.md", 300, "new post")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "base"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "new post" in proc.stdout
+
+
+def test_new_post_over_cap_fails(git_repo: Path, script_in_repo: Path):
+    """New posts have no baseline, so the absolute cap is what bounds them."""
+    _commit_post(git_repo, "a.md", 100, "base")
+    _git(git_repo, "branch", "-M", "base")
+    _git(git_repo, "checkout", "-qb", "topic")
+    _commit_post(git_repo, "b.md", 500, "huge new post")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "base", "--max-chars", "200"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "exceeds the 200-char cap" in proc.stdout
+
+
+def test_unresolvable_base_is_an_error_not_a_pass(git_repo: Path, script_in_repo: Path):
+    """The whole point: a broken diff must never read as "nothing changed"."""
+    _commit_post(git_repo, "a.md", 100, "base")
+    proc = subprocess.run(
+        [sys.executable, str(script_in_repo), "--changed", "no-such-ref"],
+        cwd=git_repo, capture_output=True, text=True,
+    )
+    assert proc.returncode == 2, proc.stdout + proc.stderr
+    assert "Refusing to report 'no changes'" in proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Live corpus canary
+# ---------------------------------------------------------------------------
+
+
+def test_live_corpus_is_under_the_cap():
+    """If this ever fails, the cap needs a decision — not a silent bump."""
+    assert main(["--all"]) == 0, (
+        "some post now exceeds the front-matter cap. Trim it, or raise --max-chars "
+        "deliberately and say why in the same PR."
+    )

--- a/scripts/tests/test_ci_jekyll_soft_gate_guard.py
+++ b/scripts/tests/test_ci_jekyll_soft_gate_guard.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""CI regression guard: jekyll.yml's validation steps must stay hard.
+
+`jekyll.yml` carries the `build` job, one of only two checks with real blocking
+evidence in the last 30 PRs. The 2026-08-10 audit found four of its steps softened,
+two of them doubly:
+
+D8  "Validate post quality" had `continue-on-error: true` AND `|| true`, under a step
+    that printed "warnings only, non-blocking". `validate_post_quality.py` defaults
+    `--fail-below` to **60**, so a real floor existed and was disabled twice over — it
+    survived only in the pre-commit hook, which `--no-verify` skips. Measured before
+    enabling: 261 posts, minimum score 80, mean 90.6, zero below 60.
+
+D9  "Check front matter size" warned above 1,000 chars via inline Python that could
+    not exit non-zero. Measured: 261 of 261 posts exceed 1,000. A threshold every file
+    violates is noise, so it became a growth ratchet plus a 3,000-char cap
+    (`check_front_matter_growth.py`, measured max 2,749).
+
+D10 The Digest gate and the front-matter quote gate both computed their changed-file
+    list with `|| true`. An unresolvable `origin/main` therefore yielded an empty list
+    and printed "skipping" — a broken checkout silently skipped the gate while the step
+    reported success. The quote gate's version was worse: the `|| true` sat inside
+    `<(...)` process substitution, where mapfile cannot see the exit code at all.
+
+D7/D11 The two PR-comment steps keep `continue-on-error: true` — failing to post a
+    comment must not fail CI — but their `gh` calls used bare `|| true`, so a failed
+    comment left no trace. They now emit `::warning::`.
+
+Direction: absence assertions on the soft shapes. Re-adding `continue-on-error` to a
+validation step, or `|| true` around a validator, trips this guard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "jekyll.yml"
+
+# Steps that make a pass/fail judgement. These must never be soft.
+VALIDATION_STEPS = (
+    "Run script unit tests",
+    "Digest quality gate",
+    "Validate Jekyll Configuration",
+    "Validate Liquid include syntax in posts",
+    "Front-matter quote gate (unescaped inner DQ)",
+    "Validate posts (severity, front matter, links)",
+    "Validate post quality (PR only)",
+    "Check front matter growth (PR only)",
+)
+
+# Steps whose only job is to post a PR comment. Soft is CORRECT here: a comment API
+# failure must not fail the build. They must still announce the failure.
+REPORTING_STEPS = (
+    "Post coverage comment (PR only)",
+    "Post quality dashboard comment (PR only)",
+)
+
+
+def _job() -> dict:
+    import yaml
+
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["build"]
+
+
+def _steps() -> dict[str, dict]:
+    return {s["name"]: s for s in _job()["steps"] if s.get("name")}
+
+
+def _uncommented(shell: str) -> str:
+    """Shell text minus comment-only lines.
+
+    Each repaired step documents the `|| true` it removed, so asserting on raw text
+    would match the very comment explaining the fix.
+    """
+    return "\n".join(ln for ln in shell.splitlines() if not ln.lstrip().startswith("#"))
+
+
+@pytest.mark.parametrize("name", VALIDATION_STEPS)
+def test_validation_steps_are_not_continue_on_error(name: str):
+    steps = _steps()
+    assert name in steps, f"step {name!r} is gone from jekyll.yml — renamed or removed?"
+    assert not steps[name].get("continue-on-error"), (
+        f"{name!r} is continue-on-error again. A validation step that cannot fail the "
+        "job is a green tick over an unchecked claim."
+    )
+
+
+@pytest.mark.parametrize("name", VALIDATION_STEPS)
+def test_validation_steps_do_not_swallow_exit_codes(name: str):
+    steps = _steps()
+    run = _uncommented(steps[name].get("run") or "")
+    offenders = [
+        ln.strip()
+        for ln in run.splitlines()
+        if "|| true" in ln and "gh api" not in ln  # comment-id lookups may legitimately be empty
+    ]
+    assert not offenders, (
+        f"{name!r} swallows an exit code with '|| true': {offenders}. If the intent is "
+        "advisory, say so in the step name — do not name it Validate and then disarm it."
+    )
+
+
+def test_post_quality_floor_is_enforced():
+    run = _uncommented(_steps()["Validate post quality (PR only)"]["run"])
+    assert "validate_post_quality.py" in run
+    assert "|| true" not in run, (
+        "the 60-point floor is disarmed again. validate_post_quality.py exits 1 below "
+        "--fail-below (default 60); measured corpus minimum is 80."
+    )
+
+
+def test_front_matter_gate_uses_the_ratchet_script():
+    steps = _steps()
+    assert "Check front matter size (PR only)" not in steps, (
+        "the old 1,000-char warning step is back. 261 of 261 posts exceed that "
+        "threshold, so it can only ever print noise."
+    )
+    run = _uncommented(steps["Check front matter growth (PR only)"]["run"])
+    assert "check_front_matter_growth.py" in run
+    assert "--changed" in run, "the ratchet needs a diff base to compare against"
+
+
+@pytest.mark.parametrize("step_name", ["Digest quality gate", "Front-matter quote gate (unescaped inner DQ)"])
+def test_changed_file_diffs_fail_closed(step_name: str):
+    """An unresolvable origin/main must not read as "nothing changed"."""
+    run = _uncommented(_steps()[step_name]["run"])
+    assert re.search(r"if !\s+\w+=\$\(git diff", run), (
+        f"{step_name!r} no longer checks whether `git diff` succeeded. A shallow or "
+        "broken checkout would yield an empty list and skip the gate while passing."
+    )
+    assert "refusing to skip" in run, "expected an explicit ::error:: on diff failure"
+
+
+def test_quote_gate_diff_is_not_inside_process_substitution():
+    """`mapfile < <(cmd || true)` hides the exit code from mapfile entirely."""
+    run = _uncommented(_steps()["Front-matter quote gate (unescaped inner DQ)"]["run"])
+    assert "mapfile -t CHANGED < <(" not in run, (
+        "the changed-file list is computed inside <(...) again; a failure there is "
+        "invisible to mapfile, which is how this gate silently skipped"
+    )
+
+
+@pytest.mark.parametrize("name", REPORTING_STEPS)
+def test_reporting_steps_stay_soft_but_announce_failures(name: str):
+    """Comment posting should not fail CI — but must not vanish silently either."""
+    steps = _steps()
+    assert name in steps, f"reporting step {name!r} disappeared"
+    assert steps[name].get("continue-on-error") is True, (
+        f"{name!r} is now hard-failing. A GitHub comment API hiccup would break "
+        "unrelated PRs; keep it soft."
+    )
+    run = steps[name].get("run") or ""
+    assert "::warning::" in run, (
+        f"{name!r} swallows posting failures without a trace. Emit ::warning:: so a "
+        "missing comment is visible, following indexnow-ping.yml."
+    )
+
+
+def test_coverage_floor_still_pinned():
+    """Canary: the pytest coverage floor is the other half of this job's value."""
+    body = _uncommented(WORKFLOW.read_text(encoding="utf-8"))
+    assert "--cov-fail-under=40" in body, (
+        "the coverage floor moved or vanished. Raising or removing it is a deliberate "
+        "decision that belongs in a PR description, not a silent edit."
+    )


### PR DESCRIPTION
`jekyll.yml`의 `build` 잡은 최근 30 PR에서 **실제 차단 이력이 있는 두 체크 중 하나**인데,
검증 스텝 4곳이 연성이었고 그중 2곳은 이중이었습니다.

**요청과 달라진 곳이 두 군데 있어 먼저 밝힙니다** — 둘 다 실측이 전제를 바꿨습니다.

## D8 — 60점 하한을 실제로 켰습니다

`validate_post_quality.py`의 `--fail-below` **기본값이 60**이라 하한은 원래 존재했는데,
스텝의 `continue-on-error: true` + 명령의 `|| true`로 **두 번 무력화**돼 있었고 스텝은
`"warnings only, non-blocking"`을 출력했습니다. 즉 하한은 pre-commit 훅에만 살아 있었고
`--no-verify`로 우회됩니다.

**켜기 전 실측 (261개 포스트):**
```
최저 80점 | 평균 90.6 | 최고 100 | 60점 미만: 0개
```
최악 포스트에도 20점 여유 → 백로그를 다음 사람에게 이연하는 변경이 아닙니다.

## D9 — 요청은 "fail-closed"였지만, 그대로 켜면 모든 PR이 red가 됩니다

1000자 한도 경고였는데 실측 결과:
```
_posts 261개 중 1000자 초과: 261개 (100%)
최대 2749자 / 상위: 2749, 2720, 2678, 2648, 2617 …
```
**100%가 위반하는 임계값은 게이트가 아니라 소음**이고, 경고 무시를 학습시킵니다. 그대로
fail-closed로 바꾸면 포스트를 건드리는 모든 PR이 red가 됩니다.

그래서 **오늘 참인 두 주장으로 재설계**했습니다 (`scripts/check_front_matter_growth.py` 신규):

| 주장 | 근거 |
|---|---|
| **래칫** — 기존 포스트의 front matter는 커지면 안 된다 | 레거시 크기는 grandfathered, 새 증가만 실패. `check_digest_structure --ratchet`·honesty baseline과 같은 형태 |
| **절대 상한 3000자** | 실측 최대 2749 → 소급 판정이 아니라 무한 증가의 천장. 신규 포스트는 비교 대상이 없으므로 이것이 경계 |

실동작 확인 (임시 커밋 → 복원):
```
front matter grew 2226 -> 2440 chars (+214). Trim it, or move the content into the body.
exit=1
```

인라인 YAML → 스크립트로 옮겼습니다. **테스트 불가였던 것이 이 체크가 조용히 썩은 이유의 일부**입니다.

## D10 — diff 실패를 "변경 없음"으로 읽던 곳 2군데

digest 게이트와 front-matter quote 게이트 모두 `|| true`로 목록을 만들어, `origin/main`이
해석 불가일 때 빈 목록 → `"skipping"`을 출력하며 **통과**했습니다.

**quote 게이트 쪽은 감사에 없던 추가 발견이고 더 나빴습니다:**
```bash
mapfile -t CHANGED < <(git diff ... || true)   # ← || true 가 프로세스 치환 안
```
`<(...)` 안의 실패는 `mapfile`이 **종료 코드를 볼 수조차 없습니다**. diff를 치환 밖에서
계산하도록 바꾸고, 빈 입력/다중 입력 동작을 bash로 실측 확인했습니다:
```
빈 입력 → 배열 길이 0
2줄 입력 → 배열 길이 2: _posts/a.md _posts/b.md
```

## D7/D11 — 코멘트 게시는 soft를 유지합니다 (의도적)

PR 코멘트 API 실패가 무관한 PR을 깨선 안 되므로 `continue-on-error`는 **옳습니다**. 고친 것은
`gh` 호출의 bare `|| true`가 실패를 흔적 없이 삼키던 부분입니다 → `::warning::`
(`indexnow-ping.yml`이 이미 쓰는 모범).

가드가 이 **구분 자체를 고정**합니다: 검증 스텝은 hard여야 하고, 보고 스텝은 soft이면서
warning을 내야 합니다. 어느 쪽으로 뒤집혀도 실패합니다.

## 회귀 가드 (뮤테이션 검증)

- `test_ci_jekyll_soft_gate_guard.py` 신규 **24건**
- `test_check_front_matter_growth.py` 신규 **14건** (성장/상한 위반 실패, 레거시·축소·신규 통과, 해석 불가 base는 exit 2)

뮤테이션 **8종 전부 caught**:

| 뮤테이션 | 결과 |
|---|---|
| D8 `continue-on-error` 복구 | caught |
| D8 `\|\| true` 복구 | caught (2건) |
| D9 옛 1000자 스텝 복구 | caught |
| D10 `\|\| true` 복구 (digest) | caught |
| quote gate 프로세스 치환 복구 | caught |
| 코멘트 스텝을 hard로 | caught |
| 코멘트 `::warning::` 제거 | caught |
| 커버리지 하한 40→0 | caught |

## 검증

- `pytest scripts/tests/` — **4,081 passed** / 5 skipped
- `ruff check` clean, `.githooks/pre-commit` exit 0
- YAML 파싱 OK, bash 로직 실측

**이 PR 자체가 D8·D9·D10을 실행합니다** — `_posts`를 건드리지 않으므로 diff-scoped 스텝은
"변경 없음"으로 통과하고, 그 경로가 diff 실패와 구별되는지는 위 bash 실측으로 확인했습니다.

## 남은 범위 (별도 PR)

item 2의 나머지 절반인 **시크릿 부재 시 green 7개 워크플로**(D14)는 성격이 갈려 한 번에
묶으면 안 됩니다 — Slack 알림은 옵셔널 통합이라 조용한 스킵이 타당하지만,
`vercel-firewall-backup`처럼 감사/백업 목적 워크플로의 스킵은 존재 이유를 무력화합니다.
분류해서 후속 PR로 올리겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
