### PR TITLE
fix(ci): Sentry 스코프 부족(403)에 fail-closed 걸어 cron을 영구 red로 만들던 문제

### DIFF
--- a/.github/workflows/sentry-healthcheck.yml
+++ b/.github/workflows/sentry-healthcheck.yml
@@ -143,6 +143,17 @@ jobs:
       # Reporting, not gating: it writes to the job summary and does not fail the
       # healthcheck on volume. It DOES fail on a missing secret or a dead API,
       # because "could not measure" must not render as "nothing was wrong".
+      #
+      # One exception, added 2026-08-12 after the first dispatch run went red:
+      # HTTP 401/403 exits 0. The token can read the project but not its events,
+      # and that predates this script — the scheduled run at 04:21Z the same day,
+      # before it existed, already logged "Sentry issues API check returned HTTP
+      # 403" from the step above and stayed green on a warning. Fail-closed on a
+      # standing scope gap produces a nightly red that gets muted, which this
+      # repo has established is worse than the gap. The run instead says, in the
+      # summary, that it measured nothing and why. Grant the token `event:read`
+      # to make it actually measure.
+      # Exit-code asymmetry is pinned by scripts/tests/test_sentry_csp_volume.py.
       - name: Report CSP report-channel volume
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/scripts/sentry_csp_volume.py
+++ b/scripts/sentry_csp_volume.py
@@ -27,12 +27,33 @@ Credentials come from the environment so the run can happen in CI, where the
 secrets already live, rather than passing a token around in plaintext.
 
 Exit codes
-  0 - report produced
+  0 - report produced, OR the token is not authorized to read issues (see below)
   1 - a required secret is missing. SENTRY_* ARE configured in this repo, so
       their absence is a regression (rotation, lost access), not an optional
       integration. Same rule as scripts/tests/test_ci_secret_absence_guard.py.
-  2 - the Sentry API call failed. "Could not measure" must never read as
-      "nothing was wrong".
+  2 - the Sentry API call failed for any other reason. "Could not measure" must
+      never read as "nothing was wrong".
+
+Why 401/403 is not fail-closed
+------------------------------
+The Sentry token in this repo can read the project endpoint but NOT issues.
+Verified from the scheduled run on 2026-08-12T04:21Z — i.e. BEFORE this script
+existed — where the pre-existing healthcheck step logged:
+
+    ⚠️ Sentry issues API check returned HTTP 403
+    - Issues API accessible: false
+
+So the missing scope (`event:read`) is a standing condition, not a regression
+this script discovered. Exiting non-zero on it would turn a daily cron
+permanently red, which this repo has repeatedly established gets muted and is
+therefore worse than the gap itself (see notes/ci-gate-audit-2026-08.md and
+scripts/tests/test_ci_secret_absence_guard.py). Instead the run stays green and
+says, unmissably, that it measured nothing — the same treatment the neighbouring
+step already gives the same 403.
+
+Direction: once the token gains `event:read`, delete the 401/403 branch so any
+authorization failure is fail-closed again, and update
+scripts/tests/test_sentry_csp_volume.py in the same PR.
 """
 
 from __future__ import annotations
@@ -108,6 +129,25 @@ def main() -> int:
     try:
         issues = _fetch(url, token)
     except urllib.error.HTTPError as exc:
+        if exc.code in (401, 403):
+            # Standing scope gap, not a regression — see the module docstring.
+            # Loud in the summary, green in the check.
+            print(f"# CSP report volume ({period})\n")
+            print(
+                f"> **MEASURED NOTHING** — Sentry returned HTTP {exc.code} for the issues "
+                f"query. The token can read the project but not its events, so this "
+                f"report is empty for a permissions reason, **not** because the CSP "
+                f"report channel is quiet.\n"
+            )
+            print(
+                "> To make it measure: grant the Sentry auth token `event:read` "
+                "(Sentry → Settings → Auth Tokens), then re-run this workflow.\n"
+            )
+            print(
+                f"::warning::CSP volume not measured: Sentry issues API HTTP {exc.code} "
+                f"(token lacks event:read). Pre-existing since at least 2026-08-12."
+            )
+            return 0
         print(f"::error::Sentry API HTTP {exc.code} for issues query", file=sys.stderr)
         return 2
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:

--- a/scripts/tests/test_sentry_csp_volume.py
+++ b/scripts/tests/test_sentry_csp_volume.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Guard the exit-code asymmetry in scripts/sentry_csp_volume.py.
+
+The script reports CSP report-channel volume from Sentry. Its exit codes encode
+a deliberate asymmetry that is easy to "simplify" away later:
+
+  - missing secret            -> 1  (SENTRY_* are configured; absence = regression)
+  - HTTP 401/403              -> 0  (standing scope gap; fail-closed here would
+                                     make a daily cron permanently red, which
+                                     gets muted — see the module docstring)
+  - any other API failure     -> 2  ("could not measure" != "nothing was wrong")
+
+Collapsing 401/403 into the generic error branch turns the nightly Sentry
+healthcheck red every night until someone grants the token `event:read`. Making
+every failure exit 0 hides real breakage. These tests pin both directions.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sentry_csp_volume.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("sentry_csp_volume", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def mod():
+    return _load()
+
+
+@pytest.fixture
+def creds(monkeypatch):
+    monkeypatch.setenv("SENTRY_AUTH_TOKEN", "dummy-not-a-real-token")
+    monkeypatch.setenv("SENTRY_ORG", "example-org")
+    monkeypatch.setenv("SENTRY_PROJECT", "example-project")
+
+
+def _http_error(code: int) -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://sentry.io/api/0/", code=code, msg="test", hdrs=None, fp=None
+    )
+
+
+def test_missing_secret_exits_1(mod, monkeypatch):
+    for key in ("SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+    assert mod.main() == 1
+
+
+def test_missing_secret_never_prints_values(mod, monkeypatch, capsys):
+    monkeypatch.setenv("SENTRY_AUTH_TOKEN", "super-secret-value")
+    monkeypatch.delenv("SENTRY_ORG", raising=False)
+    monkeypatch.delenv("SENTRY_PROJECT", raising=False)
+    mod.main()
+    captured = capsys.readouterr()
+    assert "super-secret-value" not in (captured.out + captured.err)
+
+
+@pytest.mark.parametrize("code", [401, 403])
+def test_authorization_failure_stays_green_but_says_it_measured_nothing(
+    mod, creds, monkeypatch, capsys, code
+):
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: (_ for _ in ()).throw(_http_error(code)))
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    # A green run that produced no data must not read as "volume is zero".
+    assert "MEASURED NOTHING" in out
+    assert str(code) in out
+    assert "event:read" in out
+    assert "::warning::" in out
+
+
+@pytest.mark.parametrize("code", [400, 404, 429, 500, 503])
+def test_other_http_errors_are_fail_closed(mod, creds, monkeypatch, code):
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: (_ for _ in ()).throw(_http_error(code)))
+    assert mod.main() == 2
+
+
+def test_network_failure_is_fail_closed(mod, creds, monkeypatch):
+    def boom(*_a, **_k):
+        raise urllib.error.URLError("no route to host")
+
+    monkeypatch.setattr(mod, "_fetch", boom)
+    assert mod.main() == 2
+
+
+def test_unexpected_response_shape_is_fail_closed(mod, creds, monkeypatch):
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: {"detail": "not a list"})
+    assert mod.main() == 2
+
+
+def test_successful_report_buckets_and_totals(mod, creds, monkeypatch, capsys):
+    issues = [
+        {"count": "10", "title": "CSP: script-src-elem", "culprit": "chrome-extension://x/a.js"},
+        {"count": 5, "title": "CSP: script-src-elem inline", "culprit": "about"},
+        {"count": 2, "title": "CSP: connect-src", "culprit": "https://tech.2twodragon.com/"},
+    ]
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: issues)
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "| extension | 10 |" in out
+    assert "| translate | 5 |" in out
+    assert "| first-party | 2 |" in out
+    assert "Total CSP events: **17**" in out
+
+
+def test_full_page_is_declared_a_floor_not_a_total(mod, creds, monkeypatch, capsys):
+    # No silent caps: hitting the API page limit must be stated, or the number
+    # reads as complete when it is not.
+    issues = [{"count": 1, "title": "CSP", "culprit": "https://example.com/"}] * 100
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: issues)
+    assert mod.main() == 0
+    assert "floor" in capsys.readouterr().out
+
+
+def test_zero_events_does_not_claim_the_channel_is_quiet(mod, creds, monkeypatch, capsys):
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: [])
+    assert mod.main() == 0
+    out = capsys.readouterr().out
+    assert "inbound filters" in out
+
+
+def test_malformed_count_does_not_crash(mod, creds, monkeypatch, capsys):
+    issues = [{"count": "n/a", "title": "CSP", "culprit": "https://example.com/"}]
+    monkeypatch.setattr(mod, "_fetch", lambda *_a, **_k: issues)
+    assert mod.main() == 0
+    assert "Total CSP events: **0**" in capsys.readouterr().out
+
+
+def test_classify_buckets(mod):
+    assert mod.classify({"culprit": "chrome-extension://abc/injected.js"}) == "extension"
+    assert mod.classify({"culprit": "moz-extension://abc/injected.js"}) == "extension"
+    assert mod.classify({"title": "CSP: inline", "culprit": "about"}) == "translate"
+    assert mod.classify({"culprit": "https://tech.2twodragon.com/"}) == "first-party"
+
+
+def test_docstring_records_why_401_403_is_not_fail_closed(mod):
+    # The exemption is only defensible with its reason attached. If someone
+    # strips the rationale, the next reader sees an unexplained green-on-error.
+    doc = mod.__doc__ or ""
+    assert "401/403" in doc
+    assert "event:read" in doc
+    assert "permanently red" in doc
+
+
+def test_json_decode_error_is_fail_closed(mod, creds, monkeypatch):
+    def boom(*_a, **_k):
+        raise json.JSONDecodeError("bad", "", 0)
+
+    monkeypatch.setattr(mod, "_fetch", boom)
+    assert mod.main() == 2


### PR DESCRIPTION
PR #548 병합 후 첫 `workflow_dispatch` 실행이 red 였다. 원인은 스크립트가 발견한 새 결함이 아니라 **이미 있던 조건에 fail-closed 를 건 것**이다.

## 증거 — 403은 이 스크립트보다 먼저 있었다

같은 날 04:21Z 스케줄 실행, 즉 `sentry_csp_volume.py` 가 존재하기 전 로그:

```
⚠️ Sentry issues API check returned HTTP 403
- Issues API accessible: false
```

토큰이 프로젝트 엔드포인트는 200 으로 읽지만 이슈는 못 읽는다 → `event:read` 스코프 부재. **상시 조건이지 회귀가 아니다.** 기존 스텝은 이걸 warn 으로 처리해 green 이었고, 제 스텝만 exit 2 를 냈다.

## 왜 그냥 exit 0 이 아닌가, 왜 그냥 exit 2 도 아닌가

상시 조건에 fail-closed 를 걸면 **매일 red 인 cron** 이 되고 그건 뮤트된다 — `notes/ci-gate-audit-2026-08.md` 와 `test_ci_secret_absence_guard.py` 가 반복해서 확립한 안티패턴이다.

그렇다고 조용히 통과시키면 데이터 0 이 "CSP 리포트 채널이 조용하다" 로 읽힌다. 실제로는 **권한 때문에 아무것도 못 잰 것**인데.

그래서 401/403 만 exit 0 으로 두되 job summary 상단에 박는다:

```
> **MEASURED NOTHING** — Sentry returned HTTP 403 for the issues query.
> The token can read the project but not its events, so this report is empty
> for a permissions reason, **not** because the CSP report channel is quiet.

> To make it measure: grant the Sentry auth token `event:read` … then re-run.
```

`::warning::` 도 함께 남긴다. 그 외 HTTP 오류 / 네트워크 실패 / 응답 형태 이상은 **그대로 exit 2**.

## 검증

`pytest 4170 passed`. 새 테스트 18건이 exit code 비대칭을 고정한다.

**뮤테이션으로 가드 자체를 검증** (통과만으로는 증거가 아니므로):

| 뮤테이션 | 결과 |
|---|---|
| `401/403` 면제 제거 (`in ()`) | 해당 **2건만** 실패 (16 passed) |
| `MEASURED NOTHING` → 무해한 문구 (조용한 green 위장) | 해당 **2건만** 실패 (16 passed) |

두 번째 뮤테이션은 첫 시도에서 sed 문법 오류로 적용조차 안 됐다(18 passed 가 나왔지만 그건 원본을 돌린 것). perl 로 다시 해서 실제 적용을 `grep -c` 로 확인한 뒤 측정했다.

시크릿 값 노출 방지도 테스트로 고정했다 — 부재 시 **이름만** 출력한다.

## 남은 사용자 작업

토큰에 `event:read` 를 부여하면 실제 볼륨이 측정된다 (Sentry → Settings → Auth Tokens). 부여 후에는 **401/403 분기를 삭제**하고 테스트를 같은 PR 에서 갱신해야 한다 — 그 방향을 docstring 과 워크플로 주석에 남겼다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)