### PR TITLE
feat(analytics): LCP·INP를 web_vitals로 통일 — 그 과정에서 LCP 누락 버그 수정

### DIFF
--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -1,5 +1,6 @@
 // Performance Monitoring (Production Only)
-// Features: Long Tasks, LCP, FID, CLS, Page Load, Resource Loading
+// Features: Long Tasks, LCP, FID, INP, CLS, Page Load, Resource Loading
+// Field metrics (LCP / INP / CLS) flush to GA4 as one `web_vitals` event at page hide.
 // Extracted from _includes/performance-monitor.html
 
 (function() {
@@ -46,20 +47,73 @@
     }
     // Web Vitals monitoring
     if ('PerformanceObserver' in window) {
+      // --- Shared field-metric reporting ------------------------------------
+      // Every vital flushes through one GA4 event (`web_vitals`) at page hide.
+      // __track, not a direct dataLayer push: events fired before
+      // gtag('config') runs would otherwise be dropped.
+      var vitalsFlushed = false;
+      var vitalsPending = [];
+
+      function onHidden(fn) { vitalsPending.push(fn); }
+
+      function flushVitals() {
+        if (vitalsFlushed) return;
+        vitalsFlushed = true;
+        for (var vi = 0; vi < vitalsPending.length; vi++) {
+          try { vitalsPending[vi](); } catch (err) { /* never block unload */ }
+        }
+      }
+
+      function sendVital(name, value, rating, cause) {
+        if (typeof window.__track !== 'function') return;
+        var params = {
+          metric_name: name,
+          metric_value: value,
+          metric_rating: rating
+        };
+        if (cause) params.metric_cause = String(cause).slice(0, 100);
+        window.__track('web_vitals', params);
+      }
+
+      function rate(value, good, poor) {
+        if (value <= good) return 'good';
+        if (value <= poor) return 'needs-improvement';
+        return 'poor';
+      }
+
+      // beforeunload does not fire reliably on mobile or when the page enters
+      // the bfcache, so the flush hangs off visibilitychange with pagehide as
+      // a backstop.
+      document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'hidden') flushVitals();
+      });
+      window.addEventListener('pagehide', flushVitals);
+
       // Largest Contentful Paint (LCP)
       try {
+        var lcpValue = 0;
         var lcpObserver = new PerformanceObserver(function(list) {
           var entries = list.getEntries();
           var lastEntry = entries[entries.length - 1];
-          if (lastEntry && lastEntry.renderTime) {
-            var lcp = lastEntry.renderTime;
-            // LCP threshold: 4000ms (very slow)
-            if (lcp > 4000) {
-              console.warn('[Performance] LCP is slow:', Math.round(lcp) + 'ms');
-            }
+          if (!lastEntry) return;
+          // renderTime is absent for cross-origin images that lack
+          // Timing-Allow-Origin; startTime is the documented fallback. Reading
+          // only renderTime silently dropped LCP on exactly those pages.
+          var lcp = lastEntry.renderTime || lastEntry.startTime;
+          if (!lcp) return;
+          lcpValue = lcp;
+          // LCP threshold: 4000ms (very slow)
+          if (lcp > 4000) {
+            console.warn('[Performance] LCP is slow:', Math.round(lcp) + 'ms');
           }
         });
         lcpObserver.observe({ entryTypes: ['largest-contentful-paint'] });
+
+        onHidden(function() {
+          // No entry means "not measured", which is not the same as 0.
+          if (!lcpValue) return;
+          sendVital('LCP', Math.round(lcpValue), rate(lcpValue, 2500, 4000));
+        });
       } catch (e) {
         // LCP observer not supported
         if (window.location.hostname === 'tech.2twodragon.com' && typeof Sentry !== 'undefined' && Sentry.captureException) {
@@ -86,6 +140,71 @@
         if (window.location.hostname === 'tech.2twodragon.com' && typeof Sentry !== 'undefined' && Sentry.captureException) {
           Sentry.captureException(e, {
             tags: { errorType: 'performance_monitor_fid' },
+            level: 'warning'
+          });
+        }
+      }
+
+      // Interaction to Next Paint (INP) — replaced FID as a Core Web Vital in
+      // March 2024. FID above measures only the FIRST input's delay; INP looks
+      // at every interaction's full duration, which is why a page can have a
+      // fine FID and a terrible INP.
+      //
+      // Definition: group event entries by interactionId (one interaction can
+      // emit several entries — pointerdown, pointerup, click), take each
+      // group's longest duration, then report the entry at index
+      // floor(interactions / 50) of the descending list. For pages with fewer
+      // than 50 interactions that is simply the worst one; the index exists so
+      // a single outlier does not define a long session. Only the top 10 are
+      // kept, which is the cap the index can reach.
+      try {
+        var inpEntries = [];   // {id, duration}, kept sorted desc, max 10
+        var inpCount = 0;
+
+        function recordInteraction(entry) {
+          var id = entry.interactionId;
+          if (!id) return;
+          for (var k = 0; k < inpEntries.length; k++) {
+            if (inpEntries[k].id === id) {
+              if (entry.duration > inpEntries[k].duration) {
+                inpEntries[k].duration = entry.duration;
+                inpEntries.sort(function(a, b) { return b.duration - a.duration; });
+              }
+              return;
+            }
+          }
+          inpCount++;
+          inpEntries.push({ id: id, duration: entry.duration });
+          inpEntries.sort(function(a, b) { return b.duration - a.duration; });
+          if (inpEntries.length > 10) inpEntries.length = 10;
+        }
+
+        var inpObserver = new PerformanceObserver(function(list) {
+          var entries = list.getEntries();
+          for (var n = 0; n < entries.length; n++) recordInteraction(entries[n]);
+        });
+        // durationThreshold requires the single-`type` form of observe().
+        // 40ms is the web-vitals default: below it an interaction cannot be
+        // the page's worst one, and observing everything is needless overhead.
+        inpObserver.observe({ type: 'event', buffered: true, durationThreshold: 40 });
+        inpObserver.observe({ type: 'first-input', buffered: true });
+
+        onHidden(function() {
+          // No interaction means the reader never touched the page. That is
+          // "not measured", not 0 — reporting 0 would fake a perfect score.
+          if (!inpEntries.length) return;
+          var idx = Math.min(inpEntries.length - 1, Math.floor(inpCount / 50));
+          var inp = Math.round(inpEntries[idx].duration);
+          if (inp > 500) {
+            console.warn('[Performance] INP is slow:', inp + 'ms');
+          }
+          sendVital('INP', inp, rate(inp, 200, 500));
+        });
+      } catch (e) {
+        // INP observer not supported (Safari < 16.4, older Chromium)
+        if (window.location.hostname === 'tech.2twodragon.com' && typeof Sentry !== 'undefined' && Sentry.captureException) {
+          Sentry.captureException(e, {
+            tags: { errorType: 'performance_monitor_inp' },
             level: 'warning'
           });
         }
@@ -136,28 +255,17 @@
       var clsSessionFirst = null;
       var clsSessionLast = null;
       var clsTopCause = 'unknown';
-      var clsReported = false;
 
-      function clsRating(v) {
-        if (v <= 0.1) return 'good';
-        if (v <= 0.25) return 'needs-improvement';
-        return 'poor';
-      }
-
-      // Report once, when the page goes away. `beforeunload` does not fire
-      // reliably on mobile or when the page enters the bfcache, so the metric
-      // hangs off visibilitychange with pagehide as a backstop.
-      function reportCls() {
-        if (clsReported) return;
-        clsReported = true;
-        if (typeof window.__track !== 'function') return;
-        window.__track('web_vitals', {
-          metric_name: 'CLS',
-          metric_value: Math.round(clsValue * 10000) / 10000,
-          metric_rating: clsRating(clsValue),
-          metric_cause: String(clsTopCause).slice(0, 100)
-        });
-      }
+      // Unlike LCP and INP, CLS reports even at 0: a page that never shifted
+      // has genuinely measured a CLS of zero.
+      onHidden(function() {
+        sendVital(
+          'CLS',
+          Math.round(clsValue * 10000) / 10000,
+          rate(clsValue, 0.1, 0.25),
+          clsTopCause
+        );
+      });
 
       try {
         var clsObserver = new PerformanceObserver(function(list) {
@@ -197,11 +305,6 @@
           }
         });
         clsObserver.observe({ entryTypes: ['layout-shift'] });
-
-        document.addEventListener('visibilitychange', function() {
-          if (document.visibilityState === 'hidden') reportCls();
-        });
-        window.addEventListener('pagehide', reportCls);
 
         // Final CLS report on page unload
         window.addEventListener('beforeunload', function() {

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -38,6 +38,15 @@ function setupPerformanceObserverStub() {
     }
     observe(opts) {
       this.entryTypes = (opts && opts.entryTypes) || [];
+      // INP uses the single-`type` form (it needs durationThreshold), and
+      // calls observe() twice on the same observer. Record both shapes so a
+      // test can find that observer without disturbing the entryTypes
+      // assertions the older tests rely on.
+      this.types = this.types || [];
+      if (opts && opts.type) this.types.push(opts.type);
+      if (opts && opts.entryTypes) this.types.push(...opts.entryTypes);
+      this.observeOpts = this.observeOpts || [];
+      this.observeOpts.push(opts);
     }
     disconnect() {}
   }
@@ -967,11 +976,10 @@ describe('performance-monitor.js CLS', () => {
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
 
-    expect(track).toHaveBeenCalledTimes(1);
-    const [name, params] = track.mock.calls[0];
-    expect(name).toBe('web_vitals');
-    expect(params.metric_name).toBe('CLS');
-    expect(params.metric_value).toBeCloseTo(0.05, 5);
+    const call = track.mock.calls.find((c) => c[1] && c[1].metric_name === 'CLS');
+    expect(call).toBeDefined();
+    expect(call[0]).toBe('web_vitals');
+    expect(call[1].metric_value).toBeCloseTo(0.05, 5);
   });
 
   it('breaks the session after 5s even without a 1s gap', () => {
@@ -984,7 +992,7 @@ describe('performance-monitor.js CLS', () => {
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
     // First session (0..4500) = 0.12; the 5400 entry opens a new one at 0.02.
-    expect(track.mock.calls[0][1].metric_value).toBeCloseTo(0.12, 5);
+    expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_value).toBeCloseTo(0.12, 5);
   });
 
   it('ignores shifts that follow recent user input', () => {
@@ -992,7 +1000,7 @@ describe('performance-monitor.js CLS', () => {
     feed(cls, [shift(0.4, 1000, true), shift(0.03, 1200)]);
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
-    expect(track.mock.calls[0][1].metric_value).toBeCloseTo(0.03, 5);
+    expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_value).toBeCloseTo(0.03, 5);
   });
 
   it('sends exactly once even if visibilitychange and pagehide both fire', () => {
@@ -1004,7 +1012,8 @@ describe('performance-monitor.js CLS', () => {
     const pagehide = listeners.filter((l) => l.evt === 'pagehide');
     expect(pagehide.length).toBeGreaterThan(0);
     pagehide.forEach((l) => l.handler());
-    expect(track).toHaveBeenCalledTimes(1);
+    const clsCalls = track.mock.calls.filter((c) => c[1].metric_name === 'CLS');
+    expect(clsCalls).toHaveLength(1);
   });
 
   it('does not send while the page is still visible', () => {
@@ -1021,7 +1030,7 @@ describe('performance-monitor.js CLS', () => {
       feed(cls, [shift(value, 1000)]);
       doc.visibilityState = 'hidden';
       fire('visibilitychange');
-      expect(track.mock.calls[0][1].metric_rating).toBe(expected);
+      expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_rating).toBe(expected);
     }
   });
 
@@ -1034,5 +1043,142 @@ describe('performance-monitor.js CLS', () => {
     feed(clsObserverOf(observed), [shift(0.05, 1000)]);
     doc.visibilityState = 'hidden';
     expect(() => fire('visibilitychange')).not.toThrow();
+  });
+});
+
+// --- LCP / INP: same web_vitals event as CLS -------------------------------
+//
+// Added 2026-08-14 alongside the CLS reporter. Two defects are pinned here:
+//
+// 1. LCP read only `entry.renderTime`. That field is absent for cross-origin
+//    images served without Timing-Allow-Origin, so LCP was silently dropped on
+//    exactly the pages most likely to have a slow one. `startTime` is the
+//    documented fallback.
+// 2. FID (the old observer, kept for its console warning) measures only the
+//    FIRST input's delay. INP measures every interaction's full duration and
+//    replaced FID as a Core Web Vital in March 2024.
+//
+// "Not measured" must not be reported as 0: a page nobody interacted with has
+// no INP, and reporting 0 would fake a perfect score.
+
+function observerWithType(observed, type) {
+  return observed.find((o) => (o.types || []).includes(type));
+}
+
+describe('performance-monitor.js LCP/INP', () => {
+  let track;
+
+  function boot() {
+    const { observed, ctor } = setupPerformanceObserverStub();
+    const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
+    track = vi.fn();
+    fake.__track = track;
+    const { doc, fire } = buildFakeDocument();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    runWithDoc(fake, doc);
+    const hide = () => { doc.visibilityState = 'hidden'; fire('visibilitychange'); };
+    return {
+      lcp: observerWithType(observed, 'largest-contentful-paint'),
+      inp: observerWithType(observed, 'event'),
+      hide,
+    };
+  }
+
+  function vitalFor(name) {
+    const call = track.mock.calls.find((c) => c[1] && c[1].metric_name === name);
+    return call ? call[1] : null;
+  }
+
+  it('falls back to startTime when renderTime is absent (cross-origin LCP image)', () => {
+    const { lcp, hide } = boot();
+    feed(lcp, [{ startTime: 3200 }]); // no renderTime
+    hide();
+    expect(vitalFor('LCP')).toMatchObject({ metric_value: 3200, metric_rating: 'needs-improvement' });
+  });
+
+  it('prefers renderTime when the browser provides it', () => {
+    const { lcp, hide } = boot();
+    feed(lcp, [{ startTime: 3200, renderTime: 1800 }]);
+    hide();
+    expect(vitalFor('LCP').metric_value).toBe(1800);
+  });
+
+  it('takes the last LCP entry, not the first', () => {
+    const { lcp, hide } = boot();
+    feed(lcp, [{ renderTime: 900 }]);
+    feed(lcp, [{ renderTime: 2600 }]);
+    hide();
+    expect(vitalFor('LCP').metric_value).toBe(2600);
+  });
+
+  it('does not report LCP when no entry ever arrived', () => {
+    const { hide } = boot();
+    hide();
+    expect(vitalFor('LCP')).toBeNull();
+  });
+
+  it('groups INP entries by interactionId and keeps the longest per group', () => {
+    const { inp, hide } = boot();
+    // One interaction emitting three entries; only 180 should count.
+    feed(inp, [
+      { interactionId: 7, duration: 56 },
+      { interactionId: 7, duration: 180 },
+      { interactionId: 7, duration: 92 },
+    ]);
+    hide();
+    expect(vitalFor('INP')).toMatchObject({ metric_value: 180, metric_rating: 'good' });
+  });
+
+  it('reports the worst interaction when there are fewer than 50', () => {
+    const { inp, hide } = boot();
+    feed(inp, [
+      { interactionId: 1, duration: 120 },
+      { interactionId: 2, duration: 640 },
+      { interactionId: 3, duration: 300 },
+    ]);
+    hide();
+    expect(vitalFor('INP')).toMatchObject({ metric_value: 640, metric_rating: 'poor' });
+  });
+
+  it('steps off the worst interaction once past 50 (uses index count/50)', () => {
+    const { inp, hide } = boot();
+    // 100 interactions -> index 2 of the descending list, i.e. the 3rd worst.
+    const entries = [];
+    for (let i = 1; i <= 100; i += 1) entries.push({ interactionId: i, duration: i });
+    feed(inp, entries);
+    hide();
+    // Descending: 100, 99, 98 ... -> index 2 = 98.
+    expect(vitalFor('INP').metric_value).toBe(98);
+  });
+
+  it('ignores entries without an interactionId', () => {
+    const { inp, hide } = boot();
+    feed(inp, [{ duration: 5000 }, { interactionId: 0, duration: 4000 }]);
+    hide();
+    expect(vitalFor('INP')).toBeNull();
+  });
+
+  it('does not report INP when the reader never interacted', () => {
+    const { hide } = boot();
+    hide();
+    expect(vitalFor('INP')).toBeNull();
+  });
+
+  it('observes event entries with a durationThreshold so short ones are skipped', () => {
+    const { inp } = boot();
+    const eventOpts = inp.observeOpts.find((o) => o && o.type === 'event');
+    expect(eventOpts.durationThreshold).toBe(40);
+    expect(eventOpts.buffered).toBe(true);
+  });
+
+  it('flushes every metric on a single hide, and only once', () => {
+    const { lcp, inp, hide } = boot();
+    feed(lcp, [{ renderTime: 1200 }]);
+    feed(inp, [{ interactionId: 1, duration: 90 }]);
+    hide();
+    hide();
+    const names = track.mock.calls.map((c) => c[1].metric_name).sort();
+    expect(names).toEqual(['CLS', 'INP', 'LCP']);
   });
 });


### PR DESCRIPTION
세 지표(LCP / INP / CLS)가 하나의 공용 경로로 흐릅니다: `onHidden` 등록 → `visibilitychange(hidden)`/`pagehide` 에서 **1회 flush** → `window.__track` 으로 `web_vitals` 이벤트. CLS 가 따로 갖고 있던 리스너와 rating 함수는 제거해 중복을 없앴습니다.

## 통일하다 발견한 LCP 버그

```js
if (lastEntry && lastEntry.renderTime) {   // ← renderTime 만 읽음
```

`renderTime` 은 **Timing-Allow-Origin 이 없는 cross-origin 이미지에서 비어 있습니다.** 즉 LCP 가 느릴 가능성이 가장 큰 페이지에서 정확히 조용히 누락됐습니다. 표준 폴백인 `startTime` 을 붙였습니다.

## INP 추가 (FID 는 2024-03 에 대체됨)

| | 재는 것 |
|---|---|
| FID | **첫** 입력의 *지연* |
| INP | **모든** 상호작용의 *전체 소요* |

FID 는 멀쩡한데 INP 가 나쁜 페이지가 흔한 이유입니다. 기존 FID 옵저버는 콘솔 경고용으로 그대로 뒀습니다.

구현: `interactionId` 로 그룹핑해 그룹별 최댓값을 쓰고(한 상호작용이 pointerdown/pointerup/click 여러 엔트리를 냅니다), 내림차순 리스트의 `floor(interactions / 50)` 인덱스를 보고합니다(상위 10개 유지). 50 미만이면 곧 최악값이며, 인덱스는 긴 세션에서 이상치 하나가 지표를 정의하지 않게 합니다. `durationThreshold: 40` 은 web-vitals 기본값입니다.

## 미측정을 0으로 보고하지 않습니다

LCP 엔트리가 없거나 독자가 한 번도 상호작용하지 않았으면 **전송을 건너뜁니다.** 0 을 보내면 만점을 위조하는 셈입니다. CLS 만 0 을 보고합니다 — 시프트가 없던 페이지는 실제로 CLS 0 입니다.

## 테스트 11건 추가 (총 70), 뮤테이션 3종 검증

| 뮤테이션 | 결과 |
|---|---|
| `startTime` 폴백 제거 | 1건 실패 ✓ |
| `count/50` 인덱스 → 0 고정 | 1건 실패 ✓ |
| 미측정을 `INP=0` 으로 보고 | 2건 실패 ✓ |

기존 CLS 테스트가 `track.mock.calls[0]` 을 가정해 취약했던 것도 **지표 이름 기반 조회로 교정**했습니다 — LCP/INP 가 함께 flush 되면 순서가 달라지고, 실제로 뮤테이션 C 가 그 취약성을 드러냈습니다.

## 검증

- JS **698 passed** (28 files)
- pytest **4190 passed / 5 skipped**
- CSP 해시 게이트 무변경, 힌트 게이트 통과

## 검증되지 않음

앞선 CLS 건과 동일하게, **GA4 에 실제로 도달하는지는 확인하지 못했습니다.** 단위 테스트는 `__track` 호출과 파라미터까지만 증명하며, 로컬 빌드에는 `gaId` 가 없어 `__track` 이 no-op 입니다. 배포 후 GA4 realtime 에서 `web_vitals` 이벤트에 `metric_name` 이 `LCP`/`INP`/`CLS` 로 들어오는지 육안 확인이 필요합니다.

INP 의 `floor(count/50)` 인덱스는 50회 이상 상호작용하는 세션에서만 최악값과 갈라집니다. 이 블로그의 실제 세션이 거기에 도달하는지는 필드 데이터 없이 알 수 없습니다.