### PR TITLE
test(api): chat.js 검증 헬퍼 커버리지 — isBotUserAgent / validateUrl

### DIFF
--- a/api/__tests__/chat-validation.test.js
+++ b/api/__tests__/chat-validation.test.js
@@ -1,0 +1,168 @@
+/**
+ * api/chat.js 의 검증 헬퍼 단위 테스트 — isBotUserAgent / validateUrl
+ *
+ * 두 함수의 성격이 다르다는 점을 먼저 알아야 한다.
+ *
+ * - `isBotUserAgent` 는 살아 있다. `handler` 가 `NODE_ENV === 'production'`
+ *   일 때만 호출한다 (api/chat.js:98).
+ * - `validateUrl` 은 **현재 아무 곳에서도 호출되지 않는다.** 레포 전체에서
+ *   호출부가 0건이다. 여기 테스트를 두는 이유는 커버리지 숫자가 아니라,
+ *   나중에 누군가 이 함수를 배선할 때 "검증된 함수"라고 믿고 쓰기 전에
+ *   실제 동작 — 특히 아래 놀라운 항목들 — 을 먼저 보게 하려는 것이다.
+ *
+ * 여기 담긴 단언은 전부 실제 실행으로 확인한 현재 동작이며, "이래야 한다"는
+ * 당위가 아니다. 동작을 바꾸려면 테스트도 같이 바꿔야 하고, 그때가 바로
+ * 바꿔도 되는지 따져볼 지점이다.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { isBotUserAgent, validateUrl } from '../chat.js';
+
+describe('isBotUserAgent - 봇으로 판정하는 경우', () => {
+  test('User-Agent 가 없으면 봇으로 간주한다', () => {
+    assert.equal(isBotUserAgent(undefined), true);
+    assert.equal(isBotUserAgent(''), true);
+    assert.equal(isBotUserAgent(null), true);
+  });
+
+  test('UA 를 숨기지 않는 CLI 클라이언트는 잡힌다', () => {
+    for (const ua of ['curl/8.4.0', 'Wget/1.21', 'python-requests/2.31.0', 'Go-http-client/2.0']) {
+      assert.equal(isBotUserAgent(ua), true, `${ua} 는 봇으로 판정되어야 한다`);
+    }
+  });
+});
+
+describe('isBotUserAgent - 허용 목록이 봇 목록보다 먼저 평가된다', () => {
+  // 이것이 이 함수의 실질적 한계다. 브라우저 허용 패턴을 먼저 검사하고
+  // 하나라도 맞으면 즉시 false 를 반환하므로, UA 에 'mozilla' 가 들어 있는
+  // 순간 봇 패턴은 아예 검사되지 않는다.
+  test('실제 Googlebot UA 는 봇으로 판정되지 않는다', () => {
+    const googlebot =
+      'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+    assert.equal(isBotUserAgent(googlebot), false);
+  });
+
+  test('실제 bingbot UA 도 봇으로 판정되지 않는다', () => {
+    const bingbot =
+      'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)';
+    assert.equal(isBotUserAgent(bingbot), false);
+  });
+
+  test('UA 에 mozilla 만 붙이면 scraper 도 통과한다', () => {
+    // 즉 이 검사는 통제가 아니라 과속방지턱이다. UA 를 설정할 줄 아는
+    // 클라이언트는 누구나 우회한다. 실제 남용 방어는 rate limiting 이다.
+    assert.equal(isBotUserAgent('my-scraper/1.0'), true);
+    assert.equal(isBotUserAgent('Mozilla/5.0 my-scraper/1.0'), false);
+  });
+
+  test('평범한 브라우저는 통과한다', () => {
+    const chrome =
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' +
+      '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+    assert.equal(isBotUserAgent(chrome), false);
+  });
+});
+
+describe('validateUrl - 차단하는 것', () => {
+  test('빈 값과 공백만 있는 문자열', () => {
+    assert.equal(validateUrl(''), null);
+    assert.equal(validateUrl('   '), null);
+    assert.equal(validateUrl(undefined), null);
+    assert.equal(validateUrl(123), null);
+  });
+
+  test('위험한 스킴은 대소문자와 선행 공백을 섞어도 차단된다', () => {
+    for (const url of [
+      'javascript:alert(1)',
+      ' javascript:alert(1)',
+      'JaVaScRiPt:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+    ]) {
+      assert.equal(validateUrl(url), null, `${url} 은 차단되어야 한다`);
+    }
+  });
+
+  test('루프백 호스트는 정확히 일치할 때 차단된다', () => {
+    assert.equal(validateUrl('http://localhost/x'), null);
+    assert.equal(validateUrl('http://LOCALHOST/x'), null);
+    assert.equal(validateUrl('http://127.0.0.1/x'), null);
+    assert.equal(validateUrl('http://[::1]/x'), null);
+  });
+
+  test('프래그먼트의 이벤트 핸들러 패턴은 차단된다', () => {
+    // 프래그먼트는 URL 파서가 인코딩하지 않으므로 패턴 검사에 걸린다.
+    assert.equal(validateUrl('http://example.com/#onerror=1'), null);
+  });
+});
+
+describe('validateUrl - 통과시키는 것', () => {
+  test('평범한 절대 URL', () => {
+    assert.equal(
+      validateUrl('https://tech.2twodragon.com/posts/x/'),
+      'https://tech.2twodragon.com/posts/x/'
+    );
+    assert.equal(validateUrl('http://example.com'), 'http://example.com/');
+  });
+
+  test('상대 경로는 사이트 도메인 기준 절대 경로가 된다', () => {
+    assert.equal(
+      validateUrl('/posts/relative/'),
+      'https://tech.2twodragon.com/posts/relative/'
+    );
+  });
+
+  test('스킴 대문자는 정규화된다', () => {
+    assert.equal(validateUrl('HTTPS://EXAMPLE.COM'), 'https://example.com/');
+  });
+});
+
+describe('validateUrl - 배선 전에 반드시 알아야 할 동작', () => {
+  // 아래 넷은 "통과시키는 것" 과 달리, 호출부가 무엇을 기대하느냐에 따라
+  // 취약점이 될 수 있는 것들이다. 지금은 호출부가 없어 무해하다.
+
+  test('프로토콜 상대 URL 은 외부 사이트로 나간다', () => {
+    // `//evil.com` 은 상대 경로처럼 생겼지만 '://' 가 없어 상대 경로 분기를
+    // 타고, URL 생성자가 이를 프로토콜 상대 URL 로 해석해 외부 절대 주소가
+    // 된다. 입력이 상대 경로면 사이트 안에 머문다고 가정하는 호출부에서는
+    // 오픈 리다이렉트가 된다.
+    assert.equal(validateUrl('//evil.com'), 'https://evil.com/');
+  });
+
+  test('클라우드 메타데이터 주소가 통과한다', () => {
+    // 루프백만 막고 링크로컬/사설 대역은 막지 않는다. 이 함수를 서버측
+    // fetch 앞에 두면 SSRF 가 된다. 렌더링용 링크 검증이라면 무해하다.
+    assert.equal(
+      validateUrl('http://169.254.169.254/latest/meta-data/'),
+      'http://169.254.169.254/latest/meta-data/'
+    );
+    assert.equal(validateUrl('http://10.0.0.1/'), 'http://10.0.0.1/');
+  });
+
+  test('URL 에 박힌 자격증명이 보존된다', () => {
+    assert.equal(
+      validateUrl('http://user:pass@example.com/'),
+      'http://user:pass@example.com/'
+    );
+  });
+
+  test('쿼리스트링의 위험 패턴은 인코딩되어 검사를 비껴간다', () => {
+    // 패턴 검사는 urlObj.search 를 보는데, URL 생성자가 이미 `<` `>` 를
+    // 퍼센트 인코딩한 뒤라 `/<script/i` 가 맞지 않는다. 결과적으로 값이
+    // 무해해지긴 하나, 차단이 아니라 통과다.
+    assert.equal(
+      validateUrl('http://example.com/?q=<script>'),
+      'http://example.com/?q=%3Cscript%3E'
+    );
+  });
+
+  test('정확히 일치하지 않는 호스트는 통과한다 (의도된 동작)', () => {
+    // 부분 문자열 검사였다면 정상 도메인을 오차단했을 것이다.
+    assert.equal(
+      validateUrl('http://localhost.evil.com/x'),
+      'http://localhost.evil.com/x'
+    );
+  });
+});

--- a/api/chat.js
+++ b/api/chat.js
@@ -55,7 +55,8 @@ function generateRequestId() {
 }
 
 // Bot 보호: User-Agent 검증
-function isBotUserAgent(userAgent) {
+// Exported for api/__tests__/chat-validation.test.js.
+export function isBotUserAgent(userAgent) {
   if (!userAgent) return true; // User-Agent가 없으면 봇으로 간주
   
   const botPatterns = [
@@ -772,7 +773,8 @@ export function sanitizeInput(input) {
 }
 
 // URL 검증 함수 (보안 강화)
-function validateUrl(url) {
+// Exported for api/__tests__/chat-validation.test.js.
+export function validateUrl(url) {
   if (typeof url !== 'string' || !url.trim()) {
     return null;
   }


### PR DESCRIPTION
#559로 `api/` 스위트가 실제로 실행되게 됐으니, 검증 로직을 덮는다. 테스트를 쓰는 과정에서 두 가지가 드러났다. **동작은 바꾸지 않고 못박기만 했다** — 보안 동작 변경은 별도 판단이 필요하다.

## 1. `isBotUserAgent` 는 사실상 과속방지턱이다

허용 목록(브라우저 패턴)을 봇 목록보다 **먼저** 평가하고, 하나라도 맞으면 즉시 `false` 를 반환한다. UA 에 `mozilla` 가 들어가는 순간 봇 패턴은 검사조차 되지 않는다.

실행 결과:

| User-Agent | 판정 |
|---|---|
| `curl/8.4.0` | 봇 ✓ |
| `python-requests/2.31.0` | 봇 ✓ |
| (빈 값 / 없음) | 봇 ✓ |
| `Mozilla/5.0 (compatible; Googlebot/2.1; ...)` | **봇 아님** |
| `Mozilla/5.0 (compatible; bingbot/2.0; ...)` | **봇 아님** |
| `my-scraper/1.0` | 봇 ✓ |
| `Mozilla/5.0 my-scraper/1.0` | **봇 아님** |

즉 UA 를 설정할 줄 아는 클라이언트는 전부 우회한다. 실제 남용 방어는 rate limiting 쪽이고, 이 검사는 UA 를 숨기지 않는 클라이언트만 걸러낸다.

호출부는 `api/chat.js:98` 하나뿐이고 `NODE_ENV === 'production'` 게이트가 걸려 있다.

**바꾸지 않은 이유**: 순서를 뒤집으면 동작이 바뀐다(예: Googlebot 이 차단된다). 그 자체는 바람직할 수 있지만 커버리지 작업에서 조용히 끼워 넣을 변경은 아니다. 현재 동작을 명시적으로 고정해 두었으니, 바꾸려면 이 테스트가 먼저 반대할 것이다.

## 2. `validateUrl` 은 죽은 코드다

```
$ grep -rn "validateUrl" --include="*.js" . | grep -v node_modules
api/chat.js:777:export function validateUrl(url) {
```

정의 한 줄이 전부다. **레포 전체에서 호출부가 0건**이고, git 히스토리상 호출된 적도 없다.

삭제는 요청 범위 밖이라 두었다. 대신 나중에 누군가 이걸 배선할 때 "이미 검증된 함수"로 오인하지 않도록 실제 동작을 테스트로 고정했다. 배선 전에 알아야 할 것들:

| 입력 | 결과 |
|---|---|
| `//evil.com` | **`https://evil.com/`** — 상대 경로처럼 생겼지만 외부 절대 주소가 된다 |
| `http://169.254.169.254/latest/meta-data/` | **통과** — 루프백만 막고 링크로컬/사설 대역은 막지 않는다 |
| `http://10.0.0.1/` | **통과** |
| `http://user:pass@example.com/` | **통과** — 자격증명 보존 |
| `http://example.com/?q=<script>` | **통과** (`%3Cscript%3E` 로 인코딩됨) |

서버측 fetch 앞에 두면 SSRF 가 되고, 렌더링용 링크 검증이라면 무해하다. **어느 쪽인지는 배선하는 사람이 정해야 한다.**

차단은 제대로 하는 것들: `javascript:` / `data:` / `vbscript:` / `file:` (대소문자·선행공백 변형 포함), 루프백 4종, 프래그먼트의 `on*=` 패턴.

## 검증

```
npm run test:api    # 95/95  (기존 77 + 신규 18)
npx vitest run      # 733/733
pytest scripts/tests/test_ci_api_test_wiring_guard.py -q   # 8 passed
```

mutation 검증 — 루프백 차단(`dangerousHosts = []`)과 빈 UA 판정(`return false`)을 각각 무력화하면 **정확히 해당 2건만** 실패:
```
# tests 18 / pass 16 / fail 2   (무력화 시)
# tests 18 / pass 18 / fail 0   (원복 후)
```

## 변경

- `api/chat.js`: `isBotUserAgent`, `validateUrl` export (로직 변경 없음)
- `api/__tests__/chat-validation.test.js`: 신규 18건

단언은 전부 실행으로 확인한 **현재 동작**이며 "이래야 한다"는 당위가 아니다. 동작을 바꾸려면 테스트도 같이 바꿔야 하고, 그때가 바꿔도 되는지 따질 지점이다.