### PR TITLE
fix(ci): 컴파일된 CSS 게이트를 빌드 뒤로 — skip 3건 해소, fail-closed 전환

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -396,6 +396,22 @@ jobs:
           BUILD_TIME: ${{ github.event.head_commit.timestamp }}
           DEPLOYMENT_URL: ${{ github.event.repository.html_url }}
 
+      # The `Run script unit tests` step above runs before build.sh, so _site/
+      # does not exist yet and TestCompiledCss skips there. It is re-run here,
+      # after the build, with REQUIRE_COMPILED_CSS=1 — which turns "artifact
+      # missing" from a skip into a failure. Without this step those three
+      # assertions never execute in CI at all, which was the case from the day
+      # the file was written until 2026-08-18.
+      # Pinned by scripts/tests/test_ci_compiled_css_gate_guard.py.
+      - name: Compiled CSS class-hook gate (post-build)
+        env:
+          REQUIRE_COMPILED_CSS: '1'
+        run: |
+          echo "🎨 Enforcing compiled-CSS class hooks against _site/..."
+          python3 -m pytest scripts/tests/test_post_image_class_hooks.py::TestCompiledCss \
+            -v --tb=short -p no:cacheprovider
+          echo "✅ Compiled CSS class-hook gate passed"
+
       # NOTE: no upload-pages-artifact / deploy job here on purpose.
       # deploy-pages.yml is the single Pages deployer (see header). This
       # workflow only proves the site builds + tests pass.

--- a/scripts/tests/test_ci_compiled_css_gate_guard.py
+++ b/scripts/tests/test_ci_compiled_css_gate_guard.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""CI regression guard: the compiled-CSS class-hook gate must run after the build.
+
+`TestCompiledCss` in test_post_image_class_hooks.py asserts that the *compiled*
+`_site/assets/css/post-page.css` carries the `.is-section-image` / `.is-svg-image`
+class hooks and no longer carries the legacy `img[src*=…]` attribute selectors.
+Section 1 of that file greps `_sass/_post.scss` for the same thing, but a source
+grep only clears the one partial it reads — the compiled check is what covers
+every stylesheet that actually lands in post-page.css.
+
+Until 2026-08-18 it covered nothing. `jekyll.yml` runs `pytest` near the top of
+the build job and `build.sh` as its last step, so `_site/` did not exist when
+those three tests were collected and they skipped on every run — visible in the
+CI summary as `4204 passed, 7 skipped`, three of which were these.
+
+The fix has two halves and this guard pins both:
+
+1. a post-build pytest step that re-runs `TestCompiledCss`, placed *after* the
+   build.sh step (order is the whole point — before it, the artifact is absent);
+2. `REQUIRE_COMPILED_CSS=1` on that step, which makes a missing artifact fail
+   instead of skip. Without the env var the step would "pass" by skipping all
+   three tests, which is exactly the silence being fixed.
+
+Drop either half and the gate is decorative again with nothing turning red.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "jekyll.yml"
+HOOKS_TEST = REPO_ROOT / "scripts" / "tests" / "test_post_image_class_hooks.py"
+
+BUILD_STEP_MARKER = "build.sh"
+GATE_MARKER = "test_post_image_class_hooks.py::TestCompiledCss"
+ENV_VAR = "REQUIRE_COMPILED_CSS"
+
+
+def _build_job_steps() -> list[dict]:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["build"]["steps"]
+
+
+def _index_of(predicate) -> int:
+    for i, step in enumerate(_build_job_steps()):
+        if predicate(step):
+            return i
+    return -1
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the tests being gated have to still exist
+# ---------------------------------------------------------------------------
+
+
+def test_compiled_css_tests_still_exist() -> None:
+    """If TestCompiledCss is gone this guard protects nothing — delete it too."""
+    source = HOOKS_TEST.read_text(encoding="utf-8")
+    assert "class TestCompiledCss:" in source, (
+        f"{HOOKS_TEST.name} no longer defines TestCompiledCss; if it was removed "
+        f"on purpose, delete {Path(__file__).name} and the workflow step with it"
+    )
+
+
+def test_missing_artifact_fails_when_the_gate_is_armed() -> None:
+    """The fail-closed branch is what distinguishes this from the old skipif.
+
+    A step that runs the tests but lets them skip is indistinguishable from no
+    step at all in the CI summary, so the `pytest.fail` branch is load-bearing.
+    """
+    source = HOOKS_TEST.read_text(encoding="utf-8")
+    assert f'os.environ.get("{ENV_VAR}")' in source, (
+        f"{HOOKS_TEST.name} no longer reads {ENV_VAR}; the gate would skip "
+        f"silently when _site/ is absent"
+    )
+    assert "pytest.fail(" in source, (
+        f"{HOOKS_TEST.name} no longer fails on a missing artifact; a skip here "
+        f"reads as success in the CI summary"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The workflow wiring
+# ---------------------------------------------------------------------------
+
+
+def test_gate_step_exists_and_is_armed() -> None:
+    idx = _index_of(lambda s: GATE_MARKER in s.get("run", ""))
+    assert idx >= 0, (
+        f"{WORKFLOW.name} build job has no step running {GATE_MARKER}; the "
+        f"compiled-CSS assertions would only ever be collected by the pre-build "
+        f"pytest step, where they skip"
+    )
+
+    step = _build_job_steps()[idx]
+    env = step.get("env") or {}
+    assert str(env.get(ENV_VAR)) == "1", (
+        f"the compiled-CSS gate step does not set {ENV_VAR}=1 (env={env!r}); "
+        f"without it a missing _site/ skips all three tests and the step passes"
+    )
+
+
+def test_gate_step_runs_after_the_build() -> None:
+    """Order is the entire fix — before build.sh the artifact does not exist."""
+    build_idx = _index_of(lambda s: BUILD_STEP_MARKER in s.get("run", ""))
+    gate_idx = _index_of(lambda s: GATE_MARKER in s.get("run", ""))
+
+    assert build_idx >= 0, f"{WORKFLOW.name} build job no longer runs build.sh"
+    assert gate_idx >= 0, f"{WORKFLOW.name} build job no longer runs the gate"
+    assert build_idx < gate_idx, (
+        f"the compiled-CSS gate (step {gate_idx}) runs before build.sh "
+        f"(step {build_idx}); _site/assets/css/post-page.css is not written yet, "
+        f"so with {ENV_VAR}=1 every run fails and without it every run skips"
+    )

--- a/scripts/tests/test_post_image_class_hooks.py
+++ b/scripts/tests/test_post_image_class_hooks.py
@@ -12,13 +12,28 @@ These tests verify:
 5. (Optional) A built post HTML page contains at least one ``<img>``
    tag emitted by the plugin with a class hook, if the site is built.
 
-The tests do NOT require a Jekyll build — they work on source files so
-CI stays fast.  The build-dependent test (``test_built_page_has_class_hook``)
-is skipped when ``_site/assets/css/main.css`` is absent.
+Sections 1-4 do NOT require a Jekyll build — they work on source files so
+CI stays fast.
+
+Section 5 (``TestCompiledCss``) does require the build, and that is where this
+file used to go quiet.  ``jekyll.yml`` runs ``pytest`` as one of its first
+steps and ``build.sh`` as its *last*, so ``_site/`` never existed when these
+three assertions were collected and they skipped on **every** CI run since the
+file was written.  A source-level grep of ``_sass/_post.scss`` (section 1) only
+proves that one partial is clean; the compiled check is what covers every
+stylesheet that actually lands in ``post-page.css``.
+
+The fix is a second, post-build ``pytest`` invocation that sets
+``REQUIRE_COMPILED_CSS=1``.  Under that flag a missing artifact is a **failure,
+not a skip**, so removing the build step (or the gate step) turns CI red
+instead of silently disarming the check — the same failure mode that let the
+Pillow-guarded raster tests sit un-run for months (PR #576).
+``scripts/tests/test_ci_compiled_css_gate_guard.py`` pins the wiring.
 """
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -126,25 +141,44 @@ class TestMarkdownImageLazyPlugin:
 
 ATTR_REGEX_PATTERN = re.compile(r"img\[src[\*\$\^]=")
 
+# Set by the post-build gate step in .github/workflows/jekyll.yml. Locally the
+# artifact is usually present from an earlier `bundle exec jekyll build`, and a
+# developer who has never built the site should get a skip rather than a
+# confusing failure — hence opt-in rather than a bare `CI` check.
+REQUIRE_COMPILED_CSS = os.environ.get("REQUIRE_COMPILED_CSS") == "1"
 
-@pytest.mark.skipif(not POST_CSS.exists(), reason="_site/assets/css/post-page.css not built")
+
+def _compiled_css() -> str:
+    """Read post-page.css, failing instead of skipping when the gate is armed."""
+    if not POST_CSS.exists():
+        rel = POST_CSS.relative_to(REPO_ROOT)
+        if REQUIRE_COMPILED_CSS:
+            pytest.fail(
+                f"REQUIRE_COMPILED_CSS=1 but {rel} is missing. This gate must run "
+                f"after build.sh; if the build step moved or was removed, these "
+                f"assertions are not being enforced."
+            )
+        pytest.skip(f"{rel} not built — run build.sh first")
+    return POST_CSS.read_text(encoding="utf-8")
+
+
 class TestCompiledCss:
     """_post.scss compiles into post-page.css — check that file."""
 
     def test_no_src_section_attr_selector_in_compiled_css(self):
-        css = POST_CSS.read_text(encoding="utf-8")
+        css = _compiled_css()
         # After the refactor the compiled CSS must not contain img[src*=section-]
         assert 'img[src*="section-"]' not in css, (
             "Legacy attribute selector img[src*=section-] found in compiled CSS"
         )
 
     def test_no_src_svg_attr_selector_in_compiled_css(self):
-        css = POST_CSS.read_text(encoding="utf-8")
+        css = _compiled_css()
         assert 'img[src$=".svg"]' not in css, (
             "Legacy attribute selector img[src$=.svg] found in compiled CSS"
         )
 
     def test_class_hooks_present_in_compiled_css(self):
-        css = POST_CSS.read_text(encoding="utf-8")
+        css = _compiled_css()
         assert "is-section-image" in css
         assert "is-svg-image" in css


### PR DESCRIPTION
#576에서 CI skip 7건 중 4건(의존성)을 해소했다. 이 PR은 **남은 3건**을 해소한다.

## 이 3건은 CI에서 단 한 번도 실행된 적이 없다

`jekyll.yml` build 잡의 스텝 순서:

```
 …
 Run script unit tests        ← pytest. 여기서 _site/ 는 아직 없다
 Digest quality gate
 Validate posts …
 Build with build.sh          ← _site/ 가 여기서 처음 생긴다 (마지막 스텝)
```

`TestCompiledCss`는 `@pytest.mark.skipif(not POST_CSS.exists())`를 클래스에 달고 있었고, 수집 시점에 `_site/assets/css/post-page.css`가 없으므로 **항상 참**이었다. CI 요약 `4204 passed, 7 skipped`의 나머지 3건이 정확히 이것이다.

**섹션 1의 소스 grep으로 대체되지 않는다.** `TestPostScssSelectors`는 `_sass/_post.scss` 한 파셜만 훑는다. 컴파일 검사는 `post-page.css`에 실제로 들어오는 **모든** 스타일시트를 덮으므로 커버리지가 다르다.

## 수정 — 두 짝이 다 있어야 성립한다

**1. build.sh 뒤에 `TestCompiledCss`만 재실행하는 스텝 추가**

전체 pytest를 빌드 뒤로 옮기지 않은 이유: 4200여 건은 `_site/`가 필요 없고, 빌드가 가장 느린 스텝이라 옮기면 그만큼 피드백이 늦어진다.

**2. `REQUIRE_COMPILED_CSS=1`일 때 산출물 부재를 skip → fail 로 전환**

env 없이 스텝만 추가하면 산출물이 사라져도 3건이 조용히 skip되고 스텝은 **초록으로 통과**한다. 그건 지금 고치려는 침묵과 구분이 안 된다. 클래스 레벨 `skipif`(수집 시점 1회 평가) 대신 런타임 헬퍼로 옮겼다.

로컬 개발자가 사이트를 빌드한 적 없을 때 혼란스러운 실패 대신 skip을 받도록, 맨 `CI` 검사가 아니라 **명시적 opt-in env**를 썼다.

### 동작 실측

| 조건 | 결과 |
|---|---|
| 무장(`=1`) + 산출물 있음 | `3 passed` |
| 무장(`=1`) + 산출물 없음 | **`3 failed`** ← skip 아님 |
| 비무장 + 산출물 없음 | `3 skipped` (로컬 개발자) |

## 재발 방지 게이트

`scripts/tests/test_ci_compiled_css_gate_guard.py` (4건). 스텝 존재·env 무장·**build.sh 이후 순서**를 모두 고정한다. 순서가 핵심이라 별도 테스트로 뺐다 — 게이트가 빌드 앞으로 가면 무장 상태에선 매번 red, 비무장이면 매번 skip이다.

**변이 테스트:**

| 변이 | 결과 |
|---|---|
| `REQUIRE_COMPILED_CSS` env 제거 | ❌ `test_gate_step_exists_and_is_armed` |
| 게이트 스텝을 build.sh 앞으로 이동 | ❌ `test_gate_step_runs_after_the_build` |
| 게이트 스텝 완전 삭제 | ❌ 2건 |

`TestCompiledCss`가 사라지면 이 가드도 같이 지우라고 실패 메시지로 지시한다(non-vacuity 선행 검사).

## 검증

```
$ python3 -m pytest scripts/tests/ -q
  4218 passed, 5 skipped

$ python3 -m pytest scripts/tests/test_ci_compiled_css_gate_guard.py -q
  4 passed
```

로컬 잔여 5 skip은 전부 `test_image_content_hash.py`의 jekyll 빌드 실패(mise가 rbenv를 가리는 로컬 환경)이며 CI에서는 실행된다.

**#576과 독립적이다** — 파일이 겹치지 않으므로 병합 순서는 무관하다. 다만 두 PR이 다 들어가면 CI pytest 요약은 `skipped 0`이 된다.