### PR TITLE
fix(ci): digest-structure 를 --all 로 + ratchet 가드 재설계

### DIFF
--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -294,24 +294,31 @@ jobs:
         id: kst_midnight
         run: python3 scripts/check_kst_midnight.py --all
 
-      - name: Digest structural invariant gate (PR-diff-scoped)
+      - name: Digest structural invariant gate
         id: digest_structure
-        # PR-diff-scoped, NOT --all: only ~5 digest posts have been backfilled
-        # to satisfy this guard as of 2026-07-16. The ~176 legacy
-        # _posts/*Weekly_Digest*.md posts still have the structural defects
-        # and would fail --all. --changed only checks digest posts touched by
-        # this PR/push, mirroring the size-gate BASE-diff pattern above.
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="origin/${{ github.event.pull_request.base.ref }}"
-          else
-            BASE="HEAD~1"
-          fi
-          echo "[digest-structure] diff base: $BASE"
-          # --ratchet: only violations NEW vs the merge base fail. Pre-existing
-          # legacy defects are reported as grandfathered (never silently dropped)
-          # so unrelated improvements can land while regressions still break CI.
-          python3 scripts/check_digest_structure.py --changed "$BASE" --ratchet
+        # --all since 2026-08-24. This read "only ~5 digest posts have been
+        # backfilled ... the ~176 legacy posts still have the structural defects
+        # and would fail --all". True when written (2026-07-16), false now: the
+        # 601 -> 0 backfill campaign (#494-#502, #509) finished and --all
+        # measures 0 violations across 203 digests.
+        #
+        # --all is strictly STRONGER than the '--changed BASE --ratchet' form it
+        # replaces: identical check_post() checks, wider scope, no
+        # grandfathering. It also sees what a diff-scoped gate structurally
+        # cannot — the blogwatcher cron pushes digests directly to main with
+        # GITHUB_TOKEN, which triggers no workflow, and a diff-scoped gate has
+        # no base to compare on the daily `schedule` either. That blind spot is
+        # how the 08-22/08-23 untranslated digests reached the corpus (#601).
+        #
+        # Only safe while the corpus is at 0: if legacy debt returns, --all here
+        # becomes a permanently red job, which this repo has twice judged worse
+        # than no gate. test_ci_digest_structure_ratchet_guard.py asserts the
+        # corpus stays at 0 so that decision resurfaces instead of rotting.
+        #
+        # The pre-commit hook deliberately KEEPS --staged --ratchet: it is a
+        # fast local pre-check, and grandfathering costs nothing there while CI
+        # is the authority.
+        run: python3 scripts/check_digest_structure.py --all
 
       - name: Digest untranslated-English gate
         id: digest_untranslated

--- a/scripts/tests/test_ci_digest_structure_ratchet_guard.py
+++ b/scripts/tests/test_ci_digest_structure_ratchet_guard.py
@@ -2,21 +2,35 @@
 """CI/pre-commit wiring guard for the digest STRUCTURE gate's --ratchet mode.
 
 check_digest_structure.py enforces digest structural invariants (contiguous
-'## N.' numbering, no body H1, a single checklist surface). The legacy corpus
-(~125 posts as of 2026-07-31) carries pre-existing defects awaiting a staged
-backfill campaign, so both wires run the gate with --ratchet: only violations
-that are NEW vs the base revision fail, while regressions still break the build.
+'## N.' numbering, no body H1, a single checklist surface).
 
-Two failure directions this guard protects against:
+**Updated 2026-08-24, as the previous version of this docstring asked for.** It
+said: "if the backfill completes and the ratchet is genuinely no longer needed,
+update this guard in the same PR and say why". The backfill completed — the
+601 -> 0 campaign (#494-#502, #509) took the corpus to 0 violations across 203
+digests — so CI moved from '--changed BASE --ratchet' to '--all'.
 
-1. The gate is dropped entirely  -> structural invariants stop being enforced.
-2. --ratchet is dropped          -> the gate reverts to file-scoped and blocks
-   every unrelated improvement to a legacy post (the exact breakage that
-   stalled Phase 2b; see notes/digest-proper-noun-policy.md §4).
+Why --all in CI, --ratchet in the hook:
 
-If the gate is intentionally moved/renamed, or the backfill completes and the
-ratchet is genuinely no longer needed, update this guard in the same PR and say
-why.
+* --all is strictly stronger. Same check_post() checks, wider scope, no
+  grandfathering. And a diff-scoped gate structurally cannot see a cron push:
+  blogwatcher pushes digests straight to main with GITHUB_TOKEN, which triggers
+  no workflow, and there is no base to diff against on the daily `schedule`.
+  That is how the 08-22/08-23 untranslated digests reached main unflagged (#601).
+* The pre-commit hook keeps --staged --ratchet. It is a fast local pre-check;
+  grandfathering there costs nothing while CI is the authority.
+
+Failure directions this guard protects against:
+
+1. The gate is dropped entirely -> structural invariants stop being enforced.
+2. --ratchet is dropped from the HOOK -> local commits get blocked by any
+   pre-existing defect on a legacy post rather than by their own regression
+   (the breakage that stalled Phase 2b; notes/digest-proper-noun-policy.md §4).
+3. CI silently narrows back to diff-scoped -> the cron blind spot reopens.
+4. **Legacy debt returns while CI is --all** -> CI becomes permanently red,
+   which this repo has twice judged worse than no gate at all. This is the new
+   risk --all introduces, so the guard asserts the corpus stays at 0 rather than
+   assuming it.
 """
 
 from __future__ import annotations
@@ -42,10 +56,8 @@ def _noncomment(text: str) -> str:
 # The hook invokes it as: python3 "$REPO_ROOT/scripts/...py" --staged --ratchet
 # so allow an optional closing quote before the flags.
 _HOOK_RE = re.compile(rf"{re.escape(SCRIPT)}\"?\s+--staged\s+--ratchet")
-# CI invokes it as: python3 scripts/...py --changed "$BASE" --ratchet
-_CI_RE = re.compile(
-    rf"{re.escape(SCRIPT)}\s+--changed\s+\"?\$?\{{?\w+\}}?\"?\s+--ratchet"
-)
+# CI invokes it as: python3 scripts/...py --all
+_CI_RE = re.compile(rf"{re.escape(SCRIPT)}\s+--all")
 
 
 def test_script_exists():
@@ -81,19 +93,51 @@ def test_install_hooks_source_also_carries_ratchet():
     )
 
 
-def test_wired_into_svg_lint_ci_with_ratchet():
+def test_wired_into_svg_lint_ci_at_corpus_scope():
     body = _noncomment(CI.read_text(encoding="utf-8"))
     assert _CI_RE.search(body), (
-        f"svg-lint CI no longer invokes '{SCRIPT} --changed <BASE> --ratchet'. "
-        "Either the structure gate was dropped from CI or --ratchet was dropped, "
-        "which would fail PRs on pre-existing legacy defects they did not cause."
+        f"svg-lint CI no longer invokes '{SCRIPT} --all'. Either the structure "
+        "gate was dropped from CI, or it narrowed back to a diff — which cannot "
+        "see a cron push to main and is how untranslated digests reached the "
+        "corpus unflagged (#601)."
     )
 
 
-def test_ci_gate_stays_diff_scoped_not_all():
-    """--all over the corpus would fail on the legacy backlog by design."""
+def test_ci_is_not_diff_scoped():
+    """The inverse of the old guard, for the same reason stated in reverse.
+
+    This file used to assert `--all` must NOT appear, because the legacy corpus
+    would have failed every build. That premise expired with the backfill. Now
+    the risk runs the other way: narrowing back to `--changed` would silently
+    reopen the cron blind spot while still looking wired.
+    """
     body = _noncomment(CI.read_text(encoding="utf-8"))
-    assert f"{SCRIPT} --all" not in body, (
-        f"svg-lint CI must not run '{SCRIPT} --all' — the legacy corpus has "
-        "known pre-existing defects and would fail every build."
+    assert f"{SCRIPT} --changed" not in body, (
+        f"svg-lint CI runs '{SCRIPT} --changed' again. If legacy debt genuinely "
+        "returned, fix the corpus or delete this test and say why — do not leave "
+        "the gate looking enforced while blind to the cron path."
+    )
+
+
+def test_corpus_is_at_zero_so_all_scope_is_safe():
+    """The invariant that justifies --all in CI. Without it, CI is born red.
+
+    Measured 2026-08-24: 0 violations across 203 digests. If this fails, --all
+    in svg-lint is now a permanently red job. The decision is then explicit:
+    backfill the offending posts, or move CI back to --ratchet and update the
+    two tests above in the same PR.
+    """
+    import subprocess
+
+    res = subprocess.run(
+        ["python3", str(REPO / SCRIPT), "--all"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, (
+        "check_digest_structure.py --all is failing, so the --all wiring in "
+        "svg-lint CI would be permanently red:\n"
+        + (res.stdout or "")[-2000:]
+        + (res.stderr or "")[-500:]
     )


### PR DESCRIPTION
이 가드의 docstring이 **직접 요청한 갱신**입니다:

> If the gate is intentionally moved/renamed, or **the backfill completes and the ratchet is genuinely no longer needed, update this guard in the same PR and say why.**

백필이 끝났습니다.

## 낡은 전제

CI 주석은 이렇게 적고 있었습니다:

> only ~5 digest posts have been backfilled ... the ~176 legacy posts still have the structural defects and **would fail --all**

2026-07-16에는 사실이었고 지금은 아닙니다. 601 → 0 캠페인(#494-#502, #509)이 끝나 `--all`이 **203 digest / 0 violations**입니다.

## `--all`이 엄격하게 강합니다

`--changed BASE --ratchet`과 **동일한 `check_post()` 검사**에, 범위가 넓고, grandfathering이 없습니다(`--ratchet`은 `--staged`/`--changed`를 요구하므로 `--all --ratchet`은 애초에 argparse 에러입니다).

그리고 diff-scoped 게이트가 **구조적으로 볼 수 없는 것**을 봅니다 — blogwatcher 크론은 `GITHUB_TOKEN`으로 main에 직푸시하고 그건 어떤 워크플로도 트리거하지 않으며, daily schedule에서도 비교할 base가 없습니다. 08-22/08-23 미번역 디제스트가 정확히 그 경로로 main에 앉았습니다(#601).

`pre-commit`은 `--staged --ratchet`을 **유지**합니다. 빠른 로컬 사전 점검이고, CI가 권위인 동안 로컬 grandfathering은 비용이 없습니다.

## 가드가 새로 생긴 리스크를 떠안습니다

`--all`은 **코퍼스가 0인 동안만** 안전합니다. 레거시 부채가 돌아오면 CI가 영구 red가 되고, 이 레포는 그 상태를 두 번 "게이트 없는 것보다 나쁘다"고 판정했습니다. 그래서 가드가 코퍼스가 0이라고 **가정하지 않고 단정합니다**:

| 테스트 | 방어 대상 |
|---|---|
| `test_wired_into_svg_lint_ci_at_corpus_scope` | 게이트가 CI에서 빠지거나 좁아짐 |
| `test_ci_is_not_diff_scoped` | **옛 가드의 역방향.** 예전엔 "`--all` 금지"였고 이제는 "`--changed`로 되돌리기 금지" — 좁히면 크론 사각지대가 조용히 다시 열리면서 배선된 것처럼 보입니다 |
| `test_corpus_is_at_zero_so_all_scope_is_safe` | `--all`을 실제 실행해 exit 0 확인. 실패 시 "backfill 하거나 `--ratchet`로 되돌리고 위 두 테스트를 같은 PR에서 갱신하라"는 메시지 |

`--ratchet` 플래그 자체는 훅이 쓰므로 계속 지원돼야 하고, 그것도 가드가 단정합니다.

## 비-공허성 3방향 확인

```
CI를 --changed로 되돌림      → 2건 실패        / 복원 → 7/7 통과
실제 포스트에 본문 H1 삽입   → corpus-at-zero 실패 / 제거 → 통과
```

포스트는 바이트 단위 복원을 확인했습니다.

## 부수 효과

PR #602에서 schedule 가드의 하드코딩 카운트(`pr_branches >= 4`)를 관계식으로 바꿔둔 덕에, **마지막 `--changed` 스텝이 사라져도 그 가드가 그대로 통과**합니다. 하드코딩이었다면 이 PR에서 또 깨졌을 것입니다.

svg-lint의 `PR-diff-scoped` 스텝은 이제 SVG 사이즈 게이트 1개만 남습니다.

## 검증

```
pytest scripts/tests/                      4361 passed / 0 failed
check_digest_structure.py --all            0 violations / 203 digests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
