### PR TITLE
fix(cover): QR fixer 좌표 앵커 제거 + L20 스펙 write에 honesty 가드 (#395 재구현)

### DIFF
--- a/scripts/fix_qr_url_in_covers.py
+++ b/scripts/fix_qr_url_in_covers.py
@@ -44,16 +44,23 @@ from scripts.news.l20_dispatch import _post_url_from_filename  # noqa: E402
 #     <rect ... fill="#FFFFFF"/>
 #     <path fill="#0A1020" d="..."/>
 #   </g>
-#   <text x="1122" y="614" ...>scan / full post</text>
+#   <text ...>scan / full post</text>
 #
-# The matcher captures both the <g> wrapper and the trailing scan label so
-# the replacement stays atomic. Some upgraded covers tweak the spacing —
-# the regex tolerates leading/trailing whitespace and any text-y caption
-# variant ("scan / full post", "Scan", etc.).
+# The matcher captures both the <g> wrapper and the trailing scan label so the
+# replacement stays atomic.
+#
+# It is anchored on the label's TEXT, not its coordinates. The label position
+# moved with the QR geometry — the legacy 84px block put it at
+# ``x="1122" y="614"`` (below the QR), the current 108px block at
+# ``x="1134" y="486"`` (above the enlarged white rect). The coordinate anchor
+# survived that change and silently matched nothing: measured 2026-08-21,
+# ``--check`` reported "Total scanned: 200 / No QR block found: 200 /
+# Changed: 0", which reads as a clean corpus while having inspected none of it.
+# All 200 live covers carry the caption verbatim, so the text is the stable key.
 _QR_BLOCK_RE = re.compile(
     r"<g transform=\"translate\(1080,504\)\"[^>]*>"
     r".*?</g>\s*"
-    r"<text x=\"1122\" y=\"614\"[^>]*>[^<]*</text>",
+    r"<text[^>]*>\s*scan / full post\s*</text>",
     re.DOTALL,
 )
 
@@ -127,6 +134,21 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Changed/needs-fix:  {changed}")
     print(f"Already correct:    {already_correct}")
     print(f"No QR block found:  {skipped_no_qr}")
+
+    # Non-vacuity. `Changed: 0` reads as "the corpus is fine", but it says the
+    # same thing when the matcher is broken — which is how the coordinate-
+    # anchored regex above went unnoticed through a QR geometry change while
+    # missing 200/200 covers. Every cover matched by the default glob emits a
+    # QR block, so a total miss is a template drift, not a clean report.
+    if paths and skipped_no_qr == len(paths):
+        print(
+            f"\nERROR: no QR block matched in ANY of the {len(paths)} scanned "
+            "covers. The template this fixer targets has drifted — update "
+            "_QR_BLOCK_RE. Reporting 0 changes here would be indistinguishable "
+            "from a healthy corpus.",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 

--- a/scripts/tests/test_fix_qr_url_in_covers.py
+++ b/scripts/tests/test_fix_qr_url_in_covers.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""The QR-URL fixer has to match the QR block it is pointed at.
+
+Until 2026-08-21 ``_QR_BLOCK_RE`` anchored the scan label on ``x="1122"
+y="614"``. The QR geometry then moved — the enlarged 108px block puts the label
+at ``x="1134" y="486"`` — and the regex kept compiling, kept running, and
+matched nothing:
+
+    Total scanned:      200
+    Changed/needs-fix:  0
+    Already correct:    0
+    No QR block found:  200
+
+``Changed: 0`` is what a healthy corpus prints too, which is why a 100% miss
+survived. Two things are pinned here: the matcher is anchored on the label's
+text rather than its coordinates (so it spans both geometries), and a total
+miss is reported as an error instead of a clean run.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts import fix_qr_url_in_covers as _mod  # noqa: E402
+
+ASSETS = REPO / "assets" / "images"
+
+# The two geometries that have shipped. Only the label coordinates differ.
+_LEGACY_84PX = (
+    '<g transform="translate(1080,504)" filter="url(#softShadow)">'
+    '<rect width="100" height="100" fill="#FFFFFF"/>'
+    '<path fill="#0A1020" d="M0 0h7v7H0z"/>'
+    "</g>\n"
+    '<text x="1122" y="614" font-size="11">scan / full post</text>'
+)
+_CURRENT_108PX = (
+    '<g transform="translate(1080,504)" filter="url(#softShadow)">'
+    '<rect width="132" height="132" fill="#FFFFFF"/>'
+    '<path fill="#0A1020" d="M0 0h7v7H0z"/>'
+    "</g>\n"
+    '<text x="1134" y="486" font-size="11">scan / full post</text>'
+)
+
+
+def test_matches_the_current_geometry() -> None:
+    assert _mod._QR_BLOCK_RE.search(_CURRENT_108PX), (
+        "the fixer cannot see the QR block shape that is actually on disk"
+    )
+
+
+def test_still_matches_the_legacy_geometry() -> None:
+    """Text-anchoring is only worth it if it spans both revisions."""
+    assert _mod._QR_BLOCK_RE.search(_LEGACY_84PX)
+
+
+def test_is_not_anchored_on_label_coordinates() -> None:
+    """The specific defect: a coordinate in the pattern re-breaks on the next tweak."""
+    pattern = _mod._QR_BLOCK_RE.pattern
+    for coord in ('x=\\"1122\\"', 'y=\\"614\\"', 'x=\\"1134\\"', 'y=\\"486\\"'):
+        assert coord not in pattern, (
+            f"_QR_BLOCK_RE anchors the scan label on {coord}. The label moved once "
+            "already and the pattern silently matched 200/200 covers as 'no QR "
+            "block found'. Anchor on the label text."
+        )
+
+
+def test_the_live_corpus_is_actually_matched() -> None:
+    """Non-vacuity against reality — this is the regression that occurred.
+
+    A unit test over synthetic strings would have passed throughout the whole
+    period the fixer was blind, because the synthetic string was written from
+    the same stale assumption as the regex.
+    """
+    covers = sorted(ASSETS.glob("*Tech_*Weekly_Digest_*.svg"))
+    assert covers, f"no digest covers under {ASSETS}"
+    missed = [p.name for p in covers if not _mod._QR_BLOCK_RE.search(p.read_text(encoding="utf-8"))]
+    assert not missed, (
+        f"{len(missed)}/{len(covers)} live covers are invisible to the fixer, "
+        f"e.g. {missed[:3]}"
+    )
+
+
+def test_total_miss_is_an_error_not_a_clean_report(tmp_path, monkeypatch, capsys) -> None:
+    """Zero matches across every file means the template drifted."""
+    cover = tmp_path / "2026-01-01-Tech_Security_Weekly_Digest_Nothing.svg"
+    cover.write_text("<svg><!-- no QR block at all --></svg>", encoding="utf-8")
+    monkeypatch.setattr(_mod, "ROOT", tmp_path)
+
+    rc = _mod.main(["--check", "--glob", "*.svg"])
+    assert rc == 1, "a corpus where nothing matched still reported success"
+    assert "no QR block matched in ANY" in capsys.readouterr().err
+
+
+def test_partial_miss_is_not_an_error(tmp_path, monkeypatch) -> None:
+    """Hand-drawn covers legitimately carry no QR; only a TOTAL miss is a defect."""
+    (tmp_path / "2026-01-01-Tech_Security_Weekly_Digest_A.svg").write_text(
+        _CURRENT_108PX, encoding="utf-8"
+    )
+    (tmp_path / "2026-01-02-Tech_Security_Weekly_Digest_B.svg").write_text(
+        "<svg></svg>", encoding="utf-8"
+    )
+    monkeypatch.setattr(_mod, "ROOT", tmp_path)
+    assert _mod.main(["--check", "--glob", "*.svg"]) == 0

--- a/scripts/tests/test_upgrade_l20_honesty_guard.py
+++ b/scripts/tests/test_upgrade_l20_honesty_guard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""The L20 spec writer must refuse to write a NEW honesty FAIL.
+
+Most ``_data/l20_covers/*.yml`` specs have drifted away from the honest on-disk
+corpus, so a blind ``--all`` re-render reintroduces covers whose bands assert
+attack/CVE/breach evidence the owning post does not have. That is not
+hypothetical: 49 covers regressed exactly this way after PR #387, and the
+recovery was manual.
+
+The svg-lint honesty gate already blocks such a corpus in CI — but only after
+it is on disk and committed, so the gate tells you to undo N files rather than
+preventing N files. This guard covers the write itself.
+
+The refusal has to be loud in the exit code too. A run that skips the covers it
+was asked to write, then exits 0, reports success for work it did not do.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts import upgrade_l20_cover as _mod  # noqa: E402
+
+SPEC_DIR = REPO / "_data" / "l20_covers"
+
+# A cover class that asserts an attack the owning post has no evidence for.
+# Measured 2026-08-21 against the AWS-security/FinOps course post: `hero:
+# ransomware_lock` and `hero: code_injection` both score FAIL, while
+# `container_escape` PASSes because that post really does cover containers —
+# the scorer is judging evidence, not vocabulary.
+OVERCLAIM = "ransomware_lock"
+
+
+def _a_spec():
+    """The first committed L20 spec, loaded through the real loader."""
+    paths = sorted(SPEC_DIR.glob("*.yml"))
+    assert paths, f"no L20 specs under {SPEC_DIR}; this guard has nothing to test"
+    return _mod.load_spec(paths[0])
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the corpus this guard protects must currently be honest
+# ---------------------------------------------------------------------------
+
+
+def test_committed_specs_render_honestly() -> None:
+    """If a real spec already FAILs, every assertion below is ambiguous."""
+    dishonest = []
+    for path in sorted(SPEC_DIR.glob("*.yml")):
+        spec = _mod.load_spec(path)
+        if _mod.honesty_regression(spec, _mod.render(spec)) is not None:
+            dishonest.append(spec.filename)
+    assert not dishonest, (
+        f"spec(s) already render a non-baselined honesty FAIL: {dishonest}. Fix "
+        "the spec (or baseline it deliberately) before trusting this guard's "
+        "negative cases."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The guard fires
+# ---------------------------------------------------------------------------
+
+
+def test_overclaiming_hero_is_reported() -> None:
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    violations = _mod.honesty_regression(mutated, _mod.render(mutated))
+    assert violations is not None, (
+        f"hero visual {OVERCLAIM!r} on {spec.filename} was accepted; the guard "
+        "cannot see the regression class it exists for"
+    )
+    assert OVERCLAIM in violations, violations
+
+
+def test_write_refuses_and_leaves_the_file_untouched(tmp_path, monkeypatch) -> None:
+    """The refusal must happen BEFORE the write, not be reported after it.
+
+    ``output_path`` is redirected into tmp_path first. Pointing this at the real
+    ``assets/images/`` entry would be a test that corrupts the corpus the moment
+    the guard it checks is absent — which is exactly the condition under which
+    it runs (verified: a mutation run that stripped the guard wrote a dishonest
+    cover into the working tree).
+    """
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    target = tmp_path / spec.filename
+    monkeypatch.setattr(
+        type(mutated), "output_path", property(lambda _self: target), raising=False
+    )
+
+    with pytest.raises(_mod.HonestyRefusal) as excinfo:
+        _mod.write(mutated)
+
+    assert excinfo.value.filename == spec.filename
+    assert not target.exists(), (
+        "the cover was written despite the refusal — the guard runs too late to "
+        "be a write guard"
+    )
+
+
+def test_honest_spec_is_not_refused() -> None:
+    spec = _a_spec()
+    assert _mod.honesty_regression(spec, _mod.render(spec)) is None
+
+
+# ---------------------------------------------------------------------------
+# Escape hatches stay escape hatches
+# ---------------------------------------------------------------------------
+
+
+def test_force_bypasses_the_guard(tmp_path, monkeypatch) -> None:
+    """`--force` exists for a wrong scorer, and must not silently do nothing."""
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    written = {}
+
+    class _Sink:
+        def write_text(self, text, encoding="utf-8"):
+            written["bytes"] = len(text.encode(encoding))
+
+    monkeypatch.setattr(
+        type(mutated), "output_path", property(lambda _self: _Sink()), raising=False
+    )
+    size = _mod.write(mutated, force=True)
+    assert size > 0 and written.get("bytes") == size
+
+
+def test_dry_run_never_writes_and_never_refuses() -> None:
+    """A dry run is for inspection; refusing there would block reading a spec."""
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    assert _mod.write(mutated, dry_run=True) == 0
+
+
+def test_baselined_cover_is_exempt(monkeypatch, tmp_path) -> None:
+    """Grandfathered legacy FAILs must not trip the guard — only new ones do.
+
+    The committed baseline is empty today (emptied 2026-06-23 when the 16 then-
+    failing covers were corrected), so the exemption branch has no live input
+    and is asserted against a temporary baseline instead.
+    """
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    assert _mod.honesty_regression(mutated, _mod.render(mutated)) is not None
+
+    baseline = tmp_path / "baseline.txt"
+    baseline.write_text(f"assets/images/{spec.filename}\n", encoding="utf-8")
+    monkeypatch.setattr(_mod, "_HONESTY_BASELINE", baseline)
+    assert _mod.honesty_regression(mutated, _mod.render(mutated)) is None
+
+
+def test_guard_fails_open_when_the_scorer_is_unavailable(monkeypatch, capsys) -> None:
+    """Defense-in-depth, not the only gate: an import error must not brick the CLI.
+
+    svg-lint still scores the on-disk corpus, so failing open here costs a
+    layer rather than the property. It must be visible, though.
+    """
+    spec = _a_spec()
+    mutated = dataclasses.replace(spec, hero={**spec.hero, "visual": OVERCLAIM})
+    monkeypatch.setitem(sys.modules, "scripts.score_cover_honesty", None)
+    assert _mod.honesty_regression(mutated, _mod.render(mutated)) is None
+    assert "honesty guard unavailable" in capsys.readouterr().err

--- a/scripts/upgrade_l20_cover.py
+++ b/scripts/upgrade_l20_cover.py
@@ -84,6 +84,7 @@ from __future__ import annotations
 import argparse
 import re
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -286,7 +287,64 @@ def render(spec: Spec) -> str:
     )
 
 
-def write(spec: Spec, *, dry_run: bool = False) -> int:
+_HONESTY_BASELINE = REPO_ROOT / "scripts" / "cover_honesty_baseline.txt"
+
+
+class HonestyRefusal(Exception):
+    """Raised instead of writing a cover that would be a new honesty FAIL."""
+
+    def __init__(self, filename: str, violations: str) -> None:
+        super().__init__(f"{filename}: {violations}")
+        self.filename = filename
+        self.violations = violations
+
+
+def honesty_regression(spec: Spec, svg: str) -> Optional[str]:
+    """Return a violation summary when writing ``svg`` would be a NEW honesty FAIL.
+
+    Most ``_data/l20_covers/*.yml`` specs have drifted away from the honest
+    on-disk corpus, so a blind ``--all`` re-render reintroduces covers whose
+    bands assert attack/CVE/breach evidence the owning post does not have. That
+    happened for real: 49 covers regressed this way (see the PR #387 aftermath).
+    The svg-lint honesty gate blocks it in CI, but only *after* the corpus on
+    disk is already wrong and has to be undone cover by cover. This refuses at
+    the write itself.
+
+    Scored off-disk: the SVG goes to a temp file under its real
+    ``spec.filename`` because ``score_cover_honesty.find_owning_post`` resolves
+    the post by matching that basename against each post's ``image:`` field.
+    Already-grandfathered legacy FAILs in the committed baseline do not trip
+    the guard — only new regressions do.
+
+    Fails OPEN with a visible warning if the scorer cannot be imported: this is
+    defense-in-depth, not the only honesty gate, and a scorer import error must
+    not make the whole CLI unusable.
+    """
+    try:
+        from scripts.score_cover_honesty import load_baseline, score_file
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"  WARN: honesty guard unavailable ({exc}); not enforced", file=sys.stderr)
+        return None
+
+    baseline = load_baseline(_HONESTY_BASELINE) if _HONESTY_BASELINE.exists() else set()
+    if f"assets/images/{spec.filename}" in baseline:
+        return None
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td) / spec.filename
+        tmp.write_text(svg, encoding="utf-8")
+        result = score_file(tmp)
+
+    if result.get("verdict") != "FAIL":
+        return None
+    violations = "; ".join(
+        f"{v.get('band')}:{v.get('visual_id')}"
+        for v in (result.get("honesty", {}).get("violations") or [])
+    )
+    return violations or "honesty FAIL"
+
+
+def write(spec: Spec, *, dry_run: bool = False, force: bool = False) -> int:
     """Render and write a spec to disk. Returns size in bytes (0 if dry-run).
 
     Matches the L22 digest CLI semantics (``upgrade_digest_cover.py:write``):
@@ -298,6 +356,10 @@ def write(spec: Spec, *, dry_run: bool = False) -> int:
     svg = render(spec)
     if dry_run:
         return 0
+    if not force:
+        violations = honesty_regression(spec, svg)
+        if violations is not None:
+            raise HonestyRefusal(spec.filename, violations)
     spec.output_path.write_text(svg, encoding="utf-8")
     return len(svg.encode("utf-8"))
 
@@ -442,6 +504,16 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
         help="Re-render each spec and exit 1 if any on-disk SVG drifts",
     )
     parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Bypass the cover-honesty guard. By default a write aborts when "
+            "rendering would introduce a NON-baselined honesty FAIL (a band "
+            "asserting evidence the owning post lacks). Use only when the spec "
+            "is known-good and the scorer is wrong — never to make CI pass."
+        ),
+    )
+    parser.add_argument(
         "--baseline",
         help="With --check: a file of slugs whose drift is grandfathered "
         "(e.g. a rotted spec that would overclaim if regenerated). One slug per "
@@ -476,6 +548,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     drift: List[str] = []
     rendered = 0
     skipped = 0
+    refused = 0
     for p in paths:
         try:
             spec = load_spec(p)
@@ -529,7 +602,20 @@ def main(argv: Optional[List[str]] = None) -> int:
                     )
                     return 3
                 continue
-            size = write(spec, dry_run=args.dry_run)
+            try:
+                size = write(spec, dry_run=args.dry_run, force=args.force)
+            except HonestyRefusal as refusal:
+                print(
+                    f"  REFUSED {refusal.filename}: would introduce a new honesty "
+                    f"FAIL [{refusal.violations}]. The spec has drifted from the "
+                    f"honest on-disk cover; fix the spec, or re-run with --force "
+                    f"if the scorer is wrong.",
+                    file=sys.stderr,
+                )
+                refused += 1
+                if args.spec:  # explicit single-spec request -> hard error
+                    return 4
+                continue
             tag = "[DRY] " if args.dry_run else ""
             print(f"  {tag}wrote {spec.filename}: {size} bytes")
             rendered += 1
@@ -543,8 +629,13 @@ def main(argv: Optional[List[str]] = None) -> int:
     msg = f"\n{rendered} spec(s) rendered"
     if skipped:
         msg += f"  ({skipped} skipped — cron/content-owned, not writable from a spec)"
+    if refused:
+        msg += f"  ({refused} REFUSED — would introduce a new honesty FAIL)"
     print(msg)
-    return 0
+    # A refusal is the guard working, but the run did not do what was asked, so
+    # it must not exit 0 — otherwise a batch regen reports success having
+    # skipped the covers that mattered.
+    return 4 if refused else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#395(2026-06-08)의 판정 결과다. **리베이스 불가, 의도는 유효 → 현재 main에 재구현.**

## #395 판정 근거

| 항목 | 실측 |
|---|---|
| base와의 거리 | **415 커밋** 뒤처짐 (마지막 갱신 2026-06-08) |
| 리베이스 | `scripts/upgrade_l20_cover.py`에서 **충돌** — 그 PR이 건드리는 유일한 핵심 파일 |
| 의도 유효성 | **두 절반 모두 오늘도 살아 있는 결함** (아래) |

415커밋 뒤처진 브랜치를 그 파일에서 충돌 해결하며 되살리는 것보다, 현재 API에 대고 재구현하는 편이 싸고 검증 가능하다. #395는 이 PR을 근거로 닫는다.

## 1. QR fixer가 200/200을 놓치고 있었다

`_QR_BLOCK_RE`가 스캔 라벨을 `x="1122" y="614"`로 앵커했다. QR 지오메트리가 108px로 커지며 라벨이 `x="1134" y="486"`으로 이동했고, 정규식은 계속 컴파일되고 계속 실행되며 아무것도 매치하지 않았다:

```
$ python3 scripts/fix_qr_url_in_covers.py --check
Total scanned:      200
Changed/needs-fix:  0
Already correct:    0
No QR block found:  200      ← 100% 미스
```

`Changed: 0`은 건강한 코퍼스도 출력하는 값이다. 그래서 이 도구는 "고칠 것 없음"을 보고하며 아무것도 검사하지 않는 상태로 살아남았다.

라이브 커버 실측 — 좌표는 1종, 캡션은 전원 동일:

```
caption='scan / full post': 200      (QR block absent: 0)
x=1134 y=486: 273
```

앵커를 좌표에서 **텍스트**로 옮겼다. 수정 후:

```
Already correct:    200
No QR block found:  0
```

QR URL은 실제로 전부 맞았고, 도구가 못 보고 있었을 뿐이다.

**추가로 비공허성 검사**: 스캔한 모든 파일에서 QR 블록을 하나도 못 찾으면 `exit 1`. 총미스는 템플릿 드리프트의 서명이고, 0건 보고와 구분되지 않는 게 이 결함의 본질이었다.

## 2. 스펙 write에 honesty 가드가 없었다

현재 `upgrade_l20_cover.py`에는 **drift 베이스라인만** 있고 honesty 검사가 없다(`_load_drift_baseline`). svg-lint의 honesty 게이트는 디스크에 써지고 커밋된 **뒤** 막으므로, "N개를 되돌려라"를 알려줄 뿐 N개가 써지는 것을 막지 못한다 — PR #387 이후 49커버가 정확히 그 경로로 회귀했다.

`write()`가 렌더 후 쓰기 전에 스코어링하고, 비-baseline honesty FAIL이면 `HonestyRefusal`로 거부한다.

| 상황 | 동작 |
|---|---|
| 정직한 스펙 | write |
| 비-baseline honesty FAIL | **REFUSED**, 디스크 무변경, `--spec`은 exit 4 |
| baseline 등재 | 면제 (레거시 grandfathered) |
| `--force` | 우회 (스코어러가 틀린 경우) |
| `--dry-run` | 불변 (검사용이므로 거부하지 않음) |
| 스코어러 import 실패 | **fail-open** + 경고 (svg-lint가 여전히 디스크를 검사하므로 층 하나 손실) |

refusal이 있으면 종료 코드 4다. 요청받은 커버를 건너뛰고 exit 0이면 하지 않은 일을 성공으로 보고하는 것이다.

### 실측

```
$ # hero visual -> ransomware_lock (FinOps/AWS 강의 포스트)
$ python3 scripts/upgrade_l20_cover.py --spec <spec>
  REFUSED …: would introduce a new honesty FAIL [hero:ransomware_lock]
  exit=4    디스크변경=0

$ python3 scripts/upgrade_l20_cover.py --all
  4 spec(s) rendered  (1 REFUSED — would introduce a new honesty FAIL)
  exit=4    디스크변경=0        ← 나머지 4개는 byte-identical

$ python3 scripts/upgrade_l20_cover.py --spec <spec> --force
  exit=0    디스크변경=1
```

`container_escape`로 바꾸면 **통과**한다 — 그 포스트에 컨테이너 근거가 실제로 있어 스코어러가 정직하게 허용한 것이다. 가드가 어휘가 아니라 근거를 보고 있다는 증거로 테스트에 기록했다.

베이스라인은 현재 비어 있다(2026-06-23에 16개 FAIL을 honest 클래스로 교정하며 비움). 그래서 면제 분기는 라이브 입력이 없고, 임시 베이스라인으로 어서션했다.

## 테스트 14건 / 뮤테이션 4종 전부 caught

| 뮤테이션 | 결과 |
|---|---|
| QR 정규식을 좌표 앵커로 환원 | ❌ 4건 (현재 지오메트리·좌표앵커금지·라이브코퍼스·부분미스) |
| 비공허성(총미스 에러) 제거 | ❌ `test_total_miss_is_an_error_not_a_clean_report` |
| honesty 가드 호출 제거 | ❌ `test_write_refuses_and_leaves_the_file_untouched` |
| baseline 면제를 무조건 면제로 | ❌ 3건 |

### 작업 중 잡은 내 테스트 설계 결함

refusal 테스트가 처음에 **실제 `assets/images/` 경로**를 대상으로 했다. 가드를 제거한 뮤테이션 실행에서 그 테스트가 부정직한 커버를 워킹트리에 실제로 썼고, `test_l20_cover_ownership_guard`의 drift 게이트가 그걸 잡아냈다:

```
M assets/images/2025-05-02-Cloud_Security_Course_7Batch_-_3Week_AWS_Security_and_Finops.svg
```

`output_path`를 `tmp_path`로 리다이렉트해 격리했다. 재검증: 가드 제거 시 테스트는 여전히 실패하고 코퍼스 오염은 0건이다. **검사하려는 가드가 없을 때 코퍼스를 오염시키는 테스트는 그 자체가 결함이다.**

## 검증

```
$ python3 -m pytest scripts/tests/ -q
  4278 passed, 5 skipped

$ python3 scripts/score_cover_honesty.py --all --baseline scripts/cover_honesty_baseline.txt --strict
  exit=0
$ python3 scripts/upgrade_l20_cover.py --all --check     # drift
  exit=0
$ python3 scripts/fix_qr_url_in_covers.py --check
  exit=0
$ git status --short assets/images/ | wc -l
  0

$ python3 -m ruff check <변경 4개 파일>
  All checks passed!
```