### PR TITLE
feat(ci): vercel-firewall-backup 주간 cron 복원 + VERCEL_TOKEN fail-closed [BLOCKED: 시크릿 등록 대기]

### DIFF
--- a/.github/workflows/vercel-firewall-backup.yml
+++ b/.github/workflows/vercel-firewall-backup.yml
@@ -15,24 +15,26 @@ name: Vercel Firewall Backup
 #   VERCEL_PROJECT_ID  — defaults to tech-blog project
 #   VERCEL_TEAM_ID     — defaults to twodragon0s-projects team
 
-# RETIRED FROM THE WEEKLY SCHEDULE (2026-08-10).
+# WEEKLY SCHEDULE RESTORED (pending VERCEL_TOKEN provisioning).
 #
-# VERCEL_TOKEN has never been configured, so no snapshot has ever been taken.
-# Verified from the live log:
+# Retired from cron on 2026-08-10 because VERCEL_TOKEN had never been
+# configured: every weekly run reported success while
 #
 #     ##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
 #
-# That is worth stating plainly given the incident in the header above: this
-# workflow exists so an unauthorized dashboard edit shows up as a committed diff,
-# and it has been reporting weekly success without ever producing one. The green
-# tick was itself the audit-trail gap it was built to close.
+# meant no snapshot was ever taken. Given the incident in the header above,
+# that green tick WAS the audit-trail gap this workflow exists to close —
+# docs/backups/vercel-firewall/latest.json had not changed since 2026-05-08.
 #
-# The cron is removed rather than made fail-closed: with the secret permanently
-# absent, failing would produce a red run every Monday, which gets muted — the same
-# failure mode digest-translate-backfill.yml was repaired for. `workflow_dispatch`
-# is kept so the first real snapshot is one click away once VERCEL_TOKEN exists;
-# restore the cron in that same PR.
+# The cron and the fail-closed branch below only make sense together with the
+# secret. Restoring the cron without it produces a red run every Monday, which
+# gets muted; making the branch soft again restores the silent no-op. That
+# pairing is enforced by scripts/tests/test_ci_secret_absence_guard.py, so this
+# change must land in the same PR as `gh secret set VERCEL_TOKEN`.
 on:
+  schedule:
+    # Monday 00:00 UTC = Monday 09:00 KST
+    - cron: "0 0 * * 1"
   workflow_dispatch:
     inputs:
       commit:
@@ -73,15 +75,17 @@ jobs:
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
         run: |
           if [ -z "$VERCEL_TOKEN" ]; then
-            echo "::warning::VERCEL_TOKEN secret not set; skipping snapshot."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "::error::VERCEL_TOKEN is not available. It is configured in this repo, so this is a regression — the weekly firewall snapshot is the only audit trail for dashboard edits (2026-05-08 incident) and it is not being taken."
+            exit 1
           fi
           python3 scripts/backup_vercel_firewall.py
         id: snapshot
 
       - name: Detect drift + commit
-        if: steps.snapshot.outputs.skip != 'true' && github.event.inputs.commit != 'false'
+        # `steps.snapshot.outputs.skip` is gone: the snapshot step no longer has
+        # a skip path — a missing VERCEL_TOKEN now fails the job instead of
+        # setting that output, so the guard on it could only ever be true.
+        if: github.event.inputs.commit != 'false'
         run: |
           # Stage backup dir; commit only if there's a meaningful change
           # (the redacted snapshot strips updatedAt timestamps, so any

--- a/scripts/tests/test_ci_secret_absence_guard.py
+++ b/scripts/tests/test_ci_secret_absence_guard.py
@@ -59,6 +59,18 @@ FAIL_CLOSED = (
 # Secrets never configured -> fail-closed would be a permanently red cron.
 NEVER_CONFIGURED = {
     "gsc-queue-refresh.yml": "GSC_SERVICE_ACCOUNT_JSON",
+}
+
+# Fail-closed on a NON-Slack secret. Same rule as FAIL_CLOSED above (an absent
+# secret is a regression, not an optional integration), but the assertions
+# differ: these workflows have no SLACK_BOT_TOKEN / SLACK_CHANNEL_ID pair to
+# match, so the guard block is keyed on the workflow's own secret name.
+#
+# vercel-firewall-backup moved here from NEVER_CONFIGURED when VERCEL_TOKEN was
+# provisioned. Its cron came back in the same change, which is what the
+# docstring's "Direction" paragraph asks for: the secret and the schedule are
+# only correct together.
+FAIL_CLOSED_NON_SLACK = {
     "vercel-firewall-backup.yml": "VERCEL_TOKEN",
 }
 
@@ -102,6 +114,48 @@ def test_missing_secret_is_an_error_annotation_not_a_warning(name: str):
     guard_region = body[body.find("SLACK_BOT_TOKEN:-") :][:1200]
     assert "::error::" in guard_region, (
         f"{name}: the missing-secret branch should emit ::error::, not ::warning::"
+    )
+
+
+@pytest.mark.parametrize(("name", "secret"), sorted(FAIL_CLOSED_NON_SLACK.items()))
+def test_non_slack_fail_closed_workflows_exit_nonzero(name: str, secret: str):
+    """A provisioned secret's absence must fail, whatever the integration is."""
+    body = _body(name)
+    assert secret in body, f"{name} no longer references {secret}"
+    blocks = re.findall(
+        rf'if \[ -z "\$\{{?{secret}}}?" \][^\n]*\n(.*?)\n\s*fi',
+        body,
+        re.DOTALL,
+    )
+    assert blocks, f"{name}: no {secret} guard block found"
+    for block in blocks:
+        assert "exit 1" in block, (
+            f"{name}: a missing {secret} still exits 0. The secret is configured, "
+            f"so a green skip hides the job silently doing nothing — which is the "
+            f"state this workflow was retired from cron for."
+        )
+        assert "exit 0" not in block, f"{name}: guard block still contains exit 0"
+        assert "::error::" in block, (
+            f"{name}: the missing-secret branch emits no ::error::. A ::warning:: "
+            f"reads as expected-and-fine; this state is neither."
+        )
+
+
+@pytest.mark.parametrize("name", sorted(FAIL_CLOSED_NON_SLACK))
+def test_non_slack_fail_closed_workflows_are_scheduled(name: str):
+    """The inverse of the NEVER_CONFIGURED rule below.
+
+    Fail-closed without a cron is a workflow that can only fail when someone
+    remembers to click it. The pairing runs both ways: no secret -> no cron, and
+    secret -> cron.
+    """
+    import yaml
+
+    parsed = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    on = parsed[True] if True in parsed else parsed["on"]
+    assert "schedule" in on, (
+        f"{name} is fail-closed on a provisioned secret but has no schedule, so "
+        f"the snapshot only happens on a manual dispatch. Restore the cron."
     )
 
 


### PR DESCRIPTION
> **⛔ 병합 금지 — `VERCEL_TOKEN` 등록 전에 머지하면 매주 월요일 red가 됩니다.**
>
> 이 PR은 2026-08-11 프로비저닝 결정의 **코드 절반**입니다. 나머지 절반(시크릿 발급·등록)은 제가 할 수 없습니다 — Vercel 대시보드 접근이 필요합니다.

## 왜 같은 PR이어야 하는가

`scripts/tests/test_ci_secret_absence_guard.py`가 페어링을 양방향으로 고정합니다:

- 시크릿 없음 → cron 없어야 함 (`test_never_configured_workflows_are_not_scheduled`)
- 시크릿 있음 → cron 있어야 함 (이 PR이 추가한 `test_non_slack_fail_closed_workflows_are_scheduled`)

`notes/ci-gate-audit-2026-08.md`의 "재개 절차"가 적어둔 그대로입니다 — 등록 없이 cron만 되살리면 이번엔 영구 green이 아니라 **영구 red**입니다.

## 필요한 사용자 작업 2단계

1. **발급** — Vercel → Account Settings → Tokens. 팀 스코프 **읽기 전용**으로 충분합니다(`PROJECT_ID`/`TEAM_ID`는 워크플로에 기본값이 있어 생략 가능).
2. **등록** — 이 세션에서 바로 실행하려면 프롬프트에 `!` 접두사를 붙이면 됩니다:

   ```
   ! gh secret set VERCEL_TOKEN
   ```

   (토큰 값은 stdin으로 입력되며 이 대화에 남지 않습니다.)

등록 확인 후 병합하면, 다음 월요일 00:00 UTC에 첫 실제 스냅샷이 생성됩니다. `workflow_dispatch`도 유지돼 있어 즉시 확인도 가능합니다.

## 배경 — 그 초록 체크가 곧 감사 공백이었다

2026-08-10에 cron이 제거됐습니다. `VERCEL_TOKEN`이 설정된 적이 없어 매주 이렇게 돌았습니다:

```
##[warning]VERCEL_TOKEN secret not set; skipping snapshot.
```

성공을 보고하며 스냅샷은 한 번도 만들지 않았습니다. 워크플로 헤더의 2026-05-08 사건(대시보드에서 `bot_protection`이 `challenge`로 바뀌어 Googlebot을 며칠간 차단)을 생각하면 이게 핵심입니다 — 이 워크플로의 존재 이유가 "무단 대시보드 편집을 커밋된 diff로 남기는 것"인데, `docs/backups/vercel-firewall/latest.json`은 **사건 당일 이후 갱신이 0**입니다.

## 변경

| 파일 | 변경 |
|---|---|
| `.github/workflows/vercel-firewall-backup.yml` | `schedule: cron "0 0 * * 1"`(월 09:00 KST) 복원, 시크릿 부재를 `::warning::`+`exit 0` → `::error::`+`exit 1` |
| `scripts/tests/test_ci_secret_absence_guard.py` | `NEVER_CONFIGURED`에서 제거 → 새 `FAIL_CLOSED_NON_SLACK` 파티션 |

**파티션을 새로 만든 이유**: 기존 `FAIL_CLOSED` 테스트는 `SLACK_BOT_TOKEN`/`SLACK_CHANNEL_ID` 쌍을 전제로 어서션합니다(`assert "SLACK_BOT_TOKEN" in body`). non-Slack 시크릿에 그대로 쓸 수 없어, 워크플로 자신의 시크릿 이름으로 가드 블록을 검사하는 파티션을 추가했습니다. **역방향도 고정**했습니다 — cron 없는 fail-closed는 누가 버튼을 눌러야만 실패할 수 있는 워크플로입니다.

내 변경이 만든 고아도 정리했습니다: `steps.snapshot.outputs.skip` 참조는 skip 경로가 사라져 항상 true였습니다.

### 뮤테이션 3종 전부 caught

| 뮤테이션 | 결과 |
|---|---|
| cron 제거 | ❌ `test_non_slack_fail_closed_workflows_are_scheduled` |
| `exit 1` → `exit 0` (침묵 no-op 환원) | ❌ `test_non_slack_fail_closed_workflows_exit_nonzero` |
| `::error::` → `::warning::` | ❌ 동일 |

가드 정규식의 비공허성도 실측했습니다 — 매치 1건, 그 블록에 `exit 1`과 `::error::`가 있음을 확인(정규식이 0건 매치면 테스트는 "no guard block found"로 실패하지만, 통과한 게 매치 때문인지 확인했습니다).

## 검증

```
$ python3 -m pytest scripts/tests/ -q
  4278 passed, 5 skipped

$ python3 -m pytest scripts/tests/test_ci_secret_absence_guard.py -q
  23 passed

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/vercel-firewall-backup.yml'))"
  yaml OK
```

`gsc-queue-refresh.yml` / `GSC_SERVICE_ACCOUNT_JSON`은 이 PR 범위 밖입니다 — `NEVER_CONFIGURED`에 그대로 남아 있고, 같은 절차가 필요합니다.