### PR TITLE
ci: CSP 상호작용 경로 위반 게이트 신설 — Path B 관문을 Sentry 없이 특정

### DIFF
--- a/.github/workflows/csp-interaction-check.yml
+++ b/.github/workflows/csp-interaction-check.yml
@@ -1,0 +1,86 @@
+name: CSP Interaction Check
+
+# Closes the gap a page-load-only CSP measurement leaves.
+#
+# vercel.json ships a Content-Security-Policy-Report-Only that drops 'unsafe-inline'
+# from script-src and allows only the two first-party inline-script hashes. It is the
+# preview of "Path B" (removing 'unsafe-inline' from the enforcing policy), and the
+# question Path B turns on is whether anything actually violates it.
+#
+# Measured 2026-08-12 on production with headless Chrome: ZERO violations on page load.
+# But head-runtime.js defers GA / AdSense / Kakao / Sentry behind the first user
+# interaction, and google-translate.js only loads Google's element.js from a click on
+# #lang-toggle. Those are the scripts most likely to inject inline code, and page load
+# never reaches them. Bisecting the interaction path found exactly one violation, and it
+# is the Translate click — reproduced WITHOUT Playwright injection (console-only
+# observation), so it is the site's behaviour, not the instrument's.
+#
+# That violation is grandfathered in scripts/tests/csp_interaction_baseline.txt. New
+# ones fail. Removing the baseline line is the definition of done for Path B.
+#
+# Why `schedule` and not a normal PR gate: the script measures PRODUCTION, so running it
+# on a PR would test the previous deployment and say nothing about the change under
+# review. The cron catches a regression after it ships; the `pull_request` trigger below
+# is deliberately narrow — it fires only when the gate or its baseline changes, so
+# editing the gate runs the gate (the self-consistency rule check-svg.yml documents).
+
+on:
+  schedule:
+    # 04:30 UTC (13:30 KST). After the blogwatcher digest (00:00), the Pages backup
+    # (00:30), and the two corpus sweeps (check-svg 03:15, svg-lint 03:45), so the
+    # runner pool is free and the day's content is already deployed.
+    - cron: "30 4 * * *"
+  pull_request:
+    paths:
+      - "scripts/tests/check_csp_interaction_violations.mjs"
+      - "scripts/tests/csp_interaction_baseline.txt"
+      - ".github/workflows/csp-interaction-check.yml"
+      # The policy under test and the scripts whose deferred loading it exercises.
+      - "vercel.json"
+      - "assets/js/head-runtime.js"
+      - "assets/js/google-translate.js"
+      - "scripts/dev/csp_inline_hashes.json"
+  workflow_dispatch: {}
+
+concurrency:
+  group: csp-interaction-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  csp-interaction:
+    name: csp interaction violations
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright chromium
+        # Same driver check_mermaid_csp_render.mjs already uses; only chromium is
+        # needed, so skip the firefox/webkit downloads.
+        run: npx playwright install --with-deps chromium
+
+      - name: Check CSP violations on the interaction path
+        # No `|| true`, no continue-on-error. Exit 1 = a NEW violation (the baseline
+        # grandfathers the known Translate one); exit 2 = the run could not be performed,
+        # which must not read as "nothing was wrong".
+        run: |
+          node scripts/tests/check_csp_interaction_violations.mjs \
+            --baseline scripts/tests/csp_interaction_baseline.txt \
+            --verbose

--- a/scripts/tests/check_csp_interaction_violations.mjs
+++ b/scripts/tests/check_csp_interaction_violations.mjs
@@ -1,0 +1,320 @@
+// CSP violation gate for the INTERACTION path.
+//
+// Why this exists
+// ---------------
+// `vercel.json` ships a Content-Security-Policy-Report-Only that drops
+// 'unsafe-inline' from script-src and allows only the two first-party inline-script
+// hashes. It is the preview of "Path B" — removing 'unsafe-inline' from the enforcing
+// policy. The question Path B turns on is: does anything actually violate it?
+//
+// Measured 2026-08-12 with headless Chrome on production: **zero** violations on page
+// load, on both the homepage and a post. But that measurement only covers what runs
+// before load. `assets/js/head-runtime.js` defers GA / AdSense / Kakao / Sentry behind
+// the first user interaction (pointermove, scroll, keydown, touchstart, click) with an
+// idle safety-net, and `assets/js/google-translate.js` only initialises the Translate
+// widget on demand. Those are exactly the scripts most likely to inject inline code,
+// and a page-load-only check cannot see them.
+//
+// This gate closes that gap: it loads the page, fires the real interaction events,
+// waits for the deferred third parties to load and execute, and asserts that the
+// Report-Only policy recorded no violations. Violations are collected structurally via
+// the `securitypolicyviolation` DOM event (the same approach as
+// check_mermaid_csp_render.mjs), not by scraping console text — report-only violations
+// fire that event too, and the event carries the directive and blocked URI.
+//
+// Usage
+//   node scripts/tests/check_csp_interaction_violations.mjs [--url <url>] [--verbose]
+//
+// Exit 0 = no violations attributable to first-party code.
+// Exit 1 = at least one violation survived; the report names the directive and URI.
+// Exit 2 = the run could not be performed (navigation failed, no policy present) —
+//          deliberately NOT exit 0, because "we could not check" must never read as
+//          "nothing was wrong".
+
+import { chromium } from 'playwright';
+import fs from 'node:fs';
+
+const DEFAULT_URLS = [
+  'https://tech.2twodragon.com/',
+  'https://tech.2twodragon.com/posts/2026/08/11/Tech_Security_Weekly_Digest_AI_Ransomware_Go_AWS/',
+];
+
+// head-runtime.js binds these five, capture+passive, to trigger its lazy loaders.
+const INTERACTION_EVENTS = ['pointermove', 'scroll', 'keydown', 'touchstart', 'click'];
+
+const NAV_TIMEOUT_MS = 45_000;
+// head-runtime.js also has a 10-12s idle safety net; give the deferred scripts room to
+// load and execute after the interaction fires.
+const SETTLE_MS = 12_000;
+
+const argv = process.argv.slice(2);
+const verbose = argv.includes('--verbose');
+const urlFlag = argv.indexOf('--url');
+const urls = urlFlag !== -1 ? [argv[urlFlag + 1]] : DEFAULT_URLS;
+// Coverage is reported always, but only ENFORCED on request: a third-party CDN being
+// unreachable from a CI runner would otherwise produce a red run every time, which is
+// the muted-noise failure mode this repo has been repairing all week.
+const requireCoverage = argv.includes('--require-coverage');
+const baselineFlag = argv.indexOf('--baseline');
+const baselinePath = baselineFlag !== -1 ? argv[baselineFlag + 1] : null;
+
+/**
+ * Grandfathered violations, keyed as `effectiveDirective|blockedURI`.
+ *
+ * The Google Translate path violates the Report-Only policy today: clicking
+ * #lang-toggle creates about:blank frames whose inline script trips
+ * script-src-elem. Verified 2026-08-12 WITHOUT any Playwright injection — a
+ * console-only observation reproduces it, so it is the site's behaviour, not the
+ * instrument's. Wiring this gate as blocking without a baseline would make CI red on
+ * every PR for a pre-existing condition, which is the muted-noise failure mode this
+ * repo spent the week removing. New violations still fail.
+ */
+function loadBaseline() {
+  if (!baselinePath) return new Set();
+  try {
+    const text = fs.readFileSync(baselinePath, 'utf8');
+    return new Set(
+      text
+        .split('\n')
+        .map((l) => l.replace(/#.*$/, '').trim())
+        .filter(Boolean),
+    );
+  } catch {
+    fail(`baseline file not readable: ${baselinePath}`);
+    process.exit(2);
+  }
+}
+
+function violationKey(v) {
+  return `${v.effectiveDirective}|${v.blockedURI}`;
+}
+
+function fail(msg) {
+  console.error(`\n✗ ${msg}`);
+}
+
+/**
+ * Violations whose blockedURI points at a browser extension or at a scheme we do not
+ * control are not ours. The user-reported console dump that started this work was
+ * dominated by MetaMask (`chrome-extension://`) WebAssembly violations; adding
+ * 'unsafe-eval' to satisfy an extension would weaken the policy for every visitor.
+ */
+function isFirstPartyConcern(v) {
+  const uri = (v.blockedURI || '').toLowerCase();
+  if (uri.startsWith('chrome-extension:') || uri.startsWith('moz-extension:')) return false;
+  if (uri === 'about' || uri.startsWith('about:')) return false;
+  return true;
+}
+
+async function checkUrl(browser, url) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const violations = [];
+  await page.exposeFunction('__reportCspViolation', (v) => violations.push(v));
+  await page.addInitScript(() => {
+    document.addEventListener('securitypolicyviolation', (e) => {
+      // eslint-disable-next-line no-undef
+      window.__reportCspViolation({
+        effectiveDirective: e.effectiveDirective,
+        violatedDirective: e.violatedDirective,
+        blockedURI: e.blockedURI,
+        disposition: e.disposition,
+        sourceFile: e.sourceFile,
+        lineNumber: e.lineNumber,
+      });
+    });
+  });
+
+  // Confirm a report-only policy is actually present. Without it this gate would pass
+  // trivially — the same vacuous-green shape the 2026-08 CI audit kept finding.
+  let sawReportOnly = false;
+  page.on('response', (res) => {
+    if (res.url() === url && res.headers()['content-security-policy-report-only']) {
+      sawReportOnly = true;
+    }
+  });
+
+  const response = await page
+    .goto(url, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS })
+    .catch((e) => {
+      fail(`navigation failed for ${url}: ${e.message}`);
+      return null;
+    });
+  if (!response) {
+    await context.close();
+    return { url, ok: false, reason: 'navigation', violations };
+  }
+
+  // Fire the interaction the lazy loaders are waiting for. A real pointer move plus a
+  // scroll covers pointermove/scroll; the rest are dispatched directly so a headless
+  // run without a pointer device still trips them.
+  await page.mouse.move(200, 200).catch(() => {});
+  await page.mouse.wheel(0, 400).catch(() => {});
+  await page.evaluate((events) => {
+    for (const type of events) {
+      window.dispatchEvent(new Event(type, { bubbles: true }));
+    }
+  }, INTERACTION_EVENTS);
+
+  // AdSense loads only when a `.adsbygoogle` slot enters the viewport
+  // (head-runtime.js installs an IntersectionObserver on it), so a shallow scroll
+  // never reaches it. Bring the slot into view explicitly.
+  const adSlotScrolled = await page
+    .locator('.adsbygoogle')
+    .first()
+    .scrollIntoViewIfNeeded({ timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  // Translate: google-translate.js loads Google's element.js from a click on
+  // #lang-toggle, then exposes `.goog-te-combo`. Clicking is the only way in — the
+  // widget container is display:none until then. Changing the select is what actually
+  // translates the page, which is the deepest interaction path we can drive headlessly.
+  const langToggleClicked = await page
+    .locator('#lang-toggle')
+    .first()
+    .click({ timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  await page.waitForTimeout(4_000);
+
+  const translated = await page
+    .evaluate(() => {
+      const select = document.querySelector('.goog-te-combo');
+      if (!select) return false;
+      select.value = 'en';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+      return true;
+    })
+    .catch(() => false);
+
+  await page.waitForTimeout(SETTLE_MS);
+
+  // What actually loaded, so a green result is auditable rather than assumed.
+  const loaded = await page.evaluate(() => {
+    const srcs = Array.from(document.scripts)
+      .map((s) => s.src)
+      .filter(Boolean);
+    const has = (needle) => srcs.some((s) => s.includes(needle));
+    return {
+      gtm: has('googletagmanager'),
+      adsense: has('googlesyndication'),
+      sentry: has('sentry-cdn'),
+      kakao: has('kakao'),
+      translate: has('translate.google') || has('translate_a'),
+      inlineExecutable: Array.from(document.scripts).filter(
+        (s) => !s.src && s.type !== 'application/ld+json' && s.textContent.trim(),
+      ).length,
+    };
+  });
+
+  // Which integrations the page is CONFIGURED for. Distinguishes "did not load
+  // because it is not configured" (fine) from "configured but this gate failed to
+  // trigger it" (a coverage gap that must not read as coverage).
+  const configured = await page.evaluate(() => {
+    const el = document.getElementById('head-runtime-script');
+    const attr = (n) => Boolean(el && (el.getAttribute(n) || '').trim());
+    return {
+      gtm: attr('data-ga-id'),
+      adsense: attr('data-adsense-client'),
+      kakao: attr('data-kakao-app-key'),
+      sentry: attr('data-sentry-dsn'),
+      translate: Boolean(document.getElementById('lang-toggle')),
+    };
+  });
+
+  await context.close();
+
+  const baseline = loadBaseline();
+  const mine = violations
+    .filter(isFirstPartyConcern)
+    .filter((v) => !baseline.has(violationKey(v)));
+  const grandfathered = violations
+    .filter(isFirstPartyConcern)
+    .filter((v) => baseline.has(violationKey(v)));
+  const uncovered = Object.keys(configured).filter((k) => configured[k] && !loaded[k]);
+  return {
+    url, ok: true, sawReportOnly, translated, adSlotScrolled, langToggleClicked,
+    loaded, configured, uncovered, violations, mine, grandfathered,
+  };
+}
+
+async function main() {
+  const browser = await chromium.launch({ args: ['--no-sandbox'] });
+  const results = [];
+  for (const url of urls) {
+    results.push(await checkUrl(browser, url));
+  }
+  await browser.close();
+
+  let exitCode = 0;
+  for (const r of results) {
+    if (!r.ok) {
+      exitCode = 2;
+      continue;
+    }
+    const path = new URL(r.url).pathname;
+    console.log(`\n${path}`);
+    console.log(`  report-only header present : ${r.sawReportOnly ? 'yes' : 'NO'}`);
+    console.log(
+      `  deferred third parties     : gtm=${r.loaded.gtm} adsense=${r.loaded.adsense} ` +
+        `sentry=${r.loaded.sentry} kakao=${r.loaded.kakao} translate=${r.loaded.translate}`,
+    );
+    console.log(
+      `  triggers fired             : ad-slot-scrolled=${r.adSlotScrolled} ` +
+        `lang-toggle-clicked=${r.langToggleClicked} translate-select=${r.translated}`,
+    );
+    console.log(
+      `  coverage                   : ${r.uncovered.length === 0 ? 'all configured integrations loaded' : 'NOT COVERED -> ' + r.uncovered.join(', ')}`,
+    );
+    console.log(`  executable inline scripts  : ${r.loaded.inlineExecutable}`);
+    console.log(
+      `  CSP violations             : ${r.violations.length} total, ` +
+        `${r.grandfathered.length} grandfathered, ${r.mine.length} NEW first-party`,
+    );
+
+    if (!r.sawReportOnly) {
+      fail(`${path}: no Content-Security-Policy-Report-Only header — this gate would pass vacuously`);
+      exitCode = 2;
+    }
+    if (verbose || r.mine.length) {
+      for (const v of r.violations) {
+        const tag = isFirstPartyConcern(v) ? 'FIRST-PARTY' : 'extension/ignored';
+        console.log(
+          `    [${tag}] ${v.disposition} ${v.effectiveDirective} blocked=${v.blockedURI} ` +
+            `at ${v.sourceFile || '?'}:${v.lineNumber ?? '?'}`,
+        );
+      }
+    }
+    if (r.uncovered.length) {
+      const msg =
+        `${path}: configured but never loaded: ${r.uncovered.join(', ')} — this run did ` +
+        `NOT exercise those code paths, so a green result does not cover them.`;
+      if (requireCoverage) {
+        fail(msg);
+        exitCode = Math.max(exitCode, 2);
+      } else {
+        console.log(`  ::warning:: ${msg}`);
+      }
+    }
+    if (r.mine.length) {
+      fail(
+        `${path}: ${r.mine.length} first-party CSP violation(s). Removing 'unsafe-inline' ` +
+          `from the enforcing policy would break these. Hash or externalise them first.`,
+      );
+      exitCode = 1;
+    }
+  }
+
+  if (exitCode === 0) {
+    console.log('\n✓ No first-party CSP violations on the interaction path.');
+  }
+  process.exit(exitCode);
+}
+
+main().catch((e) => {
+  fail(`unexpected error: ${e.stack || e.message}`);
+  process.exit(2);
+});

--- a/scripts/tests/csp_interaction_baseline.txt
+++ b/scripts/tests/csp_interaction_baseline.txt
@@ -1,0 +1,15 @@
+# Grandfathered CSP Report-Only violations, keyed as `effectiveDirective|blockedURI`.
+#
+# Verified 2026-08-12 on production WITHOUT Playwright injection (console-only
+# observation reproduces it, and a run with no interaction produces zero), so this is
+# the site's behaviour rather than an instrumentation artifact.
+#
+# Isolated by bisecting the interaction path: no interaction -> 0, mouse/scroll/synthetic
+# events -> 0 (with GTM and Sentry loaded), clicking #lang-toggle alone -> 1. The click
+# creates about:blank frames (hence sourceFile="about") whose inline script trips
+# script-src-elem.
+#
+# This is the concrete blocker for CSP Path B (dropping 'unsafe-inline' from the
+# enforcing script-src): Google Translate would break. Removing this line is the
+# definition of done for that work — do not delete it to make the gate quiet.
+script-src-elem|inline

--- a/scripts/tests/test_ci_csp_interaction_guard.py
+++ b/scripts/tests/test_ci_csp_interaction_guard.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""CI regression guard: the CSP interaction gate must keep measuring the hard path.
+
+Background (2026-08-12)
+-----------------------
+`vercel.json` ships a Report-Only policy that drops 'unsafe-inline' from script-src and
+allows only the two first-party inline-script hashes — the preview of CSP Path B. A
+headless page-load measurement on production found ZERO violations, which looked like a
+green light for Path B. It was not: `head-runtime.js` defers GA / AdSense / Kakao /
+Sentry behind the first user interaction, and `google-translate.js` only loads Google's
+element.js from a click on `#lang-toggle`. Page load never reaches them.
+
+Bisecting the interaction path produced the actual answer:
+
+    no interaction                        -> 0 violations (GTM + Sentry already loaded)
+    mouse move / scroll / synthetic events -> 0 violations
+    click #lang-toggle alone              -> 1 violation (script-src-elem, blockedURI=inline)
+
+Reproduced WITHOUT any Playwright injection (console-only observation), and a run with no
+interaction produces zero, so it is the site's behaviour rather than an instrumentation
+artifact. The click creates `about:blank` frames, which inherit the parent CSP — hence
+`sourceFile="about"`.
+
+So the Path B blocker is Google Translate, isolated locally in minutes without waiting
+for Sentry data. That violation is grandfathered; new ones fail.
+
+What these tests protect
+------------------------
+The gate is only worth anything while it still (a) drives the interactions, (b) refuses
+to pass when it could not measure, and (c) keeps the known violation visible instead of
+deleting it to go quiet. Each is easy to erode with a one-line edit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "csp-interaction-check.yml"
+SCRIPT = REPO_ROOT / "scripts" / "tests" / "check_csp_interaction_violations.mjs"
+BASELINE = REPO_ROOT / "scripts" / "tests" / "csp_interaction_baseline.txt"
+VERCEL_JSON = REPO_ROOT / "vercel.json"
+
+
+def _yaml(path: Path) -> dict:
+    import yaml
+
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _uncommented(text: str, marker: str) -> str:
+    return "\n".join(ln for ln in text.splitlines() if not ln.lstrip().startswith(marker))
+
+
+def _script() -> str:
+    return _uncommented(SCRIPT.read_text(encoding="utf-8"), "//")
+
+
+def _workflow_body() -> str:
+    return _uncommented(WORKFLOW.read_text(encoding="utf-8"), "#")
+
+
+# ---------------------------------------------------------------------------
+# The gate must exist and must not be soft
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_and_script_exist():
+    assert WORKFLOW.is_file(), f"{WORKFLOW.name} is gone"
+    assert SCRIPT.is_file(), f"{SCRIPT.name} is gone"
+    assert BASELINE.is_file(), f"{BASELINE.name} is gone"
+
+
+def test_gate_is_not_soft():
+    job = _yaml(WORKFLOW)["jobs"]["csp-interaction"]
+    assert not job.get("continue-on-error"), "the CSP interaction job is continue-on-error"
+    for step in job["steps"]:
+        run = step.get("run") or ""
+        if "check_csp_interaction_violations.mjs" in run:
+            assert "|| true" not in run, "the gate invocation is wrapped in '|| true'"
+            assert not step.get("continue-on-error"), "the gate step is continue-on-error"
+            assert "--baseline" in run, (
+                "the gate must run with --baseline, otherwise the known Translate "
+                "violation fails every run and the gate gets muted"
+            )
+            return
+    pytest.fail("no step invokes check_csp_interaction_violations.mjs")
+
+
+# ---------------------------------------------------------------------------
+# It must still drive the interactions that make it worth running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fragment", "why"),
+    [
+        ("#lang-toggle", "the Translate click is the only interaction that found a violation"),
+        (".adsbygoogle", "AdSense loads via IntersectionObserver on this slot, not on scroll"),
+        ("pointermove", "head-runtime.js binds this to its lazy loaders"),
+        ("securitypolicyviolation", "structural violation capture, not console scraping"),
+    ],
+)
+def test_script_still_drives_the_interaction_path(fragment: str, why: str):
+    assert fragment in _script(), f"{SCRIPT.name} no longer references {fragment!r} — {why}"
+
+
+def test_script_reports_coverage_gaps():
+    """A green result must say which integrations it did NOT exercise."""
+    src = _script()
+    assert "uncovered" in src, "coverage tracking is gone; a green run would overstate what it covered"
+    assert "configured" in src, (
+        "the script no longer distinguishes 'not configured' from 'configured but not "
+        "triggered' — the second is a coverage gap, the first is not"
+    )
+
+
+def test_script_refuses_to_pass_when_it_cannot_measure():
+    """"Could not check" must not read as "nothing was wrong"."""
+    src = _script()
+    assert "sawReportOnly" in src, (
+        "the script no longer verifies a Report-Only header is present; without one it "
+        "would pass vacuously"
+    )
+    assert "process.exit(2)" in src or "exitCode = 2" in src or "Math.max(exitCode, 2)" in src, (
+        "the distinct 'could not measure' exit code is gone"
+    )
+
+
+def test_extension_violations_are_excluded():
+    """The console dump that started this work was mostly MetaMask."""
+    src = _script()
+    assert "chrome-extension:" in src, (
+        "extension-origin violations are no longer filtered out. Adding 'unsafe-eval' or "
+        "'unsafe-inline' to satisfy a browser extension would weaken the policy for every "
+        "visitor."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The baseline is a record, not a mute button
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_documents_the_known_blocker():
+    text = BASELINE.read_text(encoding="utf-8")
+    assert "script-src-elem|inline" in text, (
+        "the grandfathered Translate violation is gone from the baseline. If Path B work "
+        "actually fixed it, that is the definition of done — say so in the PR. If it was "
+        "deleted to quiet the gate, restore it."
+    )
+    assert "lang-toggle" in text, "the baseline no longer records HOW the violation was isolated"
+
+
+def test_baseline_stays_small():
+    """A growing baseline means Path B is receding, and that should be visible."""
+    entries = [
+        ln.strip()
+        for ln in BASELINE.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and not ln.lstrip().startswith("#")
+    ]
+    assert len(entries) <= 3, (
+        f"the CSP interaction baseline has grown to {len(entries)} entries: {entries}. Each "
+        "one is a first-party violation that blocks Path B — grandfathering more of them "
+        "quietly converts the gate into a record of defeat."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Premise canary
+# ---------------------------------------------------------------------------
+
+
+def test_report_only_policy_still_exists_to_measure():
+    """The gate has nothing to measure if the Report-Only policy is dropped."""
+    import json
+
+    config = json.loads(VERCEL_JSON.read_text(encoding="utf-8"))
+    keys = {h["key"] for entry in config["headers"] for h in entry["headers"]}
+    assert "Content-Security-Policy-Report-Only" in keys, (
+        "vercel.json no longer sends a Report-Only policy, so this gate measures nothing. "
+        "If Path B shipped and the preview is obsolete, retire the gate deliberately."
+    )
+
+
+def test_schedule_present_because_the_target_is_production():
+    """A PR run tests the PREVIOUS deployment; the cron is what catches regressions."""
+    parsed = _yaml(WORKFLOW)
+    triggers = parsed[True] if True in parsed else parsed["on"]
+    assert "schedule" in triggers, (
+        "the schedule is gone. This gate measures production, so a pull_request run tests "
+        "the deployment that is already live — the cron is the trigger that actually "
+        "catches a regression after it ships."
+    )
+    assert "workflow_dispatch" in triggers, "no way to run the gate on demand"


### PR DESCRIPTION
요청은 "CDP로 상호작용을 시뮬레이션해 CI에서 재는 게이트"였습니다. 만들었고, **만드는 과정에서
Path B의 실제 관문이 특정됐습니다** — Sentry 데이터를 며칠 기다릴 필요가 없었습니다.

## 페이지 로드 측정이 청신호가 아니었던 이유

프로덕션 헤드리스 측정에서 로드 시점 위반은 **0건**이었습니다. 그런데 `head-runtime.js`는
GA/AdSense/Kakao/Sentry를 **첫 상호작용 뒤로** 미루고, `google-translate.js`는 `#lang-toggle`
클릭에서만 Google `element.js`를 로드합니다. 인라인 코드를 주입할 가능성이 가장 높은 스크립트들이
정확히 그 뒤에 있습니다.

## 이분 탐색 결과

```
아무것도 안 함                   → 위반 0   (GTM·Sentry 는 이미 로드됨)
마우스 + 스크롤 + 합성 이벤트     → 위반 0
#lang-toggle 클릭만              → 위반 1   script-src-elem, blockedURI=inline
```

**계측 오염이 아님을 별도로 증명했습니다** — Playwright 주입(`addInitScript`/`exposeFunction`)을
전부 제거하고 콘솔만 관찰한 시행에서도 재현되고, 상호작용 없는 시행은 0건입니다:

```
C) 주입X + 콘솔 관찰 → "Executing inline script violates … 'script-src-elem 'self' 'sha2…"
D) 클릭 후 about:blank 프레임 5개 생성   ← sourceFile="about" 의 정체
```

`about:blank` 프레임은 부모 CSP를 상속합니다. 즉 **Path B의 관문은 Google Translate**이고,
메모리에 적혀 있던 "Translate는 unsafe-inline 필요"가 실증됐습니다.

## 게이트 설계

- **구조적 수집** — `securitypolicyviolation` DOM 이벤트로 받습니다(콘솔 텍스트 스크래핑 아님).
  report-only 위반도 이 이벤트를 발생시키고 directive·blockedURI를 실어줍니다.
  기존 `check_mermaid_csp_render.mjs`가 쓰는 것과 같은 방식입니다.
- **베이스라인 래칫** — 알려진 Translate 위반은 `csp_interaction_baseline.txt`에
  grandfathered. 없이 걸면 기존 조건 때문에 **매 실행 red**가 되고, 그건 이번 주에 걷어낸
  "무시되는 소음" 그대로입니다. **그 한 줄을 지우는 것이 Path B의 완료 정의**입니다.
- **확장 유래 위반 제외** — 보고해주신 콘솔 덤프는 대부분 MetaMask였습니다. 확장을 만족시키려
  `unsafe-eval`/`unsafe-inline`을 넣는 것은 모든 방문자에게 정책을 약화시키는 일입니다.
- **커버리지 명시** — 설정됐는데 로드되지 않은 통합을 나열해 green이 실제 커버 범위를
  과장하지 못하게 합니다(현재 `translate` 스크립트 자체는 미로드 = 미커버로 보고).
- **exit 0/1/2 구분** — 2 = 측정 불가(내비게이션 실패, Report-Only 헤더 부재). "확인할 수
  없었다"가 "문제 없었다"로 읽히지 않게 합니다.

## 트리거 (PR 게이트가 아닌 이유)

`schedule`(04:30 UTC) + `workflow_dispatch` + **게이트 자신이 바뀔 때만** `pull_request`.
이 스크립트는 **프로덕션**을 재므로 PR 실행은 이미 배포된 것을 테스트합니다 — cron이 회귀를
잡는 트리거입니다. PR 트리거를 좁게 둔 것은 `check-svg.yml`이 문서화한 자기일관성 규칙입니다.

## 실측 (전부 로컬 실행)

| 시나리오 | exit | 비고 |
|---|---|---|
| 정상 | **0** | 1 grandfathered / 0 NEW |
| 빈 베이스라인 | **1** | 신규 위반으로 판정 |
| 베이스라인 경로 부재 | **2** | 측정 불가 |
| `--require-coverage` + translate 미커버 | **2** | 커버리지 강제 시 |

AdSense가 `.adsbygoogle` 슬롯을 **뷰포트로 스크롤해야** 로드된다는 것도 실측으로 찾아 트리거에
넣었습니다(포스트 페이지에서 `adsense=true`로 커버 확인). 초기 버전은 얕은 스크롤만 해서
AdSense를 놓치고 있었습니다.

## 회귀 가드 (뮤테이션 10종 전부 caught)

`test_ci_csp_interaction_guard.py` 13건:

| 뮤테이션 | 결과 |
|---|---|
| `\|\| true` 추가 / `--baseline` 제거 | caught |
| `schedule` 제거 / `workflow_dispatch` 제거 | caught |
| `#lang-toggle` 트리거 제거 | caught |
| `.adsbygoogle` 스크롤 제거 | caught |
| 확장 필터 제거 | caught |
| 커버리지 추적 제거 | caught |
| **베이스라인 항목 삭제(뮤트)** | caught |
| **베이스라인 4항목으로 증식** | caught |

마지막 둘이 핵심입니다 — 베이스라인을 지워 조용히 만드는 것도, 늘려서 패배를 기록하는 것도
막습니다(상한 3).

## 검증

- `pytest scripts/tests/` — **4,148 passed** / 5 skipped
- `check_workflow_action_pins.py` 전체 일관, `ruff` clean, pre-commit exit 0
- `playwright`는 이미 `devDependencies`에 있어 `npm ci`로 설치됩니다(기존 mermaid CSP 검사와 동일 드라이버)

## 남은 미커버

Translate의 **실제 번역 완료 흐름**(`.goog-te-combo` 변경)은 Google `element.js`가 헤드리스에서
초기화되지 않아 도달하지 못했습니다. 게이트가 이를 `NOT COVERED -> translate`로 명시 보고합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
