### PR TITLE
feat(analytics): CLS를 GA4로 전송 — 보내기 전에 표준 계산으로 교정

### DIFF
--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -125,13 +125,63 @@
         return causes.length > 0 ? causes.join(', ') : 'unknown';
       }
 
+      // Session-window CLS, the way Core Web Vitals actually defines it: the
+      // LARGEST burst of shifts, where a burst breaks on a 1s gap or after 5s.
+      // `clsValue` used to be the running SUM of every shift, which is a
+      // different (and always larger) number than the one Vercel Speed
+      // Insights, CrUX and Lighthouse report — so the console figure could not
+      // be compared against any of them, and shipping it to GA4 under the name
+      // "CLS" would have made that mismatch permanent.
+      var clsSessionValue = 0;
+      var clsSessionFirst = null;
+      var clsSessionLast = null;
+      var clsTopCause = 'unknown';
+      var clsReported = false;
+
+      function clsRating(v) {
+        if (v <= 0.1) return 'good';
+        if (v <= 0.25) return 'needs-improvement';
+        return 'poor';
+      }
+
+      // Report once, when the page goes away. `beforeunload` does not fire
+      // reliably on mobile or when the page enters the bfcache, so the metric
+      // hangs off visibilitychange with pagehide as a backstop.
+      function reportCls() {
+        if (clsReported) return;
+        clsReported = true;
+        if (typeof window.__track !== 'function') return;
+        window.__track('web_vitals', {
+          metric_name: 'CLS',
+          metric_value: Math.round(clsValue * 10000) / 10000,
+          metric_rating: clsRating(clsValue),
+          metric_cause: String(clsTopCause).slice(0, 100)
+        });
+      }
+
       try {
         var clsObserver = new PerformanceObserver(function(list) {
           for (var i = 0; i < list.getEntries().length; i++) {
             var entry = list.getEntries()[i];
             if (!entry.hadRecentInput) {
               var cause = analyzeCLSCause(entry);
-              clsValue += entry.value;
+
+              if (
+                clsSessionLast !== null &&
+                entry.startTime - clsSessionLast < 1000 &&
+                entry.startTime - clsSessionFirst < 5000
+              ) {
+                clsSessionValue += entry.value;
+              } else {
+                clsSessionValue = entry.value;
+                clsSessionFirst = entry.startTime;
+              }
+              clsSessionLast = entry.startTime;
+
+              if (clsSessionValue > clsValue) {
+                clsValue = clsSessionValue;
+                clsTopCause = cause;
+              }
 
               clsEntries.push({
                 value: entry.value,
@@ -147,6 +197,11 @@
           }
         });
         clsObserver.observe({ entryTypes: ['layout-shift'] });
+
+        document.addEventListener('visibilitychange', function() {
+          if (document.visibilityState === 'hidden') reportCls();
+        });
+        window.addEventListener('pagehide', reportCls);
 
         // Final CLS report on page unload
         window.addEventListener('beforeunload', function() {

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -900,3 +900,139 @@ describe('performance-monitor.js', () => {
     });
   });
 });
+
+// --- CLS: session-window value + GA4 reporting -----------------------------
+//
+// Added 2026-08-14. Two things are pinned here:
+//
+// 1. The reported number is the Core Web Vitals SESSION-WINDOW CLS (largest
+//    burst, broken by a 1s gap or a 5s span), not the running sum of every
+//    shift. The sum is always the larger number, so shipping it to GA4 as
+//    "CLS" would have disagreed with Vercel Speed Insights, CrUX and
+//    Lighthouse forever.
+// 2. It is sent exactly once, through window.__track — the buffered path.
+//    A direct dataLayer push would be dropped whenever the metric fires
+//    before gtag('config') has run.
+
+function clsObserverOf(observed) {
+  return observed.find((o) => (o.entryTypes || []).includes('layout-shift'));
+}
+
+function feed(observer, entries) {
+  observer._cb({ getEntries: () => entries });
+}
+
+function shift(value, startTime, hadRecentInput = false) {
+  return { value, startTime, hadRecentInput, sources: [] };
+}
+
+function buildFakeDocument() {
+  const handlers = {};
+  return {
+    doc: {
+      visibilityState: 'visible',
+      addEventListener: (evt, h) => { (handlers[evt] = handlers[evt] || []).push(h); },
+      querySelectorAll: () => [],
+      querySelector: () => null,
+    },
+    fire: (evt) => (handlers[evt] || []).forEach((h) => h()),
+  };
+}
+
+function runWithDoc(fakeWindow, fakeDoc) {
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', SCRIPT_SOURCE)(fakeWindow, fakeDoc);
+}
+
+describe('performance-monitor.js CLS', () => {
+  let track;
+
+  function boot() {
+    const { observed, ctor } = setupPerformanceObserverStub();
+    const { fake, listeners } = buildFakeWindow({ PerformanceObserver: ctor });
+    track = vi.fn();
+    fake.__track = track;
+    const { doc, fire } = buildFakeDocument();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    runWithDoc(fake, doc);
+    return { cls: clsObserverOf(observed), doc, fire, listeners, fake };
+  }
+
+  it('reports the largest burst, not the sum, when bursts are >1s apart', () => {
+    const { cls, doc, fire } = boot();
+    // Burst A = 0.03, then a 2s gap, then burst B = 0.05. Sum would be 0.08.
+    feed(cls, [shift(0.02, 1000), shift(0.01, 1500)]);
+    feed(cls, [shift(0.05, 3600)]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+
+    expect(track).toHaveBeenCalledTimes(1);
+    const [name, params] = track.mock.calls[0];
+    expect(name).toBe('web_vitals');
+    expect(params.metric_name).toBe('CLS');
+    expect(params.metric_value).toBeCloseTo(0.05, 5);
+  });
+
+  it('breaks the session after 5s even without a 1s gap', () => {
+    const { cls, doc, fire } = boot();
+    // Every entry <1s apart, but the span exceeds 5s -> a new session starts.
+    feed(cls, [
+      shift(0.02, 0), shift(0.02, 900), shift(0.02, 1800), shift(0.02, 2700),
+      shift(0.02, 3600), shift(0.02, 4500), shift(0.02, 5400),
+    ]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+    // First session (0..4500) = 0.12; the 5400 entry opens a new one at 0.02.
+    expect(track.mock.calls[0][1].metric_value).toBeCloseTo(0.12, 5);
+  });
+
+  it('ignores shifts that follow recent user input', () => {
+    const { cls, doc, fire } = boot();
+    feed(cls, [shift(0.4, 1000, true), shift(0.03, 1200)]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+    expect(track.mock.calls[0][1].metric_value).toBeCloseTo(0.03, 5);
+  });
+
+  it('sends exactly once even if visibilitychange and pagehide both fire', () => {
+    const { cls, doc, fire, listeners } = boot();
+    feed(cls, [shift(0.05, 1000)]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+    fire('visibilitychange');
+    const pagehide = listeners.filter((l) => l.evt === 'pagehide');
+    expect(pagehide.length).toBeGreaterThan(0);
+    pagehide.forEach((l) => l.handler());
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send while the page is still visible', () => {
+    const { cls, fire } = boot();
+    feed(cls, [shift(0.05, 1000)]);
+    fire('visibilitychange'); // visibilityState stays 'visible'
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it('classifies the rating on the Core Web Vitals thresholds', () => {
+    const cases = [[0.05, 'good'], [0.2, 'needs-improvement'], [0.4, 'poor']];
+    for (const [value, expected] of cases) {
+      const { cls, doc, fire } = boot();
+      feed(cls, [shift(value, 1000)]);
+      doc.visibilityState = 'hidden';
+      fire('visibilitychange');
+      expect(track.mock.calls[0][1].metric_rating).toBe(expected);
+    }
+  });
+
+  it('survives a page where __track was never defined', () => {
+    const { observed, ctor } = setupPerformanceObserverStub();
+    const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
+    const { doc, fire } = buildFakeDocument();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    runWithDoc(fake, doc);
+    feed(clsObserverOf(observed), [shift(0.05, 1000)]);
+    doc.visibilityState = 'hidden';
+    expect(() => fire('visibilitychange')).not.toThrow();
+  });
+});


### PR DESCRIPTION
`performance-monitor.js` 는 CLS 를 **콘솔에만** 경고했습니다. `window.__track` 으로 `web_vitals` 이벤트를 보내 기존 GA4 이벤트와 함께 볼 수 있게 합니다.

`dataLayer` 직접 push 가 아니라 `__track` 을 쓰는 이유는 `gtag('config')` 이전에 발생한 push 가 유실되기 때문입니다(버퍼 경로).

## 보내기 전에 계산부터 고쳤습니다

기존 `clsValue` 는 **모든 시프트의 단순 합계**였습니다. 그건 Core Web Vitals 가 정의하는 CLS 가 아닙니다.

| | 정의 |
|---|---|
| 기존 (합계) | 페이지 수명 동안의 모든 `layout-shift` 값의 합 |
| 표준 (세션 윈도우) | **가장 큰 버스트** — 1초 간격 또는 5초 경과로 끊김 |

합계는 항상 세션 윈도우 값보다 큽니다. 그대로 "CLS" 라는 이름으로 GA4 에 보냈다면 **Vercel Speed Insights / CrUX / Lighthouse 와 영구히 어긋난 숫자**가 쌓였을 것입니다. 콘솔 경고도 같은 값을 쓰도록 통일했습니다.

이건 이번 세션에서 실제로 겪은 함정이기도 합니다 — 콘솔의 0.20 과 랩 측정이 계속 엇갈렸고, 그 원인의 일부가 이 비표준 계산이었습니다.

## 전송 시점

`visibilitychange` → `hidden`, `pagehide` 백스톱, **1회 가드**.

`beforeunload` 는 모바일과 bfcache 진입 시 신뢰할 수 없어 지표 전송에 쓰지 않았습니다(기존 `beforeunload` 콘솔 경고는 그대로 둠).

## 이벤트 형태

```js
web_vitals {
  metric_name:   'CLS',
  metric_value:  0.0537,          // 소수 4자리
  metric_rating: 'good' | 'needs-improvement' | 'poor',
  metric_cause:  'Ad: adsbygoogle…' // 100자 절단
}
```

## 테스트 (7건 추가, 뮤테이션 검증)

- 버스트가 1초 이상 떨어지면 **합계가 아니라 최대 버스트**를 보고
- 1초 간격이 없어도 **5초를 넘으면 세션이 끊김**
- `hadRecentInput` 시프트 제외
- `visibilitychange` + `pagehide` 가 모두 발생해도 **정확히 1회**
- 페이지가 아직 보이는 동안에는 미전송
- 등급 경계값 (0.1 / 0.25)
- `__track` 이 정의되지 않은 페이지에서도 예외 없음

뮤테이션: 세션 윈도우를 합계로 되돌리면 2건 실패, 1회 전송 가드를 빼면 1건 실패.

## 검증

- JS **687 passed** (28 files)
- pytest **4190 passed / 5 skipped**
- CSP 해시 게이트 무변경, 힌트 게이트 2종 통과

## 검증되지 않음

**GA4 에 실제로 도달하는지는 확인하지 못했습니다.** 단위 테스트는 `__track` 호출과 파라미터까지만 증명합니다. 로컬 빌드에서는 `gaId` 가 없어 `__track` 이 no-op 이라 통합 확인이 불가능했습니다(호스트명 위장까지 시도했으나 얻을 정보가 없어 중단). 배포 후 GA4 realtime 에서 `web_vitals` 이벤트 1회 육안 확인이 필요합니다 — 앞서 `lang_toggle_open` / `lang_select` 와 같은 성격의 확인입니다.