### PR TITLE
fix(csp): 게이트가 Translate 커버리지를 과소보고하던 버그 수정 + Path B 보류 결정

### DIFF
--- a/.github/workflows/csp-interaction-check.yml
+++ b/.github/workflows/csp-interaction-check.yml
@@ -18,6 +18,16 @@ name: CSP Interaction Check
 # That violation is grandfathered in scripts/tests/csp_interaction_baseline.txt. New
 # ones fail. Removing the baseline line is the definition of done for Path B.
 #
+# Updated 2026-08-12 after two measurement bugs were found in the gate itself:
+#   - `translate` was reported as never loaded. element.js deletes its own <script>
+#     node after running, so the DOM scan missed it and the gate printed a coverage
+#     gap that did not exist. Detection now reads the request log.
+#   - the translated document was never reached. Driving `.goog-te-combo` cannot work
+#     headlessly, so each URL is now also driven with the `googtrans` cookie a
+#     returning visitor carries, which does translate the page.
+# Both fixes widen coverage without adding a baseline entry: all four passes report
+# the same single grandfathered violation and zero new ones.
+#
 # Why `schedule` and not a normal PR gate: the script measures PRODUCTION, so running it
 # on a PR would test the previous deployment and say nothing about the change under
 # review. The cron catches a regression after it ships; the `pull_request` trigger below

--- a/.github/workflows/csp-interaction-check.yml
+++ b/.github/workflows/csp-interaction-check.yml
@@ -16,7 +16,13 @@ name: CSP Interaction Check
 # observation), so it is the site's behaviour, not the instrument's.
 #
 # That violation is grandfathered in scripts/tests/csp_interaction_baseline.txt. New
-# ones fail. Removing the baseline line is the definition of done for Path B.
+# ones fail.
+#
+# Path B is DEFERRED as of 2026-08-12 (notes/decisions.md). Promoting the Report-Only
+# policy to enforcing does not degrade Google Translate, it disables it — measured, not
+# inferred. So this workflow's job is no longer "watch until the baseline can be
+# emptied"; it is to catch a SECOND violation appearing, which would mean some other
+# integration started depending on 'unsafe-inline' too.
 #
 # Updated 2026-08-12 after two measurement bugs were found in the gate itself:
 #   - `translate` was reported as never loaded. element.js deletes its own <script>

--- a/notes/decisions.md
+++ b/notes/decisions.md
@@ -233,3 +233,31 @@ legacy 커버를 honesty FAIL 해소 목적으로 **재생성하거나 L22→L20
 - **fail-closed는 조건부로만 옳다**: 100%가 위반하는 임계값(front matter 1000자)이나 영구 부재 시크릿에 fail-closed를 적용하면 "무시되는 red"를 생산한다. 전자는 래칫으로, 후자는 cron 폐기로 처리 (#534, #536)
 - **자가치유에는 재검증이 필수**: `fixer || true` 뒤에 checker 재실행이 없으면 "고치려 했다"가 "고쳐졌다"로 위장된다. 크론 자가치유 4곳 중 1곳에 없었다 (#537)
 - **가드는 뮤테이션으로 자기검증한다**: 새 가드를 믿기 전에 각 수정을 되돌려 잡히는지 확인. 누적 60여 종 전부 caught. 반복 함정 — 검사 대상 파일의 주석이 안티패턴을 언급하므로 주석 제거 후 검사
+
+### CSP Path B 보류 — Google Translate 유지 (2026-08-12)
+
+**결정**: enforcing CSP의 `script-src`에서 `'unsafe-inline'`을 제거하는 Path B를 **보류**하고
+Google Translate를 유지한다.
+
+**근거 (추론 아님, 실측)**: Report-Only는 차단하지 않으므로 "Translate가 깨질 것"은 그동안
+추론이었다. 응답 헤더를 인플라이트로 바꿔 Report-Only를 enforcing으로 승격시킨 A/B로 측정:
+
+| | 현재 정책 | Path B enforcing |
+|---|---|---|
+| 본문 한글 잔존 | 0자 | 1061자 (26.6%) |
+| Google `<font>` 마커 | 446개 | 0개 |
+| `<html>` | `lang=en` / `translated-ltr` | `lang=ko` (미번역) |
+
+Path B는 Translate를 **저하시키는 게 아니라 완전히 비활성화**한다.
+
+**기각한 대안 — iframe 격리 후 별도 CSP**: 위반 문서는 `about:blank`이고 about:blank는
+임베더의 CSP를 상속한다. Chrome은 iframe `csp` 속성을 제거했고, Translate는 호스트 문서
+자체를 재작성해야 동작하므로 프레임에 가둘 수 없다. (명세·구현 논거이며 별도 A/B 미실시.)
+
+**적용**:
+- `csp_interaction_baseline.txt`의 1건은 "제거 대상 blocker"가 아니라 **수용된 trade-off**다.
+  Path B 재개 없이 이 줄을 지우지 말 것.
+- `csp-interaction-check.yml`의 임무는 "baseline이 비워질 때까지 감시"에서 **"두 번째 위반
+  등장 감지"**로 바뀐다. 다른 통합이 `unsafe-inline`에 새로 의존하기 시작하면 그것이 신호다.
+- 재개 조건: Google Translate 제거를 받아들이거나, about:blank 인라인 부트스트랩을 쓰지 않는
+  번역 수단으로 교체할 때.

--- a/scripts/tests/check_csp_interaction_violations.mjs
+++ b/scripts/tests/check_csp_interaction_violations.mjs
@@ -22,6 +22,10 @@
 // check_mermaid_csp_render.mjs), not by scraping console text — report-only violations
 // fire that event too, and the event carries the directive and blocked URI.
 //
+// Each URL is driven twice, in 'interaction' and 'translated' mode — see checkUrl().
+// The second pass exists because Google Translate rewrites the whole document, and the
+// gate previously never reached that state.
+//
 // Usage
 //   node scripts/tests/check_csp_interaction_violations.mjs [--url <url>] [--verbose]
 //
@@ -106,9 +110,48 @@ function isFirstPartyConcern(v) {
   return true;
 }
 
-async function checkUrl(browser, url) {
+/**
+ * Drive the page in one of two modes.
+ *
+ * 'interaction' — load, fire the deferred-loader triggers, click #lang-toggle.
+ * 'translated'  — additionally pre-set the `googtrans` cookie and `preferredLang`
+ *                 that the site's own changeLang() writes, so the page loads
+ *                 already translated and the gate sees the DOM Google Translate
+ *                 actually produces.
+ *
+ * Why the second mode exists: driving `.goog-te-combo` (what this gate used to
+ * attempt) never works headlessly — the dropdown widget renders inside
+ * about:blank frames and the combo never appears in the main document, so
+ * `translate-select` was permanently false and the translated page state was
+ * never exercised. The cookie path is the same one a returning visitor hits, and
+ * it does translate: verified 2026-08-12 on production, body Hangul 1061 -> 0
+ * chars with 446 <font> marker elements injected.
+ */
+async function checkUrl(browser, url, mode = 'interaction') {
   const context = await browser.newContext();
+  if (mode === 'translated') {
+    await context.addCookies([
+      { name: 'googtrans', value: '/ko/en', domain: `.${new URL(url).hostname}`, path: '/' },
+    ]);
+  }
   const page = await context.newPage();
+  if (mode === 'translated') {
+    await page.addInitScript(() => {
+      try {
+        localStorage.setItem('preferredLang', 'en');
+      } catch (_e) {
+        /* private mode — the cookie alone still drives the translation */
+      }
+    });
+  }
+
+  // Authoritative record of what the page fetched. Neither `document.scripts` nor
+  // Resource Timing is reliable here: Google's translate_a/element.js removes its own
+  // <script> node after running, and Resource Timing silently stops recording once the
+  // 250-entry default buffer fills — which this page exceeds, so a late-loading script
+  // vanishes from it. The CDP-level request log has neither problem.
+  const requested = [];
+  page.on('request', (r) => requested.push(r.url()));
 
   const violations = [];
   await page.exposeFunction('__reportCspViolation', (v) => violations.push(v));
@@ -193,22 +236,28 @@ async function checkUrl(browser, url) {
   await page.waitForTimeout(SETTLE_MS);
 
   // What actually loaded, so a green result is auditable rather than assumed.
-  const loaded = await page.evaluate(() => {
-    const srcs = Array.from(document.scripts)
-      .map((s) => s.src)
-      .filter(Boolean);
-    const has = (needle) => srcs.some((s) => s.includes(needle));
-    return {
-      gtm: has('googletagmanager'),
-      adsense: has('googlesyndication'),
-      sentry: has('sentry-cdn'),
-      kakao: has('kakao'),
-      translate: has('translate.google') || has('translate_a'),
-      inlineExecutable: Array.from(document.scripts).filter(
+  //
+  // Sourced from the request log above, not from a DOM scan: element.js deletes its
+  // own <script> node once it has run, so `document.scripts` reported translate=false
+  // for a script that demonstrably loaded and executed (verified 2026-08-12 — the
+  // element.js request fires and pulls in translate_http JS/CSS and translate-pa
+  // supportedLanguages, while `script[src*="translate_a/element.js"]` is null). A gate
+  // understating its own coverage is the failure mode this file exists to prevent.
+  const has = (needle) => requested.some((s) => s.includes(needle));
+  const inlineExecutable = await page.evaluate(
+    () =>
+      Array.from(document.scripts).filter(
         (s) => !s.src && s.type !== 'application/ld+json' && s.textContent.trim(),
       ).length,
-    };
-  });
+  );
+  const loaded = {
+    gtm: has('googletagmanager'),
+    adsense: has('googlesyndication'),
+    sentry: has('sentry-cdn'),
+    kakao: has('kakao'),
+    translate: has('translate.google') || has('translate_a'),
+    inlineExecutable,
+  };
 
   // Which integrations the page is CONFIGURED for. Distinguishes "did not load
   // because it is not configured" (fine) from "configured but this gate failed to
@@ -225,6 +274,20 @@ async function checkUrl(browser, url) {
     };
   });
 
+  // Did Google Translate actually rewrite the document? `translated-ltr` on <html>
+  // and the <font> wrappers are Google's own markers. In 'translated' mode a false
+  // here means the gate did not reach the translated state, so its green says
+  // nothing about that code path.
+  const translation = await page.evaluate(() => {
+    const text = document.body.innerText || '';
+    return {
+      applied: document.documentElement.classList.contains('translated-ltr'),
+      htmlLang: document.documentElement.lang,
+      fontMarkers: document.querySelectorAll('font').length,
+      hangulChars: (text.match(/[가-힣]/g) || []).length,
+    };
+  });
+
   await context.close();
 
   const baseline = loadBaseline();
@@ -236,8 +299,8 @@ async function checkUrl(browser, url) {
     .filter((v) => baseline.has(violationKey(v)));
   const uncovered = Object.keys(configured).filter((k) => configured[k] && !loaded[k]);
   return {
-    url, ok: true, sawReportOnly, translated, adSlotScrolled, langToggleClicked,
-    loaded, configured, uncovered, violations, mine, grandfathered,
+    url, mode, ok: true, sawReportOnly, translated, adSlotScrolled, langToggleClicked,
+    loaded, configured, uncovered, translation, violations, mine, grandfathered,
   };
 }
 
@@ -245,7 +308,8 @@ async function main() {
   const browser = await chromium.launch({ args: ['--no-sandbox'] });
   const results = [];
   for (const url of urls) {
-    results.push(await checkUrl(browser, url));
+    results.push(await checkUrl(browser, url, 'interaction'));
+    results.push(await checkUrl(browser, url, 'translated'));
   }
   await browser.close();
 
@@ -255,7 +319,7 @@ async function main() {
       exitCode = 2;
       continue;
     }
-    const path = new URL(r.url).pathname;
+    const path = `${new URL(r.url).pathname} [${r.mode}]`;
     console.log(`\n${path}`);
     console.log(`  report-only header present : ${r.sawReportOnly ? 'yes' : 'NO'}`);
     console.log(
@@ -268,6 +332,11 @@ async function main() {
     );
     console.log(
       `  coverage                   : ${r.uncovered.length === 0 ? 'all configured integrations loaded' : 'NOT COVERED -> ' + r.uncovered.join(', ')}`,
+    );
+    console.log(
+      `  translated DOM reached     : ${r.translation.applied} ` +
+        `(html lang=${r.translation.htmlLang || '?'}, ${r.translation.fontMarkers} <font> markers, ` +
+        `${r.translation.hangulChars} Hangul chars left)`,
     );
     console.log(`  executable inline scripts  : ${r.loaded.inlineExecutable}`);
     console.log(
@@ -292,6 +361,21 @@ async function main() {
       const msg =
         `${path}: configured but never loaded: ${r.uncovered.join(', ')} — this run did ` +
         `NOT exercise those code paths, so a green result does not cover them.`;
+      if (requireCoverage) {
+        fail(msg);
+        exitCode = Math.max(exitCode, 2);
+      } else {
+        console.log(`  ::warning:: ${msg}`);
+      }
+    }
+    // A 'translated' run that never reached the translated DOM covers no more than the
+    // 'interaction' run does. Say so rather than letting the extra pass imply coverage
+    // it did not deliver.
+    if (r.mode === 'translated' && !r.translation.applied) {
+      const msg =
+        `${path}: googtrans cookie was set but the document was never translated ` +
+        `(html lang=${r.translation.htmlLang || '?'}, ${r.translation.fontMarkers} <font> markers) ` +
+        `— this pass adds no coverage over the interaction pass.`;
       if (requireCoverage) {
         fail(msg);
         exitCode = Math.max(exitCode, 2);

--- a/scripts/tests/csp_interaction_baseline.txt
+++ b/scripts/tests/csp_interaction_baseline.txt
@@ -9,9 +9,13 @@
 # creates about:blank frames (hence sourceFile="about") whose inline script trips
 # script-src-elem.
 #
-# This is the concrete blocker for CSP Path B (dropping 'unsafe-inline' from the
-# enforcing script-src): Google Translate would break. Removing this line is the
-# definition of done for that work — do not delete it to make the gate quiet.
+# This was tracked as the blocker for CSP Path B (dropping 'unsafe-inline' from the
+# enforcing script-src). As of 2026-08-12 it is no longer a blocker to clear: Path B
+# is DEFERRED and Google Translate is kept. See notes/decisions.md.
+#
+# So this line is an accepted trade-off, not a to-do. It still must not be deleted to
+# quiet the gate — it is the record that the site runs with 'unsafe-inline' knowingly,
+# and it is what makes a SECOND violation appearing here visible as a new one.
 #
 # "Would break" is no longer an inference. Measured 2026-08-12 by rewriting the
 # response header in flight so the Report-Only policy became the enforcing one
@@ -24,5 +28,6 @@
 #                                translated-ltr    (no class)
 #   violation disposition        report            enforce
 #
-# Path B does not degrade Google Translate. It disables it outright.
+# Path B does not degrade Google Translate. It disables it outright. That measurement
+# is what the deferral decision was made on.
 script-src-elem|inline

--- a/scripts/tests/csp_interaction_baseline.txt
+++ b/scripts/tests/csp_interaction_baseline.txt
@@ -12,4 +12,17 @@
 # This is the concrete blocker for CSP Path B (dropping 'unsafe-inline' from the
 # enforcing script-src): Google Translate would break. Removing this line is the
 # definition of done for that work — do not delete it to make the gate quiet.
+#
+# "Would break" is no longer an inference. Measured 2026-08-12 by rewriting the
+# response header in flight so the Report-Only policy became the enforcing one
+# (Path B), against the same page with the policy left as production ships it:
+#
+#            production policy   Path B enforcing
+#   Hangul chars left in body    0                 1061  (26.6% of body)
+#   Google <font> markers        446               0
+#   <html>                       lang=en           lang=ko
+#                                translated-ltr    (no class)
+#   violation disposition        report            enforce
+#
+# Path B does not degrade Google Translate. It disables it outright.
 script-src-elem|inline


### PR DESCRIPTION
## 무엇을 고쳤나

`csp-interaction-check` 게이트는 매 실행마다 다음 경고를 냈다.

```
coverage : NOT COVERED -> translate
::warning:: configured but never loaded: translate — this run did NOT exercise those code paths
```

실측해보니 **이 경고 자체가 틀렸다.** element.js 는 매번 정상 로드되고 있었다.

### 버그 1 — 자기 제거 스크립트를 놓침

`translate_a/element.js` 는 실행 후 자신의 `<script>` 노드를 DOM 에서 삭제한다.
게이트는 `document.scripts` 를 스캔했으므로 로드된 스크립트를 미로드로 보고했다.

```
elementJsNodeStillInDom : false        <- DOM 에는 없지만
[req] https://translate.google.com/translate_a/element.js?cb=...   <- 요청은 나갔고
[req] https://translate.googleapis.com/_/translate_http/_/js/...   <- 후속 번들까지 받았다
```

Resource Timing 으로 바꾸는 것도 답이 아니었다 — 기본 250 엔트리 버퍼를 이 페이지가
초과해서 늦게 로드된 항목이 유실된다(실제로 `interaction` 패스에서 여전히 false 였다).
요청 로그 기반으로 교체했다.

### 버그 2 — 번역된 문서 상태를 한 번도 검사하지 않음

게이트는 `.goog-te-combo` 를 구동하려 했지만 헤드리스에서 성립하지 않는다. 위젯
드롭다운은 about:blank 프레임 안에 렌더되어 메인 문서에 combo 가 나타나지 않는다.
`translate-select` 는 영구히 false 였다.

재방문자가 들고 오는 `googtrans` 쿠키 경로를 쓰면 번역이 실제로 일어난다. URL 당
`translated` 패스를 추가했다.

## Path B 결정 — 보류

Report-Only 는 차단하지 않으므로 "Path B 를 켜면 Translate 가 깨진다"는 그동안
**추론**이었다. 응답 헤더를 인플라이트로 바꿔 Report-Only 를 enforcing 으로 승격시킨
A/B 로 측정했다.

| | 현재 정책 | Path B enforcing |
|---|---|---|
| 본문 한글 잔존 | 0자 (0%) | 1061자 (26.6%) |
| Google `<font>` 마커 | 446개 | 0개 |
| `<html>` | `lang=en` / `translated-ltr` | `lang=ko` (미번역) |
| 위반 disposition | `report` | `enforce` |

Path B 는 Translate 를 저하시키는 게 아니라 **완전히 비활성화**한다. 이 측정을 근거로
Path B 를 보류하고 Translate 를 유지하기로 결정했다(`notes/decisions.md`).

따라서 baseline 1건은 "제거해야 할 blocker" 가 아니라 **수용된 trade-off** 이고,
이 워크플로의 임무도 "baseline 이 비워질 때까지 감시" 에서 **"두 번째 위반 등장 감지"**
로 바뀐다.

기각한 대안(iframe 격리 후 별도 CSP): 위반 문서는 `about:blank` 이고 about:blank 는
임베더의 CSP 를 상속한다. Chrome 은 iframe `csp` 속성을 제거했고, Translate 는 호스트
문서 자체를 재작성해야 동작하므로 프레임에 가둘 수 없다. (명세·구현 논거이며 별도 A/B
는 하지 않았다.)

## 검증

프로덕션 대상 전체 실행, 2 URL x 2 모드 = 4 패스:

```
/ [interaction]              coverage: all configured integrations loaded   translate=true
/ [translated]               translated DOM reached: true (lang=en, 446 <font>)
/posts/...Digest... [interaction]   coverage: all configured integrations loaded
/posts/...Digest... [translated]    translated DOM reached: true (lang=en, 594 <font>)

각 패스: 1 total, 1 grandfathered, 0 NEW first-party
exit 0
```

커버리지는 넓어졌는데 baseline 은 늘지 않았다 — 네 패스 모두 동일한 기존 1건만 보고한다.

```
pytest scripts/tests/  ->  4148 passed, 5 skipped
pytest scripts/tests/test_ci_csp_interaction_guard.py  ->  13 passed
```

## 검증하지 않은 것

- `translate-select` 는 여전히 false 다(헤드리스에서 combo 는 나타나지 않는다). 코드는
  남겨두고 왜 성립하지 않는지 주석으로 기록했다.
- CI 러너에서의 실행은 미검증 — 이 PR 이 `paths` 필터에 걸려 있어 PR CI 가 게이트 자신을
  돌린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)