### PR TITLE
test(ci): 레포 산출물 부재를 skip → fail 로 — fail-open 11지점 + 정책 게이트

### DIFF
--- a/scripts/tests/test_asset_hint_version.py
+++ b/scripts/tests/test_asset_hint_version.py
@@ -20,12 +20,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 REPO = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO / "scripts"))
 
-check_asset_hint_version = pytest.importorskip("check_asset_hint_version")
+# Imported hard, not via `pytest.importorskip`. The gate under test is a
+# first-party file with stdlib-only imports, so the only way this import can
+# fail is that `scripts/check_asset_hint_version.py` was deleted or renamed —
+# and then every test below has to go red, not quiet.
+import check_asset_hint_version  # noqa: E402
 
 check_file = check_asset_hint_version.check_file
 collect_versioned_assets = check_asset_hint_version.collect_versioned_assets

--- a/scripts/tests/test_dependabot_auto_merge_workflow.py
+++ b/scripts/tests/test_dependabot_auto_merge_workflow.py
@@ -66,8 +66,10 @@ def _strip_yaml_comments(text: str) -> str:
 
 @pytest.fixture(scope="module")
 def raw() -> str:
-    if not TARGET.is_file():
-        pytest.skip(f"{TARGET} not found")
+    # No existence skip here: `test_target_exists` is the canary for a
+    # moved/renamed workflow, and a skip would additionally silence the ~15
+    # tests below on the exact event this guard exists to catch. A missing
+    # file raises FileNotFoundError, which errors the tests instead.
     return TARGET.read_text(encoding="utf-8")
 
 

--- a/scripts/tests/test_draft_rollup_spec.py
+++ b/scripts/tests/test_draft_rollup_spec.py
@@ -47,6 +47,15 @@ WEEKLY_CASES = [
     ("2026-04-19", "2026-04-19-Week3_April_2026_Security_Digest.md"),
 ]
 
+# These integration cases assert the drafter reproduces a hand-authored spec,
+# so an absent owning post makes them verify nothing. It is asserted rather
+# than skipped: the post disappearing is the drift this file is here to catch.
+_MISSING_POST_MSG = (
+    "owning post missing: {post_name}. It is required by this integration "
+    "case — restore it, or retire the case together with its hand spec under "
+    "_data/rollup_covers/."
+)
+
 
 def _load_hand_spec(date: str) -> dict:
     return yaml.safe_load((ROLLUP_DIR / f"{date}.yml").read_text(encoding="utf-8"))
@@ -125,8 +134,7 @@ def test_parse_frontmatter_returns_dict_and_body():
 @pytest.mark.parametrize("date,post_name", WEEKLY_CASES)
 def test_draft_reproduces_hand_spec_structure(date, post_name):
     post = POSTS_DIR / post_name
-    if not post.exists():
-        pytest.skip(f"owning post missing: {post_name}")
+    assert post.exists(), _MISSING_POST_MSG.format(post_name=post_name)
     hand = _load_hand_spec(date)
 
     spec = build_spec(post)
@@ -161,8 +169,7 @@ def test_draft_reproduces_hand_spec_structure(date, post_name):
 def test_draft_top_highlight_sources_are_daily_derived(date, post_name):
     """Every drafted top_highlight source must come from a daily's highlights."""
     post = POSTS_DIR / post_name
-    if not post.exists():
-        pytest.skip(f"owning post missing: {post_name}")
+    assert post.exists(), _MISSING_POST_MSG.format(post_name=post_name)
     fm, _ = parse_frontmatter(post.read_text(encoding="utf-8"))
     daily_sources: set = set()
     for (_y, _m, _d, slug) in daily_urls_from_redirects(fm.get("redirect_from")):
@@ -182,8 +189,7 @@ def test_draft_top_highlight_sources_are_daily_derived(date, post_name):
 @pytest.mark.parametrize("date,post_name", WEEKLY_CASES)
 def test_draft_severity_matches_enum(date, post_name):
     post = POSTS_DIR / post_name
-    if not post.exists():
-        pytest.skip(f"owning post missing: {post_name}")
+    assert post.exists(), _MISSING_POST_MSG.format(post_name=post_name)
     spec = build_spec(post)
     for d in spec["days"]:
         assert d["severity"] in {"HIGH", "MEDIUM", "LOW"}
@@ -192,8 +198,7 @@ def test_draft_severity_matches_enum(date, post_name):
 @pytest.mark.parametrize("date,post_name", WEEKLY_CASES)
 def test_rendered_draft_is_ascii_only_and_valid_yaml(date, post_name):
     post = POSTS_DIR / post_name
-    if not post.exists():
-        pytest.skip(f"owning post missing: {post_name}")
+    assert post.exists(), _MISSING_POST_MSG.format(post_name=post_name)
     spec = build_spec(post)
     text = render_yaml(spec)
 
@@ -214,8 +219,7 @@ def test_rendered_draft_is_ascii_only_and_valid_yaml(date, post_name):
 def test_resolve_owning_post_by_date_prefers_rollup_over_daily():
     """A date shared by a daily + a weekly rollup resolves to the rollup post."""
     week2 = POSTS_DIR / "2026-04-12-Week2_April_2026_Security_Digest.md"
-    if not week2.exists():
-        pytest.skip("Week2 rollup post missing")
+    assert week2.exists(), _MISSING_POST_MSG.format(post_name=week2.name)
     resolved = resolve_owning_post("2026-04-12")
     # The rollup (with daily redirect_from URLs) wins over the same-date daily.
     assert resolved.name.startswith("2026-04-12-Week")

--- a/scripts/tests/test_skip_path_policy.py
+++ b/scripts/tests/test_skip_path_policy.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Policy gate: a test may skip for a missing *environment*, never for a
+missing *repo artifact*.
+
+Both classes read identically in a pytest summary — one `s` — but they mean
+opposite things:
+
+- "fontTools is not installed" / "node is not on PATH" — the runner lacks an
+  optional dependency. Skipping keeps local development usable, and CI
+  declares the dependency so the test runs there.
+- "owning post missing" / "not on disk" / "{TARGET} not found" — the file the
+  test exists to guard is gone. That is the regression, and a skip reports it
+  as green.
+
+Eleven sites of the second kind were removed in the same commit as this file
+(`test_draft_rollup_spec`, `test_svg_size_gate`, `test_stats_trend_consistency`,
+`test_dependabot_auto_merge_workflow`, `test_asset_hint_version`). This guard
+keeps them from coming back, and is written against skip *reasons* rather than
+file/line locations so it does not go stale when unrelated skips move.
+
+`pytest.importorskip` is judged by its module argument instead: a third-party
+module is an environment fact, but a first-party module under `scripts/` can
+only be missing because it was deleted or renamed.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+TESTS_DIR = REPO / "scripts" / "tests"
+
+# Reasons that describe the *environment*, so a skip is honest. Matched
+# case-insensitively as a substring of the skip reason.
+ALLOWED_REASON_PATTERNS: dict[str, str] = {
+    r"not installed": "optional third-party dependency absent",
+    r"required for ": "optional third-party dependency absent",
+    r"not on path": "external CLI tool absent",
+    r"not available in this environment": "external CLI tool absent",
+    r"not built": "site build artifact absent (local dev without a build)",
+    r"not in golden baseline": (
+        "intentional ratchet: corpus grew after the golden snapshot, so new "
+        "posts are out of scope for a snapshot comparison"
+    ),
+    # DEFERRED, not accepted: a jekyll build that fails while `bundle` IS
+    # present is a real defect, and skipping hides it. Arming it needs an
+    # explicit opt-in env on the CI step in jekyll.yml (the pattern used for
+    # REQUIRE_COMPILED_CSS), and that file is being edited by another open PR.
+    r"jekyll build failed": "DEFERRED — see this module's docstring",
+}
+
+# Lower bound on how many skip sites the scanner must find in the live suite.
+# A parser that silently matches nothing would otherwise report a clean pass.
+# Deliberately loose: legitimate dependency skips come and go.
+MIN_EXPECTED_SITES = 8
+
+
+class Site(NamedTuple):
+    path: str
+    line: int
+    kind: str  # "skip" | "skipif" | "importorskip" | "skip-marker"
+    detail: str  # reason text, or module name for importorskip
+
+
+def _literal_text(node: ast.AST | None) -> str | None:
+    """Best-effort literal text of a reason argument.
+
+    Handles plain strings, f-strings (interpolations become ``{}``), and
+    implicit/explicit ``+`` concatenation of the two. Returns ``None`` when the
+    reason is not statically readable.
+    """
+    if isinstance(node, ast.Constant):
+        return node.value if isinstance(node.value, str) else None
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            else:
+                parts.append("{}")
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = _literal_text(node.left), _literal_text(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _kwarg(call: ast.Call, name: str) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _attr_chain(node: ast.AST) -> str:
+    """``pytest.mark.skipif`` -> ``"pytest.mark.skipif"``."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def collect_sites(source: str, path: str = "<memory>") -> list[Site]:
+    """Every skip-producing call in ``source``."""
+    sites: list[Site] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        chain = _attr_chain(node.func)
+        if not chain.startswith("pytest."):
+            continue
+        tail = chain.rsplit(".", 1)[-1]
+
+        if tail == "importorskip":
+            module = _literal_text(node.args[0]) if node.args else None
+            sites.append(Site(path, node.lineno, "importorskip", module or ""))
+        elif tail == "skipif":
+            reason = _literal_text(_kwarg(node, "reason"))
+            sites.append(Site(path, node.lineno, "skipif", reason or ""))
+        elif tail == "skip":
+            # `pytest.mark.skip(...)` disables a test outright; `pytest.skip(...)`
+            # is a runtime skip. Distinguished so the message can differ.
+            kind = "skip-marker" if ".mark." in chain else "skip"
+            reason = _literal_text(_kwarg(node, "reason"))
+            if reason is None and node.args:
+                reason = _literal_text(node.args[0])
+            sites.append(Site(path, node.lineno, kind, reason or ""))
+    return sites
+
+
+def is_first_party(module: str) -> bool:
+    """True when ``module`` resolves to a file this repo owns."""
+    rel = module.replace(".", "/")
+    for base in (REPO / "scripts", REPO):
+        if (base / f"{rel}.py").is_file() or (base / rel / "__init__.py").is_file():
+            return True
+    return False
+
+
+def classify(site: Site) -> str | None:
+    """Return a violation message, or ``None`` when the site is allowed."""
+    if site.kind == "importorskip":
+        if not site.detail:
+            return "importorskip() with a non-literal module name is unauditable"
+        if is_first_party(site.detail):
+            return (
+                f"importorskip({site.detail!r}) targets a first-party module. It "
+                "can only fail because the file was deleted or renamed, and then "
+                "the whole module skips instead of going red. Import it directly."
+            )
+        return None
+
+    if site.kind == "skip-marker":
+        return (
+            "pytest.mark.skip disables the test unconditionally. Delete the test "
+            "or fix it; a permanently skipped test is dead weight that reads green."
+        )
+
+    if not site.detail:
+        return (
+            "skip reason is missing or not a literal string, so the policy cannot "
+            "tell an absent dependency from an absent repo artifact. Spell it out."
+        )
+
+    lowered = site.detail.lower()
+    for pattern in ALLOWED_REASON_PATTERNS:
+        if re.search(pattern, lowered):
+            return None
+    return (
+        f"skip reason {site.detail!r} is not an environment fact. If the test "
+        "target is missing from the repo, assert it instead — a skip reports the "
+        "regression as green. If this really is an environment condition, add its "
+        "phrasing to ALLOWED_REASON_PATTERNS with the rationale."
+    )
+
+
+def _live_sites() -> list[Site]:
+    sites: list[Site] = []
+    for path in sorted(TESTS_DIR.glob("*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        sites.extend(collect_sites(path.read_text(encoding="utf-8"), path.name))
+    return sites
+
+
+# ---------------------------------------------------------------------------
+# The policy, applied to the live suite
+# ---------------------------------------------------------------------------
+
+
+def test_no_skip_hides_a_missing_repo_artifact() -> None:
+    violations = [
+        f"{s.path}:{s.line} [{s.kind}] {msg}"
+        for s in _live_sites()
+        if (msg := classify(s)) is not None
+    ]
+    assert not violations, "Skip-path policy violations:\n  " + "\n  ".join(violations)
+
+
+def test_scanner_sees_the_live_suite() -> None:
+    """Non-vacuity: the parser must actually be finding skip sites."""
+    sites = _live_sites()
+    assert len(sites) >= MIN_EXPECTED_SITES, (
+        f"only {len(sites)} skip sites found across {TESTS_DIR}; expected at "
+        f"least {MIN_EXPECTED_SITES}. The AST scan is probably broken, which "
+        "would make the policy test above pass while checking nothing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the classifier on synthetic sources
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        'pytest.skip(f"owning post missing: {name}")',
+        'pytest.skip("2026-04-05-Week1.svg not on disk")',
+        'pytest.skip(f"{TARGET} not found")',
+        'pytest.skip("Week2 rollup post missing")',
+        'pytest.skip("Post file for 2026-04-12 not found")',
+        'pytest.skip(reason=some_variable)',
+        '@pytest.mark.skip(reason="flaky")\ndef test_x(): pass',
+    ],
+)
+def test_banned_skips_are_flagged(snippet: str) -> None:
+    sites = collect_sites(snippet)
+    assert sites, f"scanner found no site in: {snippet}"
+    assert all(classify(s) is not None for s in sites), (
+        f"policy accepted a repo-artifact skip: {snippet}"
+    )
+
+
+@pytest.mark.parametrize(
+    "snippet",
+    [
+        'pytest.skip("qrcode library not installed")',
+        'pytest.skip("bundle not available in this environment")',
+        'pytest.importorskip("PIL", reason="Pillow required for raster generation")',
+        'pytest.importorskip("fontTools")',
+        'pytest.mark.skipif(cond, reason="node is not on PATH; cannot run")',
+        'pytest.mark.skipif(cond, reason="_site/assets/css/post-page.css not built")',
+    ],
+)
+def test_environment_skips_are_allowed(snippet: str) -> None:
+    sites = collect_sites(snippet)
+    assert sites, f"scanner found no site in: {snippet}"
+    assert all(classify(s) is None for s in sites), (
+        f"policy rejected a legitimate environment skip: {snippet} -> "
+        f"{[classify(s) for s in sites]}"
+    )
+
+
+def test_first_party_importorskip_is_flagged() -> None:
+    """The exact shape removed from test_asset_hint_version.py."""
+    sites = collect_sites('pytest.importorskip("check_asset_hint_version")')
+    assert len(sites) == 1
+    msg = classify(sites[0])
+    assert msg is not None and "first-party" in msg
+
+
+def test_first_party_detection_distinguishes_the_two_cases() -> None:
+    assert is_first_party("check_asset_hint_version")
+    assert is_first_party("news.qa_gate")
+    assert not is_first_party("fontTools")
+    assert not is_first_party("PIL")

--- a/scripts/tests/test_stats_trend_consistency.py
+++ b/scripts/tests/test_stats_trend_consistency.py
@@ -276,8 +276,11 @@ class TestAprilDigestRegression:
     def post_content(self, request):
         posts_dir = Path(__file__).resolve().parents[2] / "_posts"
         matches = list(posts_dir.glob(f"{request.param}-Tech_Security_Weekly_Digest_*.md"))
-        if not matches:
-            pytest.skip(f"Post file for {request.param} not found")
+        assert matches, (
+            f"No digest post for {request.param}. This regression case pins the "
+            "qa_gate fixes made to that post; if it was renamed or removed, "
+            "update the params — a skip would retire the check silently."
+        )
         return matches[0].read_text(encoding="utf-8"), matches[0].name
 
     def test_qa_gate_zero_issues(self, post_content):

--- a/scripts/tests/test_svg_size_gate.py
+++ b/scripts/tests/test_svg_size_gate.py
@@ -19,8 +19,6 @@ import importlib.util
 import subprocess
 from pathlib import Path
 
-import pytest
-
 REPO = Path(__file__).resolve().parent.parent.parent
 SHELL_GATE = REPO / "scripts" / "check_svg_precommit.sh"
 PY_GATE = REPO / "scripts" / "check_svg_size_gate.py"
@@ -79,8 +77,11 @@ def test_known_rollup_dates_classified_correctly() -> None:
     ]
     for stem in known_rollup_stems:
         svg = ASSETS / f"{stem}.svg"
-        if not svg.exists():
-            pytest.skip(f"{svg.name} not on disk")
+        assert svg.exists(), (
+            f"{svg.name} is not on disk. This list pins the rollup band against "
+            "real covers; if the cover was renamed or retired, update "
+            "known_rollup_stems here — do not let the check go silent."
+        )
         assert classify(svg) == "rollup", (
             f"{svg.name} classified as {classify(svg)}; expected rollup. "
             "Rollup markers may have drifted in svg_rollup_generator."
@@ -95,8 +96,10 @@ def test_l20_hero_covers_classify_as_hq() -> None:
     ]
     for stem in samples:
         svg = ASSETS / f"{stem}.svg"
-        if not svg.exists():
-            pytest.skip(f"{svg.name} not on disk")
+        assert svg.exists(), (
+            f"{svg.name} is not on disk. Pick another live L20 hero cover for "
+            "`samples` — an absent sample makes this classification check vacuous."
+        )
         assert classify(svg) == "hq", (
             f"{svg.name} classified as {classify(svg)}; expected hq."
         )
@@ -157,8 +160,11 @@ def test_inline_diagram_filenames_are_exempt() -> None:
     ]
     for name in inline_diagrams:
         svg = ASSETS / name
-        if not svg.exists():
-            pytest.skip(f"{name} not on disk")
+        assert svg.exists(), (
+            f"{name} is not on disk. The exemption list is only meaningful "
+            "against files that exist; drop the entry here and from "
+            "EXEMPT_PATTERNS together if the diagram was retired."
+        )
         assert _gate.is_exempt(name), (
             f"{name} should be exempt but is_exempt() returned False. "
             "Update EXEMPT_PATTERNS in scripts/check_svg_size_gate.py."


### PR DESCRIPTION
#576(의존성 skip 4건), #578(컴파일 CSS skip 3건)이 **CI 요약에 찍히던** skip을 없앴다. 이 PR은 **찍히지 않는** 쪽을 다룬다 — 조건이 오늘은 성립하지 않아 조용히 잠들어 있고, 성립하는 날에는 게이트를 초록으로 만들 skip 경로다.

## 두 종류의 skip이 요약에서는 구분되지 않는다

pytest 요약에는 둘 다 `s` 한 글자다.

| 이유 | 의미 | skip이 정직한가 |
|---|---|---|
| `fontTools is not installed`, `node is not on PATH` | 러너에 선택적 의존성/도구가 없다 | ✅ 로컬 개발 가능성 유지, CI는 의존성을 선언해 실제로 실행 |
| `owning post missing`, `not on disk`, `{TARGET} not found` | **테스트가 지키려던 파일이 사라졌다** | ❌ 그게 바로 회귀인데 초록으로 보고 |

두 번째 종류 11지점을 assert로 전환했다.

## 전환이 CI를 red로 만들지 않는다 (실측)

고정된 대상 20개(rollup 커버 4 + hq 샘플 2 + inline 다이어그램 7 + 소유 포스트 4 + 워크플로 1 + 퍼스트파티 스크립트 1 + 회귀 포스트 2) 전부 현재 디스크에 존재한다.

```
$ python3 -m pytest <5개 파일> -q -rs
  61 passed          ← skip 0
```

## 수정 지점

| 파일 | 지점 | 전환 |
|---|---|---|
| `test_asset_hint_version.py` | 1 | `importorskip("check_asset_hint_version")` → 직접 import |
| `test_draft_rollup_spec.py` | 5 | 소유 포스트 부재 → assert |
| `test_svg_size_gate.py` | 3 | 고정 커버 부재 → assert |
| `test_stats_trend_consistency.py` | 1 | 04-12/13 회귀 대상 포스트 부재 → assert |
| `test_dependabot_auto_merge_workflow.py` | 1 | 존재 skip 제거 |

`test_asset_hint_version.py`가 가장 무거웠다. `check_asset_hint_version.py`는 **stdlib만 임포트**하므로(ast로 확인: argparse/re/subprocess/sys/pathlib) `importorskip`이 잡을 수 있는 ImportError는 "파일이 삭제·이름변경됨" 하나뿐인데, 그때 그 파일의 테스트 **전체**가 조용히 skip된다. 그 모듈 docstring이 스스로 *"쓰여진 목적인 그 버그에 실패할 수 없는 게이트는 게이트가 아니다"* 라고 적어둔 파일이다.

`test_dependabot_auto_merge_workflow.py`는 이미 `test_target_exists` 카나리가 있어 삭제 자체는 잡힌다. 픽스처의 skip은 **나머지 15건을 추가로 침묵시키는** 절반이라 제거했다(부재 시 `FileNotFoundError`로 error).

### 뮤테이션 테스트 — 5개 대상 제거 후 실측

| 뮤테이션 | 결과 |
|---|---|
| `scripts/check_asset_hint_version.py` 제거 | ❌ 수집 단계 ERROR (모듈 전체) |
| `dependabot-auto-merge.yml` 제거 | ❌ 1 failed + 3 errors |
| 고정 rollup 커버 SVG 제거 | ❌ `test_known_rollup_dates_classified_correctly` |
| 04-12 회귀 포스트 제거 | ❌ 해당 param ERROR |
| Week1 소유 포스트 제거 | ❌ 4 failed |

전부 fail/error — **skip 0건**. 수정 전이라면 5건 모두 skip이었다.

## 재발 방지 — 위치가 아니라 *이유*로 고정

`scripts/tests/test_skip_path_policy.py` (17건). 파일·라인 allow-list는 무관한 skip이 이동할 때마다 스테일 되고, 열려 있는 다른 PR(#576/#578)이 skip 지점을 건드리므로 순서 의존이 생긴다. 그래서 **skip 이유 문자열**을 AST로 읽어 분류한다:

- 환경 사실만 allow-list (`not installed` / `not on PATH` / `not available in this environment` / `not built` / golden-baseline 래칫)
- 그 밖의 이유 → 거부. 리터럴이 아닌 이유(변수)도 거부 — 감사 불가
- `importorskip`은 이유가 아니라 **모듈이 퍼스트파티인지**로 판정
- `pytest.mark.skip` 전면 금지 (영구 skip = 초록으로 읽히는 죽은 테스트)

### 게이트 자체의 비공허성 검증

이 레포의 교훈("게이트가 0 violations면 게이트를 먼저 의심")대로 두 겹으로 확인했다.

**1. 수정을 되돌리고 실행** — 정확히 그 11지점을 지목:

```
$ git stash push <5개 파일> && pytest scripts/tests/test_skip_path_policy.py
  test_asset_hint_version.py:28 [importorskip] ... targets a first-party module
  test_dependabot_auto_merge_workflow.py:70 [skip] '{} not found' ...
  test_draft_rollup_spec.py:129/165/186/196/218 [skip] 'owning post missing: {}' ...
  test_stats_trend_consistency.py:280 [skip] 'Post file for {} not found' ...
  test_svg_size_gate.py:83/99/161 [skip] '{} not on disk' ...
  1 failed, 16 passed
```

**2. 합성 스니펫 parametrize** — 코퍼스 상태와 무관하게 분류기를 고정(금지 7종 / 허용 6종). f-string 보간은 `{}`로 정규화해 읽는다.

**3. `MIN_EXPECTED_SITES`** — AST 스캔이 조용히 0건을 반환하면(파서 파손) 정책 테스트가 통과해버리므로, 라이브 스위트에서 최소 8개 지점을 찾는지 별도 검사. #576/#578 병합으로 몇 건이 오가도 견디도록 느슨하게 뒀다.

## 보류 (1건, 의도적)

`test_image_content_hash.py`의 `jekyll build failed (rc=...)` skip 2건. **`bundle`이 있는데 빌드가 실패하는 것은 환경 부재가 아니라 결함**이므로 원칙적으로 fail이어야 한다. 다만 무장에는 `jekyll.yml` CI 스텝의 opt-in env(#578의 `REQUIRE_COMPILED_CSS` 패턴)가 필요하고, 그 파일은 지금 #578이 편집 중이다. 정책 게이트에 `DEFERRED` 주석을 달아 명시적으로 allow-list에 넣었다 — 조용히 빠뜨린 게 아니다. 이대로 두면 로컬(mise가 rbenv를 가리는 환경)에서 5건이 red가 되기도 한다.

## 검증

```
$ python3 -m pytest scripts/tests/ -q -rs
  4231 passed, 5 skipped

$ python3 -m pytest scripts/tests/test_skip_path_policy.py -q
  17 passed

$ python3 -m ruff check <변경 6개 파일>
  All checks passed!
```

잔여 5 skip은 전부 위 보류 항목(로컬 jekyll 빌드 실패)이며 CI에서는 실행된다.

**#576/#577/#578과 파일이 겹치지 않는다** — 병합 순서 무관.