### PR TITLE
deps(py): graphviz 마이너 업데이트 보류 — diagrams가 graphviz<0.21로 상한

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,6 +117,21 @@ updates:
       # with `pip install --dry-run 'moviepy>=2.0' 'Pillow>=12.0'`.
       - dependency-name: "Pillow"
         update-types: ["version-update:semver-major"]
+      # graphviz is capped by diagrams, not by preference.
+      #
+      # diagrams 0.25.1 (latest on 2026-08-18) declares
+      # `graphviz<0.21.0,>=0.13.2`, and NO diagrams release ever published
+      # allows graphviz>=0.21 — `pip install diagrams 'graphviz>=0.21'` is
+      # ResolutionImpossible across all 49 versions. Unlike the Pillow case
+      # this one fails loudly rather than silently downgrading, but merging it
+      # still breaks `pip install -r scripts/requirements.txt` outright.
+      # PR #562 was exactly this.
+      #
+      # graphviz is 0.x, so a 0.20 -> 0.21 bump is semver-minor.
+      # Remove this once diagrams relaxes the cap; re-check with
+      # `pip install --dry-run diagrams 'graphviz>=0.21'`.
+      - dependency-name: "graphviz"
+        update-types: ["version-update:semver-minor"]
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## 왜

#562(graphviz 0.20→0.21)는 병합하면 `pip install -r scripts/requirements.txt` 자체가 깨진다.

```
$ pip install --dry-run 'diagrams>=0.25.1' 'graphviz>=0.21'
ERROR: Cannot install diagrams==0.25.1 and graphviz>=0.21 because these
package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

`diagrams 0.25.1`(최신) 메타데이터:
```
Requires-Dist: graphviz<0.21.0,>=0.13.2
```

**diagrams 상한을 올려도 해제되지 않는다** — 지금까지 배포된 49개 버전 전부가 graphviz>=0.21을 배제한다:

```
$ pip install --dry-run 'diagrams' 'graphviz>=0.21'
ERROR: Cannot install diagrams==0.1.0 ... diagrams==0.25.1 and graphviz>=0.21
ERROR: ResolutionImpossible
```

## #488(Pillow)과의 차이

같은 "상위 패키지가 상한을 건다" 계열이지만 **실패 방식이 다르다.**

| | 실패 방식 |
|---|---|
| #488 Pillow | **조용히** moviepy를 1.0.3으로 강등 → import 실패 → 영상 생성만 멈춤, CI green |
| #562 graphviz | **큰 소리로** ResolutionImpossible → 설치 자체가 실패 |

후자가 덜 위험하지만, 어차피 병합할 수 없는 건 같다.

## 변경

`/scripts` pip 엔트리에 ignore 추가. graphviz는 0.x라 0.20→0.21은 semver-minor다.

```yaml
- dependency-name: "graphviz"
  update-types: ["version-update:semver-minor"]
```

해제 조건과 재확인 명령은 주석에 남겼다.

## 검증

```
python3 -m pytest scripts/tests/test_ci_dependabot_gate_guard.py -q   # 5 passed
```
`.github/dependabot.yml` 만 변경. 루트 pip 엔트리는 건드리지 않았다.

## 후속

병합되면 #562는 닫는다.