### PR TITLE
fix(ci): jekyll 빌드 실패를 skip → fail 로 무장 — #579 보류 항목 해소

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -130,7 +130,17 @@ jobs:
           pip install --quiet -r scripts/requirements-ci.txt
           echo "✅ Python dependencies installed"
 
+      # REQUIRE_JEKYLL_BUILD arms test_image_content_hash.py: `Setup Ruby` ran
+      # several steps above, so `bundle` is on PATH and the fixture's own
+      # `bundle exec jekyll build` is expected to succeed here. Unarmed, a
+      # failing build skipped its 5 tests and the step stayed green — a build
+      # defect reported as "not applicable". Measured before arming: the 7
+      # skips on the 2026-08-21 run were 4 dependency + 3 compiled-CSS, none
+      # from this file, so the build does succeed at this point in the job.
+      # Pinned by scripts/tests/test_ci_jekyll_build_gate_guard.py.
       - name: Run script unit tests
+        env:
+          REQUIRE_JEKYLL_BUILD: '1'
         run: |
           echo "🧪 Running script unit tests..."
           python3 -m pytest scripts/tests/ -v --tb=short --cov --cov-report=term-missing --cov-report=json:coverage.json --cov-fail-under=40

--- a/scripts/tests/test_ci_jekyll_build_gate_guard.py
+++ b/scripts/tests/test_ci_jekyll_build_gate_guard.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Regression guard: the jekyll-build fixture stays fail-closed in CI.
+
+``test_image_content_hash.py`` runs its own ``bundle exec jekyll build`` and
+asserts the ``?v={hash}`` cache-buster the `image_content_hash` plugin appends.
+Until 2026-08-21 a build that *failed* skipped those 5 tests and left the step
+green — a build defect reported as "not applicable". Two facts made that
+invisible: a skip and a pass are both non-failures in a step's exit code, and
+locally the build really does fail for an unrelated reason (mise ahead of rbenv
+on PATH), so the skips looked normal.
+
+The repair is the ``REQUIRE_COMPILED_CSS`` pattern from PR #578: an explicit
+opt-in env var that turns "cannot build" into a failure, set only on CI.
+
+Three parts have to hold together, and this guard pins each:
+
+1. ``REQUIRE_JEKYLL_BUILD=1`` on the pytest step in ``jekyll.yml`` — without it
+   the fixture is back to skipping and nothing turns red;
+2. the armed branches in the fixture (`bundle` absent, and build rc != 0) —
+   an env var no code reads is decoration;
+3. ``Setup Ruby`` ordered *before* that step — arming a step that runs before
+   bundler exists would make CI permanently red instead of honest.
+
+Part 3 is the one static review misses, so it is a separate test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "jekyll.yml"
+HASH_TEST = REPO_ROOT / "scripts" / "tests" / "test_image_content_hash.py"
+
+PYTEST_STEP_MARKER = "pytest scripts/tests/"
+RUBY_SETUP_MARKER = "ruby/setup-ruby"
+ENV_VAR = "REQUIRE_JEKYLL_BUILD"
+
+
+def _build_job_steps() -> list[dict]:
+    import yaml
+
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["build"]["steps"]
+
+
+def _index_of(predicate) -> int:
+    for i, step in enumerate(_build_job_steps()):
+        if predicate(step):
+            return i
+    return -1
+
+
+def _armed_pytest_step() -> dict | None:
+    for step in _build_job_steps():
+        run = step.get("run") or ""
+        if PYTEST_STEP_MARKER in run and "--cov-fail-under" in run:
+            return step
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the fixture being armed has to still exist
+# ---------------------------------------------------------------------------
+
+
+def test_the_build_fixture_still_exists() -> None:
+    """If the fixture is gone this guard protects nothing — delete it too."""
+    source = HASH_TEST.read_text(encoding="utf-8")
+    assert "def built_site_dir" in source, (
+        f"{HASH_TEST.name} no longer defines the built_site_dir fixture; if the "
+        f"jekyll-build integration was removed on purpose, delete "
+        f"{Path(__file__).name} and the workflow env var with it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The workflow arms the gate
+# ---------------------------------------------------------------------------
+
+
+def test_pytest_step_is_armed() -> None:
+    step = _armed_pytest_step()
+    assert step is not None, (
+        f"no `{PYTEST_STEP_MARKER}` step found in the build job of "
+        f"{WORKFLOW.name}; the full-suite pytest step was renamed or removed"
+    )
+    assert str((step.get("env") or {}).get(ENV_VAR)) == "1", (
+        f"{ENV_VAR} is not set to '1' on the pytest step. Without it a jekyll "
+        f"build that fails inside test_image_content_hash.py skips its 5 tests "
+        f"and the step still passes — the exact silence this gate removed."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The fixture reads it and fails, rather than skipping
+# ---------------------------------------------------------------------------
+
+
+def test_fixture_fails_closed_when_armed() -> None:
+    source = HASH_TEST.read_text(encoding="utf-8")
+    assert f'os.environ.get("{ENV_VAR}")' in source, (
+        f"{HASH_TEST.name} does not read {ENV_VAR}; the workflow env var is "
+        f"then decoration and the fixture skips as before"
+    )
+    assert source.count("pytest.fail(") >= 2, (
+        f"{HASH_TEST.name} must fail on BOTH armed conditions — `bundle` absent "
+        f"and build rc != 0 — but has {source.count('pytest.fail(')} "
+        f"pytest.fail() call(s). A missing toolchain and a broken build are "
+        f"different regressions and both were silent."
+    )
+
+
+def test_unarmed_path_still_skips_for_local_shells() -> None:
+    """Local dev keeps skipping; the arm is CI-only by design.
+
+    Removing the unarmed skip would make every dev box whose Ruby is shadowed
+    fail 5 tests it has no stake in, and the predictable response is to stop
+    running the suite locally.
+    """
+    source = HASH_TEST.read_text(encoding="utf-8")
+    assert "pytest.skip(" in source, (
+        f"{HASH_TEST.name} no longer skips when unarmed. Local runs would fail "
+        f"on toolchain issues unrelated to the change under test."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Ordering — bundler must exist before the armed step runs
+# ---------------------------------------------------------------------------
+
+
+def test_ruby_is_set_up_before_the_armed_step() -> None:
+    ruby_idx = _index_of(lambda s: RUBY_SETUP_MARKER in str(s.get("uses", "")))
+    pytest_idx = _index_of(
+        lambda s: PYTEST_STEP_MARKER in (s.get("run") or "")
+        and "--cov-fail-under" in (s.get("run") or "")
+    )
+    assert ruby_idx >= 0, f"no {RUBY_SETUP_MARKER} step in the build job"
+    assert pytest_idx >= 0, "no full-suite pytest step in the build job"
+    assert ruby_idx < pytest_idx, (
+        f"`{RUBY_SETUP_MARKER}` is at step {ruby_idx} but the armed pytest step "
+        f"is at {pytest_idx}. Armed, the fixture requires `bundle` on PATH: run "
+        f"it before Ruby is installed and CI goes permanently red on a "
+        f"condition that is not a defect."
+    )

--- a/scripts/tests/test_image_content_hash.py
+++ b/scripts/tests/test_image_content_hash.py
@@ -5,7 +5,20 @@ Plan: .omc/plans/image-content-hash-versioning.md (Step 1).
 The plugin computes SHA-256[0:8] of every image under assets/images/ and
 appends `?v={hash}` to image URLs at build time. These tests verify the
 behavior end-to-end by running a Jekyll build and inspecting the output
-HTML. Skips gracefully when `bundle` / `jekyll` is not available.
+HTML.
+
+Set ``REQUIRE_JEKYLL_BUILD=1`` to arm the gate: a missing ``bundle`` or a
+failing build becomes a **failure** instead of a skip. CI sets it on the
+pytest step in ``jekyll.yml``, where `Setup Ruby` has already run and the
+build empirically succeeds — measured on the 2026-08-21 build run, where the
+7 skips were 4 dependency skips plus 3 compiled-CSS ones and none of them
+came from this file.
+
+Unarmed (the default, for local shells) it still skips, because a dev box
+whose Ruby is shadowed — e.g. mise ahead of rbenv on PATH — should not have
+to fix its toolchain to run the other 4200 tests. What is no longer allowed
+is CI treating a failed build as "not applicable": a build that breaks while
+`bundle` is present is a defect, and skipping reported it as green.
 """
 
 from __future__ import annotations
@@ -47,10 +60,21 @@ def _bundle_available() -> bool:
     return shutil.which("bundle") is not None
 
 
+def _gate_is_armed() -> bool:
+    """True when a build that cannot run must fail rather than skip."""
+    return os.environ.get("REQUIRE_JEKYLL_BUILD") == "1"
+
+
 @pytest.fixture(scope="module")
 def built_site_dir() -> Path:
     """Run `bundle exec jekyll build` once and return the destination dir."""
     if not _bundle_available():
+        if _gate_is_armed():
+            pytest.fail(
+                "REQUIRE_JEKYLL_BUILD=1 but `bundle` is not on PATH. On CI this "
+                "means the Ruby setup step regressed — the image-content-hash "
+                "tests cannot run, and skipping them would report that as green."
+            )
         pytest.skip("bundle not available in this environment")
 
     dest = Path(tempfile.mkdtemp(prefix="jk-image-hash-pytest-"))
@@ -77,9 +101,17 @@ def built_site_dir() -> Path:
             timeout=300,
         )
         if result.returncode != 0:
+            if _gate_is_armed():
+                pytest.fail(
+                    f"REQUIRE_JEKYLL_BUILD=1 and `bundle exec jekyll build` "
+                    f"failed (rc={result.returncode}). A build that breaks while "
+                    f"bundler is present is a defect, not a reason to stand "
+                    f"down:\n{result.stderr[-2000:]}"
+                )
             pytest.skip(
-                f"jekyll build failed (rc={result.returncode}): "
-                f"{result.stderr[-500:]}"
+                f"jekyll build not available in this environment "
+                f"(rc={result.returncode}); set REQUIRE_JEKYLL_BUILD=1 to make "
+                f"this a failure: {result.stderr[-300:]}"
             )
         yield dest
     finally:

--- a/scripts/tests/test_skip_path_policy.py
+++ b/scripts/tests/test_skip_path_policy.py
@@ -47,11 +47,6 @@ ALLOWED_REASON_PATTERNS: dict[str, str] = {
         "intentional ratchet: corpus grew after the golden snapshot, so new "
         "posts are out of scope for a snapshot comparison"
     ),
-    # DEFERRED, not accepted: a jekyll build that fails while `bundle` IS
-    # present is a real defect, and skipping hides it. Arming it needs an
-    # explicit opt-in env on the CI step in jekyll.yml (the pattern used for
-    # REQUIRE_COMPILED_CSS), and that file is being edited by another open PR.
-    r"jekyll build failed": "DEFERRED — see this module's docstring",
 }
 
 # Lower bound on how many skip sites the scanner must find in the live suite.


### PR DESCRIPTION
#579가 유일하게 `DEFERRED`로 남긴 fail-open을 닫는다. 그 PR은 정책 게이트에 이 구멍을 **명시적으로 allow-list에 적어두고** 보류했다 — 무장에 `jekyll.yml` 수정이 필요했고 그 파일은 #578이 편집 중이었다. #578이 병합됐으므로 이제 닫는다.

## 무엇이 조용했나

`test_image_content_hash.py`는 자체적으로 `bundle exec jekyll build`를 돌려 `image_content_hash` 플러그인이 붙이는 `?v={hash}` 캐시버스터를 검증한다. 그 빌드가 **실패하면** 5건이 skip되고 스텝은 초록이었다. 빌드 결함이 "해당 없음"으로 보고된 것이다.

두 가지가 겹쳐 안 보였다:

1. 스텝 종료 코드에서 skip과 pass는 둘 다 비-실패다.
2. 로컬에서는 **무관한 이유로** 실제 빌드가 실패한다(mise가 rbenv를 PATH에서 가림 — `notes`/메모에 기록된 환경 이슈). 그래서 이 skip 5건이 정상처럼 보였고, #578·#579 본문에서도 "로컬 잔여 skip"으로 계속 언급됐다.

## 무장이 CI를 red로 만들지 않는다 (실측)

`REQUIRE_*` 무장의 유일한 실질 리스크는 "CI에서도 그 조건이 성립하지 않아 영구 red"다. 병합 전에 측정했다 — 2026-08-21 build run(#579)의 skip 목록 전체:

```
$ gh run view <run> --log --job <job> | grep 'SKIPPED \['
  test_auto_publish_news.py::...::test_all_five_rasters_emitted_from_og_png     (PIL)
  test_auto_publish_news.py::...::test_idempotent_skips_existing_variants       (PIL)
  test_font_tier_split.py::test_woff2_cmaps_match_the_declared_split[400]       (fontTools)
  test_font_tier_split.py::test_woff2_cmaps_match_the_declared_split[700]       (fontTools)
  test_post_image_class_hooks.py::TestCompiledCss::...                          (3건)
```

7건 = deps 4 + CompiledCss 3. **`test_image_content_hash`는 한 건도 없다** → CI에서는 `bundle`이 있고 fixture의 빌드가 성공한다. 스텝 순서도 확인: `Setup Ruby`(bundler-cache)는 step 1, pytest는 step 6.

## 수정

| 파일 | 변경 |
|---|---|
| `.github/workflows/jekyll.yml` | pytest 스텝에 `REQUIRE_JEKYLL_BUILD: '1'` (#578의 `REQUIRE_COMPILED_CSS` 패턴) |
| `scripts/tests/test_image_content_hash.py` | 무장 시 **bundle 부재**와 **빌드 rc≠0** 양쪽을 `pytest.fail` |
| `scripts/tests/test_skip_path_policy.py` | `DEFERRED` allow 항목 제거 |

비무장(로컬 기본)은 계속 skip이다. Ruby가 가려진 개발 머신이 나머지 4200건을 돌리려고 툴체인부터 고쳐야 한다면, 예측 가능한 반응은 로컬 실행을 아예 안 하는 것이다.

`fail`을 **두 분기 모두**에 둔 이유: 툴체인 부재와 빌드 파손은 다른 회귀이고 둘 다 조용했다. bundle 부재는 CI에서 Setup Ruby 스텝이 퇴화했다는 뜻이다.

정책 게이트 항목을 지우려면 비무장 skip 이유도 손봐야 했다 — 정책은 소스를 스캔하므로 `"jekyll build failed"`라는 문자열이 남아 있으면 거부된다. 비무장이 뜻하는 바가 "이 러너는 빌드 가능성을 요구받지 않는다"이므로 이유를 `"jekyll build not available in this environment (rc=…); set REQUIRE_JEKYLL_BUILD=1 to make this a failure"`로 바로잡았다. rc와 stderr 꼬리는 진단용으로 유지한다.

## 재발 방지 게이트

`scripts/tests/test_ci_jekyll_build_gate_guard.py` (5건). env 무장 · fixture의 `pytest.fail` 분기 2개 · 비무장 skip 경로 존속 · **`Setup Ruby`가 무장 스텝보다 앞** 을 고정한다.

순서는 별도 테스트로 뺐다. 정적 리뷰가 놓치는 지점이고, 실패 양상이 정반대다 — bundler보다 앞에서 무장하면 결함이 아닌 조건으로 CI가 **영구 red**가 된다(무장 없이 뒤에 두면 영구 skip). `built_site_dir` fixture가 사라지면 이 가드도 함께 지우라고 실패 메시지로 지시한다.

### 실측 + 뮤테이션

| 조건 | 결과 |
|---|---|
| 무장(`=1`) + 빌드 실패(로컬) | **5 errors** ← skip 아님 |
| 비무장 + 빌드 실패(로컬) | `5 skipped` |
| 무장 + 빌드 성공 | CI에서 첫 측정 (아래) |

| 뮤테이션 | 결과 |
|---|---|
| `REQUIRE_JEKYLL_BUILD` env 제거 | ❌ `test_pytest_step_is_armed` |
| `Setup Ruby`를 pytest 스텝 뒤로 이동 | ❌ `test_ruby_is_set_up_before_the_armed_step` |
| `pytest.fail` 분기 하나를 `pytest.skip`으로 | ❌ `test_fixture_fails_closed_when_armed` |

**"무장 + 빌드 성공"은 로컬에서 검증 불가**다(로컬 빌드가 실제로 깨져 있음). 이 레포의 선례(#533 `--verify` 배선)와 같이 **이 PR의 CI가 첫 시험대**다. 위 skip 목록 실측이 근거이지만 증명은 CI가 한다 — `build` 잡이 초록이고 pytest 요약의 skip이 이 파일에서 나오지 않으면 확정이다.

## 검증

```
$ python3 -m pytest scripts/tests/ -q
  4257 passed, 5 skipped        ← 잔여 5건이 정확히 이 파일(비무장 로컬)

$ python3 -m pytest scripts/tests/test_ci_jekyll_build_gate_guard.py -q
  5 passed

$ python3 -m ruff check <변경 3개 파일>
  All checks passed!

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/jekyll.yml'))"
  yaml OK, build steps: 18
```