### PR TITLE
test(ci): JS 스위트 빈 껍데기·커버리지 게이트 이탈 차단 — #581 보완

### DIFF
--- a/scripts/tests/test_ci_api_test_wiring_guard.py
+++ b/scripts/tests/test_ci_api_test_wiring_guard.py
@@ -26,6 +26,7 @@ today, and would have failed nothing before the import was wired.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -120,6 +121,67 @@ def test_api_step_fails_when_zero_tests_are_collected() -> None:
         )
         return
     pytest.fail("no step running test:api found")
+
+
+def test_api_test_files_are_not_empty_shells() -> None:
+    """A file with zero `test()` calls counts as ONE passing test.
+
+    Measured 2026-08-21: `node --test` on a file containing no `test()` call
+    reports ``# tests 1 / # pass 1`` and exits 0 — it wraps the file itself as a
+    single vacuous test. So the ``# tests >= 1`` floor in the workflow step
+    cannot see this case: four emptied files would report ``# tests 4`` and pass.
+
+    Only a static check distinguishes them, so the content assertion lives here
+    rather than in the runner. `test_api_test_files_still_exist` above checks
+    that the files are present; this checks they still contain tests.
+    """
+    empty = []
+    for path in sorted(API_TESTS.glob("*.test.js")):
+        source = path.read_text(encoding="utf-8")
+        if "test(" not in source:
+            empty.append(path.name)
+    assert not empty, (
+        f"api test file(s) with no `test(` call: {empty}. node --test reports "
+        f"each such file as 1 passing test, so the suite would stay green while "
+        f"asserting nothing. Restore the tests or delete the file."
+    )
+
+
+def test_vitest_ci_step_uses_the_coverage_gate() -> None:
+    """The coverage flag is what makes a mass-skip fail — measured, not assumed.
+
+    `vitest run` with every test filtered out reports ``698 skipped`` and exits
+    **0**. The same run with ``--coverage`` exits **1**, because 0% trips the
+    thresholds in vitest.config.js. CI therefore has to keep running the
+    coverage script; switching the step to plain `npm test` would silently
+    reopen the hole.
+    """
+    for step in _steps():
+        run = str(step.get("run", ""))
+        if "vitest" in run or "test:coverage" in run:
+            assert "test:coverage" in run, (
+                "the Vitest CI step no longer runs `npm run test:coverage`. Plain "
+                "`vitest run` exits 0 when every test is skipped (measured: "
+                "`698 skipped`, exit 0); only the coverage gate turns that red."
+            )
+            return
+    pytest.fail("no step running vitest found in vitest.yml")
+
+
+def test_vitest_coverage_thresholds_are_non_trivial() -> None:
+    """Zeroed thresholds would neuter the gate the test above relies on."""
+    config = (REPO_ROOT / "vitest.config.js").read_text(encoding="utf-8")
+    found = dict(
+        re.findall(r"(branches|functions|lines|statements):\s*(\d+)", config)
+    )
+    missing = {"branches", "functions", "lines", "statements"} - set(found)
+    assert not missing, f"vitest.config.js lost coverage thresholds for: {sorted(missing)}"
+    zeroed = {k: v for k, v in found.items() if int(v) <= 0}
+    assert not zeroed, (
+        f"coverage threshold(s) set to zero: {zeroed}. A 0% floor cannot fail, "
+        f"which is what a mass-skip regression produces — the gate would pass "
+        f"with every test skipped."
+    )
 
 
 def test_vitest_still_fails_on_an_empty_collection() -> None:


### PR DESCRIPTION
병렬로 돌린 감사 세션 2건이 뒤늦게 보고했고, 실측 재확인 결과 **#581이 못 막는 경로 2개**가 확인됐다. 동료 보고의 두 지점은 정정이 필요했다(맨 아래).

## 1. 빈 껍데기 파일 — #581의 하한이 볼 수 없는 경우

`node --test`는 `test()` 호출이 하나도 없는 파일을 **1건 통과**로 센다.

```
$ printf 'const x = 1;\n' > /tmp/emptysuite/empty.test.js
$ node --test /tmp/emptysuite/empty.test.js; echo $?
# tests 1
# pass 1
# fail 0
0
```

#581이 워크플로에 넣은 `# tests >= 1` 하한은 이걸 구분할 수 없다. 실제 스위트에서 한 파일을 비우고 재현:

```
$ printf '// emptied by a bad merge\n' > api/__tests__/ratelimit.test.js
$ node --test api/__tests__/*.test.js
# tests 72
# pass 72
# fail 0          ← 12건이 사라졌는데 초록, 하한(>=1)도 통과
```

런타임 카운트로는 "12건이 있었다"를 알 수 없으므로 **정적 검사**로 막는다. `api/__tests__/*.test.js`는 각각 `test(` 호출을 최소 1개 가져야 한다. 기존 `test_api_test_files_still_exist`가 파일 존재를 보고, 이게 내용을 본다.

## 2. 커버리지 게이트가 load-bearing이었다

전수 skip 시나리오를 직접 측정했다(동료 주장 검증):

```
$ npx vitest run           --testNamePattern '__nope__'; echo $?
 Test Files  28 skipped (28)
      Tests  698 skipped (698)
0                                    ← 초록

$ npx vitest run --coverage --testNamePattern '__nope__'; echo $?
ERROR: Coverage for lines (0%) does not meet global threshold (80%)
ERROR: Coverage for functions (0%) does not meet global threshold (82%)
ERROR: Coverage for statements (0%) does not meet global threshold (80%)
ERROR: Coverage for branches (0%) does not meet global threshold (62%)
1
```

즉 vitest의 전수-skip 방어는 **커버리지 게이트가 하고 있다**. CI 스텝을 plain `npm test`로 바꾸거나 threshold를 0으로 내리면 조용히 구멍이 열린다. 둘 다 고정했다.

| 새 가드 | 막는 것 |
|---|---|
| `test_api_test_files_are_not_empty_shells` | `test()` 없는 파일 = 1건 통과 |
| `test_vitest_ci_step_uses_the_coverage_gate` | CI 스텝이 `test:coverage`를 떠나는 것 |
| `test_vitest_coverage_thresholds_are_non_trivial` | threshold 0화 (0% 하한은 실패할 수 없다) |

새 파일을 만들지 않고 `test_ci_api_test_wiring_guard.py`에 넣었다 — 두 스위트가 `vitest.yml` 하나를 공유하므로 fail-closed 속성을 같은 곳에서 고정하는 게 맞다(#581도 거기에 `passWithNoTests` 검사를 넣었다).

### 뮤테이션

| 뮤테이션 | 결과 |
|---|---|
| api 테스트 파일 하나를 비우기 | ❌ `test_api_test_files_are_not_empty_shells` |
| CI 스텝을 `npm test`로 교체 | ❌ `test_vitest_ci_step_uses_the_coverage_gate` |
| threshold 4개를 0으로 | ❌ `test_vitest_coverage_thresholds_are_non_trivial` |

## 동료 보고 정정 2건

이 PR의 근거는 전부 재측정한 것이고, 두 지점은 보고와 다르다.

1. **baseline 95/29는 스테일**. 그 세션은 #577 병합(03:21) 전 트리에서 측정했다 — 근거: 보고가 `api/chat.js:777 validateUrl`을 "존재·export됨"으로 적었는데 #577이 그 함수를 삭제했다. 현재 main은 `grep -c validateUrl api/chat.js` → **0**, `npm run test:api` → **83 tests / 26 suites**. 정성적 결론(skip 지시자 0건 등)은 제가 현재 main에서 독립 확인했으므로 유효하다.

2. **"0건 매치 글로브는 ENOENT로 fail-closed"는 틀렸다**. 보고가 "이미 안전하다고 추론했으므로 파괴적으로 검증하지 않았다"고 명시한 항목이다. 실측:

   ```
   $ bash -c 'node --test api/__tests__/__nope__*.test.js'; echo $?
   1..0
   # tests 0
   0                  ← 초록
   ```

   #581이 막은 경로가 정확히 이것이다. 추론이 실측을 대체하지 못한 사례라 남겨둔다.

동료가 소프트 항목으로 올린 `ratelimit.test.js:149-157`의 `assert.ok(true, ...)`는 **손대지 않았다**. 인접 주석이 "clearInterval의 효과는 Node Timeout에서 관측 불가"라고 명시하고, 그 줄이 실제로 검증하는 것은 "destroy()가 throw하지 않는다"이며 그건 그 줄에 도달하는 것으로 성립한다. 정직하게 한계를 적은 코드이고 요청 범위 밖이다.

## 검증

```
$ python3 -m pytest scripts/tests/test_ci_api_test_wiring_guard.py -q
  13 passed

$ python3 -m pytest scripts/tests/ -q
  4262 passed, 5 skipped

$ npm run test:api
  # tests 83 / # pass 83 / # fail 0

$ npx vitest run
  Test Files  28 passed (28) / Tests  698 passed (698)

$ python3 -m ruff check scripts/tests/test_ci_api_test_wiring_guard.py
  All checks passed!
```