### PR TITLE
fix(perf): 버전 불일치 prefetch 5건 제거 — 받아놓고 안 쓰는 14KB/포스트

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -260,3 +260,23 @@ if [ -n "$STAGED_ANY_POSTS" ]; then
   fi
   echo "[pre-commit] Template-echo check: passed."
 fi
+
+# 14. Resource-hint cache-buster consistency gate — a preload/prefetch href that
+#     omits the ?v= its loader uses is a separate cache entry, so the browser
+#     downloads it and never uses it. Five such hints in head.html wasted ~14 KB
+#     compressed per post view until 2026-08-14; Chrome never warned because it
+#     flags only unused *preload*, not unused prefetch. Runs whenever a template
+#     is staged: the hint and its versioned loader live in different files, so
+#     editing either side can introduce the mismatch.
+STAGED_TEMPLATES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^_(includes|layouts)/.*\.html$' || true)
+if [ -n "$STAGED_TEMPLATES" ]; then
+  echo "[pre-commit] Checking resource-hint cache-buster consistency..."
+  python3 "$REPO_ROOT/scripts/check_asset_hint_version.py" --all
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] Version-mismatched resource hint found."
+    echo "             Delete the hint, or append the same ?v= the loader uses."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Resource-hint version check: passed."
+fi

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -62,7 +62,15 @@ on:
       - 'scripts/rewrite_template_echo_summaries.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
-      - '_includes/head.html'
+      # Broadened from '_includes/head.html' (2026-08-14): the asset-hint gate
+      # below scans every template in _includes/ and _layouts/, and the
+      # mismatch it catches is inherently cross-file — the hint lives in
+      # head.html while the versioned loader lives in footer.html/mermaid.html.
+      # A trigger narrower than the scan is the hazard this file's header warns
+      # about, so both sides of the pair must trigger it.
+      - '_includes/**.html'
+      - '_layouts/**.html'
+      - 'scripts/check_asset_hint_version.py'
       - '_posts/**.md'
       - 'vercel.json'
       - 'assets/js/mermaid-init.js'
@@ -109,7 +117,15 @@ on:
       - 'scripts/rewrite_template_echo_summaries.py'
       - 'scripts/dev/check_csp_inline_hashes.py'
       - 'scripts/dev/csp_inline_hashes.json'
-      - '_includes/head.html'
+      # Broadened from '_includes/head.html' (2026-08-14): the asset-hint gate
+      # below scans every template in _includes/ and _layouts/, and the
+      # mismatch it catches is inherently cross-file — the hint lives in
+      # head.html while the versioned loader lives in footer.html/mermaid.html.
+      # A trigger narrower than the scan is the hazard this file's header warns
+      # about, so both sides of the pair must trigger it.
+      - '_includes/**.html'
+      - '_layouts/**.html'
+      - 'scripts/check_asset_hint_version.py'
       - '_posts/**.md'
       - 'vercel.json'
       - 'assets/js/mermaid-init.js'
@@ -345,6 +361,18 @@ jobs:
         # anywhere in scripts/, which is precisely the state where a regression
         # would otherwise be silent.
         run: python3 scripts/check_template_echo.py --all --quiet
+
+      - name: Resource-hint cache-buster consistency gate
+        id: asset_hint_version_gate
+        # --all: the corpus is at 0 after the five head.html prefetch hints
+        # were removed (2026-08-14), so any hit is fresh drift. Those five
+        # pointed at versionless URLs while footer.html/mermaid.html loaded the
+        # same files with ?v={{ site.time }}, so the prefetched copies were
+        # downloaded and never used — ~14 KB compressed wasted per post view.
+        # It stayed invisible because Chrome warns only about an unused
+        # *preload*, never an unused prefetch, and an earlier preload->prefetch
+        # switch had silenced the warning without fixing the URL mismatch.
+        run: python3 scripts/check_asset_hint_version.py --all
 
       - name: CSP inline-script sha256 regression gate (prep for CSP Path B)
         id: csp_inline_hashes

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -280,15 +280,30 @@
     })();
   </script>
 
-  <!-- Prefetch Resources (preload 경고 방지를 위해 prefetch 사용) -->
-  <!-- 분할된 JavaScript 파일들을 prefetch로 미리 캐시 -->
-  <link rel="prefetch" href="{{ "/assets/js/main-core.js" | relative_url }}" as="script">
-  {% if page.layout == 'post' %}
-  <link rel="prefetch" href="{{ "/assets/js/main-post.js" | relative_url }}" as="script">
-  <link rel="prefetch" href="{{ "/assets/js/post-page.js" | relative_url }}" as="script">
-  <link rel="prefetch" href="{{ "/assets/js/mermaid-init.js" | relative_url }}" as="script">
-  {% endif %}
-  <link rel="prefetch" href="{{ "/assets/js/main-search.js" | relative_url }}" as="script">
+  {% comment %}
+    JS prefetch 힌트 제거 (2026-08-14).
+
+    이 자리에 main-core / main-post / post-page / mermaid-init / main-search
+    5개의 `rel="prefetch"`가 버전 쿼리 **없는** URL로 있었다. 실제 스크립트
+    태그는 footer.html / mermaid.html 에서 `?v={{ site.time }}` 를 붙여
+    로드하므로 두 URL은 서로 다른 캐시 항목이고, prefetch 받은 사본은 한 번도
+    쓰이지 않았다. 포스트 1회 로드당 압축 기준 약 14 KB(원본 37.6 KB)와 요청
+    5건이 그대로 낭비되면서, 정작 필요한 버전 URL의 대역폭을 잠식했다.
+
+    앞선 주석("preload 경고 방지를 위해 prefetch 사용")이 남긴 것은 수정이
+    아니라 은폐였다. Chrome은 미사용 *preload* 만 경고하고 미사용 prefetch는
+    조용히 넘어가므로, preload→prefetch 전환은 URL 불일치라는 원인을 두고
+    경고만 지웠다.
+
+    버전을 맞추는 대신 삭제한 이유: 이 5개는 현재 페이지가 어차피 로드하는
+    파일이라 preload 스캐너가 footer의 defer 스크립트를 파싱 단계에서 이미
+    발견한다. 그리고 `?v=` 는 site.time 기반이라 빌드마다 바뀌므로, 버전을
+    맞춰도 다음 빌드에서 프리페치 사본은 즉시 무효가 된다 — 현재 내비게이션
+    에도 다음 내비게이션에도 이득이 없다. 292행 OG AVIF preload 제거(2026-04-17)
+    와 같은 판단이다.
+
+    회귀 방지: scripts/check_asset_hint_version.py (pre-commit + svg-lint CI)
+  {% endcomment %}
   {% comment %}OG AVIF 이미지 preload 제거: 소셜 메타에만 사용되며 페이지 렌더에 미사용 -> "preloaded but not used" 경고 방지 (2026-04-17){% endcomment %}
 
   <!-- DNS Prefetch and Preconnect for External Resources (TTFB 최적화)

--- a/scripts/check_asset_hint_version.py
+++ b/scripts/check_asset_hint_version.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Resource-hint cache-buster consistency gate for Jekyll templates.
+
+A ``<link rel="preload">`` / ``<link rel="prefetch">`` only helps if its href
+is **byte-identical** to the URL the page actually requests.  The HTTP cache
+keys on the full URL including the query string, so a hint pointing at::
+
+    /assets/js/post-page.js
+
+can never satisfy a tag that loads::
+
+    /assets/js/post-page.js?v=202608130114
+
+The browser downloads both.  The hint becomes pure waste — extra bytes and an
+extra request competing for bandwidth with the copy the page will actually
+run.
+
+This is the bug that shipped in ``_includes/head.html`` and survived until
+2026-08-14: five JS files were hinted without ``?v=`` while ``footer.html``
+and ``mermaid.html`` loaded them with ``?v={{ site.time }}``.  It cost ~14 KB
+compressed per post page view.  It went unnoticed because Chrome only warns
+about an unused **preload**, not an unused **prefetch**, so an earlier
+preload→prefetch switch silenced the console warning while leaving the URL
+mismatch in place.
+
+The rule enforced here:
+
+    If an asset under /assets/ is referenced somewhere in the templates WITH
+    a ``?v=`` cache-buster, then every resource hint pointing at that same
+    asset must carry a ``?v=`` too.
+
+Assets that are versionless everywhere (fonts, for example) are consistent by
+definition and pass.  The gate does not compare the *values*, only presence —
+comparing values across Liquid expressions would be brittle, and presence is
+enough to catch the split-cache-entry failure.
+
+Usage:
+    python3 scripts/check_asset_hint_version.py            # default: --all
+    python3 scripts/check_asset_hint_version.py --all
+    python3 scripts/check_asset_hint_version.py --staged   # staged templates
+    python3 scripts/check_asset_hint_version.py _includes/head.html
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TEMPLATE_DIRS = ("_includes", "_layouts")
+TEMPLATE_SUFFIXES = (".html",)
+
+# <link ... rel="preload|prefetch" ... href="..."> in any attribute order.
+_LINK_TAG_RE = re.compile(r"<link\b[^>]*>", re.IGNORECASE)
+_REL_RE = re.compile(r"""\brel\s*=\s*["']([^"']+)["']""", re.IGNORECASE)
+_HREF_RE = re.compile(r"""\bhref\s*=\s*["']([^"']*)["']""", re.IGNORECASE)
+
+# Any reference to an /assets/ file: src="...", href="...", data-*-src="...".
+_ASSET_REF_RE = re.compile(
+    r"""(?:src|href)\s*=\s*["']([^"']*?/assets/[^"']+?)["']""", re.IGNORECASE
+)
+# data-search-src="/assets/js/main-search.js?v=..." (footer.html loads the
+# search bundle through an attribute, not a src=).
+_DATA_SRC_RE = re.compile(
+    r"""\bdata-[a-z-]*src\s*=\s*["']([^"']*?/assets/[^"']+?)["']""", re.IGNORECASE
+)
+
+HINT_RELS = {"preload", "prefetch", "modulepreload"}
+
+# Liquid expression, possibly spanning lines: {{ ... }} or {% ... %}.
+_LIQUID_RE = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+_ASSET_PATH_RE = re.compile(r"/assets/[A-Za-z0-9_./-]+")
+
+
+def _strip_liquid(text: str) -> str:
+    """Collapse Liquid expressions so ordinary attribute parsing works.
+
+    Templates here write ``href="{{ "/assets/js/x.js" | relative_url }}"`` —
+    double quotes nested inside a double-quoted attribute.  A quote-terminated
+    attribute regex stops at the inner quote and yields an empty value, which
+    is precisely why the first version of this gate reported 0 violations
+    against head.html while the bug was still present.
+
+    Each Liquid expression is replaced by the /assets/ path it contains (or by
+    nothing), so the example above becomes ``href="/assets/js/x.js"``.  Newline
+    count is preserved so reported line numbers still match the source file.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        body = match.group(0)
+        path_match = _ASSET_PATH_RE.search(body)
+        replacement = path_match.group(0) if path_match else ""
+        return replacement + "\n" * body.count("\n")
+
+    return _LIQUID_RE.sub(_replace, text)
+
+
+def _normalize(url: str) -> str:
+    """Reduce a Liquid-laden href to a comparable /assets/... path.
+
+    ``{{ "/assets/js/x.js" | relative_url }}?v={{ site.time }}`` becomes
+    ``/assets/js/x.js``.  Returns "" when no /assets/ path is present.
+    """
+    stripped = url.split("?", 1)[0]
+    match = re.search(r"/assets/[A-Za-z0-9_./-]+", stripped)
+    return match.group(0) if match else ""
+
+
+def _has_cache_buster(url: str) -> bool:
+    """True when the URL carries a ?v= query (Liquid value or literal)."""
+    return bool(re.search(r"\?[^\"']*\bv=", url))
+
+
+def collect_versioned_assets(files: list[Path]) -> dict[str, Path]:
+    """Map /assets/... path -> first template that loads it with ?v=."""
+    versioned: dict[str, Path] = {}
+    for path in files:
+        try:
+            text = _strip_liquid(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError):
+            continue
+        for pattern in (_ASSET_REF_RE, _DATA_SRC_RE):
+            for raw in pattern.findall(text):
+                if not _has_cache_buster(raw):
+                    continue
+                asset = _normalize(raw)
+                if asset:
+                    versioned.setdefault(asset, path)
+    return versioned
+
+
+def check_file(path: Path, versioned: dict[str, Path]) -> list[tuple[int, str]]:
+    """Return (line_no, message) for every version-mismatched resource hint."""
+    try:
+        text = _strip_liquid(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    violations: list[tuple[int, str]] = []
+    for match in _LINK_TAG_RE.finditer(text):
+        tag = match.group(0)
+        rel_match = _REL_RE.search(tag)
+        if not rel_match:
+            continue
+        rels = {r.strip().lower() for r in rel_match.group(1).split()}
+        if not (rels & HINT_RELS):
+            continue
+
+        href_match = _HREF_RE.search(tag)
+        if not href_match:
+            continue
+        href = href_match.group(1)
+        asset = _normalize(href)
+        if not asset or asset not in versioned:
+            continue
+        if _has_cache_buster(href):
+            continue
+
+        line_no = text.count("\n", 0, match.start()) + 1
+        loader = versioned[asset]
+        loader_rel = loader.relative_to(REPO) if loader.is_relative_to(REPO) else loader
+        rel_name = "/".join(sorted(rels & HINT_RELS))
+        violations.append(
+            (
+                line_no,
+                f"rel=\"{rel_name}\" href points at {asset} without a ?v= "
+                f"cache-buster, but {loader_rel} loads it WITH ?v=. "
+                f"The two URLs are separate cache entries, so this hint is "
+                f"downloaded and never used.",
+            )
+        )
+    return violations
+
+
+def _all_template_paths() -> list[Path]:
+    files: list[Path] = []
+    for directory in TEMPLATE_DIRS:
+        base = REPO / directory
+        if not base.is_dir():
+            continue
+        for suffix in TEMPLATE_SUFFIXES:
+            files.extend(sorted(base.rglob(f"*{suffix}")))
+    return files
+
+
+def _staged_template_paths() -> list[Path]:
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return []
+    staged = []
+    for name in out.split("\0"):
+        if not name:
+            continue
+        path = REPO / name
+        if path.suffix.lower() in TEMPLATE_SUFFIXES and path.is_file():
+            if any(name.startswith(f"{d}/") for d in TEMPLATE_DIRS):
+                staged.append(path)
+    return staged
+
+
+def _explicit_paths(raw: list[str]) -> list[Path]:
+    return [Path(p) if Path(p).is_absolute() else REPO / p for p in raw]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag preload/prefetch hints whose href lacks the ?v= cache-buster "
+            "used by the tag that actually loads the asset. Exits 1 on any "
+            "violation."
+        )
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--staged",
+        action="store_true",
+        help="Only check templates in the git staging area.",
+    )
+    mode.add_argument(
+        "--all",
+        action="store_true",
+        help="Check every template (default when no paths given).",
+    )
+    parser.add_argument("paths", nargs="*", help="Explicit template paths to check.")
+    args = parser.parse_args()
+
+    # The versioned-asset index must always be built from the WHOLE template
+    # set: head.html carries the hint while footer.html carries the ?v= loader,
+    # so a --staged run that only sees head.html would otherwise find nothing.
+    versioned = collect_versioned_assets(_all_template_paths())
+
+    if args.staged:
+        files = _staged_template_paths()
+    elif args.paths:
+        files = _explicit_paths(args.paths)
+    else:
+        files = _all_template_paths()
+
+    files = [f for f in files if f.is_file()]
+    if not files:
+        print("[asset-hint] No template files to check.")
+        sys.exit(0)
+
+    total = 0
+    for path in files:
+        violations = check_file(path, versioned)
+        if violations:
+            rel = path.relative_to(REPO) if path.is_relative_to(REPO) else path
+            for line_no, msg in violations:
+                print(f"{rel}:{line_no}: {msg}", file=sys.stderr)
+            total += len(violations)
+
+    if total:
+        print(
+            f"\n[asset-hint] FAIL — {total} resource hint(s) point at a "
+            f"versioned asset without ?v=.\n"
+            f"  Fix by either:\n"
+            f"    1. Deleting the hint (correct when the current page already "
+            f"loads the asset — the preload scanner finds it anyway), or\n"
+            f"    2. Appending the same ?v= expression the loader uses.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"[asset-hint] OK — {len(files)} template(s) checked, 0 violations.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/check_csp_inline_hashes.py
+++ b/scripts/dev/check_csp_inline_hashes.py
@@ -62,6 +62,16 @@ DEFAULT_MANIFEST = REPO / "scripts" / "dev" / "csp_inline_hashes.json"
 import re
 
 _COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+# Liquid comments too (2026-08-14). Stripping only HTML comments was not
+# enough: a {% comment %} block in head.html that merely *described* a script
+# tag in prose opened a phantom tag boundary, and the scanner paired it with
+# the next real </script>, reporting a NEW inline script that does not exist.
+# The dangerous part is the suggested remedy — running --update would have
+# written the phantom's sha256 into the CSP manifest, i.e. degraded a security
+# control to silence a false positive.
+_LIQUID_COMMENT_RE = re.compile(
+    r"\{%-?\s*comment\s*-?%\}.*?\{%-?\s*endcomment\s*-?%\}", re.DOTALL | re.IGNORECASE
+)
 _SCRIPT_RE = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.DOTALL | re.IGNORECASE)
 _SRC_ATTR_RE = re.compile(r"\bsrc\s*=", re.IGNORECASE)
 _LDJSON_ATTR_RE = re.compile(
@@ -79,15 +89,16 @@ def extract_inline_scripts(html: str) -> list[InlineScript]:
     """Return every first-party executable inline ``<script>`` in *html*.
 
     Excludes scripts with a ``src`` attribute and ``application/ld+json``
-    data blocks. HTML comments are stripped first so prose that merely
-    *mentions* a ``<script ...>`` tag (e.g. inside a code-comment explaining
-    a removed tag) is not mistaken for a real tag boundary.
+    data blocks. HTML comments **and Liquid ``{% comment %}`` blocks** are
+    stripped first so prose that merely *mentions* a ``<script ...>`` tag
+    (e.g. inside a comment explaining a removed tag) is not mistaken for a
+    real tag boundary.
 
     Label: the script's ``id`` attribute if present, otherwise
     ``inline-script-N`` where N is the 1-based ordinal among qualifying
     inline scripts in document order.
     """
-    no_comments = _COMMENT_RE.sub("", html)
+    no_comments = _LIQUID_COMMENT_RE.sub("", _COMMENT_RE.sub("", html))
     results: list[InlineScript] = []
     ordinal = 0
     for match in _SCRIPT_RE.finditer(no_comments):

--- a/scripts/tests/test_asset_hint_version.py
+++ b/scripts/tests/test_asset_hint_version.py
@@ -1,0 +1,185 @@
+"""Tests for scripts/check_asset_hint_version.py.
+
+The gate exists because five `rel="prefetch"` hints in `_includes/head.html`
+pointed at versionless URLs while `_includes/footer.html` and
+`_includes/mermaid.html` loaded the same files with `?v={{ site.time }}`.
+Separate URLs are separate cache entries, so every post page view downloaded
+~14 KB compressed that was never used.
+
+The first draft of the gate reported "0 violations" against the still-broken
+head.html. The cause is pinned by `test_nested_liquid_quotes_still_detected`:
+these templates write `href="{{ "/assets/js/x.js" | relative_url }}"`, nesting
+double quotes inside a double-quoted attribute, and a quote-terminated
+attribute regex stops at the inner quote and captures nothing. A gate that
+cannot fail on the bug it was written for is not a gate, so that case is a
+required test, not an edge case.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+check_asset_hint_version = pytest.importorskip("check_asset_hint_version")
+
+check_file = check_asset_hint_version.check_file
+collect_versioned_assets = check_asset_hint_version.collect_versioned_assets
+_strip_liquid = check_asset_hint_version._strip_liquid
+
+
+# The exact shape that shipped: Liquid with nested double quotes.
+BROKEN_HINT = (
+    '<link rel="prefetch" href="{{ "/assets/js/post-page.js" | relative_url }}"'
+    ' as="script">\n'
+)
+# The exact shape of the loader in footer.html: single quotes inside, ?v= after.
+VERSIONED_LOADER = (
+    "<script src=\"{{ '/assets/js/post-page.js' | relative_url }}"
+    "?v={{ site.time | date: '%Y%m%d%H%M' }}\" defer></script>\n"
+)
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_nested_liquid_quotes_still_detected(tmp_path):
+    """The regression that made the first version of this gate useless."""
+    loader = _write(tmp_path, "footer.html", VERSIONED_LOADER)
+    hint = _write(tmp_path, "head.html", BROKEN_HINT)
+
+    versioned = collect_versioned_assets([loader])
+    assert "/assets/js/post-page.js" in versioned, (
+        "loader with nested single quotes inside a double-quoted src was not "
+        "recognized as versioned"
+    )
+
+    violations = check_file(hint, versioned)
+    assert len(violations) == 1
+    assert "/assets/js/post-page.js" in violations[0][1]
+
+
+def test_hint_with_matching_cache_buster_passes(tmp_path):
+    loader = _write(tmp_path, "footer.html", VERSIONED_LOADER)
+    hint = _write(
+        tmp_path,
+        "head.html",
+        '<link rel="prefetch" href="{{ "/assets/js/post-page.js" | relative_url }}'
+        "?v={{ site.time | date: '%Y%m%d%H%M' }}\" as=\"script\">\n",
+    )
+    versioned = collect_versioned_assets([loader])
+    assert check_file(hint, versioned) == []
+
+
+def test_hint_removed_passes(tmp_path):
+    """The fix actually applied to head.html: delete the hint."""
+    loader = _write(tmp_path, "footer.html", VERSIONED_LOADER)
+    hint = _write(tmp_path, "head.html", "<title>no hints here</title>\n")
+    versioned = collect_versioned_assets([loader])
+    assert check_file(hint, versioned) == []
+
+
+def test_versionless_everywhere_passes(tmp_path):
+    """Fonts: preload and @font-face both omit ?v=, so they agree."""
+    loader = _write(
+        tmp_path,
+        "font-face.html",
+        "@font-face { src: url('{{ \"/assets/fonts/x-tier1.woff2\" | relative_url }}')"
+        " format('woff2'); }\n"
+        '<link rel="preload" as="font" type="font/woff2" crossorigin'
+        ' href="{{ "/assets/fonts/x-tier1.woff2" | relative_url }}">\n',
+    )
+    versioned = collect_versioned_assets([loader])
+    assert versioned == {}
+    assert check_file(loader, versioned) == []
+
+
+def test_data_attribute_loader_counts_as_versioned(tmp_path):
+    """footer.html loads the search bundle via data-search-src, not src."""
+    loader = _write(
+        tmp_path,
+        "footer.html",
+        "<script src=\"{{ '/assets/js/footer-runtime.js' | relative_url }}\""
+        " data-search-src=\"{{ '/assets/js/main-search.js' | relative_url }}"
+        "?v={{ site.time | date: '%Y%m%d%H%M' }}\" defer></script>\n",
+    )
+    versioned = collect_versioned_assets([loader])
+    assert "/assets/js/main-search.js" in versioned
+    # The unversioned sibling in the same tag must NOT be marked versioned.
+    assert "/assets/js/footer-runtime.js" not in versioned
+
+
+def test_unversioned_asset_hint_is_not_flagged(tmp_path):
+    """No ?v= anywhere for this asset -> the hint is consistent, so no error."""
+    loader = _write(
+        tmp_path,
+        "footer.html",
+        "<script src=\"{{ '/assets/js/subscribe-float.js' | relative_url }}\""
+        " defer></script>\n",
+    )
+    hint = _write(
+        tmp_path,
+        "head.html",
+        '<link rel="prefetch" href="{{ "/assets/js/subscribe-float.js"'
+        ' | relative_url }}" as="script">\n',
+    )
+    versioned = collect_versioned_assets([loader])
+    assert check_file(hint, versioned) == []
+
+
+def test_stylesheet_rel_is_not_a_hint(tmp_path):
+    """rel="stylesheet" actually uses the asset; only hints can go unused."""
+    loader = _write(
+        tmp_path,
+        "footer.html",
+        "<script src=\"{{ '/assets/css/main.css' | relative_url }}"
+        "?v={{ site.time }}\"></script>\n",
+    )
+    sheet = _write(
+        tmp_path,
+        "head.html",
+        '<link rel="stylesheet" href="{{ "/assets/css/main.css" | relative_url }}">\n',
+    )
+    versioned = collect_versioned_assets([loader])
+    assert check_file(sheet, versioned) == []
+
+
+def test_line_numbers_survive_liquid_stripping(tmp_path):
+    """Reported lines must match the source file, not the stripped copy."""
+    loader = _write(tmp_path, "footer.html", VERSIONED_LOADER)
+    hint = _write(
+        tmp_path,
+        "head.html",
+        "<head>\n"
+        "  {% comment %}\n    multi-line\n    liquid block\n  {% endcomment %}\n"
+        + BROKEN_HINT,
+    )
+    versioned = collect_versioned_assets([loader])
+    violations = check_file(hint, versioned)
+    assert len(violations) == 1
+    assert violations[0][0] == 6, "line number drifted after Liquid removal"
+
+
+def test_strip_liquid_preserves_newline_count():
+    text = '{% comment %}\na\nb\n{% endcomment %}<link rel="prefetch">'
+    assert _strip_liquid(text).count("\n") == text.count("\n")
+
+
+def test_repo_templates_are_clean():
+    """The live invariant: the shipped templates must have no mismatch."""
+    files = check_asset_hint_version._all_template_paths()
+    assert files, "no templates discovered — the gate would be vacuous"
+    versioned = collect_versioned_assets(files)
+    offenders = {
+        str(path.relative_to(REPO)): check_file(path, versioned)
+        for path in files
+        if check_file(path, versioned)
+    }
+    assert offenders == {}, f"version-mismatched resource hints: {offenders}"

--- a/scripts/tests/test_csp_inline_hashes.py
+++ b/scripts/tests/test_csp_inline_hashes.py
@@ -302,3 +302,39 @@ def test_enforcing_policy_keeps_upgrade_insecure_requests():
         "the enforcing CSP lost upgrade-insecure-requests — that is where it is "
         "honoured, and dropping it allows mixed-content subresource loads."
     )
+
+
+def test_liquid_comment_prose_is_not_a_script_boundary():
+    """A {% comment %} block describing a script tag must not invent one.
+
+    Regression from 2026-08-14: head.html gained a Liquid comment explaining
+    removed prefetch hints. Its prose contained a literal ``<script defer>``,
+    which paired with the next real ``</script>`` and surfaced as a NEW
+    inline script. The remedy the gate suggests is ``--update``, which would
+    have written that phantom's sha256 into the CSP manifest — a security
+    control weakened to silence a false positive.
+    """
+    html = (
+        '<script id="real">var a = 1;</script>\n'
+        "{% comment %}\n"
+        "  We removed the <script defer> tag that used to live here.\n"
+        "{% endcomment %}\n"
+        '<script id="real2">var b = 2;</script>\n'
+    )
+    labels = [s.label for s in extract_inline_scripts(html)]
+    assert labels == ["real", "real2"], f"phantom script detected: {labels}"
+
+
+def test_liquid_comment_whitespace_control_variant():
+    """{%- comment -%} must be stripped as well."""
+    # No src= decoy here: a src-bearing tag is skipped anyway and would
+    # swallow the phantom's closing tag, letting this test pass even with
+    # Liquid stripping disabled. Verified by mutation.
+    html = (
+        "{%- comment -%}\n"
+        "  prose mentioning <script>phantom()</script>\n"
+        "{%- endcomment -%}\n"
+        '<script id="only">var a = 1;</script>\n'
+    )
+    labels = [s.label for s in extract_inline_scripts(html)]
+    assert labels == ["only"], f"phantom script detected: {labels}"


### PR DESCRIPTION
## 무엇이 문제였나

라이브 포스트 콘솔에서 `main-core.js` / `main-post.js` / `post-page.js` / `mermaid-init.js` / `main-search.js` 가 **버전 쿼리 없는 URL**로 별도 로드(3.3~4.1초대)되는 것이 관찰됐습니다.

원인은 `_includes/head.html` 의 prefetch 힌트입니다:

| | URL |
|---|---|
| 힌트 (`head.html`) | `/assets/js/post-page.js` |
| 실제 로더 (`footer.html`) | `/assets/js/post-page.js?v={{ site.time }}` |

HTTP 캐시는 쿼리를 포함한 전체 URL로 키를 잡으므로 둘은 **별개 캐시 항목**입니다. prefetch 로 받은 사본은 한 번도 쓰이지 않고 버려졌습니다.

### 실측 낭비량

```
main-core.js     raw=6355B   compressed=2562B
main-post.js     raw=9730B   compressed=3569B
post-page.js     raw=10449B  compressed=3583B
mermaid-init.js  raw=3264B   compressed=1427B
main-search.js   raw=7812B   compressed=3061B
--- 합계: 14,202 B 압축 (원본 37,610 B) + 요청 5건 / 포스트 1회 로드
```

### 왜 여태 안 드러났나

기존 주석 `preload 경고 방지를 위해 prefetch 사용` 이 실마리입니다. Chrome 은 **미사용 preload 만** 경고하고 미사용 prefetch 는 조용히 넘어갑니다. 과거의 `preload`→`prefetch` 전환은 URL 불일치라는 원인을 두고 **경고만 지운** 것이었습니다.

## 왜 버전을 맞추는 대신 삭제했나

1. 이 5개는 현재 페이지가 어차피 로드하는 파일입니다. preload 스캐너가 footer 의 defer 스크립트를 파싱 단계에서 이미 발견합니다.
2. `?v=` 는 `site.time` 기반이라 **빌드마다 바뀝니다.** 버전을 맞춰도 다음 빌드에서 프리페치 사본은 즉시 무효 — 다음 내비게이션에도 이득이 없습니다.

2026-04-17 OG AVIF preload 제거와 같은 판단입니다.

## 회귀 가드

`scripts/check_asset_hint_version.py` — pre-commit 14번 + svg-lint CI(`--all`).

> 불변식: `/assets/` 자산이 어딘가에서 `?v=` 와 함께 로드된다면, 그 자산을 가리키는 모든 resource hint 도 `?v=` 를 가져야 한다.

폰트처럼 어디서나 버전이 없는 자산은 정의상 일관되므로 통과합니다.

### 가드 초안이 버그를 못 잡았던 건

첫 버전은 **아직 고치지 않은 head.html 을 상대로 `0 violations`** 를 냈습니다. 템플릿이 `href="{{ "/assets/…" | relative_url }}"` 처럼 큰따옴표 안에 큰따옴표를 중첩하는데, 따옴표로 끝나는 속성 정규식이 내부 따옴표에서 끊겨 빈 값을 잡았기 때문입니다. Liquid 를 먼저 정규화하도록 고쳤고 그 케이스를 필수 테스트로 고정했습니다 (`test_nested_liquid_quotes_still_detected`).

svg-lint 트리거도 `_includes/**.html` + `_layouts/**.html` 로 넓혔습니다 — 힌트와 로더가 서로 다른 파일에 있어서, 스캔 범위보다 좁은 트리거는 이 워크플로 헤더가 경고하는 바로 그 위험입니다.

## 부수 변경: CSP 게이트 강화

head.html 에 추가한 설명 주석 안의 `<script>` 리터럴이 가짜 태그 경계를 만들어 `check_csp_inline_hashes.py` 가 유령 인라인 스크립트를 `NEW` 로 보고했습니다. 게이트가 권하는 `--update` 를 눌렀다면 **CSP 매니페스트에 유령의 sha256 이 박힐 뻔했습니다** — 오탐을 잠재우려다 보안 통제를 약화시키는 경로입니다. 게이트가 Liquid 주석도 제거하도록 고쳤습니다.

## 검증

- `pytest scripts/tests/` — **4182 passed, 5 skipped**
- `bundle exec jekyll build` 성공, 빌드 산출물에 버전없는 JS 힌트 **0건**, 폰트 preload·17개 script 태그 그대로
- CSP 매니페스트 **무변경**(2항목), 게이트 통과
- 가드/테스트 모두 **뮤테이션 테스트로 회귀 탐지 확인** — Liquid 정규화를 무력화하면 해당 테스트들이 실제로 실패
- 신규 pre-commit 스텝이 이 커밋에서 실제 실행되어 통과

## 검증되지 않음

프로덕션 배포 후 실제 브라우저에서 5건 감소를 재확인하는 것은 병합·배포 이후에만 가능합니다.