### PR TITLE
deps(py): Pillow 메이저 보류를 루트 엔트리에도 — #560의 구멍 메움

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -157,6 +157,24 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Same moviepy constraint as the /scripts entry above — repeated here
+      # because the ignore list is per-update-entry, not per-file, and this
+      # root entry reaches scripts/requirements.txt too.
+      #
+      # PR #560 added the ignore only to /scripts. Dependabot then re-proposed
+      # the identical `Pillow>=11.3.0,<12.0` -> `>=12.3.0,<13.0` edit to
+      # scripts/requirements.txt from THIS entry (PR #572), walking straight
+      # around it. Guarding one entry guards one entry.
+      #
+      # Cost of the blunt instrument: requirements-visual.txt (pillow 12, no
+      # moviepy) and requirements-blogwatcher.txt (Pillow>=10.0, no moviepy)
+      # also stop receiving major bumps. Both are floors with no ceiling
+      # conflict, so pip still installs current Pillow for those workflows —
+      # only the declared floor goes stale. If that ever matters, split the
+      # root entry per-file rather than dropping this.
+      - dependency-name: "Pillow"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## #560이 불완전했습니다

#560은 `/scripts` pip 엔트리에만 Pillow 메이저 ignore를 걸었습니다. dependabot은 곧바로 **루트 pip 엔트리에서 같은 파일에 동일한 편집을 다시 제안**했습니다 — #572:

```diff
--- a/scripts/requirements.txt
-Pillow>=11.3.0,<12.0  # moviepy 2.x requires pillow<12.0; ceiling prevents transitive break
+Pillow>=12.3.0,<13.0  # moviepy 2.x requires pillow<12.0; ceiling prevents transitive break
```

#488과 **글자 그대로 같은 변경**이고, 경고하는 주석까지 그대로 둔 채입니다. `ignore` 는 파일이 아니라 update 엔트리 단위라, 한 엔트리를 막으면 한 엔트리만 막힙니다.

`dependabot.yml` 상단 주석은 `scripts/requirements.txt` 를 `/scripts` 엔트리에 배정한다고 적어두었지만, 실제로는 루트 엔트리도 그 파일에 닿습니다.

## 변경

루트 `/` pip 엔트리에도 동일한 ignore 추가.

## 대가 (숨기지 않음)

`Pillow` 를 쓰는 다른 두 파일도 메이저 업데이트를 못 받게 됩니다:

| 파일 | 현재 | moviepy | 영향 |
|---|---|---|---|
| `requirements-visual.txt` | `pillow>=12.2.0,<13.0.0` | 없음 | 12→13 때 막힘 |
| `requirements-blogwatcher.txt` | `Pillow>=10.0` | 없음 | 10→12 floor 상향 막힘 |

둘 다 **상한 충돌이 없는 floor** 라, pip 은 해당 워크플로에서 여전히 최신 Pillow 를 설치합니다. 낡는 것은 선언된 floor 뿐입니다. 그게 실제로 문제가 되면 ignore 를 빼는 게 아니라 **루트 엔트리를 파일별로 쪼개야** 합니다 — 주석에 그렇게 적어뒀습니다.

참고: `requirements-visual.txt` 의 `12.2.0 → 12.3.0` 같은 패치/마이너 bump 는 `semver-major` ignore 에 걸리지 않으므로 계속 받습니다.

## 검증

```
python3 -m pytest scripts/tests/test_ci_dependabot_gate_guard.py -q   # 5 passed
```

`.github/dependabot.yml` 만 변경.

## 후속

병합 후 #572 는 닫습니다. #571(graphviz 0.20.0→**0.20.3**, 패치)은 정상 통과해야 하고 실제로 통과했습니다 — `semver-minor` ignore 가 0.21 만 막고 0.20.3 은 허용하는 것이 의도대로 동작한 증거입니다.