### PR TITLE
fix(ci): node --test 0건 수집을 차단 — 러너 레벨 fail-open

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -64,5 +64,24 @@ jobs:
       - name: Run Vitest with coverage gate
         run: npm run test:coverage
 
+      # `node --test <glob>` exits 0 when the glob matches nothing — measured:
+      # `1..0 / # tests 0 / # pass 0`, exit 0. So renaming api/__tests__, moving
+      # it, or changing the `.test.js` suffix would leave this step green while
+      # running zero assertions. Vitest fails closed on an empty collection
+      # (exit 1), node:test does not, so the floor has to be asserted here.
+      #
+      # A floor of 1 closes "collected nothing", not "collected fewer": pinning
+      # today's 83 would fail any PR that legitimately deletes a test, as #577
+      # did. Parse failure is fail-closed — a missing or renamed `# tests` line
+      # yields an empty string, which trips the same check.
+      # Pinned by scripts/tests/test_ci_api_test_wiring_guard.py.
       - name: Run api/ suite (node:test)
-        run: npm run test:api
+        run: |
+          set -o pipefail
+          npm run test:api | tee /tmp/api-suite.log
+          COLLECTED=$(grep -E '^# tests [0-9]+' /tmp/api-suite.log | tail -1 | awk '{print $3}')
+          echo "api suite collected ${COLLECTED:-<unparsed>} test(s)"
+          if [ "${COLLECTED:-0}" -lt 1 ]; then
+            echo "::error::node --test collected 0 tests and still exited 0. The api/__tests__ glob matched nothing — this step passed having verified nothing."
+            exit 1
+          fi

--- a/scripts/tests/test_ci_api_test_wiring_guard.py
+++ b/scripts/tests/test_ci_api_test_wiring_guard.py
@@ -91,6 +91,51 @@ def test_api_suite_step_is_not_soft() -> None:
     pytest.fail("no step running test:api found")
 
 
+def test_api_step_fails_when_zero_tests_are_collected() -> None:
+    """`node --test <glob>` exits 0 on an empty match — measured 2026-08-21.
+
+    A glob that matches nothing prints ``1..0 / # tests 0 / # pass 0`` and exits
+    0, so renaming ``api/__tests__``, moving it, or changing the ``.test.js``
+    suffix would leave the step green while running zero assertions. Vitest
+    fails closed on an empty collection; node:test does not, so the floor has to
+    live in the workflow step.
+    """
+    for step in _steps():
+        run = str(step.get("run", ""))
+        if "test:api" not in run:
+            continue
+        assert "# tests" in run, (
+            "the api/ suite step no longer reads the collected-test count. "
+            "Without it, a glob matching nothing exits 0 and this step passes "
+            "having verified nothing (measured: `1..0`, `# tests 0`, exit 0)."
+        )
+        assert "exit 1" in run, (
+            "the api/ suite step parses the test count but never fails on it; "
+            "the check is decorative without a non-zero exit"
+        )
+        assert "set -o pipefail" in run, (
+            "the api/ suite step pipes `npm run test:api` into tee without "
+            "`set -o pipefail`, so a failing suite is masked by tee's exit code "
+            "— the count check would then be the only thing that can fail"
+        )
+        return
+    pytest.fail("no step running test:api found")
+
+
+def test_vitest_still_fails_on_an_empty_collection() -> None:
+    """`passWithNoTests` would give Vitest the same hole node:test has."""
+    config = (REPO_ROOT / "vitest.config.js").read_text(encoding="utf-8")
+    assert "passWithNoTests" not in config, (
+        "vitest.config.js sets passWithNoTests; an empty `include` match would "
+        "then exit 0 and the JS gate could report success with no tests run"
+    )
+    for name, script in _scripts().items():
+        if "vitest" in script:
+            assert "--passWithNoTests" not in script, (
+                f"npm script {name!r} passes --passWithNoTests to vitest: {script!r}"
+            )
+
+
 @pytest.mark.parametrize("trigger", ["pull_request", "push"])
 def test_api_changes_trigger_the_workflow(trigger: str) -> None:
     # PyYAML parses a bare `on:` key as the boolean True.


### PR DESCRIPTION
#579의 skip 정책을 JS 스위트로 확장한 감사 결과다. 결론이 예상과 달랐다: **파일 내부에는 fail-open이 하나도 없었고, 러너에 하나 있었다.**

## 파일 내부 감사 — 0건

| 부류 | 결과 |
|---|---|
| `.skip` / `.todo` / `.skipIf` / `.runIf` / `.only` / `{skip:true}` / `ctx.skip()` | **0건** |
| `expect(true)` / `assert.ok(true)` / `expect(1).toBe(1)` | **0건** |
| 테스트 본문 조기 `return` (JS의 조용한 skip — grep으로 안 잡히는 부류) | **0건** |
| `existsSync` / `process.env` 가드 | **0건** |
| assertion을 먹는 `try/catch {}` | **0건** |
| 파일시스템에서 케이스를 유도하는 루프 (빈 컬렉션 = 자동 초록) | **0건** — `readdirSync`/`glob` 사용 없음, 픽스처는 전부 인라인 `Array.from` |

서브젝트 로딩도 fail-closed다. `tests/js/*.test.js`는 모듈 최상단에서 `readFileSync(assets/js/x.js)` + `new Function`으로 로드하므로 소스가 사라지면 throw다(skip 아님).

## 0건이면 스캐너를 먼저 의심하라 — 러너 레벨에서 나왔다

이 레포의 교훈(`liquid_nested_quotes_break_template_gates`, "게이트가 0 violations면 게이트를 먼저 의심")대로 러너 종료 코드를 실측했다.

```
$ node --test api/__tests__/__nope__*.test.js     # 매치 0건 (bash, CI와 동일)
TAP version 13
1..0
# tests 0
# suites 0
# pass 0
exit 0                                             ← 초록
```

대조군 — 실제 스위트:

```
$ npm run test:api
# tests 83
# pass 83
# fail 0
```

`api/__tests__`를 이름변경·이동하거나 `.test.js` 접미사를 바꾸면 `npm run test:api`가 **0건 실행으로 성공**을 보고한다. #579가 파이썬에서 닫은 부류("레포 산출물 부재가 초록으로 보고됨")와 정확히 같은데, 위치가 파일 안이 아니라 러너라서 어떤 in-file skip 스캔으로도 잡히지 않는다.

**vitest는 해당 없음** (실측): 빈 수집에 `exit 1`. 그래서 node:test 쪽만 막는다.

```
$ npx vitest run --include '**/__nope__/*.test.js'; echo $?
1
```

## 수정

`.github/workflows/vitest.yml`의 api 스텝이 `# tests` 카운트를 읽고 1 미만이면 실패한다.

- **파싱 실패도 fail-closed**: `# tests` 줄이 사라지거나 이름이 바뀌면 빈 문자열 → `0` → 차단. #530에서 `check_posts.py` stdout grep이 traceback 시 `TOTAL=0`으로 통과했던 것과 극성이 반대다
- `set -o pipefail`: `tee` 파이프가 실패한 스위트의 종료 코드를 먹지 않게
- **하한을 1로 둔 이유**: 오늘의 83을 박으면 테스트를 정당하게 삭제하는 PR이 전부 red가 된다 — 바로 직전 #577이 죽은 `validateUrl` 테스트 3개를 지웠다. 이 게이트는 "0건 수집"을 막고 "적게 수집"은 막지 않는다. 본문과 워크플로 주석에 명시했다

## 재발 방지 게이트

새 파일을 만들지 않고 기존 `scripts/tests/test_ci_api_test_wiring_guard.py`를 확장했다 — 그 파일의 주제가 정확히 "api 스위트가 장식으로 되돌아가지 않게 배선을 고정"이고, 이건 그 배선의 새로 발견된 구멍이다.

추가된 2건:
- `test_api_step_fails_when_zero_tests_are_collected` — 카운트 검사·`exit 1`·`pipefail` 세 요소를 모두 고정
- `test_vitest_still_fails_on_an_empty_collection` — `passWithNoTests`가 config나 npm script에 들어오면 실패. 그게 켜지면 vitest도 node:test와 같은 구멍이 된다

### 실측 + 뮤테이션

| 조건 | 결과 |
|---|---|
| 실제 스위트(83건)에 새 스텝 로직 적용 | `collected=83` → GATE PASS |
| 0건 매치 글로브에 적용 | `node exit=0` 인데 → **GATE exit 1** |

| 뮤테이션 | 결과 |
|---|---|
| 카운트 검사 제거(bare `npm run test:api`로 환원) | ❌ `test_api_step_fails_when_zero_tests_are_collected` |
| `exit 1` 제거(카운트만 읽고 통과) | ❌ 동일 |
| `set -o pipefail` 제거 | ❌ 동일 |
| `passWithNoTests: true` 추가 | ❌ `test_vitest_still_fails_on_an_empty_collection` |

## 비-발견으로 기각한 것

- **경로 필터**: `vitest.yml`의 필터는 `tests/js/**`, `assets/js/**`, `api/**`, `package.json`, lock, config, 워크플로 자신을 모두 포함한다 — 서브젝트 대비 빠짐이 없다
- **크론 봇 push 사각지대** (`ci_gates_blind_to_cron_bot_push` 메모): 여기엔 없다. 봇은 `_posts/**`와 `assets/images/**`만 쓰고, 이 워크플로의 서브젝트(`assets/js`, `api`)를 건드리지 않는다. schedule 추가는 #529 때 `visual-regression`에서 기각한 것과 같은 이유로 소음이다

## 검증

```
$ python3 -m pytest scripts/tests/test_ci_api_test_wiring_guard.py -q
  10 passed

$ python3 -m pytest scripts/tests/ -q
  4259 passed, 5 skipped

$ npx vitest run
  Test Files  28 passed (28)
  Tests  698 passed (698)

$ npm run test:api
  # tests 83 / # pass 83 / # fail 0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/vitest.yml'))"
  yaml OK, vitest steps: 5
```