### PR TITLE
test(ci): api/ 스위트를 러너와 CI에 연결 — 5개월간 한 번도 안 돌았다

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,14 +1,22 @@
 name: Vitest JS regression
 
-# Runs the Vitest suite under tests/js/ whenever PR / main push touches the
-# scripts under test or the test files themselves. Keeps the gate scoped:
-# unrelated content edits (_posts/**, docs/**) skip CI to save runner time.
+# Runs the JS regression suites whenever PR / main push touches the scripts
+# under test or the test files themselves. Keeps the gate scoped: unrelated
+# content edits (_posts/**, docs/**) skip CI to save runner time.
+#
+# Two runners, deliberately:
+#   tests/js/**       -> Vitest (jsdom), with the coverage floor
+#   api/__tests__/**  -> node:test, which is what those files import
+# The api/ suite existed since March 2026 but was wired to NO runner and had
+# never executed in CI; api/** was also missing from the path filters below,
+# so an api/ change triggered nothing at all.
 
 on:
   pull_request:
     paths:
       - "tests/js/**"
       - "assets/js/**"
+      - "api/**"
       - "package.json"
       - "package-lock.json"
       - "vitest.config.js"
@@ -19,6 +27,7 @@ on:
     paths:
       - "tests/js/**"
       - "assets/js/**"
+      - "api/**"
       - "package.json"
       - "package-lock.json"
       - "vitest.config.js"
@@ -54,3 +63,6 @@ jobs:
 
       - name: Run Vitest with coverage gate
         run: npm run test:coverage
+
+      - name: Run api/ suite (node:test)
+        run: npm run test:api

--- a/api/__tests__/sanitize.test.js
+++ b/api/__tests__/sanitize.test.js
@@ -1,83 +1,19 @@
 /**
- * sanitizeInput 함수 단위 테스트
+ * sanitizeInput 단위 테스트
  *
- * 참고: sanitizeInput은 api/chat.js 내부 함수로 export되지 않아
- *       동일 로직을 이 파일에 복사했습니다.
- *       소스가 변경되면 이 함수도 동기화해야 합니다.
- *
- * Source mirrored from: api/chat.js (lines 586-658)
+ * api/chat.js 의 sanitizeInput 을 직접 import 한다.
+ * 예전에는 함수 본문을 이 파일에 손으로 복사해 두고 그 사본을 테스트했다.
+ * 사본은 원본과 조용히 어긋날 수 있어, 실제 sanitizer 가 망가져도 스위트는
+ * 초록으로 남는다 — 게이트로서 아무 것도 보장하지 못한다.
+ * (실제로 2026-08-18 시점에 사본과 원본이 이미 한 줄 어긋나 있었다. 의미는
+ *  같았지만, 다음 번에도 그러리라는 보장은 없다.)
  */
 
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
+import { sanitizeInput } from '../chat.js';
 
-// --- sanitizeInput 미러 (api/chat.js 와 동일 로직) ---
-function sanitizeInput(input) {
-  if (typeof input !== 'string') {
-    return '';
-  }
 
-  // null byte 제거
-  let sanitized = input.replace(/\0/g, '');
-
-  // 유니코드 정규화 (NFC)
-  sanitized = sanitized.normalize('NFC');
-
-  // 위험한 유니코드 조합 문자 제거
-  sanitized = sanitized.replace(/[\u200B-\u200D\uFEFF\u202A-\u202E\u2060-\u206F]/g, '');
-
-  // 유니코드 이스케이프 시퀀스 제거
-  sanitized = sanitized.replace(/\\u[0-9a-fA-F]{4}/g, '');
-  sanitized = sanitized.replace(/\\x[0-9a-fA-F]{2}/g, '');
-
-  // HTML 특수 문자 이스케이프
-  sanitized = sanitized
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;')
-    .replace(/\//g, '&#x2F;')
-    .replace(/`/g, '&#x60;');
-
-  // 중복 이스케이프 방지
-  sanitized = sanitized
-    .replace(/&amp;amp;/g, '&amp;')
-    .replace(/&amp;lt;/g, '&lt;')
-    .replace(/&amp;gt;/g, '&gt;')
-    .replace(/&amp;quot;/g, '&quot;')
-    .replace(/&amp;#x27;/g, '&#x27;')
-    .replace(/&amp;#x2F;/g, '&#x2F;')
-    .replace(/&amp;#x60;/g, '&#x60;');
-
-  // 제어 문자 제거
-  sanitized = sanitized.replace(/[\x00-\x1F\x7F-\x9F]/g, '');
-
-  // 위험한 패턴 제거
-  const dangerousPatterns = [
-    /javascript\s*:/gi,
-    /data\s*:\s*text\s*\/\s*html/gi,
-    /data\s*:\s*text\s*\/\s*javascript/gi,
-    /vbscript\s*:/gi,
-    /on\w+\s*=/gi,
-    /&lt;\s*script/gi,
-    /&lt;\s*iframe/gi,
-    /&lt;\s*object/gi,
-    /&lt;\s*embed/gi,
-    /&lt;\s*svg/gi,
-    /&lt;\s*math/gi,
-    /expression\s*\(/gi,
-    /url\s*\(/gi,
-    /import\s*\(/gi,
-  ];
-
-  for (const pattern of dangerousPatterns) {
-    sanitized = sanitized.replace(pattern, '');
-  }
-
-  return sanitized.trim();
-}
-// --- 미러 끝 ---
 
 describe('sanitizeInput - 기본 HTML 이스케이프', () => {
   test('<script> 태그를 엔티티로 변환한다', () => {

--- a/api/chat.js
+++ b/api/chat.js
@@ -694,7 +694,10 @@ export default async function handler(req, res) {
 // XSS 방지를 위한 입력 정제 함수 (강화)
 // 보안: 멀티바이트 문자, 유니코드 정규화, null byte, backtick, unicode escape 대응
 // 서버리스 환경 의존성 최소화를 위해 라이브러리 없이 구현
-function sanitizeInput(input) {
+// Exported so api/__tests__/sanitize.test.js can exercise THIS function.
+// It used to be tested against a hand-copied mirror of the body, which
+// meant the suite could stay green while the real sanitizer regressed.
+export function sanitizeInput(input) {
   if (typeof input !== 'string') {
     return '';
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "vitest run",
     "test:js": "vitest run",
+    "test:api": "node --test api/__tests__/*.test.js",
     "test:coverage": "vitest run --coverage",
     "vercel-build": "./build.sh",
     "index-posts": "node scripts/index_posts.mjs",

--- a/scripts/tests/test_ci_api_test_wiring_guard.py
+++ b/scripts/tests/test_ci_api_test_wiring_guard.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""CI regression guard: the api/ suite must stay wired to a runner and to CI.
+
+`api/__tests__/` has existed since March 2026 with 77 passing assertions covering
+the rate limiter, the log sanitizer and `sanitizeInput`. Until 2026-08-18 it had
+**never executed**, in CI or anywhere else, for two independent reasons:
+
+1. Those files `import { test } from 'node:test'`, but the only configured runner
+   was Vitest, whose `include` is `tests/js/**`. Adding `api/__tests__/**` to that
+   include would not have helped — Vitest cannot run `node:test` files. They needed
+   `node --test`, which nothing invoked.
+2. `vitest.yml` did not list `api/**` in either path filter, so a change under
+   `api/` triggered no JS gate at all.
+
+A suite that never runs is worse than no suite: it reads as coverage in the tree
+and reviewers count on it. This guard pins the wiring so it cannot be dropped
+back to decorative.
+
+It also pins that `sanitize.test.js` imports the real `sanitizeInput` from
+`api/chat.js`. That file used to hold a hand-copied mirror of the function body,
+which meant the assertions could stay green while the shipped sanitizer
+regressed — verified: mutating `api/chat.js` to stop escaping `<` fails a test
+today, and would have failed nothing before the import was wired.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "vitest.yml"
+PACKAGE_JSON = REPO_ROOT / "package.json"
+API_TESTS = REPO_ROOT / "api" / "__tests__"
+SANITIZE_TEST = API_TESTS / "sanitize.test.js"
+CHAT = REPO_ROOT / "api" / "chat.js"
+
+
+def _workflow() -> dict:
+    import yaml
+
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _scripts() -> dict:
+    return json.loads(PACKAGE_JSON.read_text(encoding="utf-8")).get("scripts", {})
+
+
+def _steps() -> list[dict]:
+    return _workflow()["jobs"]["vitest"]["steps"]
+
+
+def test_api_test_files_still_exist() -> None:
+    """If these are gone the rest of the guard is vacuous, so assert it first."""
+    found = sorted(p.name for p in API_TESTS.glob("*.test.js"))
+    assert found, f"no *.test.js under {API_TESTS}"
+
+
+def test_npm_exposes_a_runner_for_the_api_suite() -> None:
+    script = _scripts().get("test:api")
+    assert script, "package.json lost the `test:api` script; the api/ suite has no runner"
+    assert "node --test" in script, (
+        "`test:api` must invoke `node --test` — these files import from 'node:test' "
+        f"and Vitest cannot execute them. Got: {script!r}"
+    )
+    assert "api/__tests__" in script, f"`test:api` no longer targets api/__tests__: {script!r}"
+
+
+def test_ci_actually_runs_the_api_suite() -> None:
+    runs = [str(s.get("run", "")) for s in _steps()]
+    assert any("test:api" in r for r in runs), (
+        "vitest.yml no longer runs `npm run test:api`; the api/ suite is back to "
+        f"never executing. Steps: {runs}"
+    )
+
+
+def test_api_suite_step_is_not_soft() -> None:
+    """A step that cannot fail the job is the same as no step."""
+    for step in _steps():
+        if "test:api" in str(step.get("run", "")):
+            assert not step.get("continue-on-error"), (
+                "the api/ suite step is marked continue-on-error, so a failure "
+                "would not block the PR"
+            )
+            assert "|| true" not in str(step["run"]), (
+                "the api/ suite step swallows its exit code with `|| true`"
+            )
+            return
+    pytest.fail("no step running test:api found")
+
+
+@pytest.mark.parametrize("trigger", ["pull_request", "push"])
+def test_api_changes_trigger_the_workflow(trigger: str) -> None:
+    # PyYAML parses a bare `on:` key as the boolean True.
+    on = _workflow().get("on") or _workflow()[True]
+    paths = on[trigger]["paths"]
+    assert "api/**" in paths, (
+        f"`api/**` missing from the {trigger} path filter; a change under api/ "
+        f"would trigger no JS gate. Current: {paths}"
+    )
+
+
+def test_sanitize_test_exercises_the_real_function() -> None:
+    source = SANITIZE_TEST.read_text(encoding="utf-8")
+    assert "from '../chat.js'" in source, (
+        "sanitize.test.js no longer imports sanitizeInput from api/chat.js. If the "
+        "function body was copied back into the test, the suite tests a mirror and "
+        "can stay green while the shipped sanitizer regresses."
+    )
+    assert "function sanitizeInput(input)" not in source, (
+        "sanitize.test.js defines its own sanitizeInput again — that is the mirror "
+        "this guard exists to prevent."
+    )
+
+
+def test_chat_exports_sanitize_input() -> None:
+    assert "export function sanitizeInput(input)" in CHAT.read_text(encoding="utf-8"), (
+        "api/chat.js stopped exporting sanitizeInput, which breaks the import in "
+        "sanitize.test.js"
+    )


### PR DESCRIPTION
## 발견

`api/__tests__/` 는 2026-03부터 존재했고 **77건이 전부 통과**한다. 그런데 **한 번도 실행된 적이 없다.** 이유가 두 개 겹쳐 있었다.

1. 이 파일들은 `import { test } from 'node:test'` 를 쓰는데, 설정된 러너는 Vitest 뿐이었다. `vitest.config.js` 의 `include` 에 `api/__tests__/**` 를 추가해도 소용없다 — **Vitest 는 `node:test` 파일을 실행하지 못한다.** `node --test` 가 필요했고 아무도 호출하지 않았다.
2. `vitest.yml` 의 path 필터에 `api/**` 가 없어, `api/` 변경은 애초에 JS 게이트를 트리거하지 않았다.

안 도는 스위트는 없는 것보다 나쁘다. 트리에서는 커버리지로 읽히고 리뷰어가 그걸 믿는다.

## 변경

| 파일 | 변경 |
|---|---|
| `package.json` | `test:api` = `node --test api/__tests__/*.test.js` |
| `.github/workflows/vitest.yml` | `api/**` 를 양쪽 path 필터에 추가 + 실행 스텝 |
| `api/__tests__/sanitize.test.js` | 미러 제거, 실물 import |
| `api/chat.js` | `sanitizeInput` export |
| `scripts/tests/test_ci_api_test_wiring_guard.py` | 회귀 가드 (신규) |

두 러너를 의도적으로 병행한다 — `tests/js/**` 는 Vitest(+커버리지 하한), `api/__tests__/**` 는 `node:test`.

## 미러 문제가 더 컸다

`sanitize.test.js` 는 `api/chat.js` 의 `sanitizeInput` **본문을 손으로 복사해 두고 그 사본을 테스트**하고 있었다. 파일 상단에 "소스가 변경되면 이 함수도 동기화해야 합니다"라고 적혀 있었지만, 동기화를 강제하는 것은 아무것도 없었다.

**실제로 이미 어긋나 있었다** — 원본은 `sanitized = sanitized.trim(); return sanitized;`, 사본은 `return sanitized.trim();`. 이번엔 의미가 같아 무해했지만, 다음에도 그러리라는 보장은 없다.

사본을 테스트하는 게이트를 CI에 넣으면 헛돈다. 그래서 실물을 import 하도록 바꿨고, 그게 실제로 물리는지 확인했다:

```
# api/chat.js 의 < 이스케이프를 제거하면
node --test api/__tests__/sanitize.test.js  →  27 tests, 26 pass, 1 fail
# 되돌리면
                                            →  27 tests, 27 pass, 0 fail
```

사본 시절이었다면 이 회귀는 **아무 테스트도 잡지 못했다.**

## 검증

```
npm run test:api      # 77/77 (node:test)
npx vitest run        # 733/733
python3 -m pytest scripts/tests/ -q   # 4214 passed, 5 skipped
```

가드 mutation 검증 — 배선을 제거하면 정확히 해당 3건만 실패:
```
FAILED test_npm_exposes_a_runner_for_the_api_suite
FAILED test_ci_actually_runs_the_api_suite
FAILED test_api_suite_step_is_not_soft
3 failed, 5 passed
```

## 범위 밖

`api/lib/ratelimit.js` 와 `log-sanitizer.js` 는 이미 실물을 import 하고 있어 손대지 않았다. 워크플로/잡 이름은 유지했다 — 체크 이름이 바뀌면 branch protection 의 required check 설정이 깨질 수 있다.