### PR TITLE
feat(ops): 런타임 env 계약 가드 — GA4_API_SECRET 부재 실측 확인

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -854,7 +854,19 @@ merge. Confirm the **live** bundle, then the **event**:
    **`GA4_API_SECRET` must be set in Vercel or the endpoint drops everything.**
    The gtag path is gone, so an unset secret means zero collection, not
    degraded collection. The function logs
-   `[vitals] GA4_API_SECRET is not set` in that case.
+   `[vitals] GA4_API_SECRET is not set` in that case — into a Vercel function
+   log nobody reads, which is why it went unnoticed. **Measured 2026-08-24: the
+   secret is absent, so this pipeline has collected nothing since #558 shipped.**
+
+   Check it in one command instead of reading logs (names only, no values):
+   ```bash
+   python3 scripts/check_runtime_env_contract.py --vercel
+   ```
+   The credentials-free half of that script — every `process.env.*` in `api/`
+   must be declared with what breaks when it is absent — runs in the normal
+   pytest suite (`scripts/tests/test_runtime_env_contract.py`), so a new runtime
+   dependency cannot land undocumented. Provisioning runbook and the full
+   verification sequence: `docs/setup/VERCEL_ENV_SETUP.md`.
 
 Background on why the transport moved (gtag batches behind a ~5s timer and
 vitals are pushed at hide, so tab-close and internal navigation lost them

--- a/docs/setup/VERCEL_ENV_SETUP.md
+++ b/docs/setup/VERCEL_ENV_SETUP.md
@@ -2,6 +2,86 @@
 
 tech-blog 프로젝트에 필요한 Vercel 환경 변수 설정 가이드입니다.
 
+## 런타임 env 계약 (2026-08-24 실측)
+
+`api/`의 서버리스 함수가 읽는 환경 변수 전체다. 이 표는 손으로 관리하지 않는다 —
+`scripts/check_runtime_env_contract.py`가 `api/**/*.js`의 `process.env.*`를
+스캔해서 선언 누락·고아 선언을 CI에서 차단하고, `--vercel`로 실제 프로비저닝
+여부까지 확인한다.
+
+```bash
+# 선언 동기화만 (자격증명 불필요, CI가 도는 것과 동일)
+python3 scripts/check_runtime_env_contract.py
+
+# Vercel에 실제로 있는지까지 (vercel CLI 로그인 필요, 이름만 조회)
+python3 scripts/check_runtime_env_contract.py --vercel
+```
+
+| 변수 | 분류 | 상태 (2026-08-24) | 부재 시 |
+|---|---|---|---|
+| `GA4_API_SECRET` | REQUIRED | ❌ **미설정** | `api/vitals.js`가 모든 web_vitals 비콘을 폐기. 엔드포인트는 그래도 204를 반환하므로 **수집이 정상인 것처럼 보인다** |
+| `DEEPSEEK_API_KEY` | REQUIRED | ✅ Production | 챗봇 위젯 오류 |
+| `SENTRY_DSN` | OPTIONAL | ✅ Production | 서버측 오류 리포팅 없음, 기능은 동작 |
+| `GA4_MEASUREMENT_ID` / `SITE_ORIGIN` / `DEEPSEEK_MODEL` / `DEBUG` / `SEARCH_*` / `RATELIMIT_*` | OPTIONAL | 미설정 | 코드에 기본값 있음 |
+| `USE_UPSTASH_RATELIMIT` / `UPSTASH_REDIS_REST_*` | OPTIONAL | 미설정 | **의도된 상태**. in-memory 레이트리미터는 서버리스에서 인스턴스별로 동작하고 코드가 시작 시 그걸 경고한다. 선택된 trade-off이며 누락된 자격증명이 아니다 |
+| `NODE_ENV` / `VERCEL_ENV` | PLATFORM | 런타임 주입 | — |
+
+프로젝트에 `REDIS_URL`, `POSTGRES_URL`, `DATABASE_URL`, `PRISMA_DATABASE_URL`,
+`BLOB_READ_WRITE_TOKEN`이 있지만 **`api/`의 어떤 코드도 읽지 않는다** — Vercel
+스토리지 연동이 만든 것이다. 결함은 아니지만, `REDIS_URL`이 있다고 레이트리밋이
+Redis를 쓰는 것은 아니다(위 표의 `USE_UPSTASH_RATELIMIT` 참조).
+
+### `GA4_API_SECRET` 등록 체크리스트
+
+`web_vitals` 수집은 이 값 없이는 **0건**이다. PR #558·#586이 gtag 배치 유실을
+없애려고 퍼스트파티 비콘으로 옮겼지만, 시크릿이 없어 그 파이프라인은 아직 아무것도
+수집하지 않았다. 근거: `vercel env ls production`에 이름이 없음(2026-08-24).
+
+1. **GA4에서 값 생성**
+   Google Analytics → **Admin** → **Data streams** → 웹 스트림 선택 →
+   **Measurement Protocol API secrets** → **Create**.
+   생성된 secret value를 복사한다. Measurement ID는 코드에 기본값
+   `G-B29150XJ73`으로 있으므로 따로 등록하지 않아도 된다.
+
+2. **Vercel에 등록** — 대시보드 또는 CLI 중 하나로.
+
+   ```bash
+   vercel env add GA4_API_SECRET production
+   # 프롬프트에 1단계에서 복사한 값 붙여넣기
+   ```
+
+   Production만으로 충분하다. Preview 배포에서 vitals를 수집할 이유가 없고,
+   같은 GA4 속성에 프리뷰 트래픽이 섞이면 데이터가 오염된다.
+
+3. **재배포** — 환경 변수는 빌드 시점에 주입되므로 **기존 배포에는 적용되지
+   않는다.** Vercel 대시보드에서 최신 Production 배포를 Redeploy 하거나, 아무
+   커밋이나 main에 올린다.
+
+4. **검증** — 세 단계를 순서대로. 앞 단계를 건너뛰면 실패 원인을 구분할 수 없다.
+
+   ```bash
+   # (a) 등록 자체 확인 — 이름만 조회, 값은 노출되지 않는다
+   python3 scripts/check_runtime_env_contract.py --vercel
+   # 기대: [runtime-env] OK — ... all 2 REQUIRED present in Vercel.
+   ```
+
+   (b) **전송 확인**: DevTools → Network → `vitals` 필터 → 탭을 닫거나 내부
+   링크 클릭. `/api/vitals`로 POST 1건, status 204, metric 최대 3개.
+   204는 시크릿이 있어도 없어도 같으므로 **이것만으로는 수집을 증명하지
+   못한다.**
+
+   (c) **수집 확인**: GA4 → Realtime → `web_vitals` 이벤트. LCP/CLS는 상호작용
+   없이도 올라오고, INP는 독자가 상호작용해야 나타난다. 여기서 이벤트가 보이면
+   비로소 파이프라인이 살아 있다.
+
+5. **회귀 방지** — 값을 로테이션하거나 삭제하면 다시 조용히 0건이 된다.
+   `--vercel` 체크를 주기적으로 돌리는 것이 유일한 감시 수단이다. CI에는 걸 수
+   없다(`VERCEL_TOKEN` 미등록, PR #585가 그 프로비저닝 대기 중).
+
+배경: `notes/ga4-web-vitals-delivery-loss.md`(왜 gtag를 버렸나),
+`notes/ga4-web-vitals-reporting.md`(이벤트 계약·리포트 스펙),
+`notes/ci-skip-campaign-2026-08.md`(런타임 자격증명이 왜 감사 사각지대였나).
+
 ## DeepSeek API 키 설정
 
 ### 방법 1: Vercel 대시보드에서 설정 (권장)
@@ -44,11 +124,15 @@ vercel env add DEEPSEEK_API_KEY development
 vercel env ls
 ```
 
-다음과 같이 표시되어야 합니다:
+다음과 같이 표시됩니다 (2026-08-24 실측):
 
 ```
-DEEPSEEK_API_KEY    Encrypted    Development, Preview, Production
+DEEPSEEK_API_KEY    Encrypted    Production
 ```
+
+이 문서는 이전에 `Development, Preview, Production`이라고 적고 있었으나 실제
+등록은 Production 하나다. 챗봇을 프리뷰에서 시험할 일이 있으면 그때 추가하면
+되고, 없다면 Production만으로 충분하다.
 
 ## 참고사항
 

--- a/scripts/check_runtime_env_contract.py
+++ b/scripts/check_runtime_env_contract.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Keep every runtime env var that `api/` reads declared, so absence is loud.
+
+Why this exists
+---------------
+`notes/ci-skip-campaign-2026-08.md` closed with the observation that every
+credential guard in this repo is keyed to **CI secrets** — it walks
+`.github/workflows/` and asserts each referenced secret either fails closed or
+is listed as never-configured. Runtime credentials live somewhere that axis
+cannot see: the Vercel project's environment variables. So half of the same
+defect class was a structural blind spot, and it cost us one:
+
+`GA4_API_SECRET` was never provisioned. `api/vitals.js` drops every report when
+it is absent (`api/vitals.js:205-210`), and because the endpoint is
+fire-and-forget it answers 204 either way. Two PRs of first-party beacon work
+(#558, #586) shipped into a pipeline that collected nothing, and the only signal
+was a `console.warn` in a Vercel function log that nobody reads. Verified absent
+via `vercel env ls production` on 2026-08-24.
+
+What it checks
+--------------
+Two things, and only the first needs credentials-free CI:
+
+1. **Declaration sync (always).** Every ``process.env.NAME`` in ``api/`` must
+   appear in the manifest below, and every manifest entry must still be read by
+   ``api/``. A new runtime dependency therefore cannot land without someone
+   writing down what breaks when it is missing and where it gets provisioned.
+   This is the part that runs in CI.
+2. **Provisioning (``--vercel``, opt-in).** Runs ``vercel env ls`` and reports
+   REQUIRED names that are absent from the Vercel project. Needs an
+   authenticated Vercel CLI, so it is a one-command owner check, not a CI gate.
+   Only variable *names* are read; values are never fetched or printed.
+
+Manifest categories
+-------------------
+``PLATFORM``  Vercel injects it. Nothing to provision.
+``REQUIRED``  Absence silently disables a shipped feature. Must exist in Vercel.
+``OPTIONAL``  Has a working default, or is an explicit opt-in flag that is
+              deliberately off. Absence is a documented state, not a defect.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Set
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+API_DIR = REPO_ROOT / "api"
+
+_ENV_RE = re.compile(r"process\.env\.([A-Z][A-Z0-9_]*)")
+
+PLATFORM: Dict[str, str] = {
+    "NODE_ENV": "injected by the runtime; 'production' on Vercel",
+    "VERCEL_ENV": "injected by Vercel; production | preview | development",
+}
+
+REQUIRED: Dict[str, str] = {
+    "GA4_API_SECRET": (
+        "api/vitals.js — GA4 Measurement Protocol secret. Absent: every "
+        "web_vitals beacon is dropped and the endpoint still answers 204, so "
+        "collection reads as working. Provision: Vercel project env "
+        "(Production). Create the value in GA4 Admin > Data Streams > the web "
+        "stream > Measurement Protocol API secrets."
+    ),
+    "DEEPSEEK_API_KEY": (
+        "api/chat.js — chatbot upstream key. Absent: the chat widget errors. "
+        "Provision: Vercel project env (Production). Present as of 2026-08-24."
+    ),
+}
+
+OPTIONAL: Dict[str, str] = {
+    "SENTRY_DSN": (
+        "api/chat.js — error reporting. Absent: no server-side reporting, "
+        "feature still works. Present as of 2026-08-24."
+    ),
+    "GA4_MEASUREMENT_ID": "api/vitals.js — defaults to the hardcoded G-B29150XJ73.",
+    "SITE_ORIGIN": "api/vitals.js — defaults to https://tech.2twodragon.com.",
+    "DEEPSEEK_MODEL": "api/chat.js — model override; code carries a default.",
+    "DEBUG": "api/chat.js — verbose logging switch.",
+    "SEARCH_CACHE_TTL": "api/search.js — cache TTL override; code carries a default.",
+    "SEARCH_RATE_LIMIT_RPM": "api/search.js — rate override; code carries a default.",
+    "RATELIMIT_ANONYMOUS_RPM": "api/lib/ratelimit.js — override; code carries a default.",
+    "RATELIMIT_AUTHENTICATED_RPM": "api/lib/ratelimit.js — override; code carries a default.",
+    "USE_UPSTASH_RATELIMIT": (
+        "api/lib/ratelimit.js — explicit opt-in ('true') for the Redis-backed "
+        "limiter. Deliberately unset: the in-memory limiter is per-instance on "
+        "serverless, which the code warns about at startup. This is a chosen "
+        "trade-off, not a missing credential."
+    ),
+    "UPSTASH_REDIS_REST_URL": (
+        "api/search.js, api/lib/ratelimit.js — only read when "
+        "USE_UPSTASH_RATELIMIT is 'true'. Unset, consistent with that flag "
+        "being off. Note the Vercel project has REDIS_URL from a storage "
+        "integration, which no code in api/ reads."
+    ),
+    "UPSTASH_REDIS_REST_TOKEN": "api/lib/ratelimit.js — pairs with the URL above.",
+}
+
+
+def declared() -> Dict[str, str]:
+    return {**PLATFORM, **REQUIRED, **OPTIONAL}
+
+
+def referenced() -> Dict[str, Set[str]]:
+    """env name -> set of api/ files reading it, excluding tests."""
+    found: Dict[str, Set[str]] = {}
+    for path in sorted(API_DIR.rglob("*.js")):
+        if "__tests__" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for name in _ENV_RE.findall(text):
+            found.setdefault(name, set()).add(str(path.relative_to(REPO_ROOT)))
+    return found
+
+
+def vercel_env_names(environment: str) -> Set[str]:
+    """Variable NAMES configured in the Vercel project. Values never fetched."""
+    res = subprocess.run(
+        ["vercel", "env", "ls", environment],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if res.returncode != 0:
+        raise RuntimeError(
+            "`vercel env ls` failed — is the CLI installed and logged in?\n"
+            + res.stderr.strip()
+        )
+    names = set()
+    for line in res.stdout.splitlines():
+        parts = line.split()
+        # Rows look like: NAME  Encrypted  Production, Preview  210d ago
+        if len(parts) >= 2 and re.fullmatch(r"[A-Z][A-Z0-9_]*", parts[0]):
+            names.add(parts[0])
+    return names
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--vercel",
+        action="store_true",
+        help="also check REQUIRED names against the Vercel project (needs CLI login)",
+    )
+    parser.add_argument("--environment", default="production")
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+
+    refs = referenced()
+    dec = declared()
+
+    undeclared = sorted(set(refs) - set(dec))
+    orphaned = sorted(set(dec) - set(refs))
+
+    report = {
+        "referenced": {k: sorted(v) for k, v in sorted(refs.items())},
+        "undeclared": undeclared,
+        "orphaned": orphaned,
+        "missing_in_vercel": [],
+    }
+    failures = []
+
+    if undeclared:
+        failures.append(
+            "undeclared runtime env var(s) read by api/ — add each to REQUIRED or "
+            "OPTIONAL in this script, saying what breaks when it is absent:\n"
+            + "\n".join(f"    {n}  (read by {', '.join(sorted(refs[n]))})" for n in undeclared)
+        )
+    if orphaned:
+        failures.append(
+            "declared but no longer read by api/ — delete the entry:\n"
+            + "\n".join(f"    {n}" for n in orphaned)
+        )
+
+    if args.vercel:
+        try:
+            configured = vercel_env_names(args.environment)
+        except RuntimeError as exc:
+            print(f"[runtime-env] {exc}", file=sys.stderr)
+            return 2
+        missing = sorted(n for n in REQUIRED if n not in configured)
+        report["missing_in_vercel"] = missing
+        if missing:
+            failures.append(
+                f"REQUIRED runtime env var(s) absent from Vercel "
+                f"({args.environment}) — the feature is silently off:\n"
+                + "\n".join(f"    {n}\n      {REQUIRED[n]}" for n in missing)
+            )
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    elif failures:
+        print("[runtime-env] FAIL\n", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}\n", file=sys.stderr)
+    else:
+        scope = f", all {len(REQUIRED)} REQUIRED present in Vercel" if args.vercel else ""
+        print(
+            f"[runtime-env] OK — {len(refs)} env var(s) read by api/, all declared"
+            f"{scope}."
+        )
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_runtime_env_contract.py
+++ b/scripts/tests/test_runtime_env_contract.py
@@ -1,0 +1,84 @@
+"""Tests for the runtime env-var declaration contract.
+
+Every credential guard in this repo before 2026-08-24 was keyed to CI secrets —
+`test_ci_secret_absence_guard.py` walks `.github/workflows/`. Runtime
+credentials live in the Vercel project, which that axis cannot see, and the gap
+cost us `GA4_API_SECRET`: two PRs of first-party beacon work shipped into an
+endpoint that dropped every report and answered 204 anyway.
+
+CI cannot check Vercel (no token), so what CI *can* enforce is that a new
+runtime dependency is never added without someone writing down what breaks when
+it is absent. These tests keep that enforcement honest.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts import check_runtime_env_contract as contract
+
+
+def test_every_env_var_read_by_api_is_declared():
+    refs = contract.referenced()
+    undeclared = sorted(set(refs) - set(contract.declared()))
+    assert undeclared == [], (
+        f"add to REQUIRED or OPTIONAL in check_runtime_env_contract.py, "
+        f"saying what breaks when absent: {undeclared}"
+    )
+
+
+def test_no_declaration_outlives_its_code():
+    refs = contract.referenced()
+    orphaned = sorted(set(contract.declared()) - set(refs))
+    assert orphaned == [], f"declared but no longer read by api/: {orphaned}"
+
+
+def test_the_three_categories_do_not_overlap():
+    names = [
+        set(contract.PLATFORM),
+        set(contract.REQUIRED),
+        set(contract.OPTIONAL),
+    ]
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            assert not a & b, f"a var is in two categories: {sorted(a & b)}"
+
+
+@pytest.mark.parametrize("name", sorted(contract.REQUIRED))
+def test_required_entries_say_what_breaks_and_where_to_provision(name: str):
+    """A REQUIRED entry that just names a file teaches nobody anything.
+
+    The whole failure mode was that absence looked like success, so the
+    declaration has to record the symptom and the provisioning location.
+    """
+    note = contract.REQUIRED[name]
+    assert "Absent:" in note, f"{name}: record what breaks when it is absent"
+    assert "Provision:" in note, f"{name}: record where it gets provisioned"
+
+
+def test_ga4_api_secret_is_required_not_optional():
+    """Regression guard for the specific miscategorisation that caused the loss.
+
+    `api/vitals.js` treats an absent secret as a soft drop, which reads like an
+    optional dependency at the call site. It is not: with it unset, the feature
+    collects zero data while reporting success.
+    """
+    assert "GA4_API_SECRET" in contract.REQUIRED
+    assert "GA4_API_SECRET" not in contract.OPTIONAL
+
+
+def test_test_fixtures_are_not_mistaken_for_dependencies():
+    """`api/__tests__/sanitize.test.js` contains the literal 'process.env.SECRET'.
+
+    It is assertion text for the sanitizer, not a runtime dependency. If the
+    scanner ever starts walking __tests__, this fails and points at why.
+    """
+    assert "SECRET" not in contract.referenced()
+
+
+def test_the_scanner_actually_finds_something():
+    """Proof the two corpus assertions above are not vacuously green."""
+    refs = contract.referenced()
+    assert "GA4_API_SECRET" in refs
+    assert any("vitals.js" in f for f in refs["GA4_API_SECRET"])
+    assert len(refs) > 10


### PR DESCRIPTION
## 진단 결과

`vercel env ls production`에 **`GA4_API_SECRET`이 없다**. 등록된 것은 7개뿐:

```
SENTRY_DSN, REDIS_URL, BLOB_READ_WRITE_TOKEN, PRISMA_DATABASE_URL,
DATABASE_URL, POSTGRES_URL, DEEPSEEK_API_KEY
```

즉 PR #558·#586의 퍼스트파티 비콘 작업은 **아무것도 수집하지 않았다**. `api/vitals.js:205-210`이 시크릿 없으면 폐기하고, fire-and-forget이라 204를 반환하므로 수집이 정상인 것처럼 보인다. 유일한 신호는 아무도 읽지 않는 Vercel 함수 로그의 `console.warn`이었다 — `api/`에 서버측 Sentry가 없어서 Sentry로도 가지 않는다.

`notes/ci-skip-campaign-2026-08.md`가 "감사 축이 CI에 묶여 있어 런타임 자격증명(Vercel env)은 구조적 사각지대"라고 적고 다음 축으로 지목한 그 미완 작업이다. 이전 회고는 "런타임 로그 라인 미확보"로 미검증을 명시했는데, env 목록 직접 조회로 확정했다.

## 가드

`scripts/check_runtime_env_contract.py` — 두 층으로 나눴다.

**1. 선언 동기화 (자격증명 불필요, CI 강제)**

`api/**/*.js`의 `process.env.*` 전부가 `REQUIRED` / `OPTIONAL` / `PLATFORM` 중 하나로 선언돼야 하고, 코드가 더 이상 읽지 않는 선언은 고아로 잡는다. `REQUIRED` 항목은 `Absent:`(무엇이 깨지나)와 `Provision:`(어디서 등록하나)를 반드시 적어야 하며 이를 테스트가 강제한다 — 파일명만 적은 선언은 아무것도 가르쳐주지 않기 때문이다.

`scripts/tests/test_runtime_env_contract.py`가 일반 pytest 스위트에서 돌기 때문에 **별도 워크플로 배선이 필요 없다**(기존 `build` 잡이 이미 실행).

**2. `--vercel` (옵트인)**

`REQUIRED`가 Vercel에 실제로 있는지 확인. **이름만** 조회하고 값은 가져오지도 출력하지도 않는다. `VERCEL_TOKEN` 미등록(PR #585가 그 프로비저닝 대기)이라 CI 게이트가 아니라 소유자 1커맨드 점검이다.

```
$ python3 scripts/check_runtime_env_contract.py
[runtime-env] OK — 16 env var(s) read by api/, all declared.        exit 0

$ python3 scripts/check_runtime_env_contract.py --vercel
[runtime-env] FAIL
  REQUIRED runtime env var(s) absent from Vercel (production):
    GA4_API_SECRET                                                  exit 1
```

## 분류에서 판정한 것 (오탐 방지)

- **`UPSTASH_REDIS_REST_*`는 결함이 아니다.** `USE_UPSTASH_RATELIMIT`이 명시적 옵트인이고 꺼져 있으며, 코드가 시작 시 in-memory 폴백을 경고한다 — 선택된 trade-off이지 누락된 자격증명이 아니다. `OPTIONAL`로 분류하고 그 이유를 선언에 적었다.
- 프로젝트에 `REDIS_URL`이 있지만 **`api/`의 어떤 코드도 읽지 않는다**(스토리지 연동 산물). `REDIS_URL`이 있다고 레이트리밋이 Redis를 쓰는 것은 아니다.
- `api/__tests__/sanitize.test.js`의 `process.env.SECRET`은 새니타이저 단정 텍스트다. 스캐너가 `__tests__`를 제외하고, `test_test_fixtures_are_not_mistaken_for_dependencies`가 이를 고정한다.

## 런북

`docs/setup/VERCEL_ENV_SETUP.md`에 런타임 env 계약 표 + `GA4_API_SECRET` 등록 5단계를 추가했다. 검증 순서를 **(a) 등록 확인 → (b) 전송 확인 → (c) GA4 Realtime 수집 확인**으로 명시했다 — 204는 시크릿 유무와 무관하므로 (b)만으로는 수집을 증명하지 못한다.

기존 문서가 `DEEPSEEK_API_KEY`를 `Development, Preview, Production`으로 적고 있었으나 실제 등록은 Production 하나다. 정정했다.

## 사용자 조치 필요

이 PR은 가드와 런북만 넣는다. **값 자체는 등록할 수 없다** — GA4 Admin에서 생성해야 하고, 시크릿 등록은 소유자 권한이다. 런북 1~4단계를 따르면 `--vercel`이 exit 0으로 바뀐다.

## 검증

```
pytest scripts/tests/                          4315 passed / 0 failed (신규 8건)
check_runtime_env_contract.py                  exit 0
check_runtime_env_contract.py --vercel         exit 1  (GA4_API_SECRET 정상 탐지)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
