### PR TITLE
feat(ops): notifier를 chat.postMessage로 + check_broken_links 부활(370건은 전부 오탐이었다)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -303,3 +303,24 @@ if [ -n "$STAGED_ANY_POSTS" ]; then
   fi
   echo "[pre-commit] Post-boilerplate check: passed."
 fi
+
+# 16. Internal /posts/ link gate — a link to a post that does not exist and has
+#     no declared redirect is a 404 for the reader. This gate was inert until
+#     2026-08-24 (printed a count, never exited, wired to nothing) and its
+#     revival was not a one-liner: the old version reported 370 broken links and
+#     all 370 were `redirect_from` YAML items matched inside front matter. Now
+#     front matter is skipped and declared redirect_from targets count as valid,
+#     which is what the KST/UTC filename-vs-URL date split depends on. Corpus is
+#     at 0 across 275 posts, so any hit is new drift.
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for broken internal /posts/ links..."
+  python3 "$REPO_ROOT/scripts/check_broken_links.py" --staged --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] A body link points at no post and no declared redirect."
+    echo "             Fix the link, or add the URL to the target post's"
+    echo "             \`redirect_from:\` if it is a legitimate old address."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Internal link check: passed."
+fi

--- a/.github/workflows/monthly-quality-report.yml
+++ b/.github/workflows/monthly-quality-report.yml
@@ -165,8 +165,15 @@ jobs:
       - name: Send Webhook Notification
         if: always() && steps.report.outputs.report_generated == 'true'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # Bot API, not an incoming webhook. SLACK_WEBHOOK_URL and
+          # DISCORD_WEBHOOK_URL have never been registered in this repo
+          # (`gh secret list`, 2026-08-24), so this step delivered nothing from
+          # the day it was added. SLACK_BOT_TOKEN and SLACK_CHANNEL_ID ARE
+          # configured and slack-post-notify.yml already uses them — the same
+          # move PR #583 made for monitoring.yml rather than asking for a new
+          # credential.
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           ISSUE_OUTCOME: ${{ steps.issue.outcome }}
           IMAGE_ISSUES: ${{ steps.images.outputs.image_issues || 0 }}
           POST_ISSUES: ${{ steps.posts.outputs.post_issues || 0 }}
@@ -186,7 +193,13 @@ jobs:
               HEADLINE="Report generated but issue creation FAILED (outcome: ${ISSUE_OUTCOME:-unknown}). The monthly report does not exist on GitHub Issues."
               ;;
           esac
+          # --require-delivery: fail rather than skip. The bot secrets are
+          # configured, so their absence means a removal or lost secret access,
+          # and silently skipping would hide exactly the regression worth
+          # knowing about — notifications quietly stopping, which is what
+          # happened here for a month.
           python3 scripts/notify_webhook.py \
             --title "Monthly Blog Quality Report (${CURRENT_MONTH})" \
             --message "• ${HEADLINE}\n• Image Issues: ${IMAGE_ISSUES}\n• Post Warnings: ${POST_ISSUES}" \
-            --status "${STATUS}"
+            --status "${STATUS}" \
+            --require-delivery

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -1,9 +1,9 @@
 name: SVG Compliance Lint
 
-# This workflow carries 16 corpus-wide gates (`--all`): cover drift for four
+# This workflow carries 17 corpus-wide gates (`--all`): cover drift for four
 # generator families, the honesty scorer, title-ASCII, spec-slug consistency,
 # KST-midnight URLs, checklist headings, bare URLs, template-echo, and repeated
-# body boilerplate. They scan the
+# body boilerplate, and internal post links. They scan the
 # WHOLE corpus, so the same trigger-narrower-than-scan hazard that hid a
 # three-week regression in check-svg.yml applies here — see that file's header.
 #
@@ -16,9 +16,9 @@ name: SVG Compliance Lint
 # the bot cover commit 685ca468 carried 12 workflow runs, every one of them
 # `schedule` and not a single `push` or `pull_request` event.
 #
-# So the dominant producer of the artifacts these 16 gates exist to check was
+# So the dominant producer of the artifacts these 17 gates exist to check was
 # invisible to both triggers. The daily `schedule` below closes that: it scans main
-# regardless of paths, exactly as check-svg.yml does. All 16 gates were verified
+# regardless of paths, exactly as check-svg.yml does. All 17 gates were verified
 # green against the current corpus before this was added, so it is not born red.
 on:
   push:
@@ -59,6 +59,7 @@ on:
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/check_post_boilerplate.py'
+      - 'scripts/check_broken_links.py'
       - 'scripts/linkify_bare_urls.py'
       - 'scripts/check_template_echo.py'
       - 'scripts/rewrite_template_echo_summaries.py'
@@ -116,6 +117,7 @@ on:
       - 'scripts/check_digest_proper_nouns.py'
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/check_post_boilerplate.py'
+      - 'scripts/check_broken_links.py'
       - 'scripts/linkify_bare_urls.py'
       - 'scripts/check_template_echo.py'
       - 'scripts/rewrite_template_echo_summaries.py'
@@ -361,6 +363,23 @@ jobs:
         # Whole blocks only: 119 posts legitimately share one canonical
         # checklist line, so a per-line rule would be all false positives.
         run: python3 scripts/check_post_boilerplate.py --all
+
+      - name: Internal /posts/ link gate
+        id: broken_links_gate
+        # This gate was inert until 2026-08-24: it printed a count, never called
+        # sys.exit(), and was wired to nothing. Reviving it was not a one-line
+        # change — the old version reported 370 broken links and ALL 370 were
+        # `redirect_from` YAML items in front matter, matched because its regex
+        # allowed a leading whitespace. Wiring that would have produced a
+        # permanently red job, the state this repo has twice judged worse than
+        # no gate (see NEVER_CONFIGURED in test_ci_secret_absence_guard.py).
+        # Fixed to skip front matter and to count declared redirect_from targets
+        # as valid destinations (jekyll-redirect-from serves them, and the
+        # KST/UTC filename-vs-URL date split relies on exactly that). Body count
+        # is now 0 across 275 posts against 645 valid targets, so --all with no
+        # ratchet: any hit is fresh drift, including one from a cron push that
+        # never ran pre-commit.
+        run: python3 scripts/check_broken_links.py --all
 
       - name: Bare-URL gate (unlinked https:// in post prose)
         id: bare_url_gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,7 +523,7 @@ the 9 historical posts affected before the rule was introduced. The 7
 posts that still violated the rule were fixed in commit `b4ff35c4`
 (2026-05-28).
 
-### Active automation gates (11 enforcing)
+### Active automation gates (12 enforcing)
 
 | # | Script | Scope | Wired to |
 |---|--------|-------|----------|
@@ -538,6 +538,17 @@ posts that still violated the rule were fixed in commit `b4ff35c4`
 | 9 | `check_digest_checklist_heading.py` | exactly one canonical `## 실무 체크리스트` H2 | pre-commit (9d) + svg-lint CI (`--all`) + blogwatcher publish (self-heal, then block) |
 | 10 | `check_template_echo.py` | card `summary=` that only echoes the headline + a fixed clause | pre-commit (13, `--staged`) + svg-lint CI (`--all`) + blogwatcher publish (self-heal via `rewrite_template_echo_summaries.py`, then block) |
 | 11 | `check_post_boilerplate.py` | a Mermaid fence or a whole checklist repeated verbatim across 2+ posts | pre-commit (15, `--staged`) + svg-lint CI (`--all`) |
+| 12 | `check_broken_links.py` | body `/posts/` link with no post and no declared `redirect_from` | pre-commit (16, `--staged`) + svg-lint CI (`--all`) |
+
+Gate 12 was inert from creation until 2026-08-24 — it printed a count, never
+called `sys.exit()`, and no workflow or hook invoked it. Reviving it was **not**
+a one-line change: the old version reported 370 broken links and *all 370 were
+`redirect_from` YAML items in front matter*, matched because its regex allowed a
+leading whitespace. Wiring that as-is would have produced a permanently red job.
+It now skips front matter and treats declared `redirect_from` targets as valid
+destinations — which is what the KST/UTC filename-vs-URL date split above relies
+on. **Before wiring any dormant gate, run it and read the output: a gate nobody
+has run has never been right.**
 
 Gate 11 exists because gates 1-10 all passed a pipeline that put the same
 hardcoded diagram in 43 posts and the same checklist in 55: none of them read

--- a/scripts/check_broken_links.py
+++ b/scripts/check_broken_links.py
@@ -1,27 +1,181 @@
 #!/usr/bin/env python3
-"""Check for broken internal /posts/ links in _posts/*.md files."""
+"""Fail on internal /posts/ links in post BODIES that resolve to nothing.
 
-import glob
-import os
+History, because the numbers here are counter-intuitive
+------------------------------------------------------
+This script existed but was inert: it printed a count, never called
+`sys.exit()`, and was wired to no workflow and no hook. Reviving it looked like
+a one-line fix — add an exit code — and that would have been wrong. Measured
+2026-08-24: it reported **370 broken links, and all 370 were false positives.**
+
+Two causes, both now handled:
+
+1. Its link regex allowed a leading `\\s`, so the YAML list items under
+   ``redirect_from:`` in front matter matched. Those are not links; they are
+   declarations of old URLs that should redirect *to this post* — the opposite
+   of broken. 370 of 370 flagged links were exactly this. Front matter is now
+   excluded from the scan.
+2. A body link pointing at a URL some post declares in ``redirect_from`` is
+   valid: jekyll-redirect-from serves it. So the valid-target set is
+   permalinks ∪ every declared ``redirect_from`` target, not permalinks alone.
+   This matters here because the site is pinned to ``timezone: UTC`` while posts
+   are authored in KST, so a post's filename date and its live URL date can
+   differ by one day and the filename-date URL lives in ``redirect_from``
+   (see CLAUDE.md, "Date / Timezone Rule").
+
+Body count after both fixes: 0. That is what makes it safe to wire fail-closed
+with no legacy ratchet — any hit is fresh drift. Wiring the old version would
+have produced a permanently red job, which is the state this repo has twice
+decided is worse than no gate at all (see NEVER_CONFIGURED in
+scripts/tests/test_ci_secret_absence_guard.py).
+
+Fenced blocks are stripped: a `/posts/...` path inside a code sample is
+illustrative text, matching how the other corpus gates here treat fences.
+
+Parsing note: front matter is split with `python-frontmatter` (declared in both
+requirements files) rather than a hand-rolled `---` splitter, so this script
+needs no entry in ALLOWLIST_FRONT_MATTER in
+scripts/tests/test_lib_seam_drift_guard.py. That also means `redirect_from` is
+read as real YAML instead of by regex, which handles both the block-list and
+inline-list forms for free.
+"""
+
+from __future__ import annotations
+
+import argparse
 import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Set, Tuple
 
-posts = glob.glob("_posts/*.md")
-permalinks = set()
-for p in posts:
-    m = re.match(r"(\d{4})-(\d{2})-(\d{2})-(.+)\.md", os.path.basename(p))
-    if m:
-        y, mo, d, t = m.groups()
-        permalinks.add(f"/posts/{y}/{mo}/{d}/{t}/")
+import frontmatter
 
-broken = []
-pattern = re.compile(r'(?:href=["\']|\]\(|\s)(/posts/[^\s\)\\\'"<>]+/)')
-for p in posts:
-    content = open(p, encoding="utf-8").read()
-    for m in pattern.finditer(content):
-        link = m.group(1)
-        if link not in permalinks:
-            broken.append((link, os.path.basename(p)))
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO_ROOT / "_posts"
 
-print(f"broken={len(broken)}")
-for link, fn in broken[:30]:
-    print(f"  {fn}: {link}")
+_FILENAME_RE = re.compile(r"(\d{4})-(\d{2})-(\d{2})-(.+)\.md")
+# Markdown link, HTML href, or a bare path preceded by whitespace.
+_LINK_RE = re.compile(r"""(?:href=["']|\]\(|\s)(/posts/[^\s)\\'"<>]+/)""")
+
+
+def parse(path: Path) -> Tuple[dict, str]:
+    """Return (metadata, body). Front matter is never scanned for links."""
+    try:
+        post = frontmatter.loads(path.read_text(encoding="utf-8", errors="ignore"))
+    except Exception:
+        # A post whose YAML will not parse is check_posts.py's problem, not this
+        # gate's. Treat it as bodyless rather than crashing the whole scan.
+        return {}, ""
+    return dict(post.metadata), post.content
+
+
+def strip_fences(text: str) -> str:
+    out, in_fence = [], False
+    for line in text.split("\n"):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+def redirect_targets(metadata: dict) -> Set[str]:
+    """URLs declared under `redirect_from:` — these resolve, so they are valid.
+
+    YAML gives a list for the block form and for the inline `[a, b]` form, and a
+    bare string when someone writes a single value without a list.
+    """
+    raw = metadata.get("redirect_from")
+    if raw is None:
+        return set()
+    if isinstance(raw, str):
+        raw = [raw]
+    return {str(x).strip() for x in raw if str(x).strip()}
+
+
+def valid_targets(posts: Iterable[Path]) -> Set[str]:
+    targets: Set[str] = set()
+    for path in posts:
+        m = _FILENAME_RE.match(path.name)
+        if m:
+            y, mo, d, title = m.groups()
+            targets.add(f"/posts/{y}/{mo}/{d}/{title}/")
+        metadata, _ = parse(path)
+        targets |= redirect_targets(metadata)
+    return targets
+
+
+def broken_links(path: Path, targets: Set[str]) -> List[str]:
+    _, body = parse(path)
+    return [
+        m.group(1) for m in _LINK_RE.finditer(strip_fences(body)) if m.group(1) not in targets
+    ]
+
+
+def staged_posts() -> List[Path]:
+    res = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM", "--", "_posts"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        REPO_ROOT / line
+        for line in res.stdout.split("\n")
+        if line.strip().endswith(".md") and (REPO_ROOT / line).exists()
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument("--all", action="store_true", help="scan every post (default)")
+    scope.add_argument("--staged", action="store_true", help="scan staged posts only")
+    parser.add_argument("--quiet", action="store_true", help="only print the summary")
+    args = parser.parse_args()
+
+    corpus = sorted(POSTS_DIR.glob("*.md"))
+    if not corpus:
+        print("[broken-links] no posts found", file=sys.stderr)
+        return 1
+
+    # Targets always come from the whole corpus: a staged post may legitimately
+    # link to a post it does not contain.
+    targets = valid_targets(corpus)
+    scoped = staged_posts() if args.staged else corpus
+    if args.staged and not scoped:
+        print("[broken-links] no staged posts — nothing to check.")
+        return 0
+
+    offenders = []
+    for path in scoped:
+        for link in broken_links(path, targets):
+            offenders.append(f"{path.name}: {link}")
+
+    if offenders:
+        print(
+            "[broken-links] FAIL — these body links resolve to no post and no "
+            "declared redirect:\n",
+            file=sys.stderr,
+        )
+        for line in offenders:
+            print(f"  {line}", file=sys.stderr)
+        print(
+            f"\n{len(offenders)} broken link(s). Fix the link, or add the URL to the "
+            "target post's `redirect_from:` if it is a legitimate old address.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not args.quiet:
+        print(
+            f"[broken-links] OK — {len(scoped)} post(s) scanned against "
+            f"{len(targets)} valid target(s), 0 broken."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notify_webhook.py
+++ b/scripts/notify_webhook.py
@@ -1,8 +1,29 @@
 #!/usr/bin/env python3
-"""Unified Slack & Discord Webhook Notifier for Autonomous Tech Blog & Cron Pipelines.
+"""Unified Slack / Discord notifier for cron and CI pipelines.
 
-Sends formatted status cards to Slack/Discord webhooks with security masking,
-timeouts, and graceful fallbacks.
+Three transports, tried in this order:
+
+1. **Slack Bot API** (`chat.postMessage`) via `SLACK_BOT_TOKEN` +
+   `SLACK_CHANNEL_ID`. This is the one that actually works here: both secrets
+   are configured in this repo and two workflows already use them
+   (`slack-post-notify.yml`, `slack-category-digest.yml`).
+2. Slack incoming webhook via `SLACK_WEBHOOK_URL`.
+3. Discord webhook via `DISCORD_WEBHOOK_URL`.
+
+Neither webhook secret has ever been registered here (`gh secret list`,
+2026-08-24), which is why every call to this script was a silent no-op until the
+Bot API transport was added. It printed `[INFO]` and returned True — the same
+value as a successful send. Requiring a *new* credential when a working one
+exists is what PR #583 rejected for `monitoring.yml`; this follows that
+decision.
+
+Slack's Web API answers **HTTP 200 with `{"ok": false}`** on failure, so the
+Bot transport parses the response body. Treating 200 as success is precisely the
+false-success bug this module has already been fixed for once.
+
+Pass `--require-delivery` to exit non-zero when nothing was configured or the
+send failed. Use it wherever a lost notification is itself the regression worth
+knowing about.
 """
 
 from __future__ import annotations
@@ -43,8 +64,78 @@ def get_webhook_urls() -> Dict[str, Optional[str]]:
     }
 
 
+def get_slack_bot_config() -> Optional[Dict[str, str]]:
+    """Slack Bot API credentials, or None when either half is missing."""
+    token = os.getenv("SLACK_BOT_TOKEN", "").strip()
+    channel = os.getenv("SLACK_CHANNEL_ID", "").strip()
+    if token and channel:
+        return {"token": token, "channel": channel}
+    return None
+
+
+def send_slack_bot(
+    config: Dict[str, str],
+    title: str,
+    message: str,
+    status: str = "SUCCESS",
+    timeout: int = 5,
+) -> bool:
+    """POST to chat.postMessage, reading `ok` from the body.
+
+    The Web API returns HTTP 200 with `{"ok": false, "error": "..."}` for
+    channel_not_found, not_in_channel, invalid_auth and friends. Checking only
+    the status code would report every one of those as a successful send.
+    """
+    payload: Dict[str, Any] = {
+        "channel": config["channel"],
+        # `text` is the notification/accessibility fallback. Without it Slack
+        # delivers the blocks but push notifications and screen readers get
+        # nothing.
+        "text": f"{mask_sensitive_info(title)} — {status}",
+        "unfurl_links": False,
+        "unfurl_media": False,
+        **build_slack_payload(title, message, status),
+    }
+    try:
+        req = urllib.request.Request(
+            "https://slack.com/api/chat.postMessage",
+            data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {config['token']}",
+                "Content-Type": "application/json; charset=utf-8",
+                "User-Agent": "TechBlog-Notifier/1.0",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = json.loads(response.read().decode("utf-8") or "{}")
+    except Exception as e:  # noqa: BLE001 — any transport failure is a failure
+        print(
+            f"[WARN] Slack Bot API request failed: {mask_sensitive_info(str(e))}",
+            file=sys.stderr,
+        )
+        return False
+
+    if body.get("ok") is True:
+        return True
+    # `error` is a Slack error code (channel_not_found, invalid_auth, ...), not
+    # a secret, but mask anyway — this is the branch that runs when something
+    # unexpected came back.
+    print(
+        "[WARN] Slack Bot API returned ok=false: "
+        f"{mask_sensitive_info(str(body.get('error', 'unknown')))}",
+        file=sys.stderr,
+    )
+    return False
+
+
 def send_http_post(url: str, payload: Dict[str, Any], timeout: int = 5) -> bool:
-    """Send JSON payload over HTTP POST with timeout."""
+    """Send JSON payload over HTTP POST with timeout.
+
+    Incoming webhooks (Slack and Discord) genuinely signal failure with a
+    non-2xx status, so a status check is correct here — unlike the Web API
+    above.
+    """
     try:
         data = json.dumps(payload).encode("utf-8")
         req = urllib.request.Request(
@@ -128,32 +219,43 @@ def build_discord_payload(title: str, message: str, status: str = "SUCCESS") -> 
 
 
 def notify(title: str, message: str, status: str = "SUCCESS") -> bool:
-    """Send notification to all configured webhooks."""
+    """Deliver to every configured transport. False means a send failed.
+
+    "Nothing configured" returns True — it is not a delivery failure — but it
+    prints a `::warning::` so the state is visible in the Actions run summary
+    rather than buried in step output. Callers that need it to be an error pass
+    `--require-delivery`, which consults `delivered_anywhere()`.
+    """
+    bot = get_slack_bot_config()
     urls = get_webhook_urls()
     slack_url = urls.get("slack")
     discord_url = urls.get("discord")
 
-    if not slack_url and not discord_url:
-        # Neither secret is registered in this repo (measured 2026-08-24:
-        # `gh secret list` has SLACK_BOT_TOKEN and SLACK_CHANNEL_ID, but no
-        # SLACK_WEBHOOK_URL and no DISCORD_WEBHOOK_URL). Every call to this
-        # script has therefore been a no-op. It used to print [INFO] and return
-        # True, which is indistinguishable from a successful send — that is why
-        # nobody noticed. Emit a GitHub Actions warning annotation so the state
-        # is visible in the run summary instead of buried in step output.
+    if not bot and not slack_url and not discord_url:
+        # Measured 2026-08-24 (`gh secret list`): SLACK_BOT_TOKEN and
+        # SLACK_CHANNEL_ID are configured; SLACK_WEBHOOK_URL and
+        # DISCORD_WEBHOOK_URL never were. Before the Bot transport existed,
+        # every call landed here, printed [INFO] and returned True — the same
+        # value as a successful send, which is why nobody noticed for a month.
         print(
-            "::warning title=Webhook notification skipped::"
-            "Neither SLACK_WEBHOOK_URL nor DISCORD_WEBHOOK_URL is configured, "
-            "so this notification was not delivered anywhere."
+            "::warning title=Notification not delivered::"
+            "No transport configured (SLACK_BOT_TOKEN+SLACK_CHANNEL_ID, "
+            "SLACK_WEBHOOK_URL, or DISCORD_WEBHOOK_URL), so this notification "
+            "went nowhere."
         )
         print(
-            "[WARN] No Webhook URLs configured "
-            "(SLACK_WEBHOOK_URL or DISCORD_WEBHOOK_URL). Nothing was sent.",
+            "[WARN] No notification transport configured. Nothing was sent.",
             file=sys.stderr,
         )
         return True
 
     success = True
+    if bot:
+        if send_slack_bot(bot, title, message, status):
+            print("[INFO] Slack notification sent via chat.postMessage.")
+        else:
+            success = False
+
     if slack_url:
         payload = build_slack_payload(title, message, status)
         res = send_http_post(slack_url, payload)
@@ -173,12 +275,42 @@ def notify(title: str, message: str, status: str = "SUCCESS") -> bool:
     return success
 
 
+def delivered_anywhere() -> bool:
+    """Whether at least one transport is configured."""
+    urls = get_webhook_urls()
+    return bool(get_slack_bot_config() or urls.get("slack") or urls.get("discord"))
+
+
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Send Webhook Notification for Cron / Pipelines")
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--title", type=str, default="Tech Blog Cron Pipeline", help="Notification Title")
     parser.add_argument("--message", type=str, required=True, help="Notification Message Body")
     parser.add_argument("--status", choices=["SUCCESS", "WARNING", "FAILED"], default="SUCCESS", help="Execution Status")
+    parser.add_argument(
+        "--require-delivery",
+        action="store_true",
+        help=(
+            "exit non-zero when no transport is configured. Use where a lost "
+            "notification is itself the regression worth knowing about — "
+            "SLACK_BOT_TOKEN and SLACK_CHANNEL_ID are configured in this repo, "
+            "so their absence means a removal or lost secret access, not an "
+            "optional integration."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.require_delivery and not delivered_anywhere():
+        # Same reasoning as slack-post-notify.yml: fail-closed is safe precisely
+        # BECAUSE the bot secrets exist. Contrast gsc-queue-refresh.yml, whose
+        # secrets have never been configured — fail-closed there would only
+        # produce a permanently red cron that gets muted.
+        print(
+            "::error title=Notification transport missing::"
+            "--require-delivery was set but no transport is configured. "
+            "SLACK_BOT_TOKEN and SLACK_CHANNEL_ID are configured in this repo, "
+            "so this is a regression — check secret access for this workflow.",
+        )
+        return 1
 
     # Propagate delivery failure. Previously the return value was discarded and
     # main() always exited 0, so no caller could ever detect that a POST failed.

--- a/scripts/tests/test_check_broken_links.py
+++ b/scripts/tests/test_check_broken_links.py
@@ -1,0 +1,130 @@
+"""Tests for the internal /posts/ link gate.
+
+The interesting part is not that the corpus is clean — it is *why* the old
+version said it wasn't. It reported 370 broken links, all 370 of them
+``redirect_from`` YAML items in front matter, because its regex allowed a
+leading whitespace and front matter was in scope. Adding an exit code without
+fixing that would have produced a permanently red job.
+
+These tests pin both halves: front matter is not scanned, and a declared
+``redirect_from`` target counts as a valid destination.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import check_broken_links as gate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POSTS_DIR = REPO_ROOT / "_posts"
+
+_FM = """---
+layout: post
+title: "T"
+redirect_from:
+  - /posts/2026/01/Old_Shape/
+  - /posts/2026-01-02-Filename_Shape/
+---
+"""
+
+
+def _post(tmp_path: Path, name: str, body: str, front_matter: str = _FM) -> Path:
+    p = tmp_path / name
+    p.write_text(front_matter + "\n" + body, encoding="utf-8")
+    return p
+
+
+def test_front_matter_is_not_scanned(tmp_path):
+    """The whole 370-false-positive bug in one assertion."""
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", "no links here\n")
+    assert gate.broken_links(p, {"/posts/2026/01/02/Filename_Shape/"}) == []
+
+
+def test_parsing_goes_through_python_frontmatter_not_a_local_splitter():
+    """scripts/tests/test_lib_seam_drift_guard.py forbids hand-rolled parsers.
+
+    Using the library also means redirect_from arrives as real YAML, so the
+    block-list, inline-list and bare-string forms all work without three
+    separate regexes.
+    """
+    src = (REPO_ROOT / "scripts" / "check_broken_links.py").read_text(encoding="utf-8")
+    assert "import frontmatter" in src
+    assert "split_front_matter" not in src
+
+
+def test_bare_string_redirect_from_is_accepted(tmp_path):
+    fm = "---\nlayout: post\nredirect_from: /posts/2026/01/Solo/\n---\n"
+    p = _post(tmp_path, "2026-01-02-Solo.md", "", front_matter=fm)
+    assert "/posts/2026/01/Solo/" in gate.valid_targets([p])
+
+
+def test_declared_redirect_targets_are_valid_destinations(tmp_path):
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", "")
+    targets = gate.valid_targets([p])
+    assert "/posts/2026/01/02/Filename_Shape/" in targets  # from the filename
+    assert "/posts/2026/01/Old_Shape/" in targets  # from redirect_from
+    assert "/posts/2026-01-02-Filename_Shape/" in targets
+
+
+def test_a_body_link_to_a_redirect_target_is_not_broken(tmp_path):
+    """jekyll-redirect-from serves these, so flagging them would be wrong.
+
+    This is the KST/UTC case from CLAUDE.md: the filename-date URL lives in
+    redirect_from because the live URL can be one day earlier.
+    """
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", "see [old](/posts/2026/01/Old_Shape/)\n")
+    assert gate.broken_links(p, gate.valid_targets([p])) == []
+
+
+def test_a_genuinely_missing_target_is_flagged(tmp_path):
+    """Proof the gate is not vacuously green."""
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", "see [gone](/posts/2026/01/02/No_Such_Post/)\n")
+    assert gate.broken_links(p, gate.valid_targets([p])) == [
+        "/posts/2026/01/02/No_Such_Post/"
+    ]
+
+
+def test_html_href_and_bare_path_are_both_detected(tmp_path):
+    body = (
+        '<a href="/posts/2026/01/02/Gone_A/">a</a>\n'
+        "bare /posts/2026/01/02/Gone_B/ here\n"
+    )
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", body)
+    found = gate.broken_links(p, gate.valid_targets([p]))
+    assert "/posts/2026/01/02/Gone_A/" in found
+    assert "/posts/2026/01/02/Gone_B/" in found
+
+
+def test_fenced_link_is_illustrative_not_a_link(tmp_path):
+    body = "```markdown\n[x](/posts/2026/01/02/Gone_In_Fence/)\n```\n"
+    p = _post(tmp_path, "2026-01-02-Filename_Shape.md", body)
+    assert gate.broken_links(p, gate.valid_targets([p])) == []
+
+
+def test_inline_redirect_from_list_form_is_accepted(tmp_path):
+    fm = '---\nlayout: post\nredirect_from: [/posts/2026/01/Inline_One/, /posts/x/]\n---\n'
+    p = _post(tmp_path, "2026-01-02-Inline.md", "", front_matter=fm)
+    targets = gate.valid_targets([p])
+    assert "/posts/2026/01/Inline_One/" in targets
+    assert "/posts/x/" in targets
+
+
+def test_live_corpus_has_no_broken_body_links():
+    posts = sorted(POSTS_DIR.glob("*.md"))
+    targets = gate.valid_targets(posts)
+    offenders = {
+        p.name: links for p in posts if (links := gate.broken_links(p, targets))
+    }
+    assert offenders == {}, offenders
+
+
+def test_the_corpus_scan_is_actually_looking_at_something():
+    """Guards against the whole check silently reducing to an empty scan."""
+    posts = sorted(POSTS_DIR.glob("*.md"))
+    assert len(posts) > 200
+    targets = gate.valid_targets(posts)
+    # permalinks plus redirect_from declarations — measured 645 on 2026-08-24
+    assert len(targets) > len(posts), (
+        "valid targets should exceed post count because redirect_from adds more"
+    )

--- a/scripts/tests/test_ci_secret_absence_guard.py
+++ b/scripts/tests/test_ci_secret_absence_guard.py
@@ -32,6 +32,7 @@ should move to the fail-closed set and this guard should be updated in the same 
 
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -54,7 +55,25 @@ FAIL_CLOSED = (
     # monitoring has already failed, so a missing secret means an alert about a
     # real outage is being dropped.
     "monitoring.yml",
+    # Added 2026-08-24. Same history as monitoring.yml above, one step worse:
+    # this workflow's "webhook alerts" were wired to secrets.SLACK_WEBHOOK_URL /
+    # secrets.DISCORD_WEBHOOK_URL, neither of which has ever been configured, so
+    # the step delivered nothing from the day it was added while reporting a
+    # hardcoded SUCCESS. Moved to the SLACK_BOT_TOKEN / SLACK_CHANNEL_ID pair
+    # and made fail-closed. It enforces that through
+    # `notify_webhook.py --require-delivery` rather than an inline shell guard —
+    # see DELEGATED_GUARD below.
+    "monthly-quality-report.yml",
 )
+
+# Workflows in FAIL_CLOSED that enforce the rule by delegating to a script
+# instead of an inline `if [ -z "${SLACK_...}" ]` block. The delegation is only
+# acceptable because the script's exit-1 path is itself unit-tested — see
+# test_notify_webhook.py::test_require_delivery_exits_nonzero_with_no_transport.
+# Duplicating the shell guard here would mean two places to keep in sync.
+DELEGATED_GUARD = {
+    "monthly-quality-report.yml": "scripts/notify_webhook.py",
+}
 
 # Secrets never configured -> fail-closed would be a permanently red cron.
 NEVER_CONFIGURED = {
@@ -80,6 +99,16 @@ def _body(name: str) -> str:
 def test_missing_slack_secret_fails(name: str):
     body = _body(name)
     assert "SLACK_BOT_TOKEN" in body, f"{name} no longer references SLACK_BOT_TOKEN"
+
+    if name in DELEGATED_GUARD:
+        script = DELEGATED_GUARD[name]
+        assert script in body, f"{name} no longer invokes {script}"
+        assert "--require-delivery" in body, (
+            f"{name} delegates its secret guard to {script} but dropped "
+            "--require-delivery, so a missing secret is back to a silent skip."
+        )
+        return
+
     # Find the guard block and confirm it exits non-zero.
     blocks = re.findall(
         r'if \[ -z "\$\{SLACK_(?:BOT_TOKEN|CHANNEL_ID):-\}" \][^\n]*\n(.*?)\n\s*fi',
@@ -95,9 +124,50 @@ def test_missing_slack_secret_fails(name: str):
         assert "exit 0" not in block, f"{name}: guard block still contains exit 0"
 
 
+@pytest.mark.parametrize("name", sorted(DELEGATED_GUARD))
+def test_delegated_guard_script_actually_enforces_it(name: str):
+    """A delegated guard is only as good as the script it delegates to.
+
+    Without this, moving a workflow into DELEGATED_GUARD would be a way to
+    satisfy the policy test while enforcing nothing.
+    """
+    from scripts import notify_webhook
+
+    src = (REPO_ROOT / DELEGATED_GUARD[name]).read_text(encoding="utf-8")
+    assert "--require-delivery" in src, f"{DELEGATED_GUARD[name]} lost the flag"
+    assert "::error" in src, "the missing-transport branch must be ::error::"
+    assert hasattr(notify_webhook, "delivered_anywhere"), (
+        "the flag needs a transport check to consult"
+    )
+    # And it must return False when nothing is configured, or the flag is inert.
+    saved = {
+        k: os.environ.pop(k, None)
+        for k in (
+            "SLACK_BOT_TOKEN",
+            "SLACK_CHANNEL_ID",
+            "SLACK_WEBHOOK_URL",
+            "SLACK_WEBHOOK",
+            "DISCORD_WEBHOOK_URL",
+            "DISCORD_WEBHOOK",
+        )
+    }
+    try:
+        assert notify_webhook.delivered_anywhere() is False
+    finally:
+        for k, v in saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+
 @pytest.mark.parametrize("name", FAIL_CLOSED)
 def test_missing_secret_is_an_error_annotation_not_a_warning(name: str):
     """`::warning::` reads as expected-and-fine; this state is neither."""
+    if name in DELEGATED_GUARD:
+        src = (REPO_ROOT / DELEGATED_GUARD[name]).read_text(encoding="utf-8")
+        assert "::error" in src, (
+            f"{name}: the delegated missing-transport branch must emit ::error::"
+        )
+        return
     body = _body(name)
     guard_region = body[body.find("SLACK_BOT_TOKEN:-") :][:1200]
     assert "::error::" in guard_region, (

--- a/scripts/tests/test_notify_webhook.py
+++ b/scripts/tests/test_notify_webhook.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from unittest.mock import patch, MagicMock
 from scripts import notify_webhook as notifier
@@ -62,7 +63,7 @@ def test_no_configured_target_emits_a_ci_visible_warning(capsys):
         notifier.notify("Title", "Message")
     out = capsys.readouterr().out
     assert "::warning" in out
-    assert "not delivered anywhere" in out
+    assert "No transport configured" in out
 
 
 @patch("urllib.request.urlopen", side_effect=OSError("connection refused"))
@@ -106,6 +107,107 @@ def test_main_exits_zero_when_delivery_succeeds(mock_urlopen):
     _sys.argv = ["notify_webhook.py", "--message", "m"]
     try:
         rc = notifier.main()
+    finally:
+        _sys.argv = argv
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Slack Bot API transport (chat.postMessage)
+# ---------------------------------------------------------------------------
+
+BOT_ENV = {"SLACK_BOT_TOKEN": "xoxb-test-token-value", "SLACK_CHANNEL_ID": "C0123456789"}
+
+
+def _resp(body: str):
+    resp = MagicMock()
+    resp.read.return_value = body.encode("utf-8")
+    return resp
+
+
+def test_bot_config_requires_both_halves():
+    with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-x"}, clear=True):
+        assert notifier.get_slack_bot_config() is None
+    with patch.dict(os.environ, {"SLACK_CHANNEL_ID": "C1"}, clear=True):
+        assert notifier.get_slack_bot_config() is None
+    with patch.dict(os.environ, BOT_ENV, clear=True):
+        assert notifier.get_slack_bot_config() == {
+            "token": BOT_ENV["SLACK_BOT_TOKEN"],
+            "channel": BOT_ENV["SLACK_CHANNEL_ID"],
+        }
+
+
+@patch("urllib.request.urlopen")
+def test_bot_send_succeeds_only_when_body_says_ok(mock_urlopen):
+    mock_urlopen.return_value.__enter__.return_value = _resp('{"ok": true}')
+    assert notifier.send_slack_bot({"token": "t", "channel": "C1"}, "T", "M") is True
+
+
+@patch("urllib.request.urlopen")
+def test_http_200_with_ok_false_is_a_failure(mock_urlopen):
+    """Slack answers 200 for channel_not_found / invalid_auth / not_in_channel.
+
+    Checking only the status code would report every one of those as a
+    successful send — the same false-success shape this module was already
+    fixed for once.
+    """
+    mock_urlopen.return_value.__enter__.return_value = _resp(
+        '{"ok": false, "error": "channel_not_found"}'
+    )
+    assert notifier.send_slack_bot({"token": "t", "channel": "C1"}, "T", "M") is False
+
+
+@patch("urllib.request.urlopen")
+def test_bot_payload_carries_channel_and_text_fallback(mock_urlopen):
+    """Blocks alone give no push notification and nothing to a screen reader."""
+    mock_urlopen.return_value.__enter__.return_value = _resp('{"ok": true}')
+    notifier.send_slack_bot({"token": "t", "channel": "C777"}, "Title", "Body", "FAILED")
+
+    req = mock_urlopen.call_args[0][0]
+    sent = json.loads(req.data.decode("utf-8"))
+    assert sent["channel"] == "C777"
+    assert "Title" in sent["text"] and "FAILED" in sent["text"]
+    assert sent["attachments"], "Block Kit attachments missing"
+    assert req.get_header("Authorization") == "Bearer t"
+
+
+@patch("urllib.request.urlopen")
+@patch.dict(os.environ, BOT_ENV, clear=True)
+def test_notify_prefers_the_bot_transport(mock_urlopen):
+    mock_urlopen.return_value.__enter__.return_value = _resp('{"ok": true}')
+    assert notifier.notify("T", "M") is True
+    assert "chat.postMessage" in mock_urlopen.call_args[0][0].full_url
+
+
+@patch.dict(os.environ, BOT_ENV, clear=True)
+def test_require_delivery_passes_when_bot_is_configured():
+    assert notifier.delivered_anywhere() is True
+
+
+def test_require_delivery_exits_nonzero_with_no_transport():
+    """Fail-closed. Safe precisely because the bot secrets exist in this repo."""
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["notify_webhook.py", "--message", "m", "--require-delivery"]
+    try:
+        with patch.dict(os.environ, {}, clear=True):
+            assert notifier.delivered_anywhere() is False
+            rc = notifier.main()
+    finally:
+        _sys.argv = argv
+    assert rc == 1
+
+
+def test_no_transport_without_require_delivery_still_exits_zero():
+    """Proves the fail-closed case above is opt-in, not a behaviour change."""
+    import sys as _sys
+
+    argv = _sys.argv
+    _sys.argv = ["notify_webhook.py", "--message", "m"]
+    try:
+        with patch.dict(os.environ, {}, clear=True):
+            rc = notifier.main()
     finally:
         _sys.argv = argv
     assert rc == 0


### PR DESCRIPTION
후속 항목 2건. 둘 다 "동작하는 것처럼 보이지만 아무것도 하지 않던" 것을 고칩니다.

---

## 1. notify_webhook → `chat.postMessage`

이 알림은 커밋 `29a76d2d` 이후 **한 번도 발송되지 않았습니다.** `SLACK_WEBHOOK_URL`·`DISCORD_WEBHOOK_URL`이 이 레포에 등록된 적이 없습니다(`gh secret list` 실측). `SLACK_BOT_TOKEN`·`SLACK_CHANNEL_ID`는 있고 `slack-post-notify.yml`·`slack-category-digest.yml`이 이미 씁니다. 새 시크릿을 요구할 이유가 없어 있는 자격증명으로 옮겼습니다 — PR #583이 `monitoring.yml`에 내린 것과 같은 판단입니다.

**핵심 correctness 포인트**: `chat.postMessage`는 실패도 **HTTP 200 + `{"ok": false}`** 로 돌려줍니다. `channel_not_found`·`invalid_auth`·`not_in_channel` 전부 200입니다. 그래서 status code가 아니라 **body의 `ok`를 읽습니다.** 200을 성공으로 취급하는 것이 이 모듈이 이미 한 번 고쳐진 그 false-success 형태입니다.

`text` 폴백도 넣었습니다 — blocks만 보내면 푸시 알림과 스크린 리더에 아무것도 안 갑니다.

webhook 트랜스포트는 폴백으로 남깁니다(우선순위: bot → slack webhook → discord).

**`--require-delivery` (fail-closed)**: 트랜스포트가 하나도 없으면 exit 1 + `::error::`. bot 시크릿이 **실제로 존재하기 때문에** fail-closed가 안전합니다 — 부재는 제거나 접근 상실을 뜻합니다. 반대 예시는 `gsc-queue-refresh.yml`로, 그 시크릿은 한 번도 없었으므로 fail-closed면 영구 red 크론이 되어 무시하도록 학습됩니다. 플래그 없이는 기존 동작(exit 0)이라 opt-in입니다.

**정책 가드**: `monthly-quality-report.yml`을 `FAIL_CLOSED`에 추가했습니다. 다만 인라인 `if [ -z ... ]` 대신 `--require-delivery`로 위임하므로 `DELEGATED_GUARD`를 도입했습니다. 위임을 인정하되 **약화시키지 않기 위해** `test_delegated_guard_script_actually_enforces_it`이 스크립트가 플래그를 갖고 `::error::`를 내고 `delivered_anywhere()`가 트랜스포트 부재 시 False를 반환하는지 검사합니다 — 그게 없으면 `DELEGATED_GUARD`에 이름만 올려 정책을 우회할 수 있습니다.

비-공허성: 워크플로에서 `--require-delivery`를 지우면 `test_missing_slack_secret_fails[monthly-quality-report.yml]`이 실패합니다(확인).

---

## 2. `check_broken_links.py` — 370건은 전부 오탐이었다

이 스크립트는 존재만 했습니다. 카운트를 print하고 `sys.exit()`를 호출하지 않으며 워크플로·훅 어디에도 배선돼 있지 않았습니다. exit code 한 줄 추가로 보였는데 **그게 틀렸습니다.**

실측: **370건을 보고했고 370건 전부 오탐**입니다. 본문 실제 깨진 링크는 0건입니다.

| # | 원인 | 수정 |
|---|---|---|
| 1 | 링크 정규식이 선행 `\s`를 허용해 front matter의 `redirect_from:` YAML 항목이 매칭됐다. 그건 링크가 아니라 이 포스트로 리다이렉트돼야 하는 옛 URL의 **선언**이고 깨진 링크의 정반대다. **370/370이 정확히 이것** | front matter를 스캔 대상에서 제외 |
| 2 | 선언된 `redirect_from` 대상을 가리키는 본문 링크는 **유효하다**(jekyll-redirect-from이 서빙) | 유효 타깃 = 퍼머링크 ∪ 모든 `redirect_from` 선언 |

원인 2가 이 레포에서 특히 중요한 이유: 사이트가 `timezone: UTC`로 고정돼 있고 포스트는 KST로 작성되어 **파일명 날짜와 라이브 URL 날짜가 하루 어긋날 수 있고**, 파일명-날짜 URL이 `redirect_from`에 들어갑니다(CLAUDE.md "Date / Timezone Rule").

결과: **275 포스트 / 645 유효 타깃(퍼머링크 275 + redirect 370) / 0 broken.**

옛 버전을 그대로 배선하면 **영구 red 잡**이 됐습니다. 이 레포가 두 번 "게이트 없는 것보다 나쁘다"고 판정한 상태입니다(`NEVER_CONFIGURED` 근거). CLAUDE.md에 명시했습니다 — **휴면 게이트를 배선하기 전에 돌려서 출력을 읽을 것. 아무도 돌린 적 없는 게이트는 한 번도 옳은 적이 없다.**

그 외:
- 펜스 제거 — 코드 샘플 안의 `/posts/` 경로는 예시 텍스트(다른 코퍼스 게이트와 동일 취급)
- `REPO_ROOT`를 `__file__` 기준으로 — 이전엔 상대 glob이라 레포 루트에서만 동작
- front matter 파싱을 `python-frontmatter`로. 손으로 쓴 `---` splitter는 `test_lib_seam_drift_guard.py`가 차단하고 **실제로 작업 중 그 가드가 잡았습니다.** 라이브러리를 쓰니 `redirect_from`이 진짜 YAML로 와서 블록 리스트·인라인 리스트·단일 문자열 세 형태가 정규식 3개 없이 다 처리됩니다
- `--all` / `--staged` / `--quiet` 스코프(레포 관례)

배선: pre-commit step 16(`--staged`) + svg-lint CI(`--all`, daily schedule 포함이라 크론 직푸시도 사후 포착). enforcing 게이트 **12번**으로 CLAUDE.md 표 갱신, svg-lint 헤더 카운트 16 → 17.

---

## 검증

```
pytest scripts/tests/                   4356 passed / 0 failed  (신규 23건)
vitest                                  733 passed
ruff --target-version py311 scripts/    invalid-syntax 0건
check_broken_links.py --all             0 broken (다른 cwd에서도 동일)
check_post_boilerplate.py --all         PASS
check_runtime_env_contract.py           PASS
```

비-공허성 확인 2건: `--require-delivery` 제거 → 정책 테스트 실패 / 없는 타깃 링크 삽입 → 정확히 그것만 플래그.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
