### PR TITLE
ci: 리소스 힌트 실사용 게이트(실브라우저) — 정적 게이트가 못 보는 절반

### DIFF
--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -71,6 +71,7 @@ on:
       - '_includes/**.html'
       - '_layouts/**.html'
       - 'scripts/check_asset_hint_version.py'
+      - 'scripts/tests/check_resource_hint_usage.mjs'
       - '_posts/**.md'
       - 'vercel.json'
       - 'assets/js/mermaid-init.js'
@@ -126,6 +127,7 @@ on:
       - '_includes/**.html'
       - '_layouts/**.html'
       - 'scripts/check_asset_hint_version.py'
+      - 'scripts/tests/check_resource_hint_usage.mjs'
       - '_posts/**.md'
       - 'vercel.json'
       - 'assets/js/mermaid-init.js'
@@ -479,3 +481,14 @@ jobs:
 
       - name: Mermaid CSP-render guard (no 'unsafe-eval' in enforcing CSP)
         run: node scripts/tests/check_mermaid_csp_render.mjs --verbose
+
+      # Complements the static gate in the lint job. check_asset_hint_version.py
+      # reads templates and catches a hint whose href omits the loader's ?v=;
+      # only a browser can tell whether the hinted URL is fetched at all, and
+      # whether the page ends up pulling two URL variants of the same file.
+      # Verified by reintroducing the pre-2026-08-14 head.html: 5 SPLIT
+      # findings, and clean once the hints are removed. All non-local requests
+      # are aborted, so third-party fill/latency cannot make this flaky and CI
+      # ships no page loads to external services.
+      - name: Resource-hint usage guard (real browser, local build)
+        run: node scripts/tests/check_resource_hint_usage.mjs --verbose

--- a/scripts/dev/measure_cls.mjs
+++ b/scripts/dev/measure_cls.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * CLS measurement harness with per-element attribution.
+ *
+ * CLS is noisy: ad fill, font swap and iframe embeds vary run to run, so a
+ * single number proves nothing. This runs the page N times and reports the
+ * median plus the shift sources ranked by total contribution, which is what
+ * actually tells you where to reserve space.
+ *
+ * It measures the same way Chrome's field metric does — sums layout-shift
+ * entries that are NOT within 500ms of a user input — and keeps per-source
+ * attribution from `entry.sources[].node`.
+ *
+ * Usage:
+ *   node scripts/dev/measure_cls.mjs <url> [runs] [--json]
+ *
+ * Requires Playwright (already a devDependency for the CSP/mermaid guards).
+ */
+
+import { chromium } from 'playwright';
+
+const url = process.argv[2];
+const runs = Number(process.argv[3] || 5);
+const asJson = process.argv.includes('--json');
+
+if (!url) {
+  console.error('usage: node scripts/dev/measure_cls.mjs <url> [runs] [--json]');
+  process.exit(2);
+}
+
+const COLLECTOR = () => {
+  window.__shifts = [];
+  const describe = (node) => {
+    if (!node || node.nodeType !== 1) return '(detached)';
+    const el = /** @type {Element} */ (node);
+    const id = el.id ? `#${el.id}` : '';
+    const cls = typeof el.className === 'string' && el.className
+      ? '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.')
+      : '';
+    return `${el.tagName.toLowerCase()}${id}${cls}`;
+  };
+  new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+      if (entry.hadRecentInput) continue;
+      window.__shifts.push({
+        value: entry.value,
+        time: entry.startTime,
+        sources: (entry.sources || []).map((s) => ({
+          node: describe(s.node),
+          from: s.previousRect ? `${Math.round(s.previousRect.width)}x${Math.round(s.previousRect.height)}@${Math.round(s.previousRect.y)}` : '',
+          to: s.currentRect ? `${Math.round(s.currentRect.width)}x${Math.round(s.currentRect.height)}@${Math.round(s.currentRect.y)}` : '',
+        })),
+      });
+    }
+  }).observe({ type: 'layout-shift', buffered: true });
+};
+
+const browser = await chromium.launch();
+const results = [];
+
+for (let i = 0; i < runs; i += 1) {
+  const context = await browser.newContext({ viewport: { width: 1512, height: 827 } });
+  const page = await context.newPage();
+  await page.addInitScript(COLLECTOR);
+  await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+  // Scroll the whole page: shifts below the fold (ads, comments, footer)
+  // only occur once those regions are reached and their embeds load.
+  await page.evaluate(async () => {
+    for (let y = 0; y < document.body.scrollHeight; y += 600) {
+      window.scrollTo(0, y);
+      await new Promise((r) => setTimeout(r, 90));
+    }
+    window.scrollTo(0, document.body.scrollHeight);
+  });
+  await page.waitForTimeout(9000);
+  const shifts = await page.evaluate(() => window.__shifts || []);
+  const total = shifts.reduce((a, s) => a + s.value, 0);
+  results.push({ total, shifts });
+  await context.close();
+  if (!asJson) console.error(`  run ${i + 1}/${runs}: CLS=${total.toFixed(4)}`);
+}
+
+await browser.close();
+
+const totals = results.map((r) => r.total).sort((a, b) => a - b);
+const median = totals[Math.floor(totals.length / 2)];
+
+// Rank sources by summed contribution across all runs.
+const bySource = new Map();
+for (const r of results) {
+  for (const s of r.shifts) {
+    const names = s.sources.length ? s.sources.map((x) => x.node) : ['(no attribution)'];
+    for (const n of names) {
+      const cur = bySource.get(n) || { total: 0, count: 0, sample: '' };
+      cur.total += s.value / names.length;
+      cur.count += 1;
+      if (!cur.sample && s.sources.length) {
+        const src = s.sources.find((x) => x.node === n);
+        if (src) cur.sample = `${src.from} -> ${src.to}`;
+      }
+      bySource.set(n, cur);
+    }
+  }
+}
+const ranked = [...bySource.entries()]
+  .map(([node, v]) => ({ node, perRun: v.total / runs, hits: v.count, sample: v.sample }))
+  .sort((a, b) => b.perRun - a.perRun);
+
+if (asJson) {
+  console.log(JSON.stringify({ url, runs, median, totals, ranked }, null, 2));
+} else {
+  console.log('='.repeat(74));
+  console.log(`URL: ${url}`);
+  console.log(`runs=${runs}  CLS 중앙값=${median.toFixed(4)}  전체=[${totals.map((t) => t.toFixed(3)).join(', ')}]`);
+  console.log(`목표: < 0.10  →  ${median < 0.1 ? 'PASS' : 'FAIL'}`);
+  console.log('-'.repeat(74));
+  console.log('기여도 상위 (run당 평균 CLS):');
+  for (const r of ranked.slice(0, 12)) {
+    console.log(`  ${r.perRun.toFixed(4)}  ${r.node.padEnd(44)} ${r.sample}`);
+  }
+}

--- a/scripts/tests/check_resource_hint_usage.mjs
+++ b/scripts/tests/check_resource_hint_usage.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Resource-hint usage gate (real browser, local build).
+ *
+ * `scripts/check_asset_hint_version.py` reads the templates and catches one
+ * failure mode: a hint whose href omits the `?v=` its loader uses. That is a
+ * static check and it cannot see the other half of the problem — whether the
+ * hinted URL is ever requested at all, and whether the page ends up fetching
+ * two URL variants of the same file. Only a browser knows that.
+ *
+ * This gate loads pages from the local `_site` build in Chromium and fails when
+ * a same-origin preload/prefetch/modulepreload is either:
+ *
+ *   1. NEVER-FETCHED  — the hint downloads nothing the page uses, or
+ *   2. SPLIT          — the same file is fetched under two different URLs
+ *                       (the versionless/versioned split that cost ~14 KB per
+ *                       post view until 2026-08-14).
+ *
+ * Determinism: every non-local request is aborted. Third-party behaviour
+ * (AdSense fill, Sentry, giscus) varies run to run and would make this flaky,
+ * and CI has no business shipping page loads to external services. That means
+ * cross-origin preconnect/dns-prefetch hints are deliberately NOT judged here —
+ * several of them (Translate, DeepSeek chat) are lazy on user interaction and
+ * are *expected* to be unused on initial load, so "unused" is not a defect
+ * signal for them.
+ *
+ * Usage:
+ *   node scripts/tests/check_resource_hint_usage.mjs [--verbose]
+ *
+ * Requires a build first:  JEKYLL_ENV=production ./build.sh   (or jekyll build)
+ */
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SITE_DIR = path.join(REPO_ROOT, '_site');
+const VERBOSE = process.argv.includes('--verbose');
+
+const HINT_RELS = new Set(['preload', 'prefetch', 'modulepreload']);
+
+function fail(msg) {
+  console.error(`[hint-usage] ${msg}`);
+  process.exit(1);
+}
+
+if (!fs.existsSync(SITE_DIR)) {
+  fail(`_site not found — build first (JEKYLL_ENV=production ./build.sh). Looked in ${SITE_DIR}`);
+}
+
+/** Pick representative pages: home plus the first post (layout: post carries the most hints). */
+function pickPages() {
+  const pages = ['/'];
+  const postsRoot = path.join(SITE_DIR, 'posts');
+  if (fs.existsSync(postsRoot)) {
+    const stack = [postsRoot];
+    const found = [];
+    while (stack.length && found.length < 400) {
+      const dir = stack.pop();
+      for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) stack.push(full);
+        else if (e.name === 'index.html') found.push(full);
+      }
+    }
+    found.sort();
+    if (found.length) {
+      pages.push('/' + path.relative(SITE_DIR, found[found.length - 1]).replace(/index\.html$/, '').split(path.sep).join('/'));
+    }
+  }
+  return pages;
+}
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+      const candidates = [];
+      if (urlPath.endsWith('/')) candidates.push(path.join(SITE_DIR, urlPath, 'index.html'));
+      else {
+        candidates.push(path.join(SITE_DIR, urlPath));
+        candidates.push(path.join(SITE_DIR, `${urlPath}.html`));
+        candidates.push(path.join(SITE_DIR, urlPath, 'index.html'));
+      }
+      for (const c of candidates) {
+        const resolved = path.resolve(c);
+        if (!resolved.startsWith(SITE_DIR)) continue; // traversal guard
+        if (fs.existsSync(resolved) && fs.statSync(resolved).isFile()) {
+          const ext = path.extname(resolved);
+          const type = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
+            '.woff2': 'font/woff2', '.json': 'application/json', '.svg': 'image/svg+xml' }[ext] || 'application/octet-stream';
+          res.writeHead(200, { 'Content-Type': type });
+          fs.createReadStream(resolved).pipe(res);
+          return;
+        }
+      }
+      res.writeHead(404).end('not found');
+    });
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+const server = await startServer();
+const base = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch();
+const problems = [];
+let hintsChecked = 0;
+
+for (const pagePath of pickPages()) {
+  const context = await browser.newContext();
+  const localRequests = [];
+  // Abort everything that is not our local server: determinism over realism.
+  await context.route('**/*', (route) => {
+    const u = route.request().url();
+    if (u.startsWith(base)) { localRequests.push(u.split('#')[0]); route.continue(); }
+    else route.abort();
+  });
+  const page = await context.newPage();
+  await page.goto(base + pagePath, { waitUntil: 'load', timeout: 60000 }).catch(() => {});
+  await page.waitForTimeout(2500);
+
+  const hints = await page.evaluate((rels) =>
+    Array.from(document.querySelectorAll('link[rel]'))
+      .filter((l) => rels.includes(l.rel))
+      .map((l) => ({ rel: l.rel, href: l.href, as: l.getAttribute('as') || '' })),
+    [...HINT_RELS]
+  );
+
+  for (const h of hints) {
+    const href = h.href.split('#')[0];
+    if (!href.startsWith(base)) continue; // cross-origin: intentionally not judged
+    hintsChecked += 1;
+    const hits = localRequests.filter((u) => u === href).length;
+    const bare = href.split('?')[0];
+    const variants = [...new Set(localRequests.filter((u) => u.split('?')[0] === bare && u !== href))];
+    const rel = href.slice(base.length);
+
+    if (hits === 0) {
+      problems.push(`${pagePath}: NEVER-FETCHED  rel="${h.rel}" ${rel} — the hint downloads nothing the page uses.`);
+    } else if (variants.length) {
+      problems.push(
+        `${pagePath}: SPLIT  rel="${h.rel}" ${rel} is hinted, but the page also fetches ` +
+        variants.map((v) => v.slice(base.length)).join(', ') +
+        ` — separate cache entries, so the hinted copy is downloaded and never used.`
+      );
+    } else if (VERBOSE) {
+      console.log(`[hint-usage] OK ${pagePath} ${h.rel} ${rel}`);
+    }
+  }
+  await context.close();
+}
+
+await browser.close();
+server.close();
+
+if (problems.length) {
+  console.error(`[hint-usage] FAIL — ${problems.length} problem(s):\n`);
+  for (const p of problems) console.error(`  ${p}`);
+  console.error(
+    `\n  Fix by either deleting the hint (correct when the page already loads the\n` +
+    `  asset — the preload scanner finds it anyway), or making the hint href\n` +
+    `  byte-identical to the URL the loader requests.`
+  );
+  process.exit(1);
+}
+
+console.log(`[hint-usage] OK — ${hintsChecked} same-origin hint(s) checked across pages, 0 problems.`);


### PR DESCRIPTION
PR #550 에서 추가한 `check_asset_hint_version.py` 는 템플릿을 읽어 **"힌트 href 에 로더의 `?v=` 가 빠졌다"** 한 가지만 잡습니다. 정적 검사로는 알 수 없는 게 둘 있습니다.

1. 힌트가 가리키는 URL 을 브라우저가 **실제로 받는지**
2. 같은 파일을 **두 URL 로 중복해서 받는지**

이 PR 이 그 절반을 채웁니다.

## 게이트

`scripts/tests/check_resource_hint_usage.mjs` — 로컬 `_site` 빌드를 정적 서버로 올려 Chromium 으로 로드하고, same-origin `preload`/`prefetch`/`modulepreload` 가 다음이면 실패합니다.

| 판정 | 의미 |
|---|---|
| `NEVER-FETCHED` | 힌트가 페이지가 쓰지 않는 것을 받아온다 |
| `SPLIT` | 같은 파일을 두 URL 로 요청 — 별개 캐시 항목이라 힌트본은 버려짐 |

## 왜 외부 요청을 차단하나

로컬 서버 외 **모든 요청을 abort** 합니다. 광고 게재·Sentry·giscus 는 런마다 결과가 달라 플래키의 직접적 원인이고, CI 가 외부 서비스로 페이지 로드를 보낼 이유도 없습니다.

그 결과 cross-origin `preconnect`/`dns-prefetch` 는 **의도적으로 판정 대상에서 제외**했습니다. 실측해 보니 `translate.google.com`, `translate.googleapis.com`, `api.deepseek.com`, `api.mymemory.translated.net` 4개는 초기 로드에서 미사용인데 이는 **설계상 정상**입니다(번역·챗봇은 사용자 상호작용 시 지연 로드). 이런 오리진에 "미사용"은 결함 신호가 아니므로, 판정했다면 게이트가 상시 red 이거나 무의미한 allowlist 를 낳았을 것입니다.

## 게이트 검증 (양방향)

```
# 수정 전 head.html 복원 후 빌드
복원된 prefetch 태그 수: 5
[hint-usage] FAIL — 5 problem(s):
  /: SPLIT rel="prefetch" /assets/js/main-core.js ... 도 함께 요청 /assets/js/main-core.js?v=202608140309
  /posts/.../: SPLIT ... main-core.js / main-post.js / post-page.js / mermaid-init.js
exit=1

# 현재 상태
[hint-usage] OK — 4 same-origin hint(s) checked across pages, 0 problems.
exit=0
```

**첫 시도의 음성 테스트는 공허했습니다.** `git stash push` 가 no-op 이라 파일이 실제로 되돌아가지 않았는데, `grep -c 'rel="prefetch"'` 가 제가 새로 쓴 **주석 문구**를 세는 바람에 복원된 줄 알았습니다. 명시적 `git show <sha>:<path>` 로 다시 확인한 결과가 위 출력입니다.

## 배선

svg-lint `build` 잡의 mermaid CSP 가드 다음에 추가했습니다 — 그 잡은 이미 `build.sh` 로 사이트를 빌드하고 Playwright Chromium 을 설치합니다. 트리거 경로에 스크립트 자신을 추가했습니다(스캔 범위보다 좁은 트리거 금지).

## 부수: CLS 측정 하네스

`scripts/dev/measure_cls.mjs` — N회 반복 측정 + `layout-shift` `entry.sources` 기반 요소별 기여도 순위. CLS 는 광고 게재 여부에 따라 확률적이라 단발 측정으로는 아무것도 증명되지 않습니다. 게이트가 아니라 개발용 도구입니다.

## 검증되지 않음

이 게이트는 same-origin 힌트만 판정합니다. cross-origin 힌트가 죽은 오리진을 가리키는 경우(서비스 제거 후 힌트 잔존)는 **잡지 못합니다** — 위 이유로 의도적으로 범위 밖입니다.