### PR TITLE
ci(blogwatcher): proper-noun 자가치유에 재검증 추가 (4개 중 유일하게 없던 곳)

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -404,6 +404,34 @@ jobs:
           fi
           python3 scripts/check_template_echo.py "$POST_FILE" --quiet
 
+      - name: Proper-noun pre-flight (self-heal, then block)
+        if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'
+        run: |
+          # Canonicalize Hangul transliterations of proper nouns (비트코인 -> Bitcoin).
+          # Body text only; front matter untouched; deny-by-default allow-list; quoted
+          # prose titles, CVE ids, code and URLs are masked out.
+          #
+          # This ran inside "Commit and publish" as `--fix … || true` with NO
+          # re-verification — the only one of the four cron self-heals that never
+          # checked its own work. Two things made that leak: the pre-commit gate cannot
+          # see this post (the Actions commit runs with no local hooks), and the
+          # svg-lint proper-noun gate is diff-scoped (`--changed BASE`), so it only
+          # catches the bot's digest when that digest happens to be HEAD~1 at 03:45 UTC.
+          # Any other commit landing in between and a --fix failure ships uncaught.
+          #
+          # Now it follows the same shape as the checklist-heading and template-echo
+          # steps above: self-heal, re-verify, BLOCK. Blocking is the established
+          # precedent for this class — the substitution is deterministic and
+          # allow-listed, so a survivor is not a judgement call, it is a token the
+          # allow-list does not cover and a human should decide on. The alternative is
+          # the silent corpus rot that took the 98 -> 75 manual campaign to undo.
+          POST_FILE="${{ steps.check_post.outputs.post_file }}"
+          if ! python3 scripts/check_digest_proper_nouns.py "$POST_FILE"; then
+            echo "::warning::Hangul proper noun in ${POST_FILE} — attempting --fix self-heal."
+            python3 scripts/check_digest_proper_nouns.py --fix "$POST_FILE" || true
+          fi
+          python3 scripts/check_digest_proper_nouns.py "$POST_FILE"
+
       - name: Commit and publish
         if: steps.check_post.outputs.post_created == 'true' && env.DRY_RUN != 'true'
         env:
@@ -417,14 +445,10 @@ jobs:
 
           TODAY=$(date +%Y-%m-%d)
 
-          # Canonicalize proper nouns (비트코인 -> Bitcoin ...) in the new digest
-          # body BEFORE staging, so the committed digest is already compliant and
-          # the svg-lint proper-noun gate stays green on the direct-push path.
-          # Body-text only (front matter untouched); deny-by-default allow-list.
-          # Non-blocking: a failure must never stop the digest from publishing.
-          for f in "_posts/${TODAY}"*Weekly_Digest*.md; do
-            [ -f "$f" ] && python3 scripts/check_digest_proper_nouns.py --fix "$f" || true
-          done
+          # Proper-noun canonicalization moved to its own pre-flight step above
+          # ("Proper-noun pre-flight"), which self-heals and then RE-VERIFIES.
+          # It used to run here as `--fix … || true` with no re-verification: the
+          # only one of the four cron self-heals that never checked its own work.
 
           git add "_posts/${TODAY}"*.md 2>/dev/null || true
           git add "assets/images/${TODAY}"*.svg 2>/dev/null || true

--- a/scripts/tests/test_ci_blogwatcher_selfheal_reverify_guard.py
+++ b/scripts/tests/test_ci_blogwatcher_selfheal_reverify_guard.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""CI regression guard: every cron self-heal must re-verify its own work.
+
+`ai-blogwatcher.yml` publishes digests by pushing straight to main, so the pre-commit
+hooks never see the post — the Actions commit runs with no local hooks. The workflow
+compensates with self-heal pre-flight steps, and the shape that makes them trustworthy
+is always the same three moves:
+
+    if ! <check>; then warn; <fixer> || true; fi
+    <check>          # re-verify, and BLOCK on a survivor
+
+The `|| true` on the fixer is correct: a fixer crash must not be the thing that decides
+whether the site publishes. The re-verify is what makes that safe — it converts "we
+tried to fix it" into "it is actually fixed".
+
+Audit finding (2026-08-10): three of the four self-heals had the re-verify. The
+proper-noun one did not. It ran inside "Commit and publish" as
+`check_digest_proper_nouns.py --fix … || true` with nothing after it, so a failed fix
+shipped silently. Two things kept that from being caught elsewhere:
+
+- pre-commit cannot see the post (no local hooks on the Actions commit), and
+- the svg-lint proper-noun gate is diff-scoped (`--changed BASE`, BASE=HEAD~1 on
+  non-PR events), so it only catches the bot's digest when that digest happens to be
+  HEAD~1 when the sweep runs at 03:45 UTC. Any other commit landing in between and the
+  violation ships uncaught.
+
+Fixed 2026-08-11 by promoting it to its own pre-flight step with the standard shape.
+
+Direction: this asserts the SHAPE, per gate. Adding a new self-heal without a re-verify
+trips it; so does deleting a re-verify from an existing one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+
+# (step-name fragment, checker script, fixer script)
+SELF_HEALS = (
+    (
+        "Canonical checklist heading pre-flight",
+        "scripts/check_digest_checklist_heading.py",
+        "scripts/restore_digest_structure.py",
+    ),
+    (
+        "Template-echo summary pre-flight",
+        "scripts/check_template_echo.py",
+        "scripts/rewrite_template_echo_summaries.py",
+    ),
+    (
+        "Proper-noun pre-flight",
+        "scripts/check_digest_proper_nouns.py",
+        "scripts/check_digest_proper_nouns.py --fix",
+    ),
+)
+
+
+def _steps() -> dict[str, dict]:
+    import yaml
+
+    job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]["auto-publish"]
+    return {s["name"]: s for s in job["steps"] if s.get("name")}
+
+
+def _find_step(fragment: str) -> dict:
+    for name, step in _steps().items():
+        if fragment in name:
+            return step
+    pytest.fail(f"no step whose name contains {fragment!r} in ai-blogwatcher.yml")
+
+
+def _uncommented(shell: str) -> str:
+    """Shell text minus comment-only lines.
+
+    Each of these steps explains the anti-pattern it avoids, naming the fixer and
+    `|| true` in prose. Matching raw text would hit the explanation, and worse, would
+    keep passing if the comment were deleted while the re-verify was too.
+    """
+    return "\n".join(ln for ln in shell.splitlines() if not ln.lstrip().startswith("#"))
+
+
+@pytest.mark.parametrize(("fragment", "checker", "fixer"), SELF_HEALS)
+def test_self_heal_reverifies_after_fixing(fragment: str, checker: str, fixer: str):
+    run = _uncommented(_find_step(fragment)["run"])
+
+    fixer_at = run.find(fixer)
+    assert fixer_at != -1, f"{fragment}: fixer {fixer!r} is gone"
+
+    # The checker must appear again AFTER the fixer, outside any `if !` condition.
+    tail = run[fixer_at + len(fixer) :]
+    reverify = [
+        ln.strip()
+        for ln in tail.splitlines()
+        if checker in ln and not ln.strip().startswith("if ")
+    ]
+    assert reverify, (
+        f"{fragment}: {checker} is never re-run after {fixer}. Without the re-verify "
+        "the `|| true` on the fixer means a failed self-heal publishes silently — the "
+        "exact hole the proper-noun step had until 2026-08-11."
+    )
+
+
+@pytest.mark.parametrize(("fragment", "checker", "fixer"), SELF_HEALS)
+def test_reverify_is_not_itself_softened(fragment: str, checker: str, fixer: str):
+    """A re-verify wrapped in `|| true` is decoration, not a gate."""
+    run = _uncommented(_find_step(fragment)["run"])
+    tail = run[run.find(fixer) + len(fixer) :]
+    for line in tail.splitlines():
+        if checker in line and not line.strip().startswith("if "):
+            assert "|| true" not in line, (
+                f"{fragment}: the re-verify is wrapped in '|| true', so a survivor "
+                "still publishes"
+            )
+            return
+
+
+def test_proper_nouns_no_longer_runs_inside_the_commit_step():
+    """It has to be a pre-flight; inside the commit step there is nothing to block."""
+    commit = _uncommented(_steps()["Commit and publish"]["run"])
+    assert "check_digest_proper_nouns.py" not in commit, (
+        "proper-noun --fix is back inside 'Commit and publish'. There it runs after the "
+        "point where blocking is possible, which is how it went un-re-verified."
+    )
+
+
+def test_proper_noun_preflight_runs_under_the_same_partition():
+    """Must share the trusted-event + post-created condition of its neighbours."""
+    step = _find_step("Proper-noun pre-flight")
+    assert step.get("if") == (
+        "env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'"
+    ), (
+        f"unexpected condition on the proper-noun pre-flight: {step.get('if')!r}. It "
+        "should match the checklist-heading and template-echo steps exactly, so the "
+        "untrusted-dispatch partition and the no-post case behave identically."
+    )
+
+
+def test_preflight_order_puts_all_gates_before_publish():
+    """A gate after the commit cannot stop the commit."""
+    names = list(_steps())
+    publish_at = names.index("Commit and publish")
+    for fragment, _checker, _fixer in SELF_HEALS:
+        at = next(i for i, n in enumerate(names) if fragment in n)
+        assert at < publish_at, f"{fragment} runs after 'Commit and publish'"
+
+
+def test_lone_adjective_stays_a_warning():
+    """Deliberate contrast: that one IS a judgement call and must not block.
+
+    Recorded so a future sweep does not "align" it with the blocking three. It fires on
+    a cover headline reading like "Claude AI" — sometimes correct, sometimes not — and
+    blocking there would stop publishing over a style opinion.
+    """
+    body = "\n".join(
+        ln
+        for ln in WORKFLOW.read_text(encoding="utf-8").splitlines()
+        if not ln.lstrip().startswith("#")
+    )
+    assert re.search(r"check_digest_lone_adjective\.py", body), "the lone-adjective check vanished"
+    assert "::warning::" in body


### PR DESCRIPTION
블로그워처는 디제스트를 **main 직push**로 발행하므로 pre-commit 훅이 그 포스트를 보지
못합니다(Actions 커밋은 로컬 훅 없이 실행). 워크플로는 자가치유 pre-flight 스텝으로
보완하는데, 그 스텝을 신뢰할 수 있게 만드는 형태는 항상 셋입니다:

```
if ! <check>; then warn; <fixer> || true; fi
<check>          # 재검증, 생존 시 BLOCK
```

fixer의 `|| true`는 **옳습니다** — fixer 크래시가 사이트 발행 여부를 결정해선 안 됩니다.
**재검증이 그걸 안전하게** 만듭니다: "고치려 했다"를 "실제로 고쳐졌다"로 바꿉니다.

## 네 자가치유 중 하나만 재검증이 없었습니다

| 자가치유 | 재검증 | 성격 |
|---|---|---|
| checklist heading | ✅ | block |
| template-echo | ✅ | block |
| lone-adjective | — | **warn (의도적)** — 판단 문제 |
| **proper-noun** | ❌ | `--fix … \|\| true` 뒤 아무것도 없음 |

proper-noun은 `"Commit and publish"` 스텝 **안에서** 돌았고 뒤에 아무것도 없어 **fix 실패가
조용히 발행**됐습니다. 다른 곳에서 잡히지 않은 이유 둘:

1. pre-commit이 이 포스트를 볼 수 없다 (로컬 훅 없음)
2. svg-lint의 proper-noun 게이트는 **diff-scoped**(`--changed BASE`, 비-PR 이벤트에서
   `BASE=HEAD~1`)라 **03:45 UTC 스윕 시점에 봇 디제스트가 마침 `HEAD~1`일 때만** 잡습니다.
   그 사이 다른 커밋이 들어오면 위반이 그대로 통과합니다.

## 수정

이웃 두 스텝과 **동일한 pre-flight 형태**로 승격했습니다(self-heal → 재검증 → block).
`"Commit and publish"` 안에서는 블로킹이 가능한 시점을 이미 지났으므로 위치 이동이 필수입니다.

블로킹이 맞는 이유: 치환은 **결정적이고 allow-list 기반**이라 생존자는 판단 문제가 아니고
allow-list가 다루지 않는 토큰이라 사람이 결정할 일입니다. 대안은 98→75 수동 캠페인으로
되돌려야 했던 조용한 코퍼스 부식입니다.

CLI 계약은 실측 확인했습니다 — positional 경로 단독으로 check 모드가 동작하고
(`OK … 0 violations`, exit 0), `--fix`는 0을 반환합니다.

## 회귀 가드 (뮤테이션 검증)

`scripts/tests/test_ci_blogwatcher_selfheal_reverify_guard.py` 신규 **10건**. 자가치유
**3곳 각각**에 대해 형태를 강제합니다:

1. fixer 뒤에 checker 재실행이 있는가
2. 그 재검증이 `|| true`로 무력화되지 않았는가
3. 모든 게이트가 `Commit and publish` **이전**에 있는가
4. proper-noun이 commit 스텝 안으로 되돌아가지 않았는가
5. 파티션 조건(`RUN_CHECKS` + `post_created`)이 이웃과 동일한가

`lone-adjective`는 **판단 문제이므로 warn 유지가 의도**라는 것도 함께 고정했습니다 — 미래의
일괄 정리가 이것까지 "정렬"하지 않도록.

뮤테이션 **5종 전부 caught**:

| 뮤테이션 | 결과 |
|---|---|
| proper-noun 재검증 삭제 | caught |
| 재검증에 `\|\| true` 추가 | caught |
| **기존 template-echo 재검증 삭제** | caught |
| commit 스텝 안으로 회귀 | caught |
| 파티션 조건 변경 | caught |

세 번째가 중요합니다 — 이 가드는 새로 추가한 지점만이 아니라 **기존 3곳에도** 적용됩니다.

## 검증

- `pytest scripts/tests/` — **4,107 passed** / 5 skipped
- `ruff check` clean, `.githooks/pre-commit` exit 0
- YAML 파싱 후 스텝 순서 확인: `checklist → template-echo → proper-noun → Commit and publish`

이 워크플로는 cron/dispatch 전용이라 PR CI에서 실행되지 않습니다. 실제 동작은 다음
자동발행(00:00 UTC)에서 확인됩니다 — 그때 proper-noun pre-flight 스텝이 로그에 나타나야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
