### PR TITLE
fix(analytics): vitals beacon을 /api/vitals/ 로 — hide 시점의 308 왕복 제거

### DIFF
--- a/assets/js/performance-monitor.js
+++ b/assets/js/performance-monitor.js
@@ -83,8 +83,17 @@
             p: window.location.pathname,
             m: vitalsBatch
           });
+          // Trailing slash on purpose. vercel.json sets `trailingSlash: true`,
+          // so '/api/vitals' answers 308 -> '/api/vitals/' (measured on
+          // production 2026-08-21: 1 redirect vs 0 for the slashed path, both
+          // ending in 204). The redirect is followed by the browser and works,
+          // but this beacon is sent at page hide precisely because that is the
+          // moment the document is being torn down — paying an extra round trip
+          // there is the one place in the codebase where it is worth avoiding.
+          // Pinned by tests/js/performance-monitor.test.js against the
+          // vercel.json setting, so flipping trailingSlash fails loudly.
           navigator.sendBeacon(
-            '/api/vitals',
+            '/api/vitals/',
             new Blob([body], { type: 'application/json' })
           );
         } catch (err) {

--- a/tests/js/performance-monitor.test.js
+++ b/tests/js/performance-monitor.test.js
@@ -1072,7 +1072,21 @@ describe('performance-monitor.js CLS', () => {
     fire('visibilitychange');
 
     expect(sent).toHaveLength(1);
-    expect(sent[0].url).toBe('/api/vitals');
+    expect(sent[0].url).toBe('/api/vitals/');
+
+    // The slash is not cosmetic: vercel.json sets `trailingSlash: true`, so the
+    // unslashed path answers 308 (measured on production, 1 redirect vs 0).
+    // A beacon fired at page hide should not spend a round trip on a redirect.
+    // Asserted against vercel.json rather than hard-coded so flipping that
+    // setting fails here instead of silently costing every reader a hop.
+    const vercelConfig = JSON.parse(
+      readFileSync(resolve(__dirname, '../../vercel.json'), 'utf8')
+    );
+    if (vercelConfig.trailingSlash === true) {
+      expect(sent[0].url.endsWith('/')).toBe(true);
+    } else {
+      expect(sent[0].url.endsWith('/')).toBe(false);
+    }
     expect(vitalFor('CLS').metric_value).toBeCloseTo(0.05, 5);
   });
 


### PR DESCRIPTION
#558을 병합한 뒤 **라이브에서 실제로 확인하다가** 나온 것이다. CI는 전부 green이었고 코드도 맞았지만, 프로덕션 라우팅이 한 겹 더 있었다.

## 실측

`vercel.json`에 `trailingSlash: true`가 있어 슬래시 없는 `/api/*`는 308을 받는다.

```
$ curl -D - https://tech.2twodragon.com/api/vitals
HTTP/1.1 308 Permanent Redirect
Location: /api/vitals/

$ curl -X POST https://tech.2twodragon.com/api/vitals/ …
POST /api/vitals/ = 204  (redirects=0)

$ curl -L -X POST https://tech.2twodragon.com/api/vitals …
POST /api/vitals  = 204  (redirects=1)
```

**깨진 것은 아니다.** 리다이렉트는 브라우저가 따라가고(308은 메서드·본문 보존) 결과는 204다. 배포도 확인했다 — 라이브 번들에 beacon 코드가 이미 들어가 있다.

## 그런데 이 한 홉이 하필 여기 있다

이 beacon은 문서가 해체되는 **page hide** 시점에 나가고, 그 시점 생존이 이 전송 방식을 고른 유일한 이유다(#558: gtag가 ~5초 배치 타이머 뒤로 밀어 탭 닫기·내부 링크 이동에서 전량 유실). 왕복 한 번을 아끼는 것이 코드베이스에서 실제로 의미 있는 거의 유일한 지점이다.

`/api/chat`도 슬래시가 없어 같은 308을 받는다 — **레포 전반의 패턴이고 #558이 만든 것이 아니다.** 사용자가 페이지에 남아 있는 fetch라 지연이 손실로 이어지지 않으므로 그쪽은 건드리지 않았다.

## 테스트는 하드코딩이 아니라 설정에 대고 어서션한다

```js
const vercelConfig = JSON.parse(readFileSync(resolve(__dirname, '../../vercel.json'), 'utf8'));
if (vercelConfig.trailingSlash === true) {
  expect(sent[0].url.endsWith('/')).toBe(true);
} else {
  expect(sent[0].url.endsWith('/')).toBe(false);
}
```

`'/api/vitals/'`를 그냥 박아두면, 나중에 `trailingSlash`를 뒤집는 사람이 조용히 모든 독자에게 홉을 물리게 된다. 이 어서션은 그때 실패한다.

### 뮤테이션 (양방향)

| 뮤테이션 | 결과 |
|---|---|
| beacon 경로를 `/api/vitals`로 환원 | ❌ `expected '/api/vitals' to be '/api/vitals/'` |
| `vercel.json`의 `trailingSlash`를 `false`로 | ❌ `expected true to be false` |

## 검증

```
$ npx vitest run
  Test Files  29 passed (29)
       Tests  733 passed (733)

$ python3 -m pytest scripts/tests/ -q
  4278 passed, 5 skipped
```

GA4 수신 자체는 확인하지 못했다 — `GA4_API_SECRET`이 Vercel에 설정돼 있어야 하고(#558이 `CLAUDE.md`에 명시), 그 값은 이 세션에서 볼 수 없다. 엔드포인트는 시크릿이 없어도 204를 반환하도록 설계돼 있어(독자에게 영향 0) **204만으로는 수집 여부를 알 수 없다.** GA4 Realtime에서 `web_vitals` 확인이 남은 단계다.