### PR TITLE
fix(ci): 디제스트 게이트 2종을 --all 로 — diff-scoped 가 크론 푸시를 못 본다

### DIFF
--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -1,9 +1,10 @@
 name: SVG Compliance Lint
 
-# This workflow carries 17 corpus-wide gates (`--all`): cover drift for four
+# This workflow carries 19 corpus-wide gates (`--all`): cover drift for four
 # generator families, the honesty scorer, title-ASCII, spec-slug consistency,
 # KST-midnight URLs, checklist headings, bare URLs, template-echo, and repeated
-# body boilerplate, and internal post links. They scan the
+# body boilerplate, internal post links, digest translation and digest proper
+# nouns. They scan the
 # WHOLE corpus, so the same trigger-narrower-than-scan hazard that hid a
 # three-week regression in check-svg.yml applies here — see that file's header.
 #
@@ -16,9 +17,9 @@ name: SVG Compliance Lint
 # the bot cover commit 685ca468 carried 12 workflow runs, every one of them
 # `schedule` and not a single `push` or `pull_request` event.
 #
-# So the dominant producer of the artifacts these 17 gates exist to check was
+# So the dominant producer of the artifacts these 19 gates exist to check was
 # invisible to both triggers. The daily `schedule` below closes that: it scans main
-# regardless of paths, exactly as check-svg.yml does. All 17 gates were verified
+# regardless of paths, exactly as check-svg.yml does. All 19 gates were verified
 # green against the current corpus before this was added, so it is not born red.
 on:
   push:
@@ -312,39 +313,43 @@ jobs:
           # so unrelated improvements can land while regressions still break CI.
           python3 scripts/check_digest_structure.py --changed "$BASE" --ratchet
 
-      - name: Digest untranslated-English gate (PR-diff-scoped)
+      - name: Digest untranslated-English gate
         id: digest_untranslated
-        # PR-diff-scoped: only checks digest posts touched by this PR/push, so
-        # the whole legacy corpus (already Korean) is not re-scanned. Guards the
-        # repository_dispatch translation-fallback regression where LLM keys are
-        # zeroed and 요약/summary= fall back to raw English RSS text.
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="origin/${{ github.event.pull_request.base.ref }}"
-          else
-            BASE="HEAD~1"
-          fi
-          echo "[digest-untranslated] diff base: $BASE"
-          python3 scripts/check_digest_untranslated.py --changed "$BASE"
+        # --all since 2026-08-24. It was PR-diff-scoped ("the legacy corpus is
+        # already Korean, do not re-scan"), and that scoping is exactly what let
+        # the failure through: the blogwatcher cron pushes digests DIRECTLY to
+        # main with GITHUB_TOKEN, which triggers no workflow, and a diff-scoped
+        # gate has nothing to compare on the daily `schedule` either. So the
+        # 08-22 and 08-23 digests carried raw English RSS summaries on main,
+        # unflagged, until a routine branch update pulled them into a PR's merge
+        # diff — at which point every subsequent PR inherited a red job it did
+        # not cause (fixed in #601).
+        #
+        # Corpus measured at 0 violations across 203 digests after #601, so
+        # there is no legacy debt to scope around and any hit is fresh drift.
+        # Guards the repository_dispatch translation-fallback regression where
+        # LLM keys are zeroed and 요약/summary= fall back to raw English.
+        run: python3 scripts/check_digest_untranslated.py --all
 
-      - name: Digest proper-noun canonicalization gate (PR-diff-scoped)
+      - name: Digest proper-noun canonicalization gate
         id: digest_proper_nouns
-        # PR-diff-scoped, NOT --all: 135 legacy digests still use Hangul proper
-        # nouns (Phase 2 backfill pending). --changed only checks digests touched
-        # by this PR/push. Enforces English-canonical proper nouns (deny-by-default
-        # allow-list) so new digests never reintroduce 비트코인/Bitcoin mixing.
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="origin/${{ github.event.pull_request.base.ref }}"
-          else
-            BASE="HEAD~1"
-          fi
-          echo "[digest-proper-nouns] diff base: $BASE"
-          python3 scripts/check_digest_proper_nouns.py --changed "$BASE"
+        # --all since 2026-08-24. The comment here used to read "135 legacy
+        # digests still use Hangul proper nouns (Phase 2 backfill pending)" and
+        # scoped to the diff on that basis. That number was stale: the Phase 2
+        # campaign finished, and the corpus measures 0 violations across 203
+        # digests. A gate scoped around debt that no longer exists is a gate
+        # blind to cron-pushed drift for no benefit.
+        #
+        # Enforces English-canonical proper nouns (deny-by-default allow-list)
+        # so no digest reintroduces 비트코인/Bitcoin mixing — which a bot
+        # translation did on the stranded 08-22 branch, caught only because the
+        # recovery ran this gate at --all by hand.
+        run: python3 scripts/check_digest_proper_nouns.py --all
 
       - name: Digest canonical checklist heading gate
         id: digest_checklist_heading
-        # --all, unlike the three gates above: the 601 -> 0 structure campaign
+        # --all, like the two digest gates above (both moved to --all on
+        # 2026-08-24): the 601 -> 0 structure campaign
         # (#494-#502) left the corpus at 0 violations (184/184 measured
         # 2026-08-06), so there is no legacy debt to scope around and any hit
         # is fresh drift — including one arriving via a cron push that never

--- a/scripts/tests/test_check_digest_untranslated.py
+++ b/scripts/tests/test_check_digest_untranslated.py
@@ -114,3 +114,55 @@ def test_check_post_ignores_code_fence_content():
         + "\n\n```\nthe attacker is able to run code with the privileges of the process\n```\n\n---\n"
     )
     assert check_post(_write(body)) == []
+
+
+# --- CI wiring: the gate must scan the whole corpus, not a diff --------------
+#
+# This gate was PR-diff-scoped until 2026-08-24 on the premise that "the legacy
+# corpus is already Korean, do not re-scan". That scoping is exactly what let
+# the failure through: the blogwatcher cron pushes digests DIRECTLY to main with
+# GITHUB_TOKEN, which triggers no workflow (GitHub recursion prevention), and a
+# diff-scoped gate has nothing to compare against on the daily `schedule`
+# either. So the 08-22 and 08-23 digests sat on main with raw English RSS
+# summaries, unflagged, until a routine branch update pulled them into a PR's
+# merge diff — at which point every later PR inherited a red job it did not
+# cause. Fixed in #601; scope widened here so it cannot recur.
+
+import re as _re
+from pathlib import Path as _Path
+
+_REPO_ROOT = _Path(__file__).resolve().parents[2]
+_SVG_LINT = _REPO_ROOT / ".github" / "workflows" / "svg-lint.yml"
+_SCRIPT = "scripts/check_digest_untranslated.py"
+
+
+def _uncommented(text: str) -> str:
+    """Comment lines mention both flags, so match code only."""
+    return "\n".join(l for l in text.split("\n") if not l.lstrip().startswith("#"))
+
+
+def test_gate_is_wired_into_svg_lint_ci():
+    body = _uncommented(_SVG_LINT.read_text(encoding="utf-8"))
+    assert _SCRIPT in body, f"svg-lint.yml no longer runs {_SCRIPT}"
+
+
+def test_gate_scans_the_whole_corpus_not_a_diff():
+    """Measured 2026-08-24: --all reports 0 violations across 203 digests.
+
+    If a future backlog makes --all untenable, delete this test in the same PR
+    and say why. Silently narrowing the step is the regression this guards.
+    """
+    body = _uncommented(_SVG_LINT.read_text(encoding="utf-8"))
+    assert _re.search(rf"{_re.escape(_SCRIPT)}\s+--all", body), (
+        f"svg-lint.yml runs '{_SCRIPT}' diff-scoped again. A diff-scoped gate "
+        "cannot see a cron push to main, which is how the 08-22/08-23 "
+        "untranslated digests reached the corpus unflagged."
+    )
+
+
+def test_svg_lint_path_filter_covers_the_gate_script():
+    """A gate whose own script change does not trigger CI is half-wired."""
+    raw = _SVG_LINT.read_text(encoding="utf-8")
+    assert raw.count(f"'{_SCRIPT}'") >= 2, (
+        f"{_SCRIPT} should appear in both the push and pull_request path filters"
+    )

--- a/scripts/tests/test_ci_digest_proper_nouns_wiring_guard.py
+++ b/scripts/tests/test_ci_digest_proper_nouns_wiring_guard.py
@@ -58,11 +58,38 @@ def test_wired_into_canonical_hook_source():
 
 
 def test_wired_into_svg_lint_ci():
+    """The gate must be in svg-lint CI. `--all` counts; it is strictly stronger.
+
+    This asserted `--changed` until 2026-08-24, back when the step was
+    PR-diff-scoped because "135 legacy digests still use Hangul proper nouns".
+    That number went to 0 when the Phase 2 campaign finished, and diff-scoping
+    then cost coverage for nothing: the blogwatcher cron pushes digests directly
+    to main, which triggers no workflow, and a diff-scoped gate has nothing to
+    compare against on the daily `schedule` either. Accepting only `--changed`
+    here would now block the stronger wiring.
+    """
     body = _noncomment(CI.read_text(encoding="utf-8"))
-    assert re.search(rf"{re.escape(SCRIPT)}\s+--changed", body), (
+    assert re.search(rf"{re.escape(SCRIPT)}\s+--(all|changed)", body), (
         "svg-lint.yml no longer runs the digest proper-noun gate "
-        f"('{SCRIPT} --changed'). New digests could reintroduce Hangul proper "
-        "nouns without CI catching it. Re-add the PR-diff-scoped step."
+        f"('{SCRIPT} --all' or '--changed'). New digests could reintroduce "
+        "Hangul proper nouns without CI catching it. Re-add the step."
+    )
+
+
+def test_svg_lint_scope_is_all_not_diff_scoped():
+    """Corpus is at 0, so the diff-scoped form is a coverage regression.
+
+    Measured 2026-08-24: `check_digest_proper_nouns.py --all` reports 0
+    violations across 203 digests. If a future legacy backlog makes `--all`
+    untenable again, delete this test in the same PR and say why — do not
+    silently narrow the step and leave this passing on the `--changed` branch of
+    the test above.
+    """
+    body = _noncomment(CI.read_text(encoding="utf-8"))
+    assert re.search(rf"{re.escape(SCRIPT)}\s+--all", body), (
+        f"svg-lint.yml runs '{SCRIPT}' diff-scoped again. A diff-scoped gate "
+        "cannot see a cron push to main, which is how the 08-22/08-23 "
+        "untranslated digests reached the corpus unflagged (#601)."
     )
 
 

--- a/scripts/tests/test_ci_svg_lint_schedule_guard.py
+++ b/scripts/tests/test_ci_svg_lint_schedule_guard.py
@@ -134,17 +134,33 @@ def test_corpus_wide_gates_still_present():
 def test_diff_scoped_steps_have_a_non_pull_request_base():
     """On a schedule run there is no pull_request context; the fallback must exist.
 
-    The four diff-scoped steps branch on ``github.event_name`` and fall back to
-    ``HEAD~1``. Without that fallback, ``origin/`` + an empty base ref would make the
-    scheduled run fail on every diff-scoped gate — turning the new trigger into daily
-    noise that gets muted.
+    A diff-scoped step branches on ``github.event_name`` and falls back to
+    ``HEAD~1``. Without that fallback, ``origin/`` + an empty base ref would make
+    the scheduled run fail on every diff-scoped gate — turning the trigger into
+    daily noise that gets muted.
+
+    This asserted a hardcoded ``>= 4`` until 2026-08-24. That number is not the
+    invariant: it drifts down every time a gate correctly *stops* being
+    diff-scoped, which is what happened when the digest untranslated and
+    proper-noun gates moved to ``--all``. The property worth pinning is the
+    pairing — each PR-side base assignment has a scheduled-run fallback — plus
+    the fact that at least one diff-scoped step still exists to protect.
     """
     body = _body()
     pr_branches = body.count('github.event_name }}" = "pull_request"')
-    assert pr_branches >= 4, (
-        f"expected the 4 diff-scoped steps to branch on event_name, found {pr_branches}"
+    pr_bases = body.count('BASE="origin/')
+    fallbacks = body.count('BASE="HEAD~1"')
+
+    assert pr_branches >= 1, (
+        "no diff-scoped step left in svg-lint.yml. If every gate is now --all "
+        "that is an improvement, not a failure — delete this test and say so."
     )
-    assert body.count('BASE="HEAD~1"') >= pr_branches, (
-        "a diff-scoped step branches on event_name without a HEAD~1 fallback; the "
-        "scheduled sweep would fail there instead of checking the latest commit."
+    assert pr_bases == pr_branches, (
+        f"{pr_branches} event_name branch(es) but {pr_bases} origin/ base "
+        "assignment(s); one diff-scoped step is not computing a PR base."
+    )
+    assert fallbacks == pr_branches, (
+        f"{pr_branches} event_name branch(es) but {fallbacks} HEAD~1 "
+        "fallback(s); a diff-scoped step would fail on the scheduled sweep "
+        "instead of checking the latest commit."
     )


### PR DESCRIPTION
PR #601에서 드러난 **구조적** 결함을 닫습니다.

## 왜 diff-scoping이 실패 경로였나

`digest-untranslated`는 PR-diff-scoped였습니다 — 근거는 "레거시 코퍼스는 이미 한국어이므로 재스캔 불필요". 그 스코핑이 정확히 실패를 통과시켰습니다:

- blogwatcher 크론은 `GITHUB_TOKEN`으로 main에 **직푸시**하고, 그런 푸시는 **어떤 워크플로도 트리거하지 않습니다**(GitHub recursion prevention).
- daily `schedule`로 돌아도 diff-scoped 게이트는 **비교할 base가 없습니다**.

그래서 08-22·08-23 디제스트가 raw 영문 RSS 요약을 달고 main에 앉아 있었고, 평범한 브랜치 갱신이 그걸 PR 머지 diff로 끌어들인 순간부터 **이후 모든 PR이 자기가 만들지 않은 red를 상속**했습니다.

## 실측이 스코프 확대를 정당화합니다

PR #601 이후:

```
check_digest_untranslated.py --all   →  203 digest, 0 violations
check_digest_proper_nouns.py  --all  →  203 digest, 0 violations
```

스코프를 넓힐 *여지*가 생긴 게 아니라, **좁힐 이유가 사라진** 것입니다.

## 인접 게이트도 같은 상태였습니다

`digest-proper-nouns` 주석은 `"135 legacy digests still use Hangul proper nouns (Phase 2 backfill pending)"`를 근거로 diff-scoped였습니다. **그 숫자는 낡았습니다** — Phase 2가 끝나 `--all`이 203/203 통과합니다. 존재하지 않는 부채를 피해 좁혀둔 게이트는 이득 없이 크론 드리프트에만 눈이 멉니다.

실제 피해도 확인됩니다: 좌초 브랜치의 봇 번역이 `비트코인`을 넣었고, **회수 과정에서 `--all`을 손으로 돌려서야** 잡혔습니다.

## 건드리지 않은 것 (보고만)

`digest-structure`도 같은 부류입니다. 주석은 `"~176 레거시가 --all에서 실패한다"`지만 **실측은 203/203 통과**입니다. 다만 이 게이트는 `test_ci_digest_structure_ratchet_guard.py::test_ci_gate_stays_diff_scoped_not_all`이 `--all`을 **명시적으로 금지**하고 `--ratchet` 메커니즘과 얽혀 있습니다. 의도적 결정을 제가 뒤집지 않고 남겼습니다 — 별도 판단이 필요합니다.

## 가드 갱신 3건 (약화 없이)

작업 중 레포 가드 2개가 제 변경을 잡았습니다. 둘 다 **의도는 살리고 낡은 형태만** 교체했습니다.

| 가드 | 변경 |
|---|---|
| `test_ci_digest_proper_nouns_wiring_guard` | `--changed`만 받던 단정을 `--(all\|changed)`로 넓히고, **별도로 `--all`을 요구하는 테스트를 추가**. `--changed`만 받으면 더 강한 배선을 오히려 막습니다 |
| `test_check_digest_untranslated` | 동등한 배선/스코프 가드 3건 추가 (CI 배선 / `--all` 스코프 / path filter 양쪽 등재) |
| `test_ci_svg_lint_schedule_guard` | `pr_branches >= 4` 하드코딩 → **관계식**. 4는 불변식이 아닙니다 — 게이트가 올바르게 `--all`로 옮겨갈 때마다 내려가는 수치입니다. 실제 불변식은 "PR-side base 할당 수 == `event_name` 분기 수 == `HEAD~1` 폴백 수" |

svg-lint 헤더 코퍼스 게이트 카운트 17 → 19.

## 검증

```
pytest scripts/tests/                     4360 passed / 0 failed
untranslated / proper-nouns / structure   3종 모두 --all PASS
post-boilerplate / broken-links           PASS
check_workflow_action_pins                PASS
ruff --target-version py311 scripts/      invalid-syntax 0건
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
