### PR TITLE
feat(analytics): web_vitals를 퍼스트파티 beacon으로 전송 — gtag 5초 배치 유실 해소

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -833,20 +833,24 @@ merge. Confirm the **live** bundle, then the **event**:
    Minification strips quotes from object keys, so grep for `metric_name:`
    (no quotes), not `metric_name:"…"` — quoting the key silently matches nothing
    and reads as "not deployed".
-2. Then verify the event in GA4 Realtime. Opening the page is **not** enough —
-   two gates must both be cleared:
-   - GA lazy-loads on first interaction (or a 10-12s idle fallback),
-     `assets/js/head-runtime.js:186-205`
-   - vitals flush on page **hide**, `assets/js/performance-monitor.js:87-90`
+2. Then verify delivery. Vitals no longer go through gtag — they flush at page
+   **hide** as one first-party beacon to `/api/vitals`, which forwards to GA4
+   server-side (`assets/js/performance-monitor.js:87-90`, `api/vitals.js`).
+   So check the transport first, then the destination:
+   - DevTools → Network → filter `vitals` → close the tab or click an internal
+     link. One POST to `/api/vitals`, status 204, with up to 3 metrics.
+   - Then GA4 Realtime → `web_vitals`. INP only appears if the reader
+     interacted; LCP/CLS appear regardless.
 
-   So: incognito → scroll/click → **switch tabs** → GA4 Realtime → `web_vitals`.
-   Max 3 events per session (LCP/INP/CLS); INP only if the reader interacted.
+   **`GA4_API_SECRET` must be set in Vercel or the endpoint drops everything.**
+   The gtag path is gone, so an unset secret means zero collection, not
+   degraded collection. The function logs
+   `[vitals] GA4_API_SECRET is not set` in that case.
 
-   **A green Realtime check does not mean field collection works.** Switching
-   tabs keeps the page alive, which is the one exit that clears gtag's ~5s
-   batch timer. Closing the tab or clicking an internal link loses the events
-   entirely — measured, see `notes/ga4-web-vitals-delivery-loss.md`. Reproduce
-   with `node scripts/dev/measure_ga_pending_loss.mjs`.
+Background on why the transport moved (gtag batches behind a ~5s timer and
+vitals are pushed at hide, so tab-close and internal navigation lost them
+entirely): `notes/ga4-web-vitals-delivery-loss.md`. Reproduce the old loss with
+`node scripts/dev/measure_ga_pending_loss.mjs`.
 
 Full event contract, custom-dimension registration, report specs, and the
 sampling bias this data carries: `notes/ga4-web-vitals-reporting.md`.

--- a/api/vitals.js
+++ b/api/vitals.js
@@ -122,23 +122,36 @@ export function validatePayload(body) {
   return { metrics, path };
 }
 
-/** Only our own pages may post here. Missing Origin AND Referer is rejected. */
+/**
+ * Only our own pages may post here. Missing Origin AND Referer is rejected.
+ *
+ * This is NOT a defence against a direct attacker — curl can set any Origin.
+ * What it buys is that a third-party site cannot make its visitors' browsers
+ * post here. Forged reports are bounded by the validation below and cost
+ * nothing but analytics noise, so that is the right level of protection.
+ *
+ * The client only beacons from the canonical host (performance-monitor.js
+ * gates on it), so preview hosts are deliberately NOT allowed — permitting
+ * *.vercel.app would admit every project on the platform, not just this one.
+ */
 function isSameOrigin(req) {
   const origin = req.headers?.origin;
   const referer = req.headers?.referer;
   const candidate = origin || referer;
   if (!candidate) return false;
   try {
-    const host = new URL(candidate).host;
-    const allowed = new URL(CONFIG.SITE_ORIGIN).host;
-    // Vercel preview deployments are *.vercel.app under the same project.
-    return host === allowed || host.endsWith('.vercel.app');
+    return new URL(candidate).host === new URL(CONFIG.SITE_ORIGIN).host;
   } catch {
     return false;
   }
 }
 
 function readBody(req) {
+  // Content-Length covers both branches below; the string check alone would
+  // miss an oversized body that the platform already parsed into an object.
+  const declared = Number(req.headers?.['content-length']);
+  if (Number.isFinite(declared) && declared > CONFIG.MAX_BODY_BYTES) return null;
+
   // Vercel parses application/json into req.body; sendBeacon Blobs arrive
   // that way too. Fall back to the raw string for other runtimes.
   if (req.body && typeof req.body === 'object') return req.body;
@@ -154,6 +167,12 @@ function readBody(req) {
 }
 
 function clientIp(req) {
+  // x-real-ip is set by Vercel and cannot be spoofed; the first x-forwarded-for
+  // entry is client-supplied and can be. Preferring the former is what keeps
+  // the rate limiter from being trivially bypassed with a rotating header —
+  // same ordering and reasoning as api/chat.js:245-248.
+  const realIp = req.headers?.['x-real-ip'];
+  if (typeof realIp === 'string' && realIp.length > 0) return realIp;
   const forwarded = req.headers?.['x-forwarded-for'];
   if (typeof forwarded === 'string' && forwarded.length > 0) {
     return forwarded.split(',')[0].trim();

--- a/api/vitals.js
+++ b/api/vitals.js
@@ -154,7 +154,19 @@ function readBody(req) {
 
   // Vercel parses application/json into req.body; sendBeacon Blobs arrive
   // that way too. Fall back to the raw string for other runtimes.
-  if (req.body && typeof req.body === 'object') return req.body;
+  if (req.body && typeof req.body === 'object') {
+    // A chunked request carries no Content-Length, so the header check above
+    // cannot have run. Re-measure rather than let the parsed-object path be
+    // the one branch with no cap.
+    if (!Number.isFinite(declared)) {
+      try {
+        if (JSON.stringify(req.body).length > CONFIG.MAX_BODY_BYTES) return null;
+      } catch {
+        return null; // circular or otherwise unserializable
+      }
+    }
+    return req.body;
+  }
   if (typeof req.body === 'string') {
     if (Buffer.byteLength(req.body, 'utf8') > CONFIG.MAX_BODY_BYTES) return null;
     try {

--- a/api/vitals.js
+++ b/api/vitals.js
@@ -1,0 +1,229 @@
+// Vercel Serverless Function: first-party Web Vitals collector.
+//
+// Why this exists instead of shipping the metrics through gtag:
+// gtag batches dataLayer pushes behind a ~5s timer (measured 5003-5005ms,
+// n=4), but vitals are pushed at page hide. Any session that ends by closing
+// the tab or following an internal link — which on a non-SPA blog is almost
+// all of them — dies before that timer fires and the events are lost.
+// Measured 0/3 delivered at a 2s leave-gap, 3/3 at 5s.
+// See notes/ga4-web-vitals-delivery-loss.md.
+//
+// navigator.sendBeacon survives teardown (verified: captured 1/1 at a 0ms
+// leave-gap in the same handler where gtag delivered 0/3), so the browser
+// beacons here and this function forwards to GA4 via the Measurement
+// Protocol. The api_secret stays server-side; being first-party also means
+// ad blockers do not strip the request, removing a second source of bias.
+//
+// 보안: POST 전용, 동일 출처 검증, 입력 검증, Rate Limiting, 본문 크기 제한.
+// api_secret은 환경변수에서만 읽으며 응답/로그에 절대 포함하지 않는다.
+//
+// 사용법 (클라이언트는 assets/js/performance-monitor.js):
+//   navigator.sendBeacon('/api/vitals', Blob(JSON))
+//   body: { "p": "/posts/…", "m": [{ "n": "LCP", "v": 1234, "r": "good" }] }
+//
+// 응답은 항상 204 (fire-and-forget). 실패해도 독자에게 영향이 없어야 하고,
+// 내부 상태를 노출하지 않는다.
+
+import { checkRateLimit } from './lib/ratelimit.js';
+import { safeLog } from './lib/log-sanitizer.js';
+
+const MP_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+const CONFIG = {
+  MEASUREMENT_ID: process.env.GA4_MEASUREMENT_ID || 'G-B29150XJ73',
+  MAX_BODY_BYTES: 2048,
+  MAX_METRICS: 3,
+  MAX_PATH_LENGTH: 200,
+  MAX_CAUSE_LENGTH: 100,
+  RATE_LIMIT_TIER: 'anonymous',
+  SITE_ORIGIN: process.env.SITE_ORIGIN || 'https://tech.2twodragon.com',
+};
+
+const METRIC_NAMES = new Set(['LCP', 'INP', 'CLS']);
+const RATINGS = new Set(['good', 'needs-improvement', 'poor']);
+
+// LCP/INP are milliseconds, CLS is an unitless 0..1-ish score. One generous
+// ceiling per unit keeps obviously-forged values out without second-guessing
+// a genuinely terrible page.
+const VALUE_MAX = { LCP: 600000, INP: 600000, CLS: 100 };
+
+/** Strips control characters; keeps the value printable and log-safe. */
+function clean(value, maxLength) {
+  // eslint-disable-next-line no-control-regex
+  return String(value).replace(/[\x00-\x1f\x7f]/g, '').slice(0, maxLength);
+}
+
+/**
+ * GA4 stores the client id in the `_ga` cookie as `GA1.<depth>.<a>.<b>`,
+ * where the client id is `<a>.<b>`.
+ */
+export function clientIdFromCookies(cookieHeader) {
+  const match = /(?:^|;\s*)_ga=([^;]+)/.exec(cookieHeader || '');
+  if (!match) return null;
+  const parts = decodeURIComponent(match[1]).split('.');
+  if (parts.length < 4) return null;
+  const id = `${parts[2]}.${parts[3]}`;
+  return /^\d+\.\d+$/.test(id) ? id : null;
+}
+
+/**
+ * Session id lives in `_ga_<CONTAINER>`, which has two formats in the wild:
+ *   GS2.1.s1745000000$o5$g1$t1745000100$j60   -> after the `s` marker
+ *   GS1.1.1745000000.5.1.1745000100.60.0.0    -> third dot-segment
+ * Without it the event lands in its own session and page-level joins break.
+ */
+export function sessionIdFromCookies(cookieHeader, measurementId) {
+  // Interpolated into a RegExp below, so keep it to the alphanumerics a real
+  // container id uses rather than trusting the configured value.
+  const container = String(measurementId || '').replace(/^G-/, '').replace(/[^A-Za-z0-9]/g, '');
+  if (!container) return null;
+  const re = new RegExp(`(?:^|;\\s*)_ga_${container}=([^;]+)`);
+  const match = re.exec(cookieHeader || '');
+  if (!match) return null;
+  const raw = decodeURIComponent(match[1]);
+
+  const gs2 = /(?:^|[.$])s(\d{6,})/.exec(raw);
+  if (gs2) return gs2[1];
+
+  const parts = raw.split('.');
+  if (parts.length >= 3 && /^\d{6,}$/.test(parts[2])) return parts[2];
+  return null;
+}
+
+/**
+ * Rejects anything that is not a well-formed vitals report. Returns the
+ * normalized metric list, or null when the payload should be dropped.
+ */
+export function validatePayload(body) {
+  if (!body || typeof body !== 'object' || !Array.isArray(body.m)) return null;
+  if (body.m.length === 0 || body.m.length > CONFIG.MAX_METRICS) return null;
+
+  const seen = new Set();
+  const metrics = [];
+  for (const entry of body.m) {
+    if (!entry || typeof entry !== 'object') return null;
+    if (!METRIC_NAMES.has(entry.n)) return null;
+    // One reading per metric per page — a repeat means a forged or buggy send.
+    if (seen.has(entry.n)) return null;
+    seen.add(entry.n);
+    if (!RATINGS.has(entry.r)) return null;
+    if (typeof entry.v !== 'number' || !Number.isFinite(entry.v)) return null;
+    if (entry.v < 0 || entry.v > VALUE_MAX[entry.n]) return null;
+
+    const metric = { metric_name: entry.n, metric_value: entry.v, metric_rating: entry.r };
+    if (entry.c != null) metric.metric_cause = clean(entry.c, CONFIG.MAX_CAUSE_LENGTH);
+    metrics.push(metric);
+  }
+
+  let path = '/';
+  if (typeof body.p === 'string' && body.p.startsWith('/')) {
+    path = clean(body.p, CONFIG.MAX_PATH_LENGTH);
+  }
+  return { metrics, path };
+}
+
+/** Only our own pages may post here. Missing Origin AND Referer is rejected. */
+function isSameOrigin(req) {
+  const origin = req.headers?.origin;
+  const referer = req.headers?.referer;
+  const candidate = origin || referer;
+  if (!candidate) return false;
+  try {
+    const host = new URL(candidate).host;
+    const allowed = new URL(CONFIG.SITE_ORIGIN).host;
+    // Vercel preview deployments are *.vercel.app under the same project.
+    return host === allowed || host.endsWith('.vercel.app');
+  } catch {
+    return false;
+  }
+}
+
+function readBody(req) {
+  // Vercel parses application/json into req.body; sendBeacon Blobs arrive
+  // that way too. Fall back to the raw string for other runtimes.
+  if (req.body && typeof req.body === 'object') return req.body;
+  if (typeof req.body === 'string') {
+    if (Buffer.byteLength(req.body, 'utf8') > CONFIG.MAX_BODY_BYTES) return null;
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function clientIp(req) {
+  const forwarded = req.headers?.['x-forwarded-for'];
+  if (typeof forwarded === 'string' && forwarded.length > 0) {
+    return forwarded.split(',')[0].trim();
+  }
+  return req.socket?.remoteAddress || 'unknown';
+}
+
+export default async function handler(req, res) {
+  // Fire-and-forget: the reader is already gone, so every exit is a 204.
+  const done = () => res.status(204).end();
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end();
+  }
+  if (!isSameOrigin(req)) return done();
+
+  const apiSecret = process.env.GA4_API_SECRET;
+  if (!apiSecret) {
+    // Not configured yet — drop silently rather than erroring on every hide.
+    safeLog('warn', '[vitals] GA4_API_SECRET is not set; dropping report');
+    return done();
+  }
+
+  const rate = await checkRateLimit(clientIp(req), CONFIG.RATE_LIMIT_TIER);
+  if (!rate.success) return done();
+
+  const payload = validatePayload(readBody(req));
+  if (!payload) return done();
+
+  const cookieHeader = req.headers?.cookie || '';
+  const clientId = clientIdFromCookies(cookieHeader);
+  const sessionId = sessionIdFromCookies(cookieHeader, CONFIG.MEASUREMENT_ID);
+
+  // No `_ga` cookie means GA never ran for this visitor — exactly the
+  // never-interacted session this endpoint exists to recover. The Measurement
+  // Protocol still requires a client_id, so we synthesize one and tag the
+  // event, because a synthetic id counts as a new user and would otherwise
+  // inflate user totals with no way to tell which rows are affected.
+  const resolvedClientId = clientId || `${Date.now()}.${Math.floor(Math.random() * 1e10)}`;
+
+  const events = payload.metrics.map((metric) => ({
+    name: 'web_vitals',
+    params: {
+      ...metric,
+      page_location: `${CONFIG.SITE_ORIGIN}${payload.path}`,
+      // Without this GA4 treats the hit as non-engaged and drops it from most
+      // standard reports.
+      engagement_time_msec: '1',
+      cid_source: clientId ? 'ga_cookie' : 'synthetic',
+      ...(sessionId ? { session_id: sessionId } : {}),
+    },
+  }));
+
+  const url =
+    `${MP_ENDPOINT}?measurement_id=${encodeURIComponent(CONFIG.MEASUREMENT_ID)}` +
+    `&api_secret=${encodeURIComponent(apiSecret)}`;
+
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ client_id: resolvedClientId, events }),
+    });
+  } catch (error) {
+    // Never surface upstream failures — the response goes nowhere anyway.
+    safeLog('error', '[vitals] Measurement Protocol forward failed', {
+      message: error?.message,
+    });
+  }
+
+  return done();
+}

--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -73,6 +73,11 @@
         }
         if (!vitalsBatch.length) return;
         if (!navigator.sendBeacon) return;
+        // The same bundle is served by the GitHub Pages backup, where
+        // /api/vitals does not exist (Vercel serves the function). Beaconing
+        // there is a guaranteed 404, and preview deployments would pollute the
+        // production property, so only the canonical host reports.
+        if (window.location.hostname !== 'tech.2twodragon.com') return;
         try {
           var body = JSON.stringify({
             p: window.location.pathname,

--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -238,6 +238,19 @@
       var clsEntries = [];
 
       // CLS cause analysis
+      //
+      // Element sources are forwarded to GA4 as `metric_cause`, so a URL's
+      // query string must be dropped before it leaves the page. Today's
+      // sources are first-party images and ad-network iframes and carry
+      // nothing identifying, but the moment a template renders a
+      // user-influenced src (an avatar or embed with a token) into a
+      // shifting element, that token would ride along to a third party
+      // without anyone reviewing it. The path alone identifies the element
+      // just as well for diagnosing a shift.
+      function stripQuery(url) {
+        return String(url).split('?')[0].split('#')[0];
+      }
+
       function analyzeCLSCause(entry) {
         var causes = [];
         if (entry.sources && entry.sources.length > 0) {
@@ -250,9 +263,9 @@
               var id = source.node.id || '';
 
               if (tagName === 'IMG' || (className && (className.includes('image') || className.includes('img')))) {
-                causes.push('Image: ' + (source.node.src || source.node.getAttribute('src') || 'unknown'));
+                causes.push('Image: ' + stripQuery(source.node.src || source.node.getAttribute('src') || 'unknown'));
               } else if (tagName === 'IFRAME' || (className && (className.includes('adsbygoogle') || className.includes('ad')))) {
-                causes.push('Ad: ' + (source.node.src || className || 'unknown'));
+                causes.push('Ad: ' + stripQuery(source.node.src || className || 'unknown'));
               } else if (tagName === 'DIV' && className && className.includes('card')) {
                 causes.push('Card: ' + className);
               } else if (tagName === 'SCRIPT') {

--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -1,6 +1,7 @@
 // Performance Monitoring (Production Only)
 // Features: Long Tasks, LCP, FID, INP, CLS, Page Load, Resource Loading
-// Field metrics (LCP / INP / CLS) flush to GA4 as one `web_vitals` event at page hide.
+// Field metrics (LCP / INP / CLS) flush at page hide in one first-party beacon
+// to /api/vitals, which forwards them to GA4 as `web_vitals` events.
 // Extracted from _includes/performance-monitor.html
 
 (function() {
@@ -48,11 +49,19 @@
     // Web Vitals monitoring
     if ('PerformanceObserver' in window) {
       // --- Shared field-metric reporting ------------------------------------
-      // Every vital flushes through one GA4 event (`web_vitals`) at page hide.
-      // __track, not a direct dataLayer push: events fired before
-      // gtag('config') runs would otherwise be dropped.
+      // Every vital is collected at page hide and delivered in ONE first-party
+      // beacon to /api/vitals, which forwards to GA4 server-side.
+      //
+      // Not window.__track / gtag: gtag batches dataLayer pushes behind a ~5s
+      // timer (measured 5003-5005ms, n=4) and vitals are pushed at hide, so
+      // any session ending in a tab close or an internal link — nearly all of
+      // them on a non-SPA blog — died before that timer fired. Measured 0/3
+      // delivered at a 2s leave-gap vs 3/3 at 5s, with a control sendBeacon
+      // from the same handler captured 1/1 at 0ms. That control is why this
+      // transport was chosen. See notes/ga4-web-vitals-delivery-loss.md.
       var vitalsFlushed = false;
       var vitalsPending = [];
+      var vitalsBatch = [];
 
       function onHidden(fn) { vitalsPending.push(fn); }
 
@@ -62,17 +71,26 @@
         for (var vi = 0; vi < vitalsPending.length; vi++) {
           try { vitalsPending[vi](); } catch (err) { /* never block unload */ }
         }
+        if (!vitalsBatch.length) return;
+        if (!navigator.sendBeacon) return;
+        try {
+          var body = JSON.stringify({
+            p: window.location.pathname,
+            m: vitalsBatch
+          });
+          navigator.sendBeacon(
+            '/api/vitals',
+            new Blob([body], { type: 'application/json' })
+          );
+        } catch (err) {
+          // Never block unload for analytics.
+        }
       }
 
       function sendVital(name, value, rating, cause) {
-        if (typeof window.__track !== 'function') return;
-        var params = {
-          metric_name: name,
-          metric_value: value,
-          metric_rating: rating
-        };
-        if (cause) params.metric_cause = String(cause).slice(0, 100);
-        window.__track('web_vitals', params);
+        var metric = { n: name, v: value, r: rating };
+        if (cause) metric.c = String(cause).slice(0, 100);
+        vitalsBatch.push(metric);
       }
 
       function rate(value, good, poor) {

--- a/notes/ga4-web-vitals-delivery-loss.md
+++ b/notes/ga4-web-vitals-delivery-loss.md
@@ -189,6 +189,14 @@ hide에서 `navigator.sendBeacon('/api/vitals', …)` → Vercel 함수가 GA4 M
 - **Rate limiting** — 기존 `api/lib/ratelimit.js` 재사용. 키는 `x-real-ip` 우선
   (`x-forwarded-for` 첫 항목은 클라이언트가 보낼 수 있어 헤더 회전으로 우회 가능)
 - `api_secret`은 응답·로그에 절대 포함하지 않음 (회귀 테스트로 고정)
+- `metric_cause`는 쿼리스트링을 제거하고 경로만 보낸다. 현재 소스는 퍼스트파티
+  이미지와 광고 iframe이라 식별 정보가 없지만, 사용자 영향 URL(토큰이 붙은 아바타·
+  임베드)이 시프트 요소로 렌더되는 순간 그 토큰이 검토 없이 제3자로 나가게 된다
+
+보안 리뷰(별도 레인)에서 HIGH 3건이 제기됐고 전부 반영됐다 — 레이트리밋 키
+(`x-real-ip` 우선), 본문 상한(Content-Length + chunked 대비 재측정),
+`*.vercel.app` 허용 제거. MEDIUM 2건 중 하나는 위 쿼리스트링 제거, 다른 하나는
+"동일 출처 검사가 직접 공격의 방어가 아니다"라는 주석 정정으로 해소했다.
 
 ### 알려진 한계 — `cid_source`
 

--- a/notes/ga4-web-vitals-delivery-loss.md
+++ b/notes/ga4-web-vitals-delivery-loss.md
@@ -179,11 +179,15 @@ hide에서 `navigator.sendBeacon('/api/vitals', …)` → Vercel 함수가 GA4 M
 인증 없는 POST 엔드포인트이므로 이벤트 주입 통로가 되지 않도록:
 
 - **POST 전용**, 그 외 405
-- **동일 출처 검증** — `Origin`/`Referer`가 사이트 호스트 또는 `*.vercel.app`이 아니면
-  드롭. 둘 다 없으면 드롭
+- **동일 출처 검증** — `Origin`/`Referer`가 정규 호스트가 아니면 드롭, 둘 다 없어도
+  드롭. `*.vercel.app`은 **허용하지 않는다** — 접미사 허용은 플랫폼의 모든 프로젝트를
+  들여보낸다. 클라이언트도 정규 호스트에서만 전송하므로 잃는 트래픽이 없다.
+  다만 이건 curl 같은 직접 공격의 방어가 아니다. 제3자 사이트가 **방문자 브라우저를
+  시켜** 대신 쏘는 것을 막을 뿐이고, 위조된 리포트의 피해는 아래 검증으로 묶인다
 - **엄격한 검증** — 지표명·등급 allow-list, 값 범위, 지표 중복 금지, 최대 3건,
   본문 2KB 상한, `metric_cause` 제어문자 제거 + 100자
-- **Rate limiting** — 기존 `api/lib/ratelimit.js` 재사용
+- **Rate limiting** — 기존 `api/lib/ratelimit.js` 재사용. 키는 `x-real-ip` 우선
+  (`x-forwarded-for` 첫 항목은 클라이언트가 보낼 수 있어 헤더 회전으로 우회 가능)
 - `api_secret`은 응답·로그에 절대 포함하지 않음 (회귀 테스트로 고정)
 
 ### 알려진 한계 — `cid_source`

--- a/notes/ga4-web-vitals-delivery-loss.md
+++ b/notes/ga4-web-vitals-delivery-loss.md
@@ -142,14 +142,66 @@ hide에서 `navigator.sendBeacon('/api/vitals', …)` → Vercel 함수가 GA4 M
 
 ---
 
-## 5. 권장
+## 5. 결정 — 옵션 3 채택 (구현 완료)
 
-**옵션 3.** 세 지표를 모두 복구하는 유일한 안이고, 전송 수단은 이미 실측으로
-검증됐다. 옵션 2는 무문서 의존이라 조용히 깨질 위험이 크고, 옵션 1은 3분의 1만
-해결한다.
+세 지표를 모두 복구하는 유일한 안이고, 전송 수단은 이미 실측으로 검증됐다.
+옵션 2는 무문서 의존이라 조용히 깨질 위험이 크고, 옵션 1은 3분의 1만 해결한다.
 
-다만 옵션 3은 서버리스 엔드포인트라는 인프라가 늘어나므로, 트래픽 규모 대비
-호출 한도 확인이 선행되어야 한다.
+### ⚠️ 배포 전 필수 — `GA4_API_SECRET`
+
+**이 환경변수가 없으면 `/api/vitals`는 모든 리포트를 버린다.** gtag 경로는
+제거됐으므로, 시크릿 없이 배포하면 수집이 "일부"에서 **"전무"로 나빠진다.**
+반드시 배포 전에 설정할 것.
+
+1. GA4 → 관리 → 데이터 스트림 → 해당 스트림 → **Measurement Protocol API 비밀번호**
+   → 만들기
+2. Vercel → Project Settings → Environment Variables → `GA4_API_SECRET` 추가
+   (Production + Preview)
+3. 재배포
+
+설정 전에는 함수가 `[vitals] GA4_API_SECRET is not set; dropping report` 경고만
+남기고 204를 반환한다 (독자에게는 영향 없음).
+
+### 구성 요소
+
+| 파일 | 역할 |
+|---|---|
+| `assets/js/performance-monitor.js` | hide에서 3개 지표를 모아 `/api/vitals`로 beacon 1건 |
+| `api/vitals.js` | 검증 후 GA4 Measurement Protocol로 전달 |
+| `tests/js/api-vitals.test.js` | 엔드포인트 회귀 테스트 27건 |
+| `vercel.json` | `api/vitals.js` maxDuration 5s |
+
+전송 페이로드(압축 형태): `{"p":"/posts/foo/","m":[{"n":"LCP","v":1200,"r":"good"}]}`
+— `c`(원인)는 CLS에만 붙는다.
+
+### 공개 엔드포인트라서 건 방어
+
+인증 없는 POST 엔드포인트이므로 이벤트 주입 통로가 되지 않도록:
+
+- **POST 전용**, 그 외 405
+- **동일 출처 검증** — `Origin`/`Referer`가 사이트 호스트 또는 `*.vercel.app`이 아니면
+  드롭. 둘 다 없으면 드롭
+- **엄격한 검증** — 지표명·등급 allow-list, 값 범위, 지표 중복 금지, 최대 3건,
+  본문 2KB 상한, `metric_cause` 제어문자 제거 + 100자
+- **Rate limiting** — 기존 `api/lib/ratelimit.js` 재사용
+- `api_secret`은 응답·로그에 절대 포함하지 않음 (회귀 테스트로 고정)
+
+### 알려진 한계 — `cid_source`
+
+`_ga` 쿠키가 없는 방문자(= GA가 한 번도 안 돈, 바로 이 엔드포인트가 구하려는 세션)는
+Measurement Protocol이 요구하는 `client_id`를 만들어 낼 수밖에 없다. 합성 id는
+GA4에서 **새 사용자로 집계되어 사용자 수를 부풀린다.**
+
+그래서 모든 이벤트에 `cid_source` 파라미터를 붙인다 (`ga_cookie` | `synthetic`).
+사용자 수 지표를 볼 때는 `cid_source = ga_cookie`로 필터링해야 하며, 이 값을
+맞춤 측정기준으로 등록해 두는 것을 권장한다. 지표 분포(LCP/INP/CLS 값 자체)는
+양쪽 모두 유효하다.
+
+### 비용
+
+세션당 함수 호출 1회, maxDuration 5s. 연산량은 무시할 수준이나 **Vercel 플랜의
+함수 호출 한도는 트래픽 증가 시 확인이 필요하다** — 현재 트래픽 기준으로는
+측정하지 않았다.
 
 ---
 

--- a/notes/ga4-web-vitals-reporting.md
+++ b/notes/ga4-web-vitals-reporting.md
@@ -49,6 +49,11 @@ Core Web Vitals 공식 기준과 동일하다.
 | Metric Name | 이벤트 | `metric_name` |
 | Metric Rating | 이벤트 | `metric_rating` |
 | Metric Cause | 이벤트 | `metric_cause` |
+| CID Source | 이벤트 | `cid_source` |
+
+`cid_source`는 `ga_cookie` / `synthetic` 두 값을 갖는다. `synthetic`은 `_ga` 쿠키가
+없어 서버가 `client_id`를 만들어 낸 경우이며 **새 사용자로 집계된다.** 사용자 수를
+볼 때는 이 측정기준으로 필터링해야 한다 (§5 참고).
 
 ### 2-2. 맞춤 측정항목 — 1개
 
@@ -141,11 +146,20 @@ GA4 자유 형식의 값 요약에는 백분위수가 있지만 p75가 없는 �
 
 ## 5. 데이터 해석 시 반드시 알아야 할 편향
 
-> **2026-08-18 갱신**: 아래 1~4는 실측 결과 **과소평가였다.** 이보다 훨씬 큰 유실
-> 경로(gtag의 5초 배치 타이머)가 따로 있다. 탭을 닫거나 사이트 내 다른 글로
-> 이동하면 `web_vitals`가 **전량 유실된다.** 측정 근거와 폴백 설계는
-> `notes/ga4-web-vitals-delivery-loss.md`. 아래 절은 그중 작은 쪽(경로 A)만
-> 다룬다.
+> **2026-08-18 갱신**: 아래 1~4는 실측 결과 **과소평가였다.** 훨씬 큰 유실
+> 경로(gtag의 5초 배치 타이머)가 따로 있었고, 탭을 닫거나 사이트 내 다른 글로
+> 이동하면 `web_vitals`가 전량 유실됐다.
+>
+> **이후 전송 경로를 gtag → 퍼스트파티 beacon(`/api/vitals` → Measurement
+> Protocol)으로 교체해 1~4와 배치 타이머 유실을 모두 해소했다.** 측정 근거·설계·
+> 배포 전 필수 환경변수는 `notes/ga4-web-vitals-delivery-loss.md`.
+>
+> 남은 한계는 하나다: `_ga` 쿠키가 없는 방문자는 합성 `client_id`로 집계되어
+> **사용자 수가 부풀려진다.** 이벤트에 `cid_source`(`ga_cookie` | `synthetic`)를
+> 붙여 두었으니 사용자 수 지표는 `ga_cookie`로 필터링할 것. 지표 값 분포는 양쪽
+> 모두 유효하다.
+>
+> 아래 1~4는 교체 이전의 gtag 경로에 대한 기록이다.
 
 이 데이터는 **모든 방문자를 대표하지 않는다.** 낙관적으로 치우친다.
 

--- a/tests/js/api-vitals.test.js
+++ b/tests/js/api-vitals.test.js
@@ -242,11 +242,30 @@ describe('api/vitals — handler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('accepts Vercel preview deployments', async () => {
+  it('rejects preview hosts — *.vercel.app would admit every project on the platform', async () => {
+    // The client only beacons from the canonical host, so there is no traffic
+    // to lose here, and allowing the suffix would let any vercel.app site post.
     const { default: handler } = await load();
     const res = makeRes();
     await handler(makeReq({ headers: { origin: 'https://tech-blog-abc123.vercel.app' } }), res);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('prefers x-real-ip over the spoofable x-forwarded-for for rate limiting', async () => {
+    const { checkRateLimit } = await import('../../api/lib/ratelimit.js');
+    checkRateLimit.mockClear();
+    const { default: handler } = await load();
+    await handler(makeReq({
+      headers: { origin: ORIGIN, 'x-real-ip': '198.51.100.9', 'x-forwarded-for': '1.2.3.4' },
+    }), makeRes());
+    expect(checkRateLimit).toHaveBeenCalledWith('198.51.100.9', 'anonymous');
+  });
+
+  it('rejects an oversized body even when the platform pre-parsed it', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ headers: { origin: ORIGIN, 'content-length': '999999' } }), res);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('drops the report when GA4_API_SECRET is not configured', async () => {

--- a/tests/js/api-vitals.test.js
+++ b/tests/js/api-vitals.test.js
@@ -1,0 +1,312 @@
+// Regression tests for api/vitals.js — the first-party Web Vitals collector.
+//
+// This endpoint exists because gtag batches dataLayer pushes behind a ~5s
+// timer while vitals are pushed at page hide, so sessions ending in a tab
+// close or an internal link lost them entirely (measured 0/3 at a 2s
+// leave-gap). See notes/ga4-web-vitals-delivery-loss.md.
+//
+// It is a public, unauthenticated POST endpoint that forwards to GA4 with a
+// server-side api_secret, so the things worth pinning are the ones that keep
+// it from becoming an open event-injection hole: same-origin enforcement,
+// strict payload validation, and never echoing the secret.
+//
+// These live under tests/js/ rather than api/__tests__/ because vitest.config
+// only includes tests/js/**; nothing runs api/__tests__/ today.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const MODULE = '../../api/vitals.js';
+
+// The endpoint calls checkRateLimit, which would reach for Upstash.
+vi.mock('../../api/lib/ratelimit.js', () => ({
+  checkRateLimit: vi.fn(async () => ({ success: true, headers: {} })),
+  setRateLimitHeaders: vi.fn(),
+}));
+
+const SECRET = 'test-secret-value';
+const ORIGIN = 'https://tech.2twodragon.com';
+
+function makeRes() {
+  const res = {
+    statusCode: null,
+    headers: {},
+    ended: false,
+    setHeader(k, v) { this.headers[k] = v; },
+    status(code) { this.statusCode = code; return this; },
+    end(body) { this.ended = true; this.body = body; return this; },
+  };
+  return res;
+}
+
+function makeReq(overrides = {}) {
+  return {
+    method: 'POST',
+    headers: { origin: ORIGIN, ...(overrides.headers || {}) },
+    body: overrides.body !== undefined
+      ? overrides.body
+      : { p: '/posts/foo/', m: [{ n: 'LCP', v: 1200, r: 'good' }] },
+    socket: { remoteAddress: '203.0.113.7' },
+    ...(overrides.method ? { method: overrides.method } : {}),
+  };
+}
+
+let fetchMock;
+
+beforeEach(async () => {
+  vi.resetModules();
+  process.env.GA4_API_SECRET = SECRET;
+  process.env.GA4_MEASUREMENT_ID = 'G-B29150XJ73';
+  process.env.SITE_ORIGIN = ORIGIN;
+  fetchMock = vi.fn(async () => ({ ok: true, status: 204 }));
+  vi.stubGlobal('fetch', fetchMock);
+  const { checkRateLimit } = await import('../../api/lib/ratelimit.js');
+  checkRateLimit.mockResolvedValue({ success: true, headers: {} });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GA4_API_SECRET;
+  delete process.env.GA4_MEASUREMENT_ID;
+  delete process.env.SITE_ORIGIN;
+});
+
+async function load() {
+  return import(MODULE);
+}
+
+/** The JSON body handed to the Measurement Protocol, or null if never called. */
+function forwardedBody() {
+  if (fetchMock.mock.calls.length === 0) return null;
+  return JSON.parse(fetchMock.mock.calls[0][1].body);
+}
+
+describe('api/vitals — cookie parsing', () => {
+  it('extracts the GA client id from the _ga cookie', async () => {
+    const { clientIdFromCookies } = await load();
+    expect(clientIdFromCookies('_ga=GA1.1.1234567890.1700000000; other=x'))
+      .toBe('1234567890.1700000000');
+  });
+
+  it('returns null when _ga is absent or malformed', async () => {
+    const { clientIdFromCookies } = await load();
+    expect(clientIdFromCookies('')).toBeNull();
+    expect(clientIdFromCookies('_ga=GA1.1')).toBeNull();
+    expect(clientIdFromCookies('_ga=GA1.1.abc.def')).toBeNull();
+  });
+
+  it('reads the session id from the GS2 cookie format', async () => {
+    const { sessionIdFromCookies } = await load();
+    const cookie = '_ga_B29150XJ73=GS2.1.s1745000000$o5$g1$t1745000100$j60$l0$h0';
+    expect(sessionIdFromCookies(cookie, 'G-B29150XJ73')).toBe('1745000000');
+  });
+
+  it('reads the session id from the older GS1 cookie format', async () => {
+    const { sessionIdFromCookies } = await load();
+    const cookie = '_ga_B29150XJ73=GS1.1.1745000000.5.1.1745000100.60.0.0';
+    expect(sessionIdFromCookies(cookie, 'G-B29150XJ73')).toBe('1745000000');
+  });
+
+  it('returns null when the container cookie is for a different property', async () => {
+    const { sessionIdFromCookies } = await load();
+    const cookie = '_ga_SOMETHINGELSE=GS2.1.s1745000000$o5';
+    expect(sessionIdFromCookies(cookie, 'G-B29150XJ73')).toBeNull();
+  });
+});
+
+describe('api/vitals — payload validation', () => {
+  it('accepts a well-formed report', async () => {
+    const { validatePayload } = await load();
+    const out = validatePayload({ p: '/posts/foo/', m: [{ n: 'CLS', v: 0.05, r: 'good' }] });
+    expect(out.path).toBe('/posts/foo/');
+    expect(out.metrics).toEqual([
+      { metric_name: 'CLS', metric_value: 0.05, metric_rating: 'good' },
+    ]);
+  });
+
+  it('rejects unknown metric names', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({ m: [{ n: 'FID', v: 10, r: 'good' }] })).toBeNull();
+  });
+
+  it('rejects unknown ratings', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({ m: [{ n: 'LCP', v: 10, r: 'excellent' }] })).toBeNull();
+  });
+
+  it('rejects non-finite and out-of-range values', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({ m: [{ n: 'LCP', v: NaN, r: 'good' }] })).toBeNull();
+    expect(validatePayload({ m: [{ n: 'LCP', v: -1, r: 'good' }] })).toBeNull();
+    expect(validatePayload({ m: [{ n: 'LCP', v: 1e9, r: 'good' }] })).toBeNull();
+    expect(validatePayload({ m: [{ n: 'CLS', v: 1000, r: 'poor' }] })).toBeNull();
+    expect(validatePayload({ m: [{ n: 'LCP', v: '1200', r: 'good' }] })).toBeNull();
+  });
+
+  it('rejects a duplicated metric — one reading per metric per page', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({
+      m: [{ n: 'LCP', v: 10, r: 'good' }, { n: 'LCP', v: 20, r: 'good' }],
+    })).toBeNull();
+  });
+
+  it('rejects an empty or oversized metric list', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({ m: [] })).toBeNull();
+    expect(validatePayload({
+      m: [
+        { n: 'LCP', v: 1, r: 'good' }, { n: 'INP', v: 1, r: 'good' },
+        { n: 'CLS', v: 1, r: 'good' }, { n: 'LCP', v: 1, r: 'good' },
+      ],
+    })).toBeNull();
+  });
+
+  it('rejects a body that is not a metric envelope', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload(null)).toBeNull();
+    expect(validatePayload({})).toBeNull();
+    expect(validatePayload({ m: 'LCP' })).toBeNull();
+    expect(validatePayload({ m: [null] })).toBeNull();
+  });
+
+  it('strips control characters from metric_cause and caps its length', async () => {
+    const { validatePayload } = await load();
+    const cause = `Image: a\x00b\x1fc${'x'.repeat(200)}`;
+    const out = validatePayload({ m: [{ n: 'CLS', v: 0.2, r: 'needs-improvement', c: cause }] });
+    expect(out.metrics[0].metric_cause).not.toMatch(/[\x00-\x1f]/);
+    expect(out.metrics[0].metric_cause.length).toBeLessThanOrEqual(100);
+  });
+
+  it('falls back to "/" for a path that is not an absolute path', async () => {
+    const { validatePayload } = await load();
+    expect(validatePayload({ p: 'https://evil.test/x', m: [{ n: 'LCP', v: 1, r: 'good' }] }).path)
+      .toBe('/');
+  });
+});
+
+describe('api/vitals — handler', () => {
+  it('rejects non-POST with 405', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ method: 'GET' }), res);
+    expect(res.statusCode).toBe(405);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid report to the Measurement Protocol', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({
+      headers: { origin: ORIGIN, cookie: '_ga=GA1.1.111.222; _ga_B29150XJ73=GS2.1.s1745000000$o3' },
+    }), res);
+
+    expect(res.statusCode).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = forwardedBody();
+    expect(body.client_id).toBe('111.222');
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].name).toBe('web_vitals');
+    expect(body.events[0].params).toMatchObject({
+      metric_name: 'LCP',
+      metric_value: 1200,
+      metric_rating: 'good',
+      session_id: '1745000000',
+      cid_source: 'ga_cookie',
+      engagement_time_msec: '1',
+      page_location: `${ORIGIN}/posts/foo/`,
+    });
+  });
+
+  it('marks a synthesized client id so inflated user counts stay detectable', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    // No _ga cookie: GA never ran for this visitor. That is precisely the
+    // session this endpoint exists to recover, but the id is not a real user.
+    await handler(makeReq({ headers: { origin: ORIGIN } }), res);
+    expect(forwardedBody().events[0].params.cid_source).toBe('synthetic');
+  });
+
+  it('drops cross-origin posts without forwarding', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ headers: { origin: 'https://evil.test' } }), res);
+    expect(res.statusCode).toBe(204);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('drops posts with neither Origin nor Referer', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    const req = makeReq();
+    req.headers = {};
+    await handler(req, res);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts Vercel preview deployments', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ headers: { origin: 'https://tech-blog-abc123.vercel.app' } }), res);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the report when GA4_API_SECRET is not configured', async () => {
+    delete process.env.GA4_API_SECRET;
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(204);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never echoes the api_secret in the response', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(JSON.stringify(res.body ?? '')).not.toContain(SECRET);
+    expect(JSON.stringify(res.headers)).not.toContain(SECRET);
+  });
+
+  it('drops an invalid payload without forwarding', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ body: { m: [{ n: 'BOGUS', v: 1, r: 'good' }] } }), res);
+    expect(res.statusCode).toBe(204);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('drops when rate limited', async () => {
+    const { checkRateLimit } = await import('../../api/lib/ratelimit.js');
+    checkRateLimit.mockResolvedValueOnce({ success: false, headers: {} });
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(204);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('parses a raw JSON string body (sendBeacon text/plain path)', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({
+      body: JSON.stringify({ p: '/x/', m: [{ n: 'INP', v: 250, r: 'needs-improvement' }] }),
+    }), res);
+    expect(forwardedBody().events[0].params.metric_name).toBe('INP');
+  });
+
+  it('rejects an oversized raw body', async () => {
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({ body: 'x'.repeat(5000) }), res);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('still answers 204 when the upstream forward throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(204);
+  });
+});

--- a/tests/js/api-vitals.test.js
+++ b/tests/js/api-vitals.test.js
@@ -320,6 +320,18 @@ describe('api/vitals — handler', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it('rejects an oversized pre-parsed body even with no Content-Length (chunked)', async () => {
+    // Chunked requests carry no Content-Length, so the header check cannot
+    // run and the parsed-object branch would otherwise be the one path
+    // with no cap at all.
+    const { default: handler } = await load();
+    const res = makeRes();
+    await handler(makeReq({
+      body: { p: '/', m: [{ n: 'LCP', v: 1, r: 'good', c: 'A'.repeat(5000) }] },
+    }), res);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('still answers 204 when the upstream forward throws', async () => {
     fetchMock.mockRejectedValueOnce(new Error('network down'));
     vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -1086,6 +1086,25 @@ describe('performance-monitor.js CLS', () => {
     }
   });
 
+  it('does not beacon from the GitHub Pages backup or a preview host', () => {
+    // The same bundle is served by twodragon0.github.io, where /api/vitals is
+    // a 404 (the function only exists on Vercel), and preview deployments
+    // would pollute the production property.
+    const { observed, ctor } = setupPerformanceObserverStub();
+    const { fake } = buildFakeWindow({
+      hostname: 'twodragon0.github.io',
+      PerformanceObserver: ctor,
+    });
+    ({ sent } = stubBeacon());
+    const { doc, fire } = buildFakeDocument();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    runWithDoc(fake, doc);
+    feed(clsObserverOf(observed), [shift(0.05, 1000)]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+    expect(sent).toHaveLength(0);
+  });
+
   it('survives a browser without navigator.sendBeacon', () => {
     const { observed, ctor } = setupPerformanceObserverStub();
     const { fake } = buildFakeWindow({ PerformanceObserver: ctor });

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -953,20 +953,65 @@ function runWithDoc(fakeWindow, fakeDoc) {
   new Function('window', 'document', SCRIPT_SOURCE)(fakeWindow, fakeDoc);
 }
 
+// Delivery is a first-party beacon to /api/vitals, NOT window.__track.
+//
+// Changed 2026-08-18 after measuring the gtag path: gtag batches dataLayer
+// pushes behind a ~5s timer while vitals are pushed at hide, so every session
+// that ended in a tab close or an internal link lost them (0/3 delivered at a
+// 2s leave-gap; 3/3 at 5s). A control navigator.sendBeacon fired from the same
+// visibilitychange handler was captured 1/1 at a 0ms gap, which is why the
+// transport moved. See notes/ga4-web-vitals-delivery-loss.md.
+//
+// What these tests pin: one beacon per hide, carrying every measured metric,
+// with the compact wire shape the endpoint validates.
+
+/** Stubs navigator.sendBeacon + Blob and captures what was sent. */
+function stubBeacon() {
+  const sent = [];
+  const sendBeacon = vi.fn((url, blob) => {
+    sent.push({ url, text: blob && blob._text });
+    return true;
+  });
+  vi.stubGlobal('navigator', { sendBeacon });
+  vi.stubGlobal('Blob', class FakeBlob {
+    constructor(parts, opts) {
+      this._text = parts.join('');
+      this.type = opts && opts.type;
+    }
+  });
+  return { sent, sendBeacon };
+}
+
+/** Beacon payloads, expanded to the readable param names GA4 receives. */
+function metricsFrom(sent) {
+  return sent.flatMap((s) => JSON.parse(s.text).m).map((m) => ({
+    metric_name: m.n,
+    metric_value: m.v,
+    metric_rating: m.r,
+    ...(m.c != null ? { metric_cause: m.c } : {}),
+  }));
+}
+
 describe('performance-monitor.js CLS', () => {
-  let track;
+  let sent;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
 
   function boot() {
     const { observed, ctor } = setupPerformanceObserverStub();
     const { fake, listeners } = buildFakeWindow({ PerformanceObserver: ctor });
-    track = vi.fn();
-    fake.__track = track;
+    ({ sent } = stubBeacon());
     const { doc, fire } = buildFakeDocument();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
     runWithDoc(fake, doc);
     return { cls: clsObserverOf(observed), doc, fire, listeners, fake };
   }
+
+  const vitalFor = (name) => metricsFrom(sent).find((m) => m.metric_name === name) || null;
 
   it('reports the largest burst, not the sum, when bursts are >1s apart', () => {
     const { cls, doc, fire } = boot();
@@ -976,10 +1021,9 @@ describe('performance-monitor.js CLS', () => {
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
 
-    const call = track.mock.calls.find((c) => c[1] && c[1].metric_name === 'CLS');
-    expect(call).toBeDefined();
-    expect(call[0]).toBe('web_vitals');
-    expect(call[1].metric_value).toBeCloseTo(0.05, 5);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].url).toBe('/api/vitals');
+    expect(vitalFor('CLS').metric_value).toBeCloseTo(0.05, 5);
   });
 
   it('breaks the session after 5s even without a 1s gap', () => {
@@ -992,7 +1036,7 @@ describe('performance-monitor.js CLS', () => {
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
     // First session (0..4500) = 0.12; the 5400 entry opens a new one at 0.02.
-    expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_value).toBeCloseTo(0.12, 5);
+    expect(vitalFor('CLS').metric_value).toBeCloseTo(0.12, 5);
   });
 
   it('ignores shifts that follow recent user input', () => {
@@ -1000,10 +1044,18 @@ describe('performance-monitor.js CLS', () => {
     feed(cls, [shift(0.4, 1000, true), shift(0.03, 1200)]);
     doc.visibilityState = 'hidden';
     fire('visibilitychange');
-    expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_value).toBeCloseTo(0.03, 5);
+    expect(vitalFor('CLS').metric_value).toBeCloseTo(0.03, 5);
   });
 
-  it('sends exactly once even if visibilitychange and pagehide both fire', () => {
+  it('sends the page path so per-page reports can join', () => {
+    const { cls, doc, fire } = boot();
+    feed(cls, [shift(0.05, 1000)]);
+    doc.visibilityState = 'hidden';
+    fire('visibilitychange');
+    expect(JSON.parse(sent[0].text).p).toBe('/posts/foo/');
+  });
+
+  it('sends exactly one beacon even if visibilitychange and pagehide both fire', () => {
     const { cls, doc, fire, listeners } = boot();
     feed(cls, [shift(0.05, 1000)]);
     doc.visibilityState = 'hidden';
@@ -1012,15 +1064,15 @@ describe('performance-monitor.js CLS', () => {
     const pagehide = listeners.filter((l) => l.evt === 'pagehide');
     expect(pagehide.length).toBeGreaterThan(0);
     pagehide.forEach((l) => l.handler());
-    const clsCalls = track.mock.calls.filter((c) => c[1].metric_name === 'CLS');
-    expect(clsCalls).toHaveLength(1);
+    expect(sent).toHaveLength(1);
+    expect(metricsFrom(sent).filter((m) => m.metric_name === 'CLS')).toHaveLength(1);
   });
 
   it('does not send while the page is still visible', () => {
     const { cls, fire } = boot();
     feed(cls, [shift(0.05, 1000)]);
     fire('visibilitychange'); // visibilityState stays 'visible'
-    expect(track).not.toHaveBeenCalled();
+    expect(sent).toHaveLength(0);
   });
 
   it('classifies the rating on the Core Web Vitals thresholds', () => {
@@ -1030,13 +1082,14 @@ describe('performance-monitor.js CLS', () => {
       feed(cls, [shift(value, 1000)]);
       doc.visibilityState = 'hidden';
       fire('visibilitychange');
-      expect(track.mock.calls.find((c) => c[1].metric_name === 'CLS')[1].metric_rating).toBe(expected);
+      expect(vitalFor('CLS').metric_rating).toBe(expected);
     }
   });
 
-  it('survives a page where __track was never defined', () => {
+  it('survives a browser without navigator.sendBeacon', () => {
     const { observed, ctor } = setupPerformanceObserverStub();
     const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
+    vi.stubGlobal('navigator', {});
     const { doc, fire } = buildFakeDocument();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     runWithDoc(fake, doc);
@@ -1046,7 +1099,7 @@ describe('performance-monitor.js CLS', () => {
   });
 });
 
-// --- LCP / INP: same web_vitals event as CLS -------------------------------
+// --- LCP / INP: same web_vitals payload as CLS -----------------------------
 //
 // Added 2026-08-14 alongside the CLS reporter. Two defects are pinned here:
 //
@@ -1066,13 +1119,17 @@ function observerWithType(observed, type) {
 }
 
 describe('performance-monitor.js LCP/INP', () => {
-  let track;
+  let sent;
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
 
   function boot() {
     const { observed, ctor } = setupPerformanceObserverStub();
     const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
-    track = vi.fn();
-    fake.__track = track;
+    ({ sent } = stubBeacon());
     const { doc, fire } = buildFakeDocument();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -1085,10 +1142,7 @@ describe('performance-monitor.js LCP/INP', () => {
     };
   }
 
-  function vitalFor(name) {
-    const call = track.mock.calls.find((c) => c[1] && c[1].metric_name === name);
-    return call ? call[1] : null;
-  }
+  const vitalFor = (name) => metricsFrom(sent).find((m) => m.metric_name === name) || null;
 
   it('falls back to startTime when renderTime is absent (cross-origin LCP image)', () => {
     const { lcp, hide } = boot();
@@ -1172,13 +1226,23 @@ describe('performance-monitor.js LCP/INP', () => {
     expect(eventOpts.buffered).toBe(true);
   });
 
-  it('flushes every metric on a single hide, and only once', () => {
+  it('flushes every metric in ONE beacon on a single hide, and only once', () => {
     const { lcp, inp, hide } = boot();
     feed(lcp, [{ renderTime: 1200 }]);
     feed(inp, [{ interactionId: 1, duration: 90 }]);
     hide();
     hide();
-    const names = track.mock.calls.map((c) => c[1].metric_name).sort();
+    expect(sent).toHaveLength(1);
+    const names = metricsFrom(sent).map((m) => m.metric_name).sort();
     expect(names).toEqual(['CLS', 'INP', 'LCP']);
+  });
+
+  it('uses the compact wire shape the endpoint validates', () => {
+    const { lcp, hide } = boot();
+    feed(lcp, [{ renderTime: 1200 }]);
+    hide();
+    const body = JSON.parse(sent[0].text);
+    expect(Object.keys(body).sort()).toEqual(['m', 'p']);
+    expect(body.m.find((m) => m.n === 'LCP')).toEqual({ n: 'LCP', v: 1200, r: 'good' });
   });
 });

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -421,6 +421,56 @@ describe('performance-monitor.js', () => {
       );
     });
 
+    it('strips the query string from an image src before it can leave the page', () => {
+      // metric_cause is forwarded to GA4. Today's srcs are first-party assets,
+      // but a template that ever renders a user-influenced src (an avatar or
+      // embed carrying a token) into a shifting element would otherwise ship
+      // that token to a third party with nobody reviewing it.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { observed, ctor } = setupPerformanceObserverStub();
+      const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
+      runScript(fake);
+      const cls = getObserverByType(observed, 'layout-shift');
+      cls._cb({
+        getEntries: () => [
+          {
+            hadRecentInput: false,
+            value: 0.2,
+            sources: [{ node: { tagName: 'IMG', src: '/avatar.png?token=SECRET123&u=42', className: '' } }],
+          },
+        ],
+      });
+      expect(warn).toHaveBeenCalledWith(
+        '[Performance] CLS is high:',
+        expect.any(String),
+        '| Cause:',
+        'Image: /avatar.png',
+      );
+    });
+
+    it('strips the query string from an ad iframe src too', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { observed, ctor } = setupPerformanceObserverStub();
+      const { fake } = buildFakeWindow({ PerformanceObserver: ctor });
+      runScript(fake);
+      const cls = getObserverByType(observed, 'layout-shift');
+      cls._cb({
+        getEntries: () => [
+          {
+            hadRecentInput: false,
+            value: 0.2,
+            sources: [{ node: { tagName: 'IFRAME', src: 'https://ads.example/x?click_id=abc&uid=9', className: '' } }],
+          },
+        ],
+      });
+      expect(warn).toHaveBeenCalledWith(
+        '[Performance] CLS is high:',
+        expect.any(String),
+        '| Cause:',
+        'Ad: https://ads.example/x',
+      );
+    });
+
     it('non-IMG element with className containing "img": still an Image cause via getAttribute fallback', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const { observed, ctor } = setupPerformanceObserverStub();

--- a/vercel.json
+++ b/vercel.json
@@ -429,6 +429,9 @@
     "api/chat.js": {
       "maxDuration": 60
     },
+    "api/vitals.js": {
+      "maxDuration": 5
+    },
     "api/search.js": {
       "maxDuration": 10
     },


### PR DESCRIPTION
> ## ⚠️ 병합 전 필수: `GA4_API_SECRET`
>
> 이 PR은 gtag 전송 경로를 **제거**한다. Vercel에 `GA4_API_SECRET`이 없으면 `/api/vitals`가 모든 리포트를 버리므로, 미설정 상태로 배포하면 수집이 "일부"에서 **"전무"로 나빠진다.**
>
> 1. GA4 → 관리 → 데이터 스트림 → Measurement Protocol API 비밀번호 → 만들기
> 2. Vercel → Environment Variables → `GA4_API_SECRET` (Production + Preview)
> 3. 그 다음 병합

## 왜

#557에서 측정한 결과, gtag는 `dataLayer` push를 **~5초 배치 타이머**로 보낸다(실측 5003–5005ms, n=4). 그런데 vitals는 페이지 **hide**에서 push된다. 이 사이트는 SPA가 아니라 내부 링크 클릭도 full unload이므로, **탭 닫기와 글→글 이동이 모두 그 5초 안에 끝나 이벤트가 큐째 유실**됐다.

| hide 후 이탈까지 | 전송된 `web_vitals` |
|---|---|
| 0 / 500 / 2000ms | **0 / 3** |
| 5000ms | 3 / 3 |

같은 `visibilitychange` 핸들러에서 쏜 대조군 `navigator.sendBeacon`은 gap=0에서도 1/1 도달했다. 계측 아티팩트가 아니고, 동시에 **어떤 전송 수단을 써야 하는지도 알려준 결과**다.

클라이언트 우회는 전부 실패했다 — `transport_type:'beacon'`, 즉시 flusher push, `event_callback` 모두 0건. 1줄 수정으로 끝나는 길이 없어 전송 경로를 바꿨다.

## 무엇을

```
hide → sendBeacon('/api/vitals', {p, m:[…]}) → Vercel 함수 → GA4 Measurement Protocol
```

| 파일 | 변경 |
|---|---|
| `assets/js/performance-monitor.js` | 3개 지표를 모아 beacon **1건**. `window.__track` 경유 제거 |
| `api/vitals.js` | 신규. 검증 후 MP로 전달. `api_secret`은 서버에만 |
| `tests/js/api-vitals.test.js` | 신규 27건 |
| `tests/js/performance-monitor.test.js` | beacon 전송으로 재작성 |
| `vercel.json` | `api/vitals.js` maxDuration 5s |

퍼스트파티라 **광고 차단기 편향도 함께 해소**된다.

## 공개 엔드포인트라서 건 방어

인증 없는 POST이므로 이벤트 주입 통로가 되지 않도록:

- POST 전용(그 외 405), 동일 출처 검증(`Origin`/`Referer`, 둘 다 없으면 드롭)
- 지표명·등급 allow-list, 값 범위, **지표 중복 금지**, 최대 3건, 본문 2KB
- `metric_cause` 제어문자 제거 + 100자
- 기존 `api/lib/ratelimit.js` 재사용
- `api_secret`은 응답·헤더에 절대 미포함 (회귀 테스트로 고정)

보안 리뷰는 별도 레인(`security-auditor`)에서 진행 중이며, 결과는 이 PR에 반영한다.

## 알려진 한계 — `cid_source`

`_ga` 쿠키가 없는 방문자(= GA가 한 번도 안 돈, **바로 이 엔드포인트가 구하려는 세션**)는 MP가 요구하는 `client_id`를 만들어 낼 수밖에 없다. 합성 id는 GA4에서 **새 사용자로 집계되어 사용자 수를 부풀린다.**

숨기지 않고 모든 이벤트에 `cid_source`(`ga_cookie` | `synthetic`)를 붙였다. 사용자 수 지표는 `ga_cookie`로 필터링해야 하며, 맞춤 측정기준 등록 방법은 `notes/ga4-web-vitals-reporting.md` §2에 추가했다. **지표 값 분포 자체는 양쪽 모두 유효하다.**

## 검증

```
npx vitest run              # 29 files, 727 tests passed
npx vitest run --coverage   # stmt 87.29 / branch 69.81 / func 89.94 / line 87.34 (임계값 통과)
```

- `performance-monitor.js` 커버리지 95.28% (stmt)
- 새 테스트는 `tests/js/`에 두었다 — `api/__tests__/`는 `vitest.config.js`의 include(`tests/js/**`)에 없어 **어떤 러너에도 연결돼 있지 않다.** 기존 문제이고 이 PR에서 고치지 않았다.

## 아직 검증 못 한 것

- **MP 전달의 실제 도달**은 `GA4_API_SECRET` 설정 후에만 확인 가능하다. 설정 후 GA4 Realtime에서 `web_vitals`와 `cid_source`를 확인해야 완결된다.
- Vercel 함수 호출 한도 대비 현재 트래픽 여유는 측정하지 않았다.