### PR TITLE
deps(py): Pillow 메이저 업데이트 보류 — moviepy 2.x가 pillow<12를 요구

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -99,6 +99,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Pillow majors are held back by moviepy, not by preference.
+      #
+      # moviepy 2.2.1 (latest on 2026-08-18) declares
+      # `Requires-Dist: pillow<12.0,>=9.2.0`, and every 2.x release does the
+      # same — `pip install 'moviepy>=2.0' 'Pillow>=12.3.0'` is
+      # ResolutionImpossible. Allowing Pillow 12 here does not fail loudly:
+      # pip resolves moviepy DOWN to 1.0.3 instead, whose __init__.py exports
+      # only __version__. scripts/generate_post_images.py:100 does
+      # `from moviepy import AudioFileClip, ImageClip, concatenate_videoclips`
+      # (the 2.x top-level API), that import raises, and because it sits in a
+      # try/except the only symptom is video generation silently stopping with
+      # CI still green. PR #488 was exactly this.
+      #
+      # Remove this once moviepy ships a release allowing pillow>=12; re-check
+      # with `pip install --dry-run 'moviepy>=2.0' 'Pillow>=12.0'`.
+      - dependency-name: "Pillow"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## 왜

#488(Pillow 11→12)은 병합하면 영상 생성이 조용히 죽는다. 지난 리뷰에서 차단해 뒀지만, **dependabot이 매주 다시 만든다.** 보류를 설정으로 못박는다.

선호의 문제가 아니라 **해석 불가**다:

```
$ pip install --dry-run 'moviepy>=2.0' 'Pillow>=12.3.0,<13.0'
ERROR: Cannot install Pillow<13.0 and >=12.3.0, moviepy==2.0.0, moviepy==2.1.0,
moviepy==2.1.1, moviepy==2.1.2, moviepy==2.2.0 and moviepy==2.2.1 because these
package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

moviepy 2.2.1(최신) 메타데이터:
```
Requires-Dist: pillow<12.0,>=9.2.0
```

즉 **moviepy 하한을 올려도 해제되지 않는다.** 2.x 전 릴리스가 pillow 12를 배제한다.

## 조용히 깨지는 게 진짜 문제

Pillow 12를 허용하면 pip이 **실패하는 대신** moviepy를 1.0.3으로 내린다:

| 제약 | 해석 결과 |
|---|---|
| 현재 `Pillow<12.0` | pillow 11.3.0 + **moviepy 2.2.1** |
| Pillow 12 허용 | pillow 12.3.0 + **moviepy 1.0.3** |

`scripts/generate_post_images.py:100` 은 `from moviepy import AudioFileClip, ImageClip, concatenate_videoclips` (2.x top-level API)인데, moviepy 1.0.3의 `__init__.py` 는 sdist 확인 결과 `from .version import __version__` 한 줄이 전부다. import 가 실패하고, **try/except 안이라 증상은 "영상 생성이 조용히 멈춤" 뿐이며 CI는 green이다.**

## 변경

`/scripts` pip 엔트리에 ignore 추가:

```yaml
- dependency-name: "Pillow"
  update-types: ["version-update:semver-major"]
```

해제 조건과 재확인 명령을 주석에 남겼다. moviepy가 pillow>=12를 허용하는 릴리스를 내면 제거한다.

## 루트 엔트리는 건드리지 않았다

`requirements-visual.txt` 는 이미 `pillow>=12.2.0,<13.0.0` 을 쓴다. 이건 moviepy가 없는 **별개 환경**이고(`visual-baseline-*` 워크플로 전용, `scripts/requirements.txt` 와 같이 설치되는 워크플로 없음 — 확인함), 제약을 공유하지 않는다. 그래서 루트 pip 엔트리에는 ignore를 걸지 않아 그쪽 Pillow 업데이트는 계속 열려 있다.

## 후속

이 PR이 병합되면 #488은 닫아도 된다. 재생성되지 않는다.