### PR TITLE
fix(cls): 광고 높이 예약 제거 — 붕괴 CLS 0.0575 → 0.0039

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -566,14 +566,18 @@
       height: 0 !important;
       min-height: 0 !important;
     }
-    /* CLS prevention: reserve space for ads before they load */
+    /* CLS: reserve NOTHING (2026-08-14). Reserving space you then collapse is
+       itself the layout shift. The rules above delete .ad-container the moment
+       AdSense reports data-ad-status="unfilled", and measured fill rate on this
+       site is 0/4 and 0/3 — so the reservation's only reliable effect was to
+       drop 250px out from under whatever the reader was looking at.
+       Measured on a local build by driving the real transition (set
+       data-ad-status="unfilled", let the :has() rules above collapse the
+       container): 0.0575 with the reservation, 0.0039 without.
+       Harness: scripts/dev/measure_ad_collapse_cls.mjs
+       `contain` stays — it limits how far a shift propagates if one happens. */
     .adsbygoogle:not([data-ad-status]) {
-      min-height: 100px;
       contain: layout style;
-    }
-    .adsbygoogle[data-ad-format="fluid"]:not([data-ad-status]),
-    .adsbygoogle[data-ad-layout="in-article"]:not([data-ad-status]) {
-      min-height: 250px;
     }
     .google-auto-placed {
       contain: layout style;

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -2386,10 +2386,13 @@
   border-color: var(--color-border);
 }
 
-/* Ad Container - CLS 최적화 */
+/* Ad Container — 높이 예약 없음 (2026-08-14).
+   예약해 두었다가 접는 것이 곧 시프트다: head.html 의 :has() 규칙이 unfilled
+   광고의 컨테이너를 display:none 으로 지우므로, 여기서 250px 을 잡아두면 그
+   순간 독자가 보던 자리에서 250px 이 사라진다. 실측 게재율 0/4·0/3.
+   측정: scripts/dev/measure_ad_collapse_cls.mjs (0.0575 -> 0.0039) */
 .ad-container {
   position: relative;
-  min-height: 250px;
   width: 100%;
   contain: layout style;
   margin: 1.5rem 0;
@@ -2404,7 +2407,6 @@
 /* Google Auto-Placed Ads CLS 방지 */
 .google-auto-placed,
 [class*="google-auto-placed"] {
-  min-height: 250px;
   contain: layout style;
   display: block;
 }
@@ -2415,17 +2417,15 @@
 ins.adsbygoogle,
 ins.adsbygoogle-noablate {
   display: block !important;
-  min-height: 250px !important;
   contain: layout style !important;
   width: 100% !important;
   position: relative !important;
 }
 
-/* Google Ads iframe 호스트 CLS 방지 */
+/* Google Ads iframe 호스트 — 높이 예약 없음 (2026-08-14, 위와 같은 이유) */
 #aswift_1_host,
 #aswift_2_host,
 [id^="aswift_"] {
-  min-height: 250px !important;
   contain: layout style !important;
   display: block !important;
   position: relative !important;

--- a/assets/js/ad-optimizer.js
+++ b/assets/js/ad-optimizer.js
@@ -15,20 +15,11 @@
     const container = document.createElement('div');
     container.className = 'ad-container';
     
-    // 광고 타입에 따라 최소 높이 설정
-    const adData = adElement.getAttribute('data-ad-slot') || 
-                   adElement.getAttribute('data-ad-format') || '';
-    
-    // 광고 포맷에 따른 높이 설정
-    if (adData.includes('horizontal') || adData.includes('banner')) {
-      container.style.minHeight = '90px'; // 728x90 또는 970x90
-    } else if (adData.includes('vertical') || adData.includes('sidebar')) {
-      container.style.minHeight = '600px'; // 300x600 또는 160x600
-    } else if (adData.includes('rectangle')) {
-      container.style.minHeight = '250px'; // 300x250
-    } else {
-      container.style.minHeight = '250px'; // 기본값
-    }
+    // 높이 예약 없음 (2026-08-14). 예약해 두었다가 접는 것이 곧 레이아웃
+    // 시프트다. head.html 의 :has() 규칙이 unfilled 광고의 컨테이너를
+    // display:none 으로 지우므로, 여기서 90/250/600px 을 잡아두면 그 순간
+    // 독자가 보던 자리에서 그만큼이 사라진다. 실측 게재율은 0/4·0/3.
+    // 측정: scripts/dev/measure_ad_collapse_cls.mjs (0.0575 -> 0.0039)
 
     // 광고를 컨테이너로 이동
     adElement.parentNode.insertBefore(container, adElement);
@@ -54,10 +45,11 @@
       attributeFilter: ['style']
     });
 
-    // 10초 후 타임아웃
+    // 10초 후 타임아웃. 예약 높이를 더 이상 잡지 않으므로 위 observer 가 하는
+    // minHeight='auto' 는 사실상 no-op 이지만, 광고가 실제로 채워졌을 때
+    // 컨테이너가 iframe 높이를 그대로 따르도록 두는 안전장치로 남긴다.
     setTimeout(function() {
       observer.disconnect();
-      // 광고가 로드되지 않아도 최소 높이 유지 (CLS 방지)
     }, 10000);
   }
 
@@ -70,9 +62,9 @@
     
     ads.forEach(function(ad) {
       wrapAdInContainer(ad);
-      // 직접 스타일 적용으로 CLS 방지 강화
-      if (!ad.style.minHeight) {
-        ad.style.minHeight = '250px';
+      // minHeight 예약 없음 — 접힐 높이를 잡아두지 않는다. contain 은 시프트가
+      // 생기더라도 전파 범위를 제한하므로 유지.
+      if (!ad.style.contain) {
         ad.style.display = 'block';
         ad.style.contain = 'layout style';
         ad.style.width = '100%';
@@ -88,7 +80,6 @@
         // aspect-ratio 설정으로 CLS 방지
         if (!ad.style.aspectRatio) {
           ad.style.aspectRatio = 'auto';
-          ad.style.minHeight = '250px';
           ad.style.display = 'block';
           ad.style.contain = 'layout style';
         }
@@ -112,7 +103,6 @@
                 )) {
                 wrapAdInContainer(node);
                 // 즉시 스타일 적용
-                node.style.minHeight = '250px';
                 node.style.display = 'block';
                 node.style.contain = 'layout style';
                 node.style.width = '100%';
@@ -125,7 +115,6 @@
               if (ads) {
                 ads.forEach(function(ad) {
                   wrapAdInContainer(ad);
-                  ad.style.minHeight = '250px';
                   ad.style.display = 'block';
                   ad.style.contain = 'layout style';
                   ad.style.width = '100%';

--- a/scripts/dev/measure_ad_collapse_cls.mjs
+++ b/scripts/dev/measure_ad_collapse_cls.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Ad reserve-then-collapse CLS harness.
+ *
+ * The shift this measures is NOT ad *fill* — it is the opposite. AdSense marks
+ * an unfilled unit with data-ad-status="unfilled", the :has() rules in
+ * _includes/head.html then delete the .ad-container, and whatever height was
+ * reserved vanishes from under the reader.
+ *
+ * Measuring that against production is useless: fill is stochastic, and a fast
+ * scroll reaches the ad region only after the collapse already happened, which
+ * is why lab runs kept reporting CLS 0.0000 while a real reader saw 0.20. This
+ * harness drives the transition directly on a local build with all third-party
+ * requests aborted, so the number is reproducible.
+ *
+ * Usage:
+ *   JEKYLL_ENV=production ./build.sh   (or: bundle exec jekyll build -d _site)
+ *   node scripts/dev/measure_ad_collapse_cls.mjs /posts/YYYY/MM/DD/slug/
+ *
+ * Baseline recorded 2026-08-14 (3 slots, first container centred):
+ *   reservation kept   250 -> 0   CLS 0.0575
+ *   reservation removed  0 -> 0   CLS 0.0039
+ */
+
+import { chromium } from 'playwright';
+import http from 'node:http'; import fs from 'node:fs'; import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+const SITE=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'..','..','_site');
+const server=http.createServer((req,res)=>{const u=decodeURIComponent((req.url||'/').split('?')[0]);
+ const cs=u.endsWith('/')?[path.join(SITE,u,'index.html')]:[path.join(SITE,u),path.join(SITE,u,'index.html')];
+ for(const c of cs){const r=path.resolve(c); if(!r.startsWith(SITE))continue;
+  if(fs.existsSync(r)&&fs.statSync(r).isFile()){const e=path.extname(r);
+   res.writeHead(200,{'Content-Type':{'.html':'text/html','.js':'text/javascript','.css':'text/css','.woff2':'font/woff2','.svg':'image/svg+xml'}[e]||'application/octet-stream'});
+   return fs.createReadStream(r).pipe(res);}}
+ res.writeHead(404).end('nf');});
+await new Promise(r=>server.listen(0,'127.0.0.1',r));
+const base=`http://127.0.0.1:${server.address().port}`;
+const b=await chromium.launch();
+
+async function run(label, killReservation) {
+  const c=await b.newContext({viewport:{width:1512,height:827}});
+  await c.route('**/*', r=> r.request().url().startsWith(base)? r.continue(): r.abort());
+  const p=await c.newPage();
+  await p.addInitScript(()=>{ window.__m=0; new PerformanceObserver(l=>{for(const e of l.getEntries()){if(!e.hadRecentInput)window.__m+=e.value;}}).observe({type:'layout-shift',buffered:true}); });
+  await p.goto(base+process.argv[2],{waitUntil:'load',timeout:60000});
+  await p.waitForTimeout(7000);
+  if (killReservation) {
+    await p.evaluate(()=>{ document.querySelectorAll('.ad-container').forEach(el=>{el.style.minHeight='0px';});
+                           document.querySelectorAll('ins.adsbygoogle').forEach(el=>{el.style.minHeight='0px';}); });
+    await p.waitForTimeout(900);
+  }
+  const pre = await p.evaluate(()=>[...document.querySelectorAll('.ad-container')].map(e=>Math.round(e.getBoundingClientRect().height)));
+  await p.evaluate(()=>{ const el=document.querySelector('.ad-container'); if(el) el.scrollIntoView({block:'center'}); });
+  await p.waitForTimeout(1200);
+  const before = await p.evaluate(()=>window.__m);
+  // AdSense 가 실제로 하는 일: unfilled 표시 -> head.html:545/552 의 :has() 가 컨테이너를 지움
+  await p.evaluate(()=>{ document.querySelectorAll('ins.adsbygoogle').forEach(el=>el.setAttribute('data-ad-status','unfilled')); });
+  await p.waitForTimeout(1500);
+  const after = await p.evaluate(()=>window.__m);
+  const post = await p.evaluate(()=>[...document.querySelectorAll('.ad-container')].map(e=>Math.round(e.getBoundingClientRect().height)));
+  await c.close();
+  console.log(`${label}: 컨테이너 높이 ${JSON.stringify(pre)} -> ${JSON.stringify(post)}   붕괴 CLS=${(after-before).toFixed(4)}`);
+  return after-before;
+}
+const a = await run('예약 유지(현행)  ', false);
+const bb = await run('예약 제거(수정안)', true);
+console.log(`\n차이: ${(a-bb).toFixed(4)}  (현행 ${a.toFixed(4)} -> 수정안 ${bb.toFixed(4)})`);
+await b.close(); server.close();

--- a/tests/js/ad-optimizer.test.js
+++ b/tests/js/ad-optimizer.test.js
@@ -1,9 +1,17 @@
 // Regression tests for assets/js/ad-optimizer.js
 //
 // Goal: prove the ad-optimizer (a) wraps every adsbygoogle slot in a
-// .ad-container, (b) sets a CLS-preventing minHeight that matches the
-// requested ad format, (c) does not double-wrap an already-wrapped slot,
-// and (d) applies CSS containment hints to the ad element itself.
+// .ad-container, (b) reserves NO height, (c) does not double-wrap an
+// already-wrapped slot, and (d) applies CSS containment hints to the ad
+// element itself.
+//
+// (b) inverted on 2026-08-14. Reserving 90/250/600px and then collapsing it
+// is itself the layout shift: the :has() rules in _includes/head.html delete
+// .ad-container the moment AdSense reports data-ad-status="unfilled", and the
+// measured fill rate on this site is 0/4 and 0/3. Driving that transition on a
+// local build measured CLS 0.0575 with the reservation and 0.0039 without
+// (scripts/dev/measure_ad_collapse_cls.mjs). These assertions now guard
+// against the reservation coming back.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
@@ -35,7 +43,7 @@ describe('ad-optimizer.js', () => {
     document.body.innerHTML = '';
   });
 
-  it('wraps a bare adsbygoogle slot in .ad-container with a default minHeight', () => {
+  it('wraps a bare adsbygoogle slot in .ad-container and reserves no height', () => {
     document.body.innerHTML =
       '<ins class="adsbygoogle" data-ad-format="rectangle"></ins>';
     runScript();
@@ -43,21 +51,21 @@ describe('ad-optimizer.js', () => {
     const ad = document.querySelector('ins.adsbygoogle');
     const container = ad.parentElement;
     expect(container.classList.contains('ad-container')).toBe(true);
-    expect(container.style.minHeight).toBe('250px');
+    expect(container.style.minHeight).toBe('');
   });
 
-  it('sets minHeight=90px for horizontal/banner ad formats', () => {
+  it('reserves no height for horizontal/banner ad formats', () => {
     document.body.innerHTML =
       '<ins class="adsbygoogle" data-ad-format="horizontal"></ins>';
     runScript();
-    expect(document.querySelector('.ad-container').style.minHeight).toBe('90px');
+    expect(document.querySelector('.ad-container').style.minHeight).toBe('');
   });
 
-  it('sets minHeight=600px for vertical/sidebar ad formats', () => {
+  it('reserves no height for vertical/sidebar ad formats', () => {
     document.body.innerHTML =
       '<ins class="adsbygoogle" data-ad-slot="sidebar-1"></ins>';
     runScript();
-    expect(document.querySelector('.ad-container').style.minHeight).toBe('600px');
+    expect(document.querySelector('.ad-container').style.minHeight).toBe('');
   });
 
   it('does not double-wrap an ad that is already inside .ad-container', () => {
@@ -74,7 +82,7 @@ describe('ad-optimizer.js', () => {
     expect(ad.style.display).toBe('block');
     expect(ad.style.contain).toBe('layout style');
     expect(ad.style.width).toBe('100%');
-    expect(ad.style.minHeight).toBe('250px');
+    expect(ad.style.minHeight).toBe('');
   });
 
   it('handles multiple ad slots on the same page', () => {
@@ -85,7 +93,7 @@ describe('ad-optimizer.js', () => {
     runScript();
     const containers = document.querySelectorAll('.ad-container');
     expect(containers).toHaveLength(3);
-    const heights = Array.from(containers).map((c) => c.style.minHeight).sort();
-    expect(heights).toEqual(['250px', '250px', '90px'].sort());
+    const heights = Array.from(containers).map((c) => c.style.minHeight);
+    expect(heights).toEqual(['', '', '']);
   });
 });


### PR DESCRIPTION
## 메커니즘

AdSense 가 광고를 못 주면 `data-ad-status="unfilled"` 를 답니다. 그러면 `_includes/head.html:552` 의 `:has()` 규칙이 `.ad-container` 를 `display:none` 으로 지웁니다. **그 전까지 잡아둔 높이는 그 순간 독자가 보던 자리에서 통째로 사라집니다.**

실측 게재율은 **0/4, 0/3** — 이 사이트에서 광고는 사실상 채워지지 않습니다. 즉 예약의 신뢰할 수 있는 효과는 "채워질 때를 대비"가 아니라 **붕괴 시프트 유발** 하나뿐이었습니다.

## 예약이 4곳에 흩어져 서로를 덮고 있었습니다

| 위치 | 값 | 비고 |
|---|---|---|
| `_sass/_post.scss:2392` `.ad-container` | 250px | **실제로 작동하던 것** |
| `_sass/_post.scss:2407` `.google-auto-placed` | 250px | |
| `_sass/_post.scss:2418` `ins.adsbygoogle` | 250px `!important` | |
| `_sass/_post.scss:2429` `[id^="aswift_"]` | 250px `!important` | |
| `_includes/head.html` `.adsbygoogle:not([data-ad-status])` | 100/250px | 인라인에 밀려 사실상 무력 |
| `assets/js/ad-optimizer.js` | 컨테이너 90/250/600px + ins 인라인 250px ×4 | |

전부 제거했습니다. `contain: layout style` 은 **유지** — 시프트가 생기더라도 전파 범위를 제한합니다.

## 측정 경로가 이 변경의 전제였습니다

프로덕션 대상 랩 측정은 **12런 중앙값 0.0000** 으로 아무것도 보여주지 못했습니다. 게재가 확률적이고, 하네스가 빠르게 스크롤해 **붕괴가 끝난 뒤** 광고 영역에 도달하기 때문입니다. 반면 실사용자 콘솔에서는 0.20~0.23 이 관측됐습니다. 이 격차 때문에 앞선 턴에서는 수정을 보류했습니다.

`scripts/dev/measure_ad_collapse_cls.mjs` 가 그 격차를 없앱니다 — 외부 요청을 전부 abort 한 로컬 빌드에서 `data-ad-status="unfilled"` 를 직접 달아 `:has()` 붕괴를 구동합니다.

```
BEFORE  컨테이너 250 -> 0   붕괴 CLS = 0.0575
AFTER   컨테이너   0 -> 0   붕괴 CLS = 0.0039
```

수정 후 실제 코드로 재측정하면 두 경로가 모두 0.0039 로 수렴합니다(= 예약이 남아 있지 않음을 코드로 확인).

## 테스트는 삭제가 아니라 역전

`tests/js/ad-optimizer.test.js` 가 `minHeight === '250px'` 를 단언하고 있었습니다. 지우지 않고 `''` 를 단언하도록 뒤집어, **예약이 다시 들어오면 실패**하게 했습니다.

뮤테이션 확인: 컨테이너에 `min-height:250px` 를 되돌리면 4건 실패, 되돌리면 통과.

## 트레이드오프 (명시)

광고가 **실제로 채워지는** 드문 경우엔 0 → 실제 높이로 확장하며 시프트가 생깁니다. 관측된 게재율이 0이라 오늘 기준으로는 순이득이지만, 게재율이 올라가면 재검토가 필요합니다. 그때는 위 하네스로 다시 재면 됩니다.

## 검증

- JS **680 passed** (28 files)
- pytest **4190 passed / 5 skipped**
- CSP 인라인 해시 매니페스트 **무변경**(2항목), 게이트 통과
- 힌트 게이트 2종 통과 (`asset-hint`, `hint-usage`)
- `jekyll build` 성공

## 검증되지 않음

실사용자 CLS 개선은 배포 후 필드 데이터로만 확인 가능합니다. 위 수치는 로컬에서 붕괴 전이를 구동한 결정적 측정이며, 실제 독자의 스크롤 타이밍·Auto ads 주입까지 재현하지는 않습니다.