### PR TITLE
test(ci): pytest 의존성 skip 4건 해소 — Pillow / fonttools[woff] 선언

### DIFF
--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -5,3 +5,20 @@ pytest-cov>=7.1.0
 requests>=2.28.0
 beautifulsoup4>=4.12.0
 qrcode>=8.2
+
+# Pillow — without it TestGenerateAndCommitRasterVariants `importorskip("PIL")`-skips,
+# so the two tests written to reproduce the 2026-05-27/28 blogwatcher bug (Pillow
+# absent on the cron runner, raster variants therefore never emitted) had never once
+# executed in CI. `_generate_and_commit_raster_variants` encodes _og/_card .avif and
+# .webp, and AVIF is why the floor is 11.3.0: that is the release where Pillow gained
+# native AVIF encoding (verified `features.check("avif") is True` at exactly 11.3.0).
+# No <12 ceiling here — the ceiling in scripts/requirements.txt exists for moviepy,
+# which this file does not install.
+Pillow>=11.3.0
+
+# fonttools[woff] — test_font_tier_split opens the shipped tier-1/tier-2 .woff2 with
+# fontTools.ttLib to assert their cmaps match the declared unicode-range split. woff2
+# decompression needs brotli, and only the [woff] extra pulls it in: plain `fonttools`
+# imports fine and then cannot open the files, so the extra is the load-bearing part
+# of this line, not the version.
+fonttools[woff]>=4.55.0

--- a/scripts/tests/test_ci_pytest_deps_guard.py
+++ b/scripts/tests/test_ci_pytest_deps_guard.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""CI regression guard: the deps that stop 4 tests from skipping must stay declared.
+
+Until 2026-08-18 `scripts/requirements-ci.txt` installed neither Pillow nor
+fontTools, so the CI pytest run reported `4204 passed, 7 skipped` and four of
+those seven skips were dependency-caused:
+
+    test_auto_publish_news.py::TestGenerateAndCommitRasterVariants
+      ::test_all_five_rasters_emitted_from_og_png          importorskip("PIL")
+      ::test_idempotent_skips_existing_variants            importorskip("PIL")
+    test_font_tier_split.py
+      ::test_woff2_cmaps_match_the_declared_split[400]     importorskip("fontTools")
+      ::test_woff2_cmaps_match_the_declared_split[700]     importorskip("fontTools")
+
+`importorskip` fails open, which is the trap: the two raster tests were written
+to reproduce the 2026-05-27/28 blogwatcher bug where Pillow was missing on the
+cron runner and raster variants were therefore never emitted — and they skipped
+for that same missing dependency, so the regression they exist to catch was
+never actually gated. Dropping either line from requirements-ci.txt would
+restore that silence without turning a single check red.
+
+This guard is static on purpose: it pins the declaration, not the import. A test
+that merely imported PIL would itself pass in any environment that happens to
+have Pillow (every developer laptop here does), which is precisely the blind
+spot being closed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REQUIREMENTS = REPO_ROOT / "scripts" / "requirements-ci.txt"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "jekyll.yml"
+RASTER_TEST = REPO_ROOT / "scripts" / "tests" / "test_auto_publish_news.py"
+FONT_TEST = REPO_ROOT / "scripts" / "tests" / "test_font_tier_split.py"
+
+
+def _requirement_lines() -> list[str]:
+    text = REQUIREMENTS.read_text(encoding="utf-8")
+    return [
+        line.strip()
+        for line in text.splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _find(prefix: str) -> str:
+    """Return the single requirement line whose distribution name matches `prefix`."""
+    matches = [
+        line
+        for line in _requirement_lines()
+        if re.match(rf"^{re.escape(prefix)}\b", line, re.IGNORECASE)
+    ]
+    assert len(matches) == 1, (
+        f"expected exactly one {prefix} requirement in {REQUIREMENTS.name}, "
+        f"found {matches!r}"
+    )
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: assert the skipping tests still exist before pinning their deps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "needle"),
+    [
+        (RASTER_TEST, 'importorskip("PIL"'),
+        (FONT_TEST, 'importorskip("fontTools"'),
+    ],
+    ids=["raster-pil", "font-fonttools"],
+)
+def test_guarded_tests_still_use_importorskip(path: Path, needle: str) -> None:
+    """If the importorskip calls are gone this guard has nothing left to protect.
+
+    Removing them is a legitimate change — it makes the dependency hard —
+    but then this file should be deleted in the same commit rather than left
+    asserting a requirement nothing consumes.
+    """
+    assert needle in path.read_text(encoding="utf-8"), (
+        f"{path.name} no longer contains {needle!r}; if the skip guard was "
+        f"intentionally removed, delete {Path(__file__).name} too"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The declarations themselves
+# ---------------------------------------------------------------------------
+
+
+def test_pillow_is_declared_with_an_avif_capable_floor() -> None:
+    """AVIF encoding landed in Pillow 11.3.0; a lower floor cannot run the tests.
+
+    `_generate_and_commit_raster_variants` writes _og.avif and _card.avif, so a
+    Pillow that imports but reports `features.check("avif") is False` fails the
+    raster tests rather than skipping them. 11.3.0 was verified as the floor
+    where that check returns True.
+    """
+    line = _find("Pillow")
+    match = re.search(r">=\s*(\d+)\.(\d+)", line)
+    assert match, f"Pillow requirement {line!r} declares no >= floor"
+    major, minor = int(match.group(1)), int(match.group(2))
+    assert (major, minor) >= (11, 3), (
+        f"Pillow floor {major}.{minor} predates native AVIF encoding (11.3.0); "
+        f"the raster variant tests would fail rather than skip"
+    )
+
+
+def test_fonttools_is_declared_with_the_woff_extra() -> None:
+    """The `[woff]` extra is the load-bearing part — it is what pulls in brotli.
+
+    Plain `fonttools` installs and imports cleanly, so `importorskip("fontTools")`
+    passes, and then `TTFont(woff2)` raises because woff2 decompression has no
+    brotli. Dropping the extra would convert 2 skips into 2 failures, which is
+    at least loud; dropping the whole line restores the silent skip.
+    """
+    line = _find("fonttools")
+    assert "[woff]" in line.lower(), (
+        f"fonttools requirement {line!r} is missing the [woff] extra; "
+        f"without brotli, fontTools cannot open the shipped .woff2 files"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the file has to actually reach the pytest run
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_job_installs_requirements_ci() -> None:
+    """requirements-ci.txt is only load-bearing if the job running pytest installs it."""
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = workflow["jobs"]["build"]["steps"]
+    run_blocks = [step.get("run", "") for step in steps]
+
+    installs = [r for r in run_blocks if "requirements-ci.txt" in r]
+    assert installs, (
+        f"{WORKFLOW.name} build job no longer installs scripts/requirements-ci.txt; "
+        f"the pytest run would fall back to whatever the runner image ships"
+    )
+
+    pytest_runs = [r for r in run_blocks if "pytest scripts/tests" in r]
+    assert pytest_runs, (
+        f"{WORKFLOW.name} build job no longer runs `pytest scripts/tests/`; "
+        f"this guard's premise is gone"
+    )
+
+    assert run_blocks.index(installs[0]) < run_blocks.index(pytest_runs[0]), (
+        "requirements-ci.txt is installed after pytest runs, so the deps are "
+        "not present when the tests decide whether to skip"
+    )


### PR DESCRIPTION
## 무엇이 문제였나

CI의 pytest 요약은 `4204 passed, 7 skipped`였다. 7건 중 **4건은 의존성 부재로 인한 skip**이다 ([PR #558 build job 로그](https://github.com/Twodragon0/tech-blog/actions/runs/32094949227/job/95584418731) 실측):

```
test_auto_publish_news.py::TestGenerateAndCommitRasterVariants
  ::test_all_five_rasters_emitted_from_og_png          importorskip("PIL")
  ::test_idempotent_skips_existing_variants            importorskip("PIL")
test_font_tier_split.py
  ::test_woff2_cmaps_match_the_declared_split[400]     importorskip("fontTools")
  ::test_woff2_cmaps_match_the_declared_split[700]     importorskip("fontTools")
```

앞의 두 건이 특히 나쁘다. 이 테스트들은 **2026-05-27/28 blogwatcher 버그**(크론 러너에 Pillow가 없어 raster variant가 전혀 생성되지 않은 사건)를 재현하려고 쓰였는데, 정확히 그 없는 의존성 때문에 skip되어 왔다. `importorskip`은 fail-open이라 잡으려던 회귀를 **한 번도 게이팅한 적이 없다.**

나머지 3건(`test_post_image_class_hooks.py::TestCompiledCss`)은 의존성이 아니라 `_site/assets/css/post-page.css`가 pytest 시점에 아직 빌드되지 않아서 skip된다 — 이 PR 범위 밖이며 그대로 남는다.

## 무엇을

| 줄 | 이유 |
|---|---|
| `Pillow>=11.3.0` | `_generate_and_commit_raster_variants`가 `_og/_card .avif`를 쓴다. **11.3.0이 native AVIF 인코딩이 들어온 릴리스** — 플로어에서 `features.check("avif") is True` 실측 확인. moviepy가 없는 파일이라 `scripts/requirements.txt`의 `<12` 상한은 불필요 |
| `fonttools[woff]>=4.55.0` | woff2 해제에 brotli가 필요하고 **`[woff]` extra만** 이를 끌어온다. plain `fonttools`는 import가 되어 `importorskip`을 통과한 뒤 `TTFont(woff2)`에서 깨진다 — extra가 이 줄의 핵심이고 버전이 아니다 |

부수 효과: `svg-lint.yml`도 같은 파일을 설치하므로 `build.sh`의 favicon/raster 경로가 Pillow를 확보한다.

## 재발 방지 게이트

`scripts/tests/test_ci_pytest_deps_guard.py` (5건). 정적 선언을 고정한다 — import를 확인하는 테스트는 Pillow가 있는 모든 개발 머신에서 통과하므로 정확히 이 사각지대를 못 막는다.

**변이 테스트로 비어 있지 않음을 확인:**

| 변이 | 결과 |
|---|---|
| `Pillow>=` 줄 삭제 | ❌ FAILED `test_pillow_is_declared_with_an_avif_capable_floor` |
| `fonttools[woff]` → `fonttools` | ❌ FAILED `test_fonttools_is_declared_with_the_woff_extra` |
| 플로어 `11.3.0` → `10.0` | ❌ FAILED `test_pillow_is_declared_with_an_avif_capable_floor` |

`importorskip` 호출이 사라지면 게이트가 무의미해지므로, 그 경우 이 파일도 같이 지우라고 실패 메시지로 지시한다(non-vacuity 선행 검사).

## 검증

클린 venv에 `scripts/requirements-ci.txt`만 설치 (CI와 동일):

```
$ python3 -m venv /tmp/ci-final
$ /tmp/ci-final/bin/pip install -r scripts/requirements-ci.txt
  pillow 12.3.0 / fonttools 4.63.0 / brotli 1.2.0

$ /tmp/ci-final/bin/python -m pytest scripts/tests/ -q -rs
  4219 passed, 5 skipped        ← 의존성 skip 4건 소멸
```

플로어 실측(`Pillow==11.3.0` + `fonttools[woff]==4.55.0`)에서도 대상 4건 포함 22 passed / 0 skipped.

남은 로컬 5 skip은 전부 `test_image_content_hash.py`의 jekyll 빌드 실패(mise가 rbenv를 가리는 로컬 환경 문제)이며 CI에서는 실행된다 — CI skip 목록에 없었다.