### PR TITLE
ci: 아무 일도 못 하던 cron 2개를 스케줄에서 폐기 (dispatch 는 유지)

### DIFF
--- a/.github/workflows/gsc-queue-refresh.yml
+++ b/.github/workflows/gsc-queue-refresh.yml
@@ -4,10 +4,21 @@ name: GSC Queue Refresh
 # Read-only — does NOT call the Indexing API or otherwise trigger recrawl.
 # Output uploaded as workflow artifact (not committed, to avoid leaking any
 # accidental sensitive field from the inspection response into git history).
+# RETIRED FROM THE DAILY SCHEDULE (2026-08-10).
+#
+# GSC_SERVICE_ACCOUNT_JSON has never been configured in this repo, so every
+# scheduled run reported success while doing nothing. Verified from the live log:
+#
+#     ::warning::GSC_SERVICE_ACCOUNT_JSON secret is NOT set.
+#
+# A daily green tick over zero work is worse than no workflow: it reads, on the
+# Actions tab and in any audit of "what protects this repo", as a job that runs. The
+# cron is removed and `workflow_dispatch` kept, so the moment the secret is
+# provisioned this can be run on demand and the schedule restored in the same PR.
+#
+# Restoring the cron without provisioning the secret just re-creates the silent
+# no-op — see scripts/tests/test_ci_secret_absence_guard.py.
 on:
-  schedule:
-    # Daily at 06:00 UTC (= 15:00 KST). Off-peak for Search Console quota.
-    - cron: '0 6 * * *'
   workflow_dispatch:
     inputs:
       limit:

--- a/.github/workflows/vercel-firewall-backup.yml
+++ b/.github/workflows/vercel-firewall-backup.yml
@@ -15,9 +15,24 @@ name: Vercel Firewall Backup
 #   VERCEL_PROJECT_ID  — defaults to tech-blog project
 #   VERCEL_TEAM_ID     — defaults to twodragon0s-projects team
 
+# RETIRED FROM THE WEEKLY SCHEDULE (2026-08-10).
+#
+# VERCEL_TOKEN has never been configured, so no snapshot has ever been taken.
+# Verified from the live log:
+#
+#     ##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
+#
+# That is worth stating plainly given the incident in the header above: this
+# workflow exists so an unauthorized dashboard edit shows up as a committed diff,
+# and it has been reporting weekly success without ever producing one. The green
+# tick was itself the audit-trail gap it was built to close.
+#
+# The cron is removed rather than made fail-closed: with the secret permanently
+# absent, failing would produce a red run every Monday, which gets muted — the same
+# failure mode digest-translate-backfill.yml was repaired for. `workflow_dispatch`
+# is kept so the first real snapshot is one click away once VERCEL_TOKEN exists;
+# restore the cron in that same PR.
 on:
-  schedule:
-    - cron: "0 0 * * 1"   # 09:00 KST every Monday (00:00 UTC)
   workflow_dispatch:
     inputs:
       commit:

--- a/scripts/tests/test_ci_secret_absence_guard.py
+++ b/scripts/tests/test_ci_secret_absence_guard.py
@@ -113,6 +113,37 @@ def test_never_configured_workflows_stay_soft(name: str, secret: str):
     )
 
 
+@pytest.mark.parametrize("name", sorted(NEVER_CONFIGURED))
+def test_never_configured_workflows_are_not_scheduled(name: str):
+    """Retired from cron on 2026-08-10 — restoring it needs the secret, not just a cron.
+
+    Both ran on a schedule and reported success on every run while doing nothing. A
+    recurring green tick over zero work is worse than no workflow at all: on the Actions
+    tab, and in any audit of "what protects this repo", it reads as a job that runs.
+    `vercel-firewall-backup` is the sharp case — it exists so an unauthorized Vercel
+    dashboard edit shows up as a committed diff, and its weekly success had never
+    produced one.
+
+    `workflow_dispatch` is kept, so provisioning the secret makes the first real run one
+    click away. Re-adding the cron is only correct in the same change that provisions
+    the secret; this assertion is what forces that pairing to be deliberate.
+    """
+    import yaml
+
+    parsed = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    triggers = parsed[True] if True in parsed else parsed["on"]
+    assert "schedule" not in triggers, (
+        f"{name} is on a schedule again. Its secret "
+        f"({NEVER_CONFIGURED[name]}) must be provisioned in the SAME change, otherwise "
+        "every run is a green tick over zero work. If it was provisioned, move this "
+        "workflow to FAIL_CLOSED and drop it from NEVER_CONFIGURED here."
+    )
+    assert "workflow_dispatch" in triggers, (
+        f"{name} lost workflow_dispatch; there would be no way to run it once the "
+        "secret exists."
+    )
+
+
 def test_sentry_healthcheck_remains_the_reference_implementation():
     """The audit cited this as the counter-example done right; keep it that way."""
     body = _body("sentry-healthcheck.yml")


### PR DESCRIPTION
item 3의 실행 가능한 부분입니다. 결정 3건 중 2건은 "현상유지/보류"였고, 이 PR은 세 번째
결정("무용 cron 폐기")을 구현합니다.

## 무엇을 폐기하는가

시크릿이 **한 번도 설정된 적 없어** 매 실행 success를 보고하며 아무 일도 하지 않던 두
워크플로의 `schedule`을 제거합니다. `workflow_dispatch`는 유지합니다.

라이브 로그 근거:
```
gsc-queue-refresh (매일)       ::warning::GSC_SERVICE_ACCOUNT_JSON secret is NOT set.
vercel-firewall-backup (매주)  ##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
```

반복되는 green 틱은 워크플로가 없는 것보다 나쁩니다 — Actions 탭에서, 그리고 "이 레포를
무엇이 지키고 있나"를 감사할 때 **도는 잡으로 읽힙니다.**

`vercel-firewall-backup`이 날카로운 사례입니다. 헤더에 적힌 대로 이 워크플로는 **무단 Vercel
대시보드 편집이 커밋된 diff로 드러나게** 하려고 만들어졌고(2026-05-08 사건: `bot_protection`이
조용히 `challenge`로 바뀌어 Googlebot을 며칠간 차단), 매주 성공을 보고하면서 **스냅샷을 한 번도
만든 적이 없습니다.** 그 green이 곧 그 워크플로가 닫으려던 감사 추적 공백이었습니다.

## 왜 fail-closed가 아니라 cron 제거인가

시크릿이 영구 부재인 상태에서 실패시키면 **매주 red인 cron**이 됩니다 — #532에서
`digest-translate-backfill`을 고친 이유인 "무시되는 소음" 그 자체입니다. `workflow_dispatch`를
남겨 시크릿이 생기는 순간 첫 실제 실행이 **클릭 한 번 거리**에 있게 했습니다.

## 폐기하지 않은 것

`monitoring.yml`은 요구 시크릿 3종(`PAGESPEED_API_KEY`·`SLACK_WEBHOOK`·`VERCEL_TOKEN`)이
미설정이지만, **시크릿 없이도 프로덕션 HTTP 상태를 실제로 검사합니다**(실행 로그로 확인).
"아무 일도 못 하는" 워크플로가 아니므로 제외했습니다.

## 회귀 가드

`test_ci_secret_absence_guard.py`에 2건 추가 — `NEVER_CONFIGURED` 워크플로에 `schedule`이
다시 붙으면 **실패**하고(시크릿 프로비저닝과 **같은 변경**에서만 되살리도록 강제),
`workflow_dispatch`가 사라지면 실패합니다.

뮤테이션 3종:
| 뮤테이션 | 결과 |
|---|---|
| cron 재추가 | caught |
| `workflow_dispatch` 제거 | caught |
| 정상형(dispatch만) | 통과 ✓ |

## 보류 결정의 근거 (기록용)

`required checks` 보류는 실측 제약 2가지에 근거합니다:

1. **봇 main 직push가 GH006으로 차단** → App/PAT 프로비저닝이 선행돼야 자동발행이 유지됨
2. **경로 필터된 체크는 required로 지정하면 미실행 시 PR이 영구 pending** → 최근 30 PR 실측상
   지금 걸 수 있는 실질 게이트는 `build` 하나뿐(30/30 실행). `lint` 19/30, `lighthouse` 24/30,
   `check-svg` 0/30, `visual-regression` 0/30 — 나머지를 걸려면 각 워크플로에 "경로 미해당 시
   즉시 성공" shim 잡이 필요합니다.

또한 `can_approve_pull_request_reviews`는 **PR 생성과 승인을 하나의 토글로 묶습니다.** 지금은
required reviews가 없어 승인 측면이 무의미하지만, 나중에 리뷰 필수를 도입하면 워크플로
자기승인 우회 경로가 됩니다 — "설정 토글"과 "GitHub App"은 보안 등가가 아닙니다.

## 검증

- `pytest scripts/tests/` — **4,093 passed** / 5 skipped
- `ruff check` clean, `.githooks/pre-commit` exit 0
- 두 워크플로 YAML 파싱 후 트리거 확인: `['workflow_dispatch']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
