### PR TITLE
feat: 번역 사용량 계측 + CSP 리포트 채널 볼륨 측정 (결정 전 측정)

### DIFF
--- a/.github/workflows/sentry-healthcheck.yml
+++ b/.github/workflows/sentry-healthcheck.yml
@@ -134,6 +134,25 @@ jobs:
 
           echo "release_status=$release_status" >> "$GITHUB_OUTPUT"
 
+      # Measures what the CSP report-uri/report-to channel actually costs. That
+      # channel bypasses the Sentry SDK entirely, so the SDK's sampling and its
+      # ignorePatterns (which explicitly drop CSP + extension noise) never apply
+      # to it. Runs here because this job already holds the Sentry secrets — no
+      # token needs to travel anywhere else.
+      #
+      # Reporting, not gating: it writes to the job summary and does not fail the
+      # healthcheck on volume. It DOES fail on a missing secret or a dead API,
+      # because "could not measure" must not render as "nothing was wrong".
+      - name: Report CSP report-channel volume
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          STATS_PERIOD: "30d"
+        run: |
+          set -o pipefail
+          python3 scripts/sentry_csp_volume.py | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Write summary
         if: always()
         run: |

--- a/assets/js/google-translate.js
+++ b/assets/js/google-translate.js
@@ -317,6 +317,12 @@ function googleTranslateElementInit() {
 
       var isActive = langDropdown.classList.contains('active');
 
+      // Second and later opens. The first one is counted in header-runtime.js,
+      // which is the only script loaded at that point — so these do not overlap.
+      if (!isActive && window.__track) {
+        window.__track('lang_toggle_open', { first_open: false });
+      }
+
       if (isActive) {
         langDropdown.classList.remove('active');
         langToggle.setAttribute('aria-expanded', 'false');
@@ -394,6 +400,12 @@ function googleTranslateElementInit() {
         }
 
         if (lang) {
+          // The event that actually answers "does anyone use translation?" —
+          // opening the dropdown may be curiosity, picking a language is not.
+          if (window.__track) {
+            window.__track('lang_select', { language: lang });
+          }
+
           langDropdown.classList.remove('active');
           langToggle.setAttribute('aria-expanded', 'false');
           if (langDropdownOverlay) {

--- a/assets/js/head-runtime.js
+++ b/assets/js/head-runtime.js
@@ -115,6 +115,34 @@
   }
 
   /**
+   * Buffered event tracker: window.__track(name, params).
+   *
+   * GA is lazy-loaded on the first interaction and gtag('config') only runs in
+   * that script's onload. An event pushed to dataLayer before the config lands
+   * is processed ahead of it and dropped — which would silently lose exactly
+   * the first-click events this exists to measure. So events are buffered and
+   * replayed, in order, once the config has run.
+   *
+   * With no data-ga-id this is a no-op. The buffer is capped so a page that
+   * never loads GA (bot, bouncer, idle-fallback not reached) cannot grow it
+   * without bound.
+   */
+  var GA_EVENT_BUFFER_MAX = 20;
+  window.__gaPending = window.__gaPending || [];
+  window.__track = function (name, params) {
+    if (!gaId) return;
+    if (window.__gaReady) {
+      window.dataLayer = window.dataLayer || [];
+      // Same shape as the gtag shim below: push the arguments object, not an array.
+      (function gtag() { window.dataLayer.push(arguments); })('event', name, params || {});
+      return;
+    }
+    if (window.__gaPending.length < GA_EVENT_BUFFER_MAX) {
+      window.__gaPending.push({ name: name, params: params || {} });
+    }
+  };
+
+  /**
    * Lazy-loads Google Analytics on the first user interaction, with a 10-12s
    * idle safety-net fallback. Rationale:
    *   - Bots and bouncers (no interaction within 10s) skip GA entirely,
@@ -144,6 +172,13 @@
         gtag('event', 'page_view', {
           page_path: window.location.pathname + window.location.search,
         });
+        // Config has run — anything buffered before now is safe to replay.
+        window.__gaReady = true;
+        var pending = window.__gaPending || [];
+        window.__gaPending = [];
+        for (var i = 0; i < pending.length; i++) {
+          gtag('event', pending[i].name, pending[i].params);
+        }
       };
       document.head.appendChild(script);
     };

--- a/assets/js/header-runtime.js
+++ b/assets/js/header-runtime.js
@@ -21,6 +21,15 @@
     document.body.appendChild(node);
   };
 
+  // The FIRST toggle click is only observable here — google-translate.js has not
+  // loaded yet, so its own handler cannot see it. Without this, usage data for the
+  // translation feature would start at the second click and understate demand.
+  toggle.addEventListener('click', function () {
+    if (window.__track) {
+      window.__track('lang_toggle_open', { first_open: true });
+    }
+  }, { once: true, passive: true });
+
   toggle.addEventListener('click', loadTranslate, { once: true, passive: true });
 
   try {

--- a/notes/decisions.md
+++ b/notes/decisions.md
@@ -261,3 +261,34 @@ Path B는 Translate를 **저하시키는 게 아니라 완전히 비활성화**�
   등장 감지"**로 바뀐다. 다른 통합이 `unsafe-inline`에 새로 의존하기 시작하면 그것이 신호다.
 - 재개 조건: Google Translate 제거를 받아들이거나, about:blank 인라인 부트스트랩을 쓰지 않는
   번역 수단으로 교체할 때.
+
+### Report-Only 존폐와 번역 아키텍처는 둘 다 "측정 먼저" (2026-08-12)
+
+Path B 보류 직후 두 후속 질문이 나왔고, 둘 다 **데이터 없이는 결정 불가**로 판정했다.
+
+**1. Report-Only 헤더를 계속 둘 것인가.** 두 정책의 지시자 17개 중 14개가 동일하고, 차이는
+`script-src`/`script-src-elem`(해시 vs `'unsafe-inline'`)과 `upgrade-insecure-requests`(RO에선
+무시되므로 enforcing 전용)뿐이다. 즉 RO 헤더는 **정확히 Path B 가설 하나만** 시험하며, 그
+가설은 닫혔다. 남은 신호("두 번째 위반 등장")는 `csp-interaction-check` 크론이 매일 커버한다.
+
+그런데 비용 쪽에 구조적 모순이 있다: `sentry-init.js:39-42` 의 `ignorePatterns` 는 CSP·확장
+이벤트를 **명시적으로 버리는데**, `report-uri`/`report-to` 는 SDK 를 우회해 Sentry ingest 로
+직접 간다. SDK 가 버리기로 한 노이즈가 다른 문으로 무샘플 유입된다. SDK 의 월 5000 가드도
+`localStorage` 기반이라 **방문자별**로 세므로 전역 소비량을 못 본다.
+
+→ 제거/유지 결정은 실제 볼륨에 달렸다. `scripts/sentry_csp_volume.py` 를
+`sentry-healthcheck.yml` 에 붙여 매일 job summary 로 집계한다(게이팅 아님, 리포팅).
+시크릿이 이미 그 job 에 있으므로 토큰을 다른 곳으로 옮기지 않는다.
+
+**2. 번역 아키텍처(A 유지 / B 정적 사전번역 / C 온디맨드 / D 포기).** 코퍼스는 263 포스트
+469만 자, 4개 언어면 1,880만 자다. B 안은 최초 ~$376 + 페이지 263→1,315개 + sitemap/hreflang
+전면 재작업이다. **그런데 언어 토글에 계측이 전혀 없었다**(`gtag`/`dataLayer` grep 0건).
+쓰는 사람이 있는지 모르는 채로 B 를 검토하는 건 순서가 뒤바뀐 것 — 사용량이 미미하면 D 가
+$0 에 Path B 를 연다.
+
+→ `window.__track` (버퍼 후 flush) + `lang_toggle_open` / `lang_select` 이벤트를 먼저 넣는다.
+**버퍼가 필요한 이유**: GA 는 첫 상호작용에 지연 로드되고 `gtag('config')` 는 그 onload 에서만
+실행된다. config 보다 먼저 dataLayer 에 들어간 이벤트는 앞서 처리되어 유실되는데, lang-toggle
+클릭은 GA 로드 트리거이자 측정 대상이라 무버퍼 계측은 **정확히 첫 사용 신호를 잃는다.**
+첫 클릭은 `header-runtime.js` 만 볼 수 있다(그 클릭이 `google-translate.js` 를 내려받게 하는
+클릭이므로). 2회차 이후는 `google-translate.js` 가 센다 — 중복 없음.

--- a/scripts/sentry_csp_volume.py
+++ b/scripts/sentry_csp_volume.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Report how many Sentry events the CSP report channel actually consumes.
+
+Why this exists
+---------------
+`vercel.json` ships two CSP policies and both carry `report-uri` + `report-to`
+(the live `reporting-endpoints` header points at Sentry). Those reports travel
+browser -> Sentry ingest directly. They never pass through the Sentry SDK, so
+none of the SDK's filtering applies to them — and `assets/js/sentry-init.js`
+explicitly drops exactly this class of event:
+
+    var ignorePatterns = [
+      /content security policy/i, /csp/i,
+      /chrome-extension/i, /moz-extension/i,
+      ...
+
+So the noise the SDK is configured to discard is being ingested through a
+different door, unsampled. The SDK's monthly guard does not see it either:
+`getMonthlyCount()` counts in `localStorage`, i.e. per browser, not globally.
+
+Whether that matters is an empirical question — how many events, and how many
+of them are ours rather than a visitor's browser extension. This script answers
+it. It does NOT decide anything: removing the Report-Only header or adding
+Sentry inbound filters is a call for the repo owner, made on these numbers.
+
+Credentials come from the environment so the run can happen in CI, where the
+secrets already live, rather than passing a token around in plaintext.
+
+Exit codes
+  0 - report produced
+  1 - a required secret is missing. SENTRY_* ARE configured in this repo, so
+      their absence is a regression (rotation, lost access), not an optional
+      integration. Same rule as scripts/tests/test_ci_secret_absence_guard.py.
+  2 - the Sentry API call failed. "Could not measure" must never read as
+      "nothing was wrong".
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API_ROOT = "https://sentry.io/api/0"
+TIMEOUT_S = 30
+
+# assets/js/sentry-init.js:30 — the free-tier budget the SDK throttles against.
+SDK_MONTHLY_LIMIT = 5000
+
+REQUIRED = ("SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT")
+
+
+def _fetch(url: str, token: str) -> list | dict:
+    req = urllib.request.Request(
+        url,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT_S) as resp:  # noqa: S310 - fixed https host
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def classify(issue: dict) -> str:
+    """Bucket an issue by who would have to fix it.
+
+    'extension'  - a visitor's browser extension tripped our policy. Not ours,
+                   and not fixable by us: satisfying it (e.g. adding
+                   'unsafe-eval' for MetaMask's WebAssembly) would weaken the
+                   policy for every visitor.
+    'translate'  - the known Google Translate about:blank inline bootstrap,
+                   grandfathered in scripts/tests/csp_interaction_baseline.txt.
+    'first-party'- anything else. These are the ones worth reading.
+    """
+    haystack = " ".join(
+        str(issue.get(k, "")) for k in ("title", "culprit", "metadata")
+    ).lower()
+    if "chrome-extension" in haystack or "moz-extension" in haystack:
+        return "extension"
+    if "about" in haystack and "inline" in haystack:
+        return "translate"
+    return "first-party"
+
+
+def main() -> int:
+    missing = [k for k in REQUIRED if not os.getenv(k)]
+    if missing:
+        # Names only — never the values.
+        print(f"::error::missing required secret(s): {', '.join(missing)}", file=sys.stderr)
+        return 1
+
+    token = os.environ["SENTRY_AUTH_TOKEN"]
+    org = os.environ["SENTRY_ORG"]
+    project = os.environ["SENTRY_PROJECT"]
+    period = os.getenv("STATS_PERIOD", "30d")
+
+    query = urllib.parse.urlencode(
+        {
+            "query": "event.type:csp",
+            "statsPeriod": period,
+            "limit": "100",
+            "sort": "freq",
+        }
+    )
+    url = f"{API_ROOT}/projects/{org}/{project}/issues/?{query}"
+
+    try:
+        issues = _fetch(url, token)
+    except urllib.error.HTTPError as exc:
+        print(f"::error::Sentry API HTTP {exc.code} for issues query", file=sys.stderr)
+        return 2
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        print(f"::error::Sentry API call failed: {type(exc).__name__}", file=sys.stderr)
+        return 2
+
+    if not isinstance(issues, list):
+        print("::error::unexpected Sentry response shape (expected a list)", file=sys.stderr)
+        return 2
+
+    buckets: dict[str, int] = {"first-party": 0, "translate": 0, "extension": 0}
+    rows = []
+    for issue in issues:
+        try:
+            count = int(issue.get("count", 0))
+        except (TypeError, ValueError):
+            count = 0
+        bucket = classify(issue)
+        buckets[bucket] += count
+        rows.append((count, bucket, str(issue.get("title", ""))[:90]))
+
+    total = sum(buckets.values())
+    rows.sort(reverse=True)
+
+    print(f"# CSP report volume ({period})\n")
+    print(f"- CSP issue groups returned: **{len(issues)}** (API page cap 100)")
+    print(f"- Total CSP events: **{total}**")
+    if total:
+        pct = total / SDK_MONTHLY_LIMIT * 100
+        print(
+            f"- Against the {SDK_MONTHLY_LIMIT}/mo budget `sentry-init.js` throttles "
+            f"against: **{pct:.1f}%**"
+        )
+    print()
+    print("| bucket | events | share |")
+    print("|---|---:|---:|")
+    for name in ("first-party", "translate", "extension"):
+        share = f"{buckets[name] / total * 100:.1f}%" if total else "n/a"
+        print(f"| {name} | {buckets[name]} | {share} |")
+    print()
+
+    if rows:
+        print("## Top groups\n")
+        print("| events | bucket | title |")
+        print("|---:|---|---|")
+        for count, bucket, title in rows[:15]:
+            print(f"| {count} | {bucket} | `{title}` |")
+        print()
+
+    if len(issues) == 100:
+        # No silent caps: say when the page limit was hit.
+        print(
+            "> The API returned a full page (100 groups), so **totals are a floor, "
+            "not the complete count**.\n"
+        )
+    if total == 0:
+        print(
+            "> Zero CSP events in this window. Either the report channel is not "
+            "reaching Sentry, or it genuinely costs nothing — check the Sentry "
+            "project's inbound filters before concluding the latter.\n"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/js/head-runtime.test.js
+++ b/tests/js/head-runtime.test.js
@@ -87,6 +87,10 @@ describe('head-runtime.js', () => {
     // Reset idempotency guard + load-init flags between tests so each
     // runScript() call exercises a fresh init path.
     delete window.__headRuntimeInitialized;
+    delete window.__track;
+    delete window.__gaReady;
+    delete window.__gaPending;
+    delete window.dataLayer;
     delete window.__gaLoadInitiated;
     delete window.__adsenseLoadInitiated;
     delete window.__kakaoLoadInitiated;
@@ -570,6 +574,80 @@ describe('head-runtime.js', () => {
     loadCall[1]();
     expect(document.head.querySelector('script[src*="googlesyndication"]')).toBeTruthy();
     window.IntersectionObserver = originalIO;
+  });
+
+  describe('window.__track (buffered event tracker)', () => {
+    // GA is lazy-loaded and gtag('config') only runs in its onload. An event
+    // pushed to dataLayer before that config is processed ahead of it and
+    // dropped. Since the lang-toggle click is BOTH the GA trigger and the event
+    // we want, un-buffered tracking would lose exactly the first-use signal.
+
+    function fireGaLoad() {
+      const gaScript = document.head.querySelector('script[src*="googletagmanager"]');
+      expect(gaScript).toBeTruthy();
+      gaScript.onload();
+      return gaScript;
+    }
+
+    it('is a no-op when no data-ga-id is configured', () => {
+      setupConfigScript({ gaId: '' });
+      runScript();
+      expect(typeof window.__track).toBe('function');
+      window.__track('lang_toggle_open', { first_open: true });
+      expect(window.__gaPending).toEqual([]);
+      expect(window.dataLayer).toBeUndefined();
+    });
+
+    it('buffers events fired before gtag config, then replays them in order', () => {
+      setupConfigScript({ gaId: 'G-TEST123' });
+      runScript();
+
+      window.__track('lang_toggle_open', { first_open: true });
+      window.__track('lang_select', { language: 'en' });
+      // Nothing has reached dataLayer yet — GA has not loaded.
+      expect(window.__gaPending).toHaveLength(2);
+      expect(window.dataLayer).toBeUndefined();
+
+      // First interaction loads GA; its onload runs js/config/page_view.
+      window.dispatchEvent(new window.Event('click'));
+      fireGaLoad();
+
+      const events = window.dataLayer.map((args) => Array.from(args));
+      const names = events.filter((e) => e[0] === 'event').map((e) => e[1]);
+      // page_view is configured first, then the buffer replays in FIFO order.
+      expect(names).toEqual(['page_view', 'lang_toggle_open', 'lang_select']);
+      expect(window.__gaReady).toBe(true);
+      expect(window.__gaPending).toEqual([]);
+    });
+
+    it('sends straight through once GA is ready', () => {
+      setupConfigScript({ gaId: 'G-TEST123' });
+      runScript();
+      window.dispatchEvent(new window.Event('click'));
+      fireGaLoad();
+
+      const before = window.dataLayer.length;
+      window.__track('lang_select', { language: 'ja' });
+      expect(window.dataLayer).toHaveLength(before + 1);
+      const last = Array.from(window.dataLayer[window.dataLayer.length - 1]);
+      expect(last).toEqual(['event', 'lang_select', { language: 'ja' }]);
+    });
+
+    it('caps the buffer so a page that never loads GA cannot grow it unbounded', () => {
+      setupConfigScript({ gaId: 'G-TEST123' });
+      runScript();
+      for (let i = 0; i < 50; i += 1) {
+        window.__track('lang_toggle_open', { i });
+      }
+      expect(window.__gaPending).toHaveLength(20);
+    });
+
+    it('defaults params to an object when omitted', () => {
+      setupConfigScript({ gaId: 'G-TEST123' });
+      runScript();
+      window.__track('lang_toggle_open');
+      expect(window.__gaPending).toEqual([{ name: 'lang_toggle_open', params: {} }]);
+    });
   });
 
 });

--- a/tests/js/header-runtime.test.js
+++ b/tests/js/header-runtime.test.js
@@ -81,6 +81,36 @@ describe('header-runtime.js (lang toggle bootstrap)', () => {
     expect(injectedScripts()).toHaveLength(0);
   });
 
+  it('reports the first toggle click through window.__track', () => {
+    // The first click is the one google-translate.js structurally cannot see:
+    // it is what triggers that script's download. If this stops firing, usage
+    // data silently starts at the second click.
+    document.body.innerHTML = '<button id="lang-toggle" type="button">Lang</button>';
+    const calls = [];
+    window.__track = (name, params) => calls.push([name, params]);
+    runScript();
+
+    expect(calls).toHaveLength(0);
+    document.getElementById('lang-toggle').click();
+    expect(calls).toEqual([['lang_toggle_open', { first_open: true }]]);
+
+    // once:true — repeat clicks are counted by google-translate.js instead, so
+    // counting them here too would double-report.
+    document.getElementById('lang-toggle').click();
+    expect(calls).toHaveLength(1);
+    delete window.__track;
+  });
+
+  it('does not throw when window.__track is absent', () => {
+    // head-runtime.js defines __track, but it is a separate script: a load
+    // failure there must not take the lang toggle down with it.
+    document.body.innerHTML = '<button id="lang-toggle" type="button">Lang</button>';
+    delete window.__track;
+    runScript();
+    expect(() => document.getElementById('lang-toggle').click()).not.toThrow();
+    expect(injectedScripts()).toHaveLength(1);
+  });
+
   it('respects a custom data-translate-src override on the script tag', () => {
     // The IIFE reads `document.currentScript`, which is null when evaluated
     // via Function(). Instead, test the fallback default URL is honored.


### PR DESCRIPTION
Path B 보류 이후 두 후속 질문이 나왔고, 둘 다 **데이터 없이는 결정 불가**로 판정했다. 이 PR은 결정을 내리지 않고 **결정에 필요한 수치를 만들어낸다.**

---

## 1. 번역 기능 사용량 계측

번역 아키텍처(유지 / 정적 사전번역 / 온디맨드 / 포기)를 비교하려 했으나 막혔다.

```
$ grep -rn "gtag\|dataLayer\|track" assets/js/google-translate.js assets/js/header-runtime.js
(0건)
```

**언어 토글에 계측이 전혀 없다.** GA는 `head-runtime.js:141-144`에서 `page_view`만 보낸다. 즉 번역 기능을 쓰는 사람이 있는지에 대한 데이터가 0이다.

이게 왜 막는지: 코퍼스는 263 포스트 469만 자다. 4개 언어 사전번역은 1,880만 자 → 최초 ~$376 + 페이지 263→1,315개 + sitemap/hreflang 전면 재작업. 반면 사용량이 미미하면 **'포기'가 $0에 Path B를 연다.** 수요를 모르는 채 설계를 비교하는 건 순서가 뒤바뀐 것이다.

### `window.__track`이 단순 `dataLayer.push`가 아닌 이유

GA는 첫 상호작용에 지연 로드되고 `gtag('config')`는 그 `onload`에서만 실행된다. config보다 먼저 dataLayer에 들어간 이벤트는 앞서 처리되어 유실된다.

그런데 **lang-toggle 클릭은 GA 로드 트리거이자 측정 대상 그 자체다.** 무버퍼 계측은 정확히 첫 사용 신호를 잃는다 — 측정하려던 바로 그것을. 그래서 이벤트를 버퍼에 담고 config 실행 후 FIFO로 replay한다.

- `data-ga-id` 부재 시 no-op
- 버퍼 상한 20 (GA를 끝내 로드하지 않는 봇/이탈 방문 대비)
- 첫 클릭은 `header-runtime.js`만 관측 가능 — 그 클릭이 `google-translate.js`를 내려받게 하는 클릭이므로 후자의 핸들러는 볼 수 없다. 2회차 이후는 `google-translate.js`가 센다. **중복 계수 없음.**

이벤트: `lang_toggle_open{first_open}`, `lang_select{language}`

---

## 2. CSP 리포트 채널 볼륨 측정

Path B가 닫히면서 Report-Only 헤더의 잔여 가치가 좁아졌다. 두 정책을 실측 diff하면:

| 지시자 | enforcing | Report-Only |
|---|---|---|
| `script-src` / `script-src-elem` | `'unsafe-inline'` | 해시 2개 |
| `upgrade-insecure-requests` | 있음 | 없음 (RO에선 무시되므로 정상) |
| 나머지 14개 | — 완전 동일 — | |

**17개 중 14개가 동일하다. RO 헤더는 정확히 Path B 가설 하나만 시험한다.** 남은 신호("두 번째 위반 등장")는 `csp-interaction-check` 크론이 매일 결정론적으로 커버한다.

### 비용 쪽 구조적 모순

`sentry-init.js:39-42`:
```js
var ignorePatterns = [
  /content security policy/i, /csp/i,
  /chrome-extension/i, /moz-extension/i,
```

SDK는 CSP·확장 이벤트를 **명시적으로 버린다.** 그런데 `report-uri`/`report-to`(라이브 `reporting-endpoints` 헤더 확인)는 SDK를 우회해 Sentry ingest로 직접 간다 — **SDK가 버리기로 한 노이즈가 다른 문으로 무샘플·무필터 유입된다.** SDK의 월 5000 가드(`getDynamicSampleRate`)도 `localStorage` 기반이라 방문자별로 세므로 전역 소비량을 볼 수 없다.

그래서 제거/유지를 지금 결정하지 않고 볼륨부터 잰다. 스크립트는 CSP 이슈를 `first-party` / `translate`(about+inline) / `extension`으로 분류해 이벤트 수와 5000/월 대비 비중을 job summary에 쓴다.

**시크릿을 이동시키지 않는다** — 이미 Sentry 시크릿을 가진 `sentry-healthcheck` job에 붙였다.

게이팅이 아니라 리포팅이다. 다만:
- 시크릿 부재 → `exit 1` (SENTRY_*는 실제 설정돼 있으므로 부재 = 회귀. `test_ci_secret_absence_guard.py`와 같은 규칙)
- API 실패 → `exit 2` ("측정 못 했다"가 "이상 없었다"로 읽히면 안 됨)
- API가 100개 풀 페이지 반환 시 총계가 하한임을 명시 (no silent caps)

---

## 검증

```
vitest   680 passed (28 files)
pytest  4152 passed, 5 skipped
```

**가드 자체를 뮤테이션으로 검증** (통과만으로는 증거가 아니므로):

| 뮤테이션 | 결과 |
|---|---|
| replay 루프 무력화 (`for i<0`, 문법 유지) | `buffers events…` **1건만** 실패 (33 passed) |
| `header-runtime`의 `__track` 리스너 제거 | 해당 **1건만** 실패 (7 passed) |

첫 시도에서는 6줄을 통째로 지워 34/34가 실패했는데, 그건 문법을 깨뜨린 것이라 신호가 아니어서 외과적으로 다시 했다.

`sentry_csp_volume.py`: 시크릿 부재 시 `exit 1` 확인(값이 아닌 **이름만** 출력), `classify()` 4/4.

## 검증하지 않은 것

- 실제 Sentry 볼륨 수치 — 이 워크플로가 다음 스케줄(02:30 UTC)에 돌아야 나온다. 즉시 필요하면 `workflow_dispatch`.
- GA 이벤트가 GA4 대시보드에 실제로 도달하는지 — 배포 후 realtime 리포트로 확인 필요. 테스트는 dataLayer까지만 검증한다.

## 부수 발견 (미수정, 범위 밖)

`_includes/head.html:309`의 `api.mymemory.translated.net` dns-prefetch는 이를 쓰는 코드가 없다(grep 0건). CSP `connect-src`에도 남아 있는 죽은 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)