### PR TITLE
docs: README 다이어그램 2곳에서 폐기된 sns-share 제거 + 재배치

### DIFF
--- a/assets/images/readme-architecture.svg
+++ b/assets/images/readme-architecture.svg
@@ -143,27 +143,14 @@
   </g>
   <g>
     <rect x="195" y="435" width="105" height="42" rx="8" fill="#0f172a" stroke="#334155"/>
-    <text x="247" y="458" text-anchor="middle" fill="#e2e8f0" font-size="11" font-weight="500">SNS Share</text>
-    <text x="247" y="472" text-anchor="middle" fill="#64748b" font-size="9">sns-share.yml</text>
+    <text x="247" y="458" text-anchor="middle" fill="#e2e8f0" font-size="11" font-weight="500">Newsletter</text>
+    <text x="247" y="472" text-anchor="middle" fill="#64748b" font-size="9">buttondown.yml</text>
   </g>
   <g>
     <rect x="310" y="435" width="105" height="42" rx="8" fill="#0f172a" stroke="#334155"/>
-    <text x="362" y="458" text-anchor="middle" fill="#e2e8f0" font-size="11" font-weight="500">Newsletter</text>
-    <text x="362" y="472" text-anchor="middle" fill="#64748b" font-size="9">buttondown.yml</text>
+    <text x="362" y="458" text-anchor="middle" fill="#e2e8f0" font-size="11" font-weight="500">Sentry</text>
+    <text x="362" y="472" text-anchor="middle" fill="#64748b" font-size="9">sentry-release.yml</text>
   </g>
-  <g>
-    <rect x="425" y="435" width="105" height="42" rx="8" fill="#0f172a" stroke="#334155"/>
-    <text x="477" y="458" text-anchor="middle" fill="#e2e8f0" font-size="11" font-weight="500">Sentry</text>
-    <text x="477" y="472" text-anchor="middle" fill="#64748b" font-size="9">sentry-release.yml</text>
-  </g>
-  <!-- SNS icons -->
-  <rect x="80" y="485" width="70" height="32" rx="6" fill="#1da1f2"/>
-  <text x="115" y="506" text-anchor="middle" fill="#fff" font-size="10" font-weight="500">Twitter</text>
-  <rect x="160" y="485" width="70" height="32" rx="6" fill="#1877f2"/>
-  <text x="195" y="506" text-anchor="middle" fill="#fff" font-size="10" font-weight="500">Facebook</text>
-  <rect x="240" y="485" width="70" height="32" rx="6" fill="#0a66c2"/>
-  <text x="275" y="506" text-anchor="middle" fill="#fff" font-size="10" font-weight="500">LinkedIn</text>
-
   <!-- Vercel -->
   <g filter="url(#innerGlow)">
     <rect x="560" y="395" width="480" height="135" rx="12" fill="#1e293b" stroke="#fb7185" stroke-width="1"/>

--- a/assets/images/readme-ci-pipeline.svg
+++ b/assets/images/readme-ci-pipeline.svg
@@ -69,13 +69,9 @@
   <rect x="50" y="228" width="210" height="32" rx="8" fill="#1e293b" stroke="#10b981"/>
   <text x="155" y="249" text-anchor="middle" fill="#86efac" font-size="11">path: _posts/**</text>
   
-  <rect x="60" y="270" width="90" height="40" rx="6" fill="#1e293b" stroke="#334155"/>
-  <text x="105" y="293" text-anchor="middle" fill="#e2e8f0" font-size="10" font-weight="500">sns-share</text>
-  <text x="105" y="305" text-anchor="middle" fill="#64748b" font-size="8">Social</text>
-  
-  <rect x="160" y="270" width="90" height="40" rx="6" fill="#1e293b" stroke="#334155"/>
-  <text x="205" y="293" text-anchor="middle" fill="#e2e8f0" font-size="10" font-weight="500">buttondown</text>
-  <text x="205" y="305" text-anchor="middle" fill="#64748b" font-size="8">Newsletter</text>
+  <rect x="110" y="270" width="90" height="40" rx="6" fill="#1e293b" stroke="#334155"/>
+  <text x="155" y="293" text-anchor="middle" fill="#e2e8f0" font-size="10" font-weight="500">buttondown</text>
+  <text x="155" y="305" text-anchor="middle" fill="#64748b" font-size="8">Newsletter</text>
 
   <!-- Schedule -->
   <rect x="50" y="325" width="210" height="38" rx="10" fill="url(#cpCron)"/>
@@ -144,18 +140,14 @@
   <text x="800" y="328" text-anchor="middle" fill="#94a3b8" font-size="11">Build, deploy to GitHub Pages</text>
   
   <text x="395" y="355" text-anchor="middle" fill="#86efac" font-size="11">push (_posts/**)</text>
-  <text x="560" y="355" text-anchor="middle" fill="#e2e8f0" font-size="11">sns-share.yml</text>
-  <text x="800" y="355" text-anchor="middle" fill="#94a3b8" font-size="11">Twitter, Facebook, LinkedIn</text>
+  <text x="560" y="355" text-anchor="middle" fill="#e2e8f0" font-size="11">buttondown-notify.yml</text>
+  <text x="800" y="355" text-anchor="middle" fill="#94a3b8" font-size="11">RSS to email (Buttondown)</text>
   
-  <text x="395" y="382" text-anchor="middle" fill="#86efac" font-size="11">push (_posts/**)</text>
-  <text x="560" y="382" text-anchor="middle" fill="#e2e8f0" font-size="11">buttondown-notify.yml</text>
-  <text x="800" y="382" text-anchor="middle" fill="#94a3b8" font-size="11">RSS to email (Buttondown)</text>
+  <text x="395" y="382" text-anchor="middle" fill="#86efac" font-size="11">push (content)</text>
+  <text x="560" y="382" text-anchor="middle" fill="#e2e8f0" font-size="11">sentry-release.yml</text>
+  <text x="800" y="382" text-anchor="middle" fill="#94a3b8" font-size="11">Sentry release creation</text>
   
-  <text x="395" y="409" text-anchor="middle" fill="#86efac" font-size="11">push (content)</text>
-  <text x="560" y="409" text-anchor="middle" fill="#e2e8f0" font-size="11">sentry-release.yml</text>
-  <text x="800" y="409" text-anchor="middle" fill="#94a3b8" font-size="11">Sentry release creation</text>
-  
-  <text x="395" y="436" text-anchor="middle" fill="#c4b5fd" font-size="11">cron 01:00 UTC</text>
-  <text x="560" y="436" text-anchor="middle" fill="#e2e8f0" font-size="11">daily-news.yml, monitoring.yml</text>
-  <text x="800" y="436" text-anchor="middle" fill="#94a3b8" font-size="11">News collection, health check</text>
+  <text x="395" y="409" text-anchor="middle" fill="#c4b5fd" font-size="11">cron 01:00 UTC</text>
+  <text x="560" y="409" text-anchor="middle" fill="#e2e8f0" font-size="11">daily-news.yml, monitoring.yml</text>
+  <text x="800" y="409" text-anchor="middle" fill="#94a3b8" font-size="11">News collection, health check</text>
 </svg>


### PR DESCRIPTION
#542에서 `sns-share.yml`을 폐기하며 문서 8개는 정정했지만 SVG 다이어그램은 위험 대비 이득이
낮다고 판단해 부채로 남겼습니다. 이제 정리합니다 — **다이어그램이 존재하지 않는 워크플로를
계속 그리면 그것도 거짓 문서**입니다.

## `readme-ci-pipeline.svg` 2곳

**박스 행** — `path: _posts/**` 아래에서 `sns-share` 박스를 제거하고, 남은 `buttondown`
박스를 `x=160 → 110`으로 옮겨 헤더(`x=50..260`, 중심 155) 중심에 맞췄습니다.

**하단 표** — `sns-share.yml` 행을 제거하고 이후 3행을 행 간격(27px)만큼 끌어올렸습니다.

치환 순서에서 함정을 하나 만났습니다. 아래에서 위로(`436→409` 먼저) 하면 **목적지가 아직
점유돼 충돌**합니다 — 첫 시도에서 `y=409`가 6개가 되어 assert가 잡았고, 파일은 무손상이었습니다.
위에서 아래로(`382→355`, `409→382`, `436→409`) 하면 각 목적지가 이미 비어 있습니다. 각 단계마다
"목적지가 비었는지"를 단정으로 확인하도록 작성했습니다.

## `readme-architecture.svg`

`SNS Share` 박스 그룹과, 그것이 게시하던 **대상 illustration**(Twitter/Facebook/LinkedIn 색상
칩 3개)을 함께 제거했습니다. 남은 `Newsletter`/`Sentry` 박스를 각각 115px 왼쪽으로 당겼습니다.

**사전 확인**: 해당 좌표 영역(`y=435..517`)을 향하는 `path`/`line`/`polyline`이 **0개**라 끊어진
화살표가 남지 않습니다.

## SVG 게이트 전건 통과

README 아키텍처 SVG는 **3주간 은폐된 회귀**(`6bbe71af` → #481 → #489)의 진원지라 여기가
핵심입니다:

```
check_svg_quality --ci                  PASS
check_svg_title_ascii --all             PASS
lint_svg_compliance                     PASS (2 clean)
verify_images_unified --svg-validate     PASS
check_svg_size_gate --changed --strict  PASS
check_orphan_cover_rasters              PASS
XML well-formed (minidom)               OK
pre-commit (cover SVG 경로 활성)         PASS
```

두 파일 모두 `svg_visual_baseline`의 `TARGET_SVGS`에 없어 **시각 베이스라인 영향 0**입니다.

`pytest scripts/tests/` — **4,131 passed** / 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
