### PR TITLE
ci: 시크릿 부재를 "실제로 있는 시크릿"에서만 fail-closed 로 (비대칭은 의도)

### DIFF
--- a/.github/workflows/googlebot-access-monitor.yml
+++ b/.github/workflows/googlebot-access-monitor.yml
@@ -64,9 +64,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Fail, do not skip. SLACK_BOT_TOKEN and SLACK_CHANNEL_ID ARE configured in
+          # this repo (verified 2026-08-10 via `gh secret list`), so their absence is not
+          # an optional-integration case — it means the secret was removed, rotated
+          # without updating, or the job lost access. Skipping green would silence exactly
+          # the regression worth knowing about: notifications quietly stopping.
+          #
+          # This is safe to make hard precisely because the secrets exist. Contrast
+          # gsc-queue-refresh.yml and vercel-firewall-backup.yml, whose secrets have
+          # never been configured — fail-closed there would only produce a permanently
+          # red cron that gets muted. Follows sentry-healthcheck.yml, which already
+          # fails on missing secrets.
           if [ -z "${SLACK_BOT_TOKEN:-}" ] || [ -z "${SLACK_CHANNEL_ID:-}" ]; then
-            echo "::warning::SLACK_BOT_TOKEN or SLACK_CHANNEL_ID not configured, skipping notification"
-            exit 0
+            echo "::error::SLACK_BOT_TOKEN or SLACK_CHANNEL_ID is not available. Both are configured in this repo, so the alert this job exists to deliver would have been dropped silently."
+            exit 1
           fi
           payload=$(python3 -c '
           import json, os

--- a/.github/workflows/slack-category-digest.yml
+++ b/.github/workflows/slack-category-digest.yml
@@ -58,13 +58,24 @@ jobs:
           MESSAGE: ${{ steps.digest.outputs.message }}
         run: |
           set -euo pipefail
+          # Fail, do not skip. SLACK_BOT_TOKEN and SLACK_CHANNEL_ID ARE configured in
+          # this repo (verified 2026-08-10 via `gh secret list`), so their absence is not
+          # an optional-integration case — it means the secret was removed, rotated
+          # without updating, or the job lost access. Skipping green would silence exactly
+          # the regression worth knowing about: notifications quietly stopping.
+          #
+          # This is safe to make hard precisely because the secrets exist. Contrast
+          # gsc-queue-refresh.yml and vercel-firewall-backup.yml, whose secrets have
+          # never been configured — fail-closed there would only produce a permanently
+          # red cron that gets muted. Follows sentry-healthcheck.yml, which already
+          # fails on missing secrets.
           if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
-            echo "::warning::SLACK_BOT_TOKEN not configured, skipping"
-            exit 0
+            echo "::error::SLACK_BOT_TOKEN is not available. It is configured in this repo, so this is a regression — check secret access for this workflow, not an optional integration."
+            exit 1
           fi
           if [ -z "${SLACK_CHANNEL_ID:-}" ]; then
-            echo "::warning::SLACK_CHANNEL_ID not configured, skipping"
-            exit 0
+            echo "::error::SLACK_CHANNEL_ID is not available. It is configured in this repo, so this is a regression."
+            exit 1
           fi
           payload=$(python3 -c '
           import json, os

--- a/.github/workflows/slack-post-notify.yml
+++ b/.github/workflows/slack-post-notify.yml
@@ -66,13 +66,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Fail, do not skip. SLACK_BOT_TOKEN and SLACK_CHANNEL_ID ARE configured in
+          # this repo (verified 2026-08-10 via `gh secret list`), so their absence is not
+          # an optional-integration case — it means the secret was removed, rotated
+          # without updating, or the job lost access. Skipping green would silence exactly
+          # the regression worth knowing about: notifications quietly stopping.
+          #
+          # This is safe to make hard precisely because the secrets exist. Contrast
+          # gsc-queue-refresh.yml and vercel-firewall-backup.yml, whose secrets have
+          # never been configured — fail-closed there would only produce a permanently
+          # red cron that gets muted. Follows sentry-healthcheck.yml, which already
+          # fails on missing secrets.
           if [ -z "${SLACK_BOT_TOKEN:-}" ]; then
-            echo "::warning::SLACK_BOT_TOKEN not configured, skipping"
-            exit 0
+            echo "::error::SLACK_BOT_TOKEN is not available. It is configured in this repo, so this is a regression — check secret access for this workflow, not an optional integration."
+            exit 1
           fi
           if [ -z "${SLACK_CHANNEL_ID:-}" ]; then
-            echo "::warning::SLACK_CHANNEL_ID not configured, skipping"
-            exit 0
+            echo "::error::SLACK_CHANNEL_ID is not available. It is configured in this repo, so this is a regression."
+            exit 1
           fi
           payload=$(python3 -c '
           import json, os

--- a/scripts/tests/test_ci_secret_absence_guard.py
+++ b/scripts/tests/test_ci_secret_absence_guard.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""CI regression guard: a missing secret must fail where the secret actually exists.
+
+The 2026-08-10 audit flagged seven workflows as "missing secret -> green, zero work".
+Measuring `gh secret list` against what each workflow requires splits that group in
+two, and the two halves need opposite treatment:
+
+**Secrets that ARE configured** (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL_ID`) — their absence
+at runtime is not an optional-integration case. It means the secret was removed,
+rotated without updating, or the job lost access to it. Skipping green there silences
+the one regression worth knowing about: notifications quietly stopping. These three
+workflows now exit 1, following `sentry-healthcheck.yml`, which already does.
+
+**Secrets that were NEVER configured** — `GSC_SERVICE_ACCOUNT_JSON` for
+`gsc-queue-refresh.yml`, and `VERCEL_TOKEN` / `VERCEL_PROJECT_ID` / `VERCEL_TEAM_ID`
+for `vercel-firewall-backup.yml`. Verified from live run logs on 2026-08-10:
+
+    gsc-queue-refresh      ::warning::GSC_SERVICE_ACCOUNT_JSON secret is NOT set.
+    vercel-firewall-backup ##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
+
+Both report success on every scheduled run while doing nothing — `vercel-firewall-backup`
+is the one whose purpose is recording firewall drift. They are deliberately NOT made
+fail-closed here: with the secret permanently absent that would produce a permanently
+red cron, which is the muted-noise failure mode `digest-translate-backfill.yml` was
+just repaired for. Provisioning the secrets or retiring the workflows is a decision for
+the repo owner, so this guard pins the current asymmetry and the reason for it instead
+of quietly picking one.
+
+Direction: if a secret listed in NEVER_CONFIGURED gets provisioned, that workflow
+should move to the fail-closed set and this guard should be updated in the same PR.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# Secrets confirmed present in the repo -> absence is a regression -> fail.
+FAIL_CLOSED = (
+    "slack-post-notify.yml",
+    "slack-category-digest.yml",
+    "googlebot-access-monitor.yml",
+)
+
+# Secrets never configured -> fail-closed would be a permanently red cron.
+NEVER_CONFIGURED = {
+    "gsc-queue-refresh.yml": "GSC_SERVICE_ACCOUNT_JSON",
+    "vercel-firewall-backup.yml": "VERCEL_TOKEN",
+}
+
+
+def _uncommented(text: str) -> str:
+    """Workflow text minus comment-only lines.
+
+    Each repaired file explains the `exit 0` it replaced and names the never-configured
+    counter-examples, so matching raw text would hit the explanation rather than code.
+    """
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _body(name: str) -> str:
+    return _uncommented((WORKFLOWS / name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("name", FAIL_CLOSED)
+def test_missing_slack_secret_fails(name: str):
+    body = _body(name)
+    assert "SLACK_BOT_TOKEN" in body, f"{name} no longer references SLACK_BOT_TOKEN"
+    # Find the guard block and confirm it exits non-zero.
+    blocks = re.findall(
+        r'if \[ -z "\$\{SLACK_(?:BOT_TOKEN|CHANNEL_ID):-\}" \][^\n]*\n(.*?)\n\s*fi',
+        body,
+        re.DOTALL,
+    )
+    assert blocks, f"{name}: no SLACK secret guard block found"
+    for block in blocks:
+        assert "exit 1" in block, (
+            f"{name}: a missing Slack secret still exits 0. Both secrets are configured "
+            "in this repo, so a green skip hides notifications silently stopping."
+        )
+        assert "exit 0" not in block, f"{name}: guard block still contains exit 0"
+
+
+@pytest.mark.parametrize("name", FAIL_CLOSED)
+def test_missing_secret_is_an_error_annotation_not_a_warning(name: str):
+    """`::warning::` reads as expected-and-fine; this state is neither."""
+    body = _body(name)
+    guard_region = body[body.find("SLACK_BOT_TOKEN:-") :][:1200]
+    assert "::error::" in guard_region, (
+        f"{name}: the missing-secret branch should emit ::error::, not ::warning::"
+    )
+
+
+@pytest.mark.parametrize(("name", "secret"), sorted(NEVER_CONFIGURED.items()))
+def test_never_configured_workflows_stay_soft(name: str, secret: str):
+    """Deliberate asymmetry — read the module docstring before "fixing" this.
+
+    These secrets have never existed in the repo. Making the workflow fail would create
+    a cron that is red every single run, which trains people to ignore it. The state is
+    a provisioning decision, not a code defect.
+    """
+    body = _body(name)
+    assert secret in body, f"{name} no longer references {secret}"
+    assert "exit 0" in body, (
+        f"{name} now fails when {secret} is absent. That secret has never been "
+        "configured, so this would be red on every scheduled run. If it HAS now been "
+        "provisioned, move this workflow into FAIL_CLOSED and say so in the PR."
+    )
+
+
+def test_sentry_healthcheck_remains_the_reference_implementation():
+    """The audit cited this as the counter-example done right; keep it that way."""
+    body = _body("sentry-healthcheck.yml")
+    assert "exit 1" in body, (
+        "sentry-healthcheck.yml no longer fails on missing secrets. It is the pattern "
+        "the three Slack workflows were aligned to; if it changed, revisit them too."
+    )
+
+
+def test_the_two_groups_do_not_overlap():
+    """Canary against a copy-paste that puts a workflow in both lists."""
+    assert not set(FAIL_CLOSED) & set(NEVER_CONFIGURED)


### PR DESCRIPTION
item 2의 나머지 절반입니다. **요청은 "시크릿 부재 green 7개 워크플로 fail-closed"였지만,
일괄 적용은 오답입니다** — 무엇이 실제로 설정돼 있는지 대조하니 그 묶음이 둘로 갈리고 두
절반은 정반대 처리가 필요합니다.

## 실측: 요구 시크릿 vs 설정된 시크릿

`gh secret list` 결과와 대조:

| 워크플로 | 요구 시크릿 | 설정 |
|---|---|---|
| `slack-post-notify` | `SLACK_BOT_TOKEN`·`SLACK_CHANNEL_ID` | ✅ |
| `slack-category-digest` | 동일 | ✅ |
| `googlebot-access-monitor` | 동일 | ✅ |
| `gsc-queue-refresh` | `GSC_SERVICE_ACCOUNT_JSON` | ❌ |
| `vercel-firewall-backup` | `VERCEL_TOKEN`·`VERCEL_PROJECT_ID`·`VERCEL_TEAM_ID` | ❌ |
| `monitoring` | `PAGESPEED_API_KEY`·`SLACK_WEBHOOK`·`VERCEL_TOKEN` | ❌ (이미 `exit 1` 보유) |
| `vercel-deploy` | `SENTRY_AUTH_TOKEN` | ✅ (단 자동 트리거 자체가 없음) |

또한 감사의 "silent green" 표현은 과했습니다 — **7개 중 6개는 이미 `::warning::`을 냅니다.**
문제는 침묵이 아니라 **성공 보고**입니다.

## 설정된 시크릿 → fail-closed (3개 변경)

부재는 옵셔널 통합이 아니라 **회귀**입니다(제거 / 미갱신 로테이션 / 접근 상실). green 스킵은
"알림이 조용히 멈췄다"는, 유일하게 알 가치가 있는 사건을 침묵시킵니다.

```diff
-  echo "::warning::SLACK_BOT_TOKEN not configured, skipping"
-  exit 0
+  echo "::error::SLACK_BOT_TOKEN is not available. It is configured in this repo, so this is a regression..."
+  exit 1
```

시크릿이 **존재하므로** hard로 만들어도 영구 red가 되지 않습니다. 감사가 "모범"으로 꼽은
`sentry-healthcheck.yml`(이미 시크릿 부재 시 실패)을 따랐습니다.

## 한 번도 설정된 적 없는 시크릿 → 그대로 둡니다 (의도적 비대칭)

라이브 로그 실측:
```
gsc-queue-refresh      ::warning::GSC_SERVICE_ACCOUNT_JSON secret is NOT set.
vercel-firewall-backup ##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
```
둘 다 **모든 스케줄 실행에서 success를 보고하며 아무 일도 하지 않습니다** — 매일(gsc) /
매주(firewall). 특히 `vercel-firewall-backup`은 **방화벽 드리프트 기록이 존재 이유**인
워크플로인데 스냅샷을 한 번도 찍지 못했습니다.

그런데 여기서 fail-closed로 만들면 **매 실행 red인 cron**이 됩니다 — 방금 #532에서
`digest-translate-backfill`을 고친 이유인 "무시되는 소음" 그 자체입니다.

**시크릿 프로비저닝이냐 워크플로 폐기냐는 레포 소유자 결정 사안**이라, 조용히 한쪽을 고르는
대신 현재 비대칭과 그 이유를 가드로 고정했습니다. 가드에는 "프로비저닝되면 `FAIL_CLOSED`로
옮기고 같은 PR에서 가드를 갱신하라"는 지시가 들어 있습니다.

## 회귀 가드 (뮤테이션 검증)

`scripts/tests/test_ci_secret_absence_guard.py` 신규 **10건**. 뮤테이션 **5종 전부 caught**:

| 뮤테이션 | 결과 |
|---|---|
| `slack-post-notify` `exit 0` 복구 | caught |
| `::error::` → `::warning::` 회귀 | caught |
| `googlebot-access-monitor` `exit 0` 복구 | caught |
| **미설정 워크플로를 fail-closed로** | caught (비대칭을 양방향으로 고정) |
| `sentry-healthcheck`를 soft로 | caught |

마지막 두 개가 핵심입니다 — 이 가드는 "hard로 바꾸는 것"만 요구하지 않고, **hard로 바꾸면
안 되는 곳을 hard로 바꾸는 것도** 실패시킵니다.

## 검증

- `pytest scripts/tests/` — **4,091 passed** / 5 skipped
- `ruff check` clean, `.githooks/pre-commit` exit 0
- 3개 워크플로 YAML 파싱 OK

## 결정이 필요한 사항 (item 3에서 함께 다룸)

1. `GSC_SERVICE_ACCOUNT_JSON` — 프로비저닝할지, `gsc-queue-refresh`를 폐기할지
2. `VERCEL_TOKEN`/`VERCEL_PROJECT_ID`/`VERCEL_TEAM_ID` — 방화벽 드리프트 백업을 살릴지 폐기할지
3. `PAGESPEED_API_KEY`/`SLACK_WEBHOOK` — `monitoring`이 부분적으로만 동작 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)
