### PR TITLE
fix(ops): 월간 리포트 알림이 실제 결과를 보고하도록 + webhook URL 마스킹 갭

### DIFF
--- a/.github/workflows/monthly-quality-report.yml
+++ b/.github/workflows/monthly-quality-report.yml
@@ -94,6 +94,7 @@ jobs:
           echo "report_generated=true" >> $GITHUB_OUTPUT
 
       - name: Create or update issue
+        id: issue
         if: |
           steps.report.outputs.report_generated == 'true' &&
           (github.event_name == 'schedule' || github.event.inputs.create_issue == 'true')
@@ -149,14 +150,43 @@ jobs:
 
           echo "Monthly quality report issue created"
 
+      # This step used to pass a hardcoded --status "SUCCESS" and the literal claim
+      # "published to GitHub Issues", under `if: always()`. Neither was derived from
+      # whether `gh issue create` actually ran, and `always()` defeats the default
+      # skip-on-failure — so a failed issue creation still announced success, and a
+      # manual dispatch with create_issue=false announced a publication that never
+      # happened. Same bug class as the "Zero-Regression Gate: 100% Passed" literal
+      # removed on 2026-08-24. The status now comes from steps.issue.outcome, which
+      # is why the step above carries `id: issue`.
+      #
+      # `outcome` is 'skipped' when the create-issue condition was false, so the
+      # three states stay distinguishable: SUCCESS published, FAILED did not, and
+      # SKIPPED was not asked to.
       - name: Send Webhook Notification
         if: always() && steps.report.outputs.report_generated == 'true'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ISSUE_OUTCOME: ${{ steps.issue.outcome }}
+          IMAGE_ISSUES: ${{ steps.images.outputs.image_issues || 0 }}
+          POST_ISSUES: ${{ steps.posts.outputs.post_issues || 0 }}
         run: |
           CURRENT_MONTH=$(date +%Y-%m)
+          case "${ISSUE_OUTCOME}" in
+            success)
+              STATUS="SUCCESS"
+              HEADLINE="Report generated and published to GitHub Issues."
+              ;;
+            skipped)
+              STATUS="WARNING"
+              HEADLINE="Report generated. Issue creation was skipped (create_issue=false)."
+              ;;
+            *)
+              STATUS="FAILED"
+              HEADLINE="Report generated but issue creation FAILED (outcome: ${ISSUE_OUTCOME:-unknown}). The monthly report does not exist on GitHub Issues."
+              ;;
+          esac
           python3 scripts/notify_webhook.py \
-            --title "Monthly Blog Quality Report (${CURRENT_MONTH}) Published" \
-            --message "• Monthly Post Quality Report generated and published to GitHub Issues.\n• Image Issues: ${{ steps.images.outputs.image_issues || 0 }}\n• Post Warnings: ${{ steps.posts.outputs.post_issues || 0 }}\n• View report on GitHub Issues." \
-            --status "SUCCESS"
+            --title "Monthly Blog Quality Report (${CURRENT_MONTH})" \
+            --message "• ${HEADLINE}\n• Image Issues: ${IMAGE_ISSUES}\n• Post Warnings: ${POST_ISSUES}" \
+            --status "${STATUS}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,16 @@
 line-length = 88
 indent-width = 4
 
+# The oldest Python any workflow pins for scripts/ (measured 2026-08-24: 3.11 in
+# jekyll.yml, svg-lint.yml, ai-blogwatcher.yml and ten others). Local
+# interpreters here are 3.13/3.14, so without this ruff accepts syntax CI cannot
+# parse — PR #599 shipped a backslash inside an f-string expression (legal from
+# 3.12, PEP 701) that passed the whole local suite and then aborted CI test
+# COLLECTION, taking all 4319 tests down instead of failing one.
+# `ast.parse(feature_version=(3, 11))` does NOT catch this; ruff does.
+# Kept in sync with the workflows by test_ci_python_syntax_floor_guard.py.
+target-version = "py311"
+
 # Exclude directories from linting/formatting
 exclude = [
     ".bundle",

--- a/scripts/generate_quality_report.py
+++ b/scripts/generate_quality_report.py
@@ -135,11 +135,35 @@ def main() -> None:
     # Trend coverage
     trend_coverage = generate_trend_coverage()
 
-    # Architectural maturity stats
-    mermaid_count = sum(1 for p in POSTS_DIR.glob("*.md") if "```mermaid" in p.read_text(encoding="utf-8", errors="ignore"))
-    checklist_count = sum(1 for p in POSTS_DIR.glob("*.md") if re.search(r"-\s*\[\s*[ xX]?\s*\]", p.read_text(encoding="utf-8", errors="ignore")))
-    table_count = sum(1 for p in POSTS_DIR.glob("*.md") if "|" in p.read_text(encoding="utf-8", errors="ignore"))
-    faq_count = sum(1 for p in POSTS_DIR.glob("*.md") if re.search(r"^#{1,4}\s*.*(?:자주\s*묻는\s*질문|\bFAQ\b)", p.read_text(encoding="utf-8", errors="ignore"), re.MULTILINE | re.IGNORECASE) or "schema_type: FAQPage" in p.read_text(encoding="utf-8", errors="ignore"))
+    # Structural element counts. Read each post once.
+    #
+    # These are reported as counts and NOT graded. Grading presence turns it into
+    # a target: this table used to print "🟢 우수" once mermaid_count passed 30,
+    # and in 2026-08 a pipeline raised that number by injecting the same
+    # hardcoded diagram into 43 posts. Presence of a diagram is not evidence of
+    # a good diagram. See notes/autonomous-modernizer-retro.md.
+    #
+    # The FAQ row IS graded, because there the target is genuinely a fixed
+    # number: FAQ sections are banned outright, so 0 is the only correct value.
+    _FAQ_HEADING = re.compile(
+        r"^#{1,4}\s*.*(?:자주\s*묻는\s*질문|\bFAQ\b)", re.MULTILINE | re.IGNORECASE
+    )
+    # A markdown table needs a header row followed by a delimiter row. The old
+    # check was `"|" in text`, which matched Liquid tags and inline code and so
+    # reported nearly every post.
+    _MD_TABLE = re.compile(r"\|.*\|.*\n\|[-:\s|]+\|")
+
+    mermaid_count = checklist_count = table_count = faq_count = 0
+    for p in POSTS_DIR.glob("*.md"):
+        text = p.read_text(encoding="utf-8", errors="ignore")
+        if "```mermaid" in text:
+            mermaid_count += 1
+        if re.search(r"-\s*\[\s*[ xX]?\s*\]", text):
+            checklist_count += 1
+        if _MD_TABLE.search(text):
+            table_count += 1
+        if _FAQ_HEADING.search(text) or "schema_type: FAQPage" in text:
+            faq_count += 1
 
     # Build issue body
     body = f"""## 월간 포스트 품질 리포트
@@ -147,14 +171,23 @@ def main() -> None:
 **보고 기간**: {current_month}
 **총 포스트**: {total_count}개
 
-### 🏗️ 아키텍처 성숙도 & 자율 현대화 지표
+### 🏗️ 구조 요소 분포
 
-| 지표 항목 | 적용 포스트 수 | 전체 대비 비율 | 상태 |
-|---|---|---|:---:|
-| **Mermaid 아키텍처 다이어그램** | {mermaid_count}개 | {mermaid_count / total_count * 100:.1f}% | {'🟢 우수' if mermaid_count > 30 else '🟡 진행 중'} |
-| **실무 점검 체크리스트 (`- [ ]`)** | {checklist_count}개 | {checklist_count / total_count * 100:.1f}% | {'🟢 우수' if checklist_count > 200 else '🟡 보통'} |
-| **비교/통제 테이블 (`|`)** | {table_count}개 | {table_count / total_count * 100:.1f}% | {'🟢 우수' if table_count > 250 else '🟡 보통'} |
-| **금지된 FAQ 섹션/스키마** | {faq_count}개 | {faq_count / total_count * 100:.1f}% | {'🟢 완벽 준수 (0건)' if faq_count == 0 else '🔴 제거 필요'} |
+관측값이며 목표치가 아니다. 이 표는 이전에 Mermaid 30개를 넘기면 "🟢 우수"로
+표시했고, 2026-08에 한 파이프라인이 동일한 하드코딩 다이어그램을 43개 포스트에
+주입해 그 숫자를 올렸다. 다이어그램의 **존재**는 좋은 다이어그램의 근거가 아니다
+(`notes/autonomous-modernizer-retro.md`). 숫자가 낮다고 채워 넣지 말 것 —
+같은 블록의 반복은 `scripts/check_post_boilerplate.py`가 차단한다.
+
+| 구조 요소 | 포함 포스트 수 | 전체 대비 비율 |
+|---|---|---|
+| Mermaid 다이어그램 | {mermaid_count}개 | {mermaid_count / total_count * 100:.1f}% |
+| 체크리스트 (`- [ ]`) | {checklist_count}개 | {checklist_count / total_count * 100:.1f}% |
+| 마크다운 표 | {table_count}개 | {table_count / total_count * 100:.1f}% |
+
+| 금지 항목 | 검출 | 상태 |
+|---|---|:---:|
+| FAQ 섹션 / `schema_type: FAQPage` | {faq_count}개 | {'🟢 준수 (0건)' if faq_count == 0 else '🔴 제거 필요'} |
 
 ### 전체 품질 대시보드
 
@@ -191,9 +224,7 @@ def main() -> None:
 
 ### 조치 사항
 
-- [ ] 24/7 Mac mini 자율 현대화 크론 파이프라인 지속 가동
-- [ ] Mermaid 다이어그램 미적용 포스트 지속적 주입
-- [ ] 80점 미만 포스트 품질 개선
+- [ ] 80점 미만 포스트 품질 개선 (포스트 고유 내용으로. 고정 블록 주입 금지 — `scripts/check_post_boilerplate.py`가 차단한다)
 - [ ] 신규 포스트 품질 기준 준수 확인
 - [ ] 미매핑 상위 단어 _TREND_KR_MAP 추가 검토
 """

--- a/scripts/lib/security.py
+++ b/scripts/lib/security.py
@@ -18,6 +18,26 @@ def mask_sensitive_info(text: str) -> str:
     masked = re.sub(r"sk-[a-zA-Z0-9_-]{20,}", "sk-***MASKED***", masked)
     masked = re.sub(r"AIza[0-9A-Za-z_-]{35}", "AIza***MASKED***", masked)
 
+    # Webhook URLs. These must be matched explicitly: the generic 40+ char
+    # fallback below splits on '/', and a Slack webhook's longest path segment
+    # (T…/B…/24-char token) is under 40, so a full Slack webhook URL used to
+    # survive masking completely. Discord's only got masked because its token
+    # segment happens to exceed 40 — incidental, not by design. The whole URL is
+    # the credential for both, so mask from the host onward.
+    masked = re.sub(
+        r"https://hooks\.slack\.com/services/\S+",
+        "https://hooks.slack.com/services/***MASKED***",
+        masked,
+    )
+    masked = re.sub(
+        r"https://discord(?:app)?\.com/api/webhooks/\S+",
+        "https://discord.com/api/webhooks/***MASKED***",
+        masked,
+    )
+
+    # Slack bot / app tokens
+    masked = re.sub(r"xox[abposr]-[a-zA-Z0-9-]{10,}", "xox***MASKED***", masked)
+
     # Mask actual API key values from environment
     for env_var in [
         "GEMINI_API_KEY",
@@ -25,6 +45,9 @@ def mask_sensitive_info(text: str) -> str:
         "DEEPSEEK_API_KEY",
         "OPENAI_API_KEY",
         "BUTTONDOWN_API_KEY",
+        "SLACK_BOT_TOKEN",
+        "SLACK_WEBHOOK_URL",
+        "DISCORD_WEBHOOK_URL",
     ]:
         key_val = os.getenv(env_var, "")
         if key_val and len(key_val) > 10:

--- a/scripts/notify_webhook.py
+++ b/scripts/notify_webhook.py
@@ -56,7 +56,13 @@ def send_http_post(url: str, payload: Dict[str, Any], timeout: int = 5) -> bool:
         with urllib.request.urlopen(req, timeout=timeout) as response:
             return response.status in (200, 204)
     except urllib.error.HTTPError as e:
-        print(f"[WARN] Webhook HTTP Error: {e.code} - {e.reason}", file=sys.stderr)
+        # e.reason is a status phrase today, but this is the one error branch that
+        # was not masked; a future urllib that includes the URL would leak the
+        # webhook token. Mask unconditionally rather than relying on that.
+        print(
+            f"[WARN] Webhook HTTP Error: {e.code} - {mask_sensitive_info(str(e.reason))}",
+            file=sys.stderr,
+        )
         return False
     except Exception as e:
         print(f"[WARN] Webhook request failed: {mask_sensitive_info(str(e))}", file=sys.stderr)
@@ -128,7 +134,23 @@ def notify(title: str, message: str, status: str = "SUCCESS") -> bool:
     discord_url = urls.get("discord")
 
     if not slack_url and not discord_url:
-        print("[INFO] No Webhook URLs configured (SLACK_WEBHOOK_URL or DISCORD_WEBHOOK_URL). Skipping notification.")
+        # Neither secret is registered in this repo (measured 2026-08-24:
+        # `gh secret list` has SLACK_BOT_TOKEN and SLACK_CHANNEL_ID, but no
+        # SLACK_WEBHOOK_URL and no DISCORD_WEBHOOK_URL). Every call to this
+        # script has therefore been a no-op. It used to print [INFO] and return
+        # True, which is indistinguishable from a successful send — that is why
+        # nobody noticed. Emit a GitHub Actions warning annotation so the state
+        # is visible in the run summary instead of buried in step output.
+        print(
+            "::warning title=Webhook notification skipped::"
+            "Neither SLACK_WEBHOOK_URL nor DISCORD_WEBHOOK_URL is configured, "
+            "so this notification was not delivered anywhere."
+        )
+        print(
+            "[WARN] No Webhook URLs configured "
+            "(SLACK_WEBHOOK_URL or DISCORD_WEBHOOK_URL). Nothing was sent.",
+            file=sys.stderr,
+        )
         return True
 
     success = True
@@ -158,8 +180,10 @@ def main() -> int:
     parser.add_argument("--status", choices=["SUCCESS", "WARNING", "FAILED"], default="SUCCESS", help="Execution Status")
     args = parser.parse_args()
 
-    notify(title=args.title, message=args.message, status=args.status)
-    return 0
+    # Propagate delivery failure. Previously the return value was discarded and
+    # main() always exited 0, so no caller could ever detect that a POST failed.
+    delivered = notify(title=args.title, message=args.message, status=args.status)
+    return 0 if delivered else 1
 
 
 if __name__ == "__main__":

--- a/scripts/requirements-ci.txt
+++ b/scripts/requirements-ci.txt
@@ -22,3 +22,10 @@ Pillow>=11.3.0
 # imports fine and then cannot open the files, so the extra is the load-bearing part
 # of this line, not the version.
 fonttools[woff]>=4.63.0
+
+# ruff — test_ci_python_syntax_floor_guard.py shells out to it to prove every
+# file under scripts/ parses at the oldest Python the workflows pin (py311).
+# Local interpreters are 3.13/3.14, so post-3.11 syntax otherwise reaches CI and
+# aborts test collection rather than failing a single test (PR #599).
+# `ast.parse(feature_version=...)` does not reject PEP 701 f-strings; ruff does.
+ruff>=0.15.0

--- a/scripts/tests/test_ci_monthly_report_status_guard.py
+++ b/scripts/tests/test_ci_monthly_report_status_guard.py
@@ -91,9 +91,14 @@ def test_no_step_output_is_interpolated_directly_into_a_run_block():
     step = m.group(1)
     run_idx = step.find("run: |")
     assert run_idx != -1, "notification step has no run: block"
-    assert "${{" not in step[run_idx:], (
+    run_block = step[run_idx:]
+    # Built outside the f-string: CI runs Python 3.11, where a backslash inside
+    # an f-string expression is a SyntaxError (PEP 701 lifted that in 3.12, and
+    # the local .venv is 3.14 — so this parses locally and breaks in CI).
+    leaked = re.findall(r"\$\{\{[^}]*\}\}", run_block)
+    assert "${{" not in run_block, (
         "pass step outputs through env: instead of interpolating them into the "
-        f"shell: {re.findall(r'\\$\\{\\{[^}]*\\}\\}', step[run_idx:])}"
+        f"shell: {leaked}"
     )
 
 

--- a/scripts/tests/test_ci_monthly_report_status_guard.py
+++ b/scripts/tests/test_ci_monthly_report_status_guard.py
@@ -1,0 +1,115 @@
+"""Guard: the monthly report's notification must report the real outcome.
+
+`.github/workflows/monthly-quality-report.yml` used to run its notification step
+under `if: always()` with a hardcoded `--status "SUCCESS"` and the literal claim
+"published to GitHub Issues", neither derived from whether `gh issue create`
+actually ran. `always()` defeats the default skip-on-failure, so a failed issue
+creation still announced success, and a manual dispatch with `create_issue=false`
+announced a publication that never happened.
+
+This is the third instance of the same bug class in this repo:
+  1. `run-blog-autonomous-cron.sh` sent "Zero-Regression Gate: 100% Passed" as a
+     constant regardless of the gate result (removed 2026-08-24).
+  2. `monitoring.yml`'s Slack step was wired to a secret that was never
+     configured, so a real failure alert went nowhere (fixed in PR #583).
+  3. This one.
+
+The pattern to block: a notification whose status is a literal rather than a
+function of the thing it reports on.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "monthly-quality-report.yml"
+
+
+def _text() -> str:
+    assert WORKFLOW.exists(), f"{WORKFLOW} is missing"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _uncommented(text: str) -> str:
+    """Drop full-line comments.
+
+    The repo has been bitten before by grep-style checks that matched the
+    explanatory comment instead of the code — see notes/ci-gate-audit-2026-08.md.
+    """
+    return "\n".join(
+        line for line in text.split("\n") if not line.lstrip().startswith("#")
+    )
+
+
+def test_create_issue_step_is_addressable():
+    """Without an `id:` the step's outcome cannot be read by any later step."""
+    body = _uncommented(_text())
+    m = re.search(r"- name: Create or update issue\n(.*?)\n      - name: ", body, re.DOTALL)
+    assert m, "the 'Create or update issue' step is gone or was renamed"
+    assert re.search(r"^\s+id:\s*issue\s*$", m.group(1), re.MULTILINE), (
+        "add `id: issue` back — the notification step derives its status from "
+        "steps.issue.outcome, and without the id that expression is empty, which "
+        "silently falls through to the FAILED branch."
+    )
+
+
+def test_notification_status_is_derived_not_hardcoded():
+    body = _uncommented(_text())
+    assert "steps.issue.outcome" in body, (
+        "the notification status must come from the create-issue step's outcome"
+    )
+    assert not re.search(r'--status\s+"SUCCESS"', body), (
+        'a literal --status "SUCCESS" is the bug this guard exists for; derive it '
+        "from steps.issue.outcome instead"
+    )
+
+
+@pytest.mark.parametrize("state", ["SUCCESS", "WARNING", "FAILED"])
+def test_all_three_outcome_states_are_distinguishable(state: str):
+    """success / skipped / failed must not collapse into one message."""
+    body = _uncommented(_text())
+    assert f'STATUS="{state}"' in body, (
+        f"the {state} branch is gone — success, skipped and failed have to stay "
+        "tellable apart or the notification is back to asserting one state always"
+    )
+
+
+def test_no_step_output_is_interpolated_directly_into_a_run_block():
+    """`${{ }}` inside `run:` is the Actions script-injection shape.
+
+    These particular values are integer counts today, but routing them through
+    `env:` costs nothing and removes the class. Mirrors
+    test_ci_no_run_input_interpolation_guard.py.
+    """
+    body = _uncommented(_text())
+    m = re.search(r"- name: Send Webhook Notification\n(.*)", body, re.DOTALL)
+    assert m, "the notification step is gone or was renamed"
+    step = m.group(1)
+    run_idx = step.find("run: |")
+    assert run_idx != -1, "notification step has no run: block"
+    assert "${{" not in step[run_idx:], (
+        "pass step outputs through env: instead of interpolating them into the "
+        f"shell: {re.findall(r'\\$\\{\\{[^}]*\\}\\}', step[run_idx:])}"
+    )
+
+
+def test_report_template_no_longer_prescribes_boilerplate_injection():
+    """The monthly report told the reader to keep injecting fixed diagrams.
+
+    `generate_quality_report.py` shipped the action item "Mermaid 다이어그램
+    미적용 포스트 지속적 주입" — which is the instruction that produced 43
+    byte-identical fabricated diagrams. An action item that recreates the
+    incident is worse than no action item.
+    """
+    src = (REPO_ROOT / "scripts" / "generate_quality_report.py").read_text(
+        encoding="utf-8"
+    )
+    for banned in ("다이어그램 미적용 포스트 지속적 주입", "자율 현대화 크론 파이프라인"):
+        assert banned not in src, (
+            f"{banned!r} refers to a removed pipeline or prescribes boilerplate "
+            "injection; see notes/autonomous-modernizer-retro.md"
+        )

--- a/scripts/tests/test_ci_python_syntax_floor_guard.py
+++ b/scripts/tests/test_ci_python_syntax_floor_guard.py
@@ -1,0 +1,153 @@
+"""Guard: scripts/ must parse on the oldest Python that CI pins.
+
+The local interpreter is newer than CI's. Measured 2026-08-24: this machine runs
+3.13/3.14 while thirteen workflows that execute `scripts/` pin 3.11. Syntax
+introduced after 3.11 therefore parses locally, passes pre-commit, passes the
+full local suite — and then fails at *collection* time in CI, which takes the
+whole run down rather than failing one test.
+
+Not hypothetical: PR #599 shipped a backslash inside an f-string expression
+(legal from 3.12 via PEP 701). CI's 3.11 raised
+``SyntaxError: f-string expression part cannot include a backslash`` and aborted
+collection of all 4319 tests.
+
+Why ruff and not ast
+--------------------
+``ast.parse(source, feature_version=(3, 11))`` does **not** reject this — that
+parameter gates a narrow set of grammar features, and the 3.13 tokenizer handles
+f-strings the PEP 701 way regardless. Verified both directions on 2026-08-24:
+``ast.parse`` accepted the construct at ``feature_version=(3, 11)``, a real 3.11
+(`uv run --python 3.11`) raised SyntaxError, and
+``ruff check --target-version py311`` reported it. So ruff is the check.
+
+The floor is derived from the workflows rather than hardcoded, so bumping CI's
+Python relaxes this guard instead of leaving a stale number behind.
+
+Limitation, stated so a green result is not over-read: this is a *syntax* check.
+A 3.12+ standard-library call parses fine here and would still fail at runtime
+on 3.11.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+SCRIPTS = REPO_ROOT / "scripts"
+
+_PIN_RE = re.compile(r"^\s*python-version:\s*['\"]?(\d+)\.(\d+)['\"]?\s*$", re.MULTILINE)
+_ENV_RE = re.compile(r"^\s*PYTHON_VERSION:\s*['\"]?(\d+)\.(\d+)['\"]?\s*$", re.MULTILINE)
+
+
+def pinned_versions() -> dict[str, tuple[int, int]]:
+    """Lowest Python version each workflow pins, literal or via PYTHON_VERSION."""
+    found: dict[str, tuple[int, int]] = {}
+    for wf in sorted(WORKFLOWS.glob("*.yml")):
+        text = wf.read_text(encoding="utf-8")
+        versions = [
+            (int(a), int(b)) for a, b in _PIN_RE.findall(text) + _ENV_RE.findall(text)
+        ]
+        if versions:
+            found[wf.name] = min(versions)
+    return found
+
+
+def syntax_floor() -> tuple[int, int]:
+    versions = pinned_versions()
+    assert versions, "no workflow pins a python-version — has setup-python moved?"
+    return min(versions.values())
+
+
+def ruff_target() -> str:
+    cfg = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return cfg.get("tool", {}).get("ruff", {}).get("target-version", "")
+
+
+def test_a_floor_is_discoverable():
+    """If this breaks, the check below is silently measuring nothing."""
+    versions = pinned_versions()
+    assert len(versions) >= 5, f"only found pins in {sorted(versions)}"
+    assert syntax_floor() >= (3, 8), syntax_floor()
+
+
+def test_ruff_target_version_matches_the_ci_floor():
+    """A stale target-version is worse than none: it reads as protection."""
+    floor = syntax_floor()
+    expected = f"py{floor[0]}{floor[1]}"
+    actual = ruff_target()
+    assert actual == expected, (
+        f"[tool.ruff] target-version is {actual!r} but the oldest Python any "
+        f"workflow pins is {floor[0]}.{floor[1]} ({expected!r}). Update "
+        "pyproject.toml, or update the workflows — they must agree or ruff "
+        "accepts syntax CI cannot parse."
+    )
+
+
+def test_ruff_is_installed():
+    """Fail rather than skip.
+
+    A skipped gate is a gate that has never run. Repo policy since PR #579:
+    absent tooling is a failure, not a skip. ruff is declared in
+    scripts/requirements-ci.txt for exactly this test.
+    """
+    assert shutil.which("ruff"), (
+        "ruff is not on PATH. It is declared in scripts/requirements-ci.txt; "
+        "install it (`pip install -r scripts/requirements-ci.txt`) rather than "
+        "letting this check silently pass."
+    )
+
+
+def _invalid_syntax_lines(target: str, path: Path) -> list[str]:
+    res = subprocess.run(
+        [
+            "ruff",
+            "check",
+            "--no-cache",
+            "--target-version",
+            target,
+            "--output-format",
+            "concise",
+            str(path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    # Only syntax diagnostics matter here; ordinary lint findings are out of scope
+    # and must not turn this into a style gate.
+    return [ln for ln in res.stdout.splitlines() if "invalid-syntax" in ln]
+
+
+def test_every_script_parses_at_the_ci_floor():
+    floor = syntax_floor()
+    target = f"py{floor[0]}{floor[1]}"
+    offenders = _invalid_syntax_lines(target, SCRIPTS)
+    assert offenders == [], (
+        f"these use syntax newer than Python {floor[0]}.{floor[1]}, which CI pins. "
+        "They parse locally and abort test collection in CI:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_check_actually_rejects_newer_syntax(tmp_path):
+    """Proof the assertion above is not vacuously green.
+
+    A backslash inside an f-string expression is the exact construct that broke
+    PR #599: legal from 3.12, SyntaxError on 3.11. Written with chr(92) so this
+    file itself stays 3.11-clean.
+    """
+    sample = tmp_path / "pep701_sample.py"
+    backslash_n = chr(92) + "n"
+    sample.write_text(
+        'x = ["a"]\n' f"y = f\"{{ x[0].split('{backslash_n}') }}\"\n",
+        encoding="utf-8",
+    )
+    assert backslash_n in sample.read_text(encoding="utf-8"), "sample lost its backslash"
+
+    assert _invalid_syntax_lines("py311", sample), "ruff did not flag it at py311"
+    assert not _invalid_syntax_lines("py312", sample), "ruff flagged it at py312"

--- a/scripts/tests/test_lib_security.py
+++ b/scripts/tests/test_lib_security.py
@@ -75,6 +75,41 @@ class TestMaskSensitiveInfo:
         assert secret not in result
         assert "GEMINI_API_KEY_MASKED" in result
 
+    def test_masks_slack_webhook_url(self):
+        """The generic 40+ char rule never caught these.
+
+        A Slack webhook URL is T…/B…/24-char-token, and the fallback splits on
+        '/', so no segment reaches 40 characters and the whole credential used
+        to pass through untouched. Measured 2026-08-24.
+        """
+        text = (
+            "POST failed: https://hooks.slack.com/services/"
+            "T01ABCDEFGH/B02IJKLMNOP/aBcDeFgHiJkLmNoPqRsTuVwX"
+        )
+        result = mask_sensitive_info(text)
+        assert "***MASKED***" in result
+        assert "T01ABCDEFGH" not in result
+        assert "aBcDeFgHiJkLmNoPqRsTuVwX" not in result
+
+    def test_masks_discord_webhook_url_including_discordapp_host(self):
+        """Discord only got masked incidentally, and only on one host spelling."""
+        for host in ("discord.com", "discordapp.com"):
+            text = f"POST failed: https://{host}/api/webhooks/123456789012345678/shorttoken"
+            result = mask_sensitive_info(text)
+            assert "***MASKED***" in result, host
+            assert "shorttoken" not in result, host
+            assert "123456789012345678" not in result, host
+
+    def test_masks_slack_bot_token(self):
+        result = mask_sensitive_info("auth failed for xoxb-1234567890-abcdefghijkl")
+        assert "xox***MASKED***" in result
+        assert "abcdefghijkl" not in result
+
+    def test_does_not_mask_the_sites_own_urls(self):
+        """Proof the webhook patterns are anchored to the credential hosts."""
+        text = "see https://tech.2twodragon.com/feed.xml and https://github.com/Twodragon0/tech-blog"
+        assert mask_sensitive_info(text) == text
+
     def test_sk_ant_masked_before_sk_to_preserve_specificity(self):
         # sk-ant- keys must be masked with sk-ant-***MASKED***, not sk-***MASKED***
         text = "sk-ant-api03-" + "x" * 25

--- a/scripts/tests/test_notify_webhook.py
+++ b/scripts/tests/test_notify_webhook.py
@@ -48,3 +48,64 @@ def test_notify_sends_slack(mock_urlopen):
     res = notifier.notify("Daily Run", "Run succeeded", status="SUCCESS")
     assert res is True
     assert mock_urlopen.called
+
+
+def test_no_configured_target_emits_a_ci_visible_warning(capsys):
+    """Silence here is what hid the dead channel.
+
+    Neither SLACK_WEBHOOK_URL nor DISCORD_WEBHOOK_URL is registered in this repo
+    (measured 2026-08-24 via `gh secret list`), so every call has been a no-op.
+    It used to print [INFO] and return True — indistinguishable from a
+    successful send. The ::warning:: annotation puts it in the run summary.
+    """
+    with patch.dict(os.environ, {}, clear=True):
+        notifier.notify("Title", "Message")
+    out = capsys.readouterr().out
+    assert "::warning" in out
+    assert "not delivered anywhere" in out
+
+
+@patch("urllib.request.urlopen", side_effect=OSError("connection refused"))
+@patch.dict(
+    os.environ,
+    {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T00/B00/X00"},
+    clear=True,
+)
+def test_main_exits_nonzero_when_delivery_fails(_mock_urlopen):
+    """main() used to discard notify()'s result and always return 0.
+
+    A caller checking the exit code could therefore never detect that a POST
+    failed, which makes the notifier unusable as a monitored step.
+    """
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["notify_webhook.py", "--message", "m", "--status", "FAILED"]
+    try:
+        rc = notifier.main()
+    finally:
+        _sys.argv = argv
+    assert rc == 1
+
+
+@patch("urllib.request.urlopen")
+@patch.dict(
+    os.environ,
+    {"SLACK_WEBHOOK_URL": "https://hooks.slack.com/services/T00/B00/X00"},
+    clear=True,
+)
+def test_main_exits_zero_when_delivery_succeeds(mock_urlopen):
+    """The counterpart — proves the nonzero case above is not vacuous."""
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_urlopen.return_value.__enter__.return_value = mock_resp
+
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["notify_webhook.py", "--message", "m"]
+    try:
+        rc = notifier.main()
+    finally:
+        _sys.argv = argv
+    assert rc == 0


### PR DESCRIPTION
`/team-audit` 결과 수정. 감사 범위는 `0bb0ac36..233943cf`(08-22~24 main 직푸시 미리뷰 배치, 342파일).

## 감사 표면을 먼저 좁혔다

scripts/의 python 237개를 AST 비교로 분리했습니다:

| 분류 | 개수 | 근거 |
|---|---|---|
| 순수 재포맷 | **199** | docstring 포함 AST가 바이트 동일 → 동작 변경 불가능 |
| docstring 텍스트만 | 2 | 코드 AST 동일 (테스트 파일, argparse 영향 없음) |
| 실제 동작 변경 | 36 | 22개가 테스트 파일 |

주석 손실은 배치 전체에서 1줄뿐이라 재포맷이 문서를 지우지도 않았습니다. 원인은 커밋 `c65f1305`가 포매터를 무관한 파일에 걸친 것으로, 알려진 `ops_health_orchestrator.py` 부작용 패턴과 동일합니다.

그 뒤 security / cover-system / gate-integrity 3관점으로 파티션해 감사했습니다.

## HIGH — 알림이 실패해도 SUCCESS를 보고했다

`monthly-quality-report.yml`의 알림 스텝이 `if: always()` 아래에서 하드코딩 `--status "SUCCESS"`와 `"published to GitHub Issues"` 리터럴을 보냈습니다. 둘 다 `gh issue create`가 실제로 돌았는지와 무관합니다. `always()`는 기본 skip-on-failure를 무력화하므로 **이슈 생성이 실패해도 성공을 announce**하고, `create_issue=false` 수동 dispatch에서는 **일어나지 않은 발행을 announce**했습니다.

create-issue 스텝에 `id: issue`를 달고 상태를 `steps.issue.outcome`에서 파생시켰습니다. success/skipped/failure 세 상태가 구분되며, 빈 값은 FAILED로 떨어지는 안전 기본값입니다. 스텝 출력은 `run:` 안 `${{ }}` 보간 대신 `env:`로 넘겨 Actions 스크립트 인젝션 형태를 제거했습니다.

```
outcome=success  -> SUCCESS
outcome=skipped  -> WARNING
outcome=failure  -> FAILED
outcome=<empty>  -> FAILED
```

**이 버그 부류의 세 번째 사례입니다**: (1) `run-blog-autonomous-cron.sh`의 `Zero-Regression Gate: 100% Passed` 상수(2026-08-24 제거), (2) `monitoring.yml`의 미등록 시크릿 채널(PR #583), (3) 이번 것.

## MEDIUM — 배송 실패가 어디에도 안 보인다

`notify_webhook.py`의 `main()`이 `notify()` 반환값을 버리고 항상 0을 반환했습니다. 이제 실패 시 1입니다.

그리고 더 큰 문제: **`SLACK_WEBHOOK_URL`·`DISCORD_WEBHOOK_URL`이 이 레포에 둘 다 등록돼 있지 않습니다**(`gh secret list` 실측 — `SLACK_BOT_TOKEN`/`SLACK_CHANNEL_ID`는 있습니다). 즉 커밋 `29a76d2d`가 추가한 webhook alerts는 **한 번도 발송된 적이 없습니다.** 기존 코드가 `[INFO]`를 찍고 `True`를 반환해 성공 발송과 구분이 불가능했던 것이 아무도 모른 이유입니다. `::warning::` 애노테이션으로 run summary에 드러나게 했습니다.

> 후속 결정 필요: 전송 경로를 이미 동작하는 `SLACK_BOT_TOKEN` + `chat.postMessage`(PR #583이 택한 방식, `slack-post-notify.yml`이 사용 중)로 옮길지, 아니면 webhook 시크릿을 새로 등록할지. 이 PR은 보고 정확성만 고치고 전송 경로는 바꾸지 않았습니다.

## MEDIUM — Slack webhook URL이 마스킹을 통과했다

`mask_sensitive_info()`의 40자+ 폴백은 `/`로 끊기고 Slack webhook의 가장 긴 경로 세그먼트(24자 토큰)가 40자 미만이라 **URL 전체가 무마스킹 통과**했습니다(실측). Discord는 토큰 세그먼트가 40자를 넘어 우연히 마스킹된 것이지 설계가 아니었습니다.

`hooks.slack.com` / `discord(app).com/api/webhooks` 패턴과 `xox*` 봇 토큰을 추가하고, env 마스킹 목록에 `SLACK_BOT_TOKEN`·`SLACK_WEBHOOK_URL`·`DISCORD_WEBHOOK_URL`을 넣었습니다. `HTTPError` 브랜치도 마스킹을 통과시켰습니다(유일한 미적용 브랜치). 자사 URL은 통과하는지 테스트로 고정했습니다.

## LOW — 리포트가 사건을 재현하라고 지시했다

`generate_quality_report.py`의 조치 사항에 **`Mermaid 다이어그램 미적용 포스트 지속적 주입`** 이 있었습니다. 43개 동일 날조 다이어그램을 만든 그 지시입니다. `24/7 자율 현대화 크론 파이프라인 지속 가동`은 제거된 파이프라인을 가리킵니다. 둘 다 삭제했습니다.

같은 파일의 성숙도 표도 같은 유인이었습니다 — `mermaid_count > 30`이면 `🟢 우수`. **존재를 등급화하면 목표가 됩니다.** 등급을 걷고 관측값으로만 보고하며, 낮은 숫자를 채우지 말라고 명시했습니다. FAQ 행만 등급을 유지합니다(0이 유일한 정답인 금지 항목이라 목표치가 실제로 고정).

덤으로 표 카운트가 `"|" in text`였는데 Liquid·인라인코드까지 잡아 거의 모든 포스트를 세고 있었습니다 — 헤더+구분행 정규식으로 교체. 포스트당 파일 읽기도 최대 4회 → 1회.

## 감사에서 clean으로 확인된 것 (근거 포함)

- **커버 시스템 18파일 전부 AST 동일.** `cover_honesty_baseline.txt` diff 0줄(래칫 성장 없음), 스코어러 `--all --strict` 269/269 PASS, `upgrade_{digest,rollup,l25}_cover --all --check` 드리프트 0, 스코프 테스트 513 passed. 완화된 테스트 0건(assert/parametrize/skip 카운트 동일 + AST 동일).
- **게이트 스크립트 전부 순수 재포맷.** `check_workflow_action_pins.py`는 floating tag를 심어 exit 1을 확인, `check_digest_lone_adjective.py`는 미검증 lone adjective를 심어 탐지를 확인 — **실패시켜 검증**했습니다.
- **`quality_baseline.json`은 정직한 재채점.** 272→275 키, **제거 0건**, 52개 상향(체크리스트 백필), **5개 하향**(`code_blocks` 10→9). 회귀를 숨긴다면 하향이 나오지 않습니다.
- **`_data/`(+737/-3147)는 의도된 만료 정리.** `scripts/news/loader.py:54,66`이 `expires_at` 기준으로 prune합니다. 중복발행 원장은 219→217(45 만료/43 추가)로 append-only가 아닌 TTL 설계입니다.
- 워크플로 권한(`contents: read` + `issues: write`), 트리거 표면(`schedule`+`workflow_dispatch`만), action 핀(31 워크플로 102핀 전부 고정), 커맨드 인젝션·SSRF·타임아웃 모두 이상 없음.

## 이 PR 범위 밖 (보고만)

`scripts/check_broken_links.py`는 **죽은 게이트**입니다 — 어느 리비전에서도 `sys.exit()`를 호출하지 않고 CI·pre-commit 어디에도 배선돼 있지 않습니다. 이 배치가 약화시킨 것이 아니라 그 전부터 그랬습니다.

## 검증

```
pytest scripts/tests/                    4321 passed / 0 failed
vitest                                   733 passed / 29 files
워크플로 YAML + 추출한 run 블록 bash -n   유효
outcome 4분기 시뮬레이션                 SUCCESS/WARNING/FAILED/FAILED
check_workflow_action_pins.py            PASS
check_post_boilerplate.py --all          PASS
```

게이트 비-공허성: `test_ci_monthly_report_status_guard.py`를 **수정 전 워크플로에 대고 6/7 실패**, 수정 후 7/7 통과로 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
