### PR TITLE
feat(content): 영문 카드 제목 48건 한국어화 + title 언어 게이트 (enforcing #13)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -324,3 +324,24 @@ if [ -n "$STAGED_ANY_POSTS" ]; then
   fi
   echo "[pre-commit] Internal link check: passed."
 fi
+
+# 17. News-card title language gate — this blog is Korean and card titles are
+#     faithful translations of the source headline with proper nouns left in
+#     English. Measured 2026-08-24: 51 of 2312 titles were English (2.2 %), so
+#     they were drift, not a citation convention. 48 were translated; 3 pure
+#     proper-noun strings are allow-listed WITH REASONS in the script. Deny by
+#     default — check_digest_untranslated's is_untranslated() cannot serve here
+#     because it deliberately exempts cited English titles (it flagged 1 of 51).
+if [ -n "$STAGED_ANY_POSTS" ]; then
+  echo "[pre-commit] Checking staged posts for English news-card titles..."
+  python3 "$REPO_ROOT/scripts/check_card_title_language.py" --staged --quiet
+  if [ $? -ne 0 ]; then
+    echo "[pre-commit] A card title has no Korean text."
+    echo "             Translate the headline (keep proper nouns in English), or"
+    echo "             if it is a pure product/event name add it to"
+    echo "             ENGLISH_TITLE_ALLOW with its reason."
+    echo "             To bypass (not recommended): git commit --no-verify"
+    exit 1
+  fi
+  echo "[pre-commit] Card-title language check: passed."
+fi

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -1,10 +1,10 @@
 name: SVG Compliance Lint
 
-# This workflow carries 19 corpus-wide gates (`--all`): cover drift for four
+# This workflow carries 20 corpus-wide gates (`--all`): cover drift for four
 # generator families, the honesty scorer, title-ASCII, spec-slug consistency,
 # KST-midnight URLs, checklist headings, bare URLs, template-echo, and repeated
 # body boilerplate, internal post links, digest translation and digest proper
-# nouns. They scan the
+# nouns, and card-title language. They scan the
 # WHOLE corpus, so the same trigger-narrower-than-scan hazard that hid a
 # three-week regression in check-svg.yml applies here — see that file's header.
 #
@@ -17,9 +17,9 @@ name: SVG Compliance Lint
 # the bot cover commit 685ca468 carried 12 workflow runs, every one of them
 # `schedule` and not a single `push` or `pull_request` event.
 #
-# So the dominant producer of the artifacts these 19 gates exist to check was
+# So the dominant producer of the artifacts these 20 gates exist to check was
 # invisible to both triggers. The daily `schedule` below closes that: it scans main
-# regardless of paths, exactly as check-svg.yml does. All 19 gates were verified
+# regardless of paths, exactly as check-svg.yml does. All 20 gates were verified
 # green against the current corpus before this was added, so it is not born red.
 on:
   push:
@@ -61,6 +61,7 @@ on:
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/check_post_boilerplate.py'
       - 'scripts/check_broken_links.py'
+      - 'scripts/check_card_title_language.py'
       - 'scripts/linkify_bare_urls.py'
       - 'scripts/check_template_echo.py'
       - 'scripts/rewrite_template_echo_summaries.py'
@@ -119,6 +120,7 @@ on:
       - 'scripts/check_digest_checklist_heading.py'
       - 'scripts/check_post_boilerplate.py'
       - 'scripts/check_broken_links.py'
+      - 'scripts/check_card_title_language.py'
       - 'scripts/linkify_bare_urls.py'
       - 'scripts/check_template_echo.py'
       - 'scripts/rewrite_template_echo_summaries.py'
@@ -392,6 +394,18 @@ jobs:
         # ratchet: any hit is fresh drift, including one from a cron push that
         # never ran pre-commit.
         run: python3 scripts/check_broken_links.py --all
+
+      - name: News-card title language gate
+        id: card_title_language
+        # --all: the corpus is at 0 after translating 48 of the 51 English card
+        # titles found on 2026-08-24, so any hit is fresh drift — including one
+        # from a cron push, which is the path a diff-scoped gate cannot see.
+        # Deny by default with a 3-entry reasoned allow-list for pure
+        # product/event names (Google ADK + Datadog LLM Observability,
+        # KubeCon Europe 2026 Open Source SecurityCon, I/O 2026).
+        # check_digest_untranslated's is_untranslated() is NOT reusable here: it
+        # exempts cited English titles by design and flagged 1 of the 51.
+        run: python3 scripts/check_card_title_language.py --all
 
       - name: Bare-URL gate (unlinked https:// in post prose)
         id: bare_url_gate

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -1,6 +1,6 @@
 name: SVG Compliance Lint
 
-# This workflow carries 20 corpus-wide gates (`--all`): cover drift for four
+# This workflow carries 19 corpus-wide gates (`--all`): cover drift for four
 # generator families, the honesty scorer, title-ASCII, spec-slug consistency,
 # KST-midnight URLs, checklist headings, bare URLs, template-echo, and repeated
 # body boilerplate, internal post links, digest translation and digest proper
@@ -17,10 +17,13 @@ name: SVG Compliance Lint
 # the bot cover commit 685ca468 carried 12 workflow runs, every one of them
 # `schedule` and not a single `push` or `pull_request` event.
 #
-# So the dominant producer of the artifacts these 20 gates exist to check was
+# So the dominant producer of the artifacts these 19 gates exist to check was
 # invisible to both triggers. The daily `schedule` below closes that: it scans main
-# regardless of paths, exactly as check-svg.yml does. All 20 gates were verified
+# regardless of paths, exactly as check-svg.yml does. All 19 gates were verified
 # green against the current corpus before this was added, so it is not born red.
+# The count above is MEASURED, not maintained by hand: it drifted twice while
+# gates were moved to --all in 2026-08. test_ci_svg_lint_schedule_guard.py
+# asserts it equals the actual number of `--all` invocations below.
 on:
   push:
     paths:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,7 +523,7 @@ the 9 historical posts affected before the rule was introduced. The 7
 posts that still violated the rule were fixed in commit `b4ff35c4`
 (2026-05-28).
 
-### Active automation gates (12 enforcing)
+### Active automation gates (13 enforcing)
 
 | # | Script | Scope | Wired to |
 |---|--------|-------|----------|
@@ -539,6 +539,18 @@ posts that still violated the rule were fixed in commit `b4ff35c4`
 | 10 | `check_template_echo.py` | card `summary=` that only echoes the headline + a fixed clause | pre-commit (13, `--staged`) + svg-lint CI (`--all`) + blogwatcher publish (self-heal via `rewrite_template_echo_summaries.py`, then block) |
 | 11 | `check_post_boilerplate.py` | a Mermaid fence or a whole checklist repeated verbatim across 2+ posts | pre-commit (15, `--staged`) + svg-lint CI (`--all`) |
 | 12 | `check_broken_links.py` | body `/posts/` link with no post and no declared `redirect_from` | pre-commit (16, `--staged`) + svg-lint CI (`--all`) |
+| 13 | `check_card_title_language.py` | news-card `title=` with no Korean text, outside a reasoned allow-list | pre-commit (17, `--staged`) + svg-lint CI (`--all`) |
+
+Gate 13 is deny-by-default because the obvious reuse does not work:
+`check_digest_untranslated.py`'s `is_untranslated()` **exempts cited English
+titles and Title-Cased proper-noun runs by design** — correct for the prose
+summaries it inspects, and over the 51 English card titles found on 2026-08-24
+it flagged exactly 1. Card titles are faithful translations of the source
+headline with proper nouns left in English (2261 Korean vs 51 English before the
+fix). 48 were translated; 3 pure product/event names are allow-listed with
+reasons. **When a new gate looks like it can reuse an existing heuristic, run
+the heuristic over the actual violations first** — the right heuristic for one
+job is often the wrong one next door.
 
 Gate 12 was inert from creation until 2026-08-24 — it printed a count, never
 called `sys.exit()`, and no workflow or hook invoked it. Reviving it was **not**

--- a/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
+++ b/_posts/2026-01-25-Tech_Security_Weekly_Digest_VMware_vCenter_Fortinet_SSO_Sandworm_DynoWiper_AI_Agents.md
@@ -315,7 +315,7 @@ diagnose sys ha history read | grep policy
 ### Apache Airflow 3.1 in Cloud Composer
 
 {%- include news-card.html
-  title="[클라우드] Apache Airflow 3.1 in Cloud Composer"
+  title="[클라우드] Cloud Composer에서 제공되는 Apache Airflow 3.1"
   url="https://cloud.google.com/blog/products/data-analytics/cloud-composer-supports-apache-airflow-31/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/09_-_Data_Analytics_tFH57V6.max-2600x2600.jpg"
   summary="Google Cloud Composer가 Apache Airflow 3.1을 지원하기 시작했습니다. 이는 하이퍼스케일러 최초입니다."

--- a/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
+++ b/_posts/2026-02-05-Tech_Security_Weekly_Digest_CVE_AI_Malware_Go.md
@@ -123,7 +123,7 @@ n8n RCE 취약점에 대한 더 깊은 분석은 [기술·보안 주간 다이�
 ### 1.1 Critical n8n Flaw CVE-2026-25049 Enables System Command Execution via Malicious Workflows
 
 {%- include news-card.html
-  title="[보안] Critical n8n Flaw CVE-2026-25049 Enables System Command Execution via Malicious Workflows"
+  title="[보안] n8n 치명적 취약점 CVE-2026-25049, 악성 워크플로로 시스템 명령 실행 가능"
   url="https://thehackernews.com/2026/02/critical-n8n-flaw-cve-2026-25049.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEijeDfUJ3dcvTHnszlPkp_8RQkKpjpHIbWHPCfPjGf16CK3oGHnoDK4gkT5aAlsOX8xzlqoXjO607ZI5hGGrfcEcx7sVF4GPhGRAM_CzLIpjeo8x2bnmulJeGj1EcCvfXciADxkSoVB3E2EDxAfIv6SLjeWoNl073KrVdkVeSVt-VTwMoLGgApT46oEYK9-/s1700-e365/n8n-hacking.jpg"
   summary="n8n 워크플로우 자동화 플랫폼에서 새로운 심각한 보안 취약점이 공개되었습니다. 성공적으로 악용될 경우 임의의 시스템 명령을 실행할 수 있는 이 취약점은 CVE-2026-25049(CVSS 점수: 9.4)로 추적되고 있습니다. 이 결함은 기존에 발견된 또 다른 심각한 취약점인 CVE-2025-68613(CVSS 점수: 9."
@@ -204,7 +204,7 @@ RCE 취약점에 대한 더 깊은 분석은 [Tech & Security Weekly Digest: n8n
 ### 1.2 Malicious NGINX Configurations Enable Large-Scale Web Traffic Hijacking Campaign
 
 {%- include news-card.html
-  title="[보안] Malicious NGINX Configurations Enable Large-Scale Web Traffic Hijacking Campaign"
+  title="[보안] 악성 NGINX 설정을 악용한 대규모 웹 트래픽 하이재킹 캠페인"
   url="https://thehackernews.com/2026/02/hackers-exploit-react2shell-to-hijack.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEi1rduNeKuuHUpRierQx1jig2SMH0dhcoENNLniZavZ25JgD68fkxRwp3s4H42sJrL7OXa4r0QublDt9VQ2mjh1uIBuQsvPi4iHtrY2JHw4res_AZQc3pf-AQ610FvG6o_TcXxDliH5JlNJbaVN0AXj3De60H669V9fTQIyqNRNHHMgSfwbjZe8xt3cPhIy/s1700-e365/nginx-hacked.jpg"
   summary="사이버 보안 연구원들이 NGINX 설치 환경과 Baota(BT)와 같은 관리 패널을 표적으로 하여 웹 트래픽을 공격자의 인프라로 우회시키려는 활성 공격 캠페인의 세부 정보를 공개했습니다. Datadog Security Labs는 최근 React2Shell(CVE-2025-55182, CVSS 점수: 10."
@@ -277,7 +277,7 @@ AzureDiagnostics
 ### 1.3 Microsoft Develops Scanner to Detect Backdoors in Open-Weight Large Language Models
 
 {%- include news-card.html
-  title="[보안] Microsoft Develops Scanner to Detect Backdoors in Open-Weight Large Language Models"
+  title="[보안] Microsoft, 공개 가중치 대규모 언어 모델의 백도어를 탐지하는 스캐너 개발"
   url="https://thehackernews.com/2026/02/microsoft-develops-scanner-to-detect.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiBZPWiqEqWIj0fKQtxyusGomOmOzx4xkp4zh-TUGEtbgZP0yDEl91QHC-tP-8fiufd0Nue-dUYt1ajpkSkJZfV9_7M03gegp2LZaiIAyDJ1B03MCQVSn77Q8zH8x7UVq3Lir0uMWEvB7rzMEZ5jz1w3rfwTwM59h-_paVKuEdozFOAsjPb7e6aND1KapHV/s1700-e365/llm-scanner.jpg"
   summary="Microsoft는 수요일 오픈 웨이트 대규모 언어 모델(LLM)에서 백도어를 탐지하고 인공지능(AI) 시스템에 대한 전반적인 신뢰를 향상시킬 수 있는 경량 스캐너를 개발했다고 발표했습니다."
@@ -327,7 +327,7 @@ AI 모델 보안에 대한 더 깊은 이해는 [에이전틱 AI 보안 2026: AI
 ### 1.4 DEAD#VAX Malware Campaign Deploys AsyncRAT via IPFS-Based Phishing
 
 {%- include news-card.html
-  title="[보안] DEAD#VAX Malware Campaign Deploys AsyncRAT via IPFS-Based Phishing"
+  title="[보안] DEAD#VAX 악성코드 캠페인, IPFS 기반 피싱으로 AsyncRAT 배포"
   url="https://thehackernews.com/2026/02/deadvax-malware-campaign-deploys.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhq4HVk4ciPlJyef53_1ZqrcfFGmEY0t3LucRl-DSVWgMuVfBt7fc8LULklQ4Bc-8Tk6Wc9tGbL46vMwvb1CAsBNv3I5ZevSrFE67JGzn9v6VocRSrTscsmesuhc-1cS_ZlUsanT1x92ul38nd29xGW7HnJnlb6WgzzTO-kE5YSn3sLu5U6Lfi1Ra7zEaPd/s1700-e365/windows-malware.jpg"
   summary="DEAD#VAX로 명명된 새로운 악성코드 캠페인이 IPFS(InterPlanetary File System)를 활용한 피싱 이메일을 통해 AsyncRAT 원격 접근 트로이 목마를 배포하고 있습니다. 공격자는 탈중앙화 파일 시스템을 악용하여 기존 URL 기반 차단을 우회하며, 다단계 페이로드 전달 체인을 통해 최종적으로 AsyncRAT를 설치합니다."
@@ -402,7 +402,7 @@ union EmailEvents, ProxyEvents
 ### 1.5 China-Linked Amaranth-Dragon Exploits WinRAR Flaw in Espionage Campaign
 
 {%- include news-card.html
-  title="[보안] China-Linked Amaranth-Dragon Exploits WinRAR Flaw in Espionage Campaign"
+  title="[보안] 중국 연계 Amaranth-Dragon, 첩보 캠페인에서 WinRAR 취약점 악용"
   url="https://thehackernews.com/2026/02/china-linked-amaranth-dragon-exploits.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhnDkrWZsbnchuoTSKHJzBamJKGb-b_h8TY-BhcWP6QeO0n9s3DQ0WGyzcZhUOET1mMZ66n_jNrwRSU7X759cKKsmNYPobdzRk-55snSEVZTS3hq_0le0ulcDFqwncn9SsXwWVDxTVEBoa0r1y0Hz4zdMKKmuW_XNrfsRqOBh4Zd34ylZt2aKdWF8XtjN_s/s1700-e365/chinese-winrar.jpg"
   summary="중국과 연계된 위협 그룹 Amaranth-Dragon이 WinRAR 취약점을 악용하여 표적 스파이 캠페인을 수행하고 있습니다. 이 그룹은 특수하게 제작된 압축 파일을 통해 취약한 WinRAR 버전에서 임의 코드를 실행하며, 정부 기관 및 방위 산업 관련 조직을 주요 타겟으로 삼고 있습니다."
@@ -484,7 +484,7 @@ union SecurityEvent, DeviceProcessEvents
 ### 2.1 Navigating health questions with ChatGPT
 
 {%- include news-card.html
-  title="[AI/ML] Navigating health questions with ChatGPT"
+  title="[AI/ML] ChatGPT로 건강 관련 질문을 다루는 방법"
   url="https://openai.com/index/navigating-health-questions"
   summary="한 가족이 아들의 중요한 암 치료 결정을 준비하는 과정에서 의사의 전문적인 지도와 함께 ChatGPT가 어떻게 도움을 주었는지 공유했습니다."
   source="OpenAI Blog"
@@ -520,7 +520,7 @@ union SecurityEvent, DeviceProcessEvents
 ### 2.2 No Display? No Problem: Cross-Device Passkey Authentication for XR Devices
 
 {%- include news-card.html
-  title="[AI/ML] No Display? No Problem: Cross-Device Passkey Authentication for XR Devices"
+  title="[AI/ML] 디스플레이가 없어도 문제없다: XR 기기를 위한 크로스 디바이스 Passkey 인증"
   url="https://engineering.fb.com/2026/02/04/security/cross-device-passkey-authentication-for-xr-devices-meta-quest/"
   image="https://engineering.fb.com/wp-content/uploads/2026/02/Cross-device-passkeys-Meta-Quest-copy.png"
   summary="Meta는 XR 기기와 같이 디스플레이에 접근할 수 없는 장치에 대해 크로스 디바이스 패스키 인증을 가능하게 하는 새로운 접근 방식을 공유했습니다. 이 방식은 QR 코드 사용을 우회하며 디바이스 디스플레이 없이도 크로스 디바이스 인증을 가능하게 하면서, 모든 신뢰 및 근접성 요구사항을 준수합니다."
@@ -599,7 +599,7 @@ Google이 2026년 1월에 발표한 최신 AI 관련 뉴스를 종합 정리한 
 ### 3.1 The platform usage trap part 1: Why high activity doesn't necessarily mean high value
 
 {%- include news-card.html
-  title="[클라우드] The platform usage trap part 1: Why high activity doesn't necessarily mean high value"
+  title="[클라우드] 플랫폼 사용량의 함정 1부: 높은 활동량이 곧 높은 가치는 아닌 이유"
   url="https://cloud.google.com/blog/products/application-development/at-john-lewis-partnership-measuring-developer-platform-value/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_-_Application_Development_SWHuGHU.max-2600x2600.jpg"
   summary="내부 개발자 플랫폼에 투자한 조직이라면 &quot;실제로 효과가 있는가?&quot;라는 질문이 필연적으로 제기됩니다. 단순한 채택률 추적만으로는 플랫폼이 개발자에게 진정한 가치를 전달하고 있는지 알 수 없습니다. 이것이 바로 영국 대형 유통업체 John Lewis가 직면한 과제였습니다."
@@ -625,7 +625,7 @@ Google이 2026년 1월에 발표한 최신 AI 관련 뉴스를 종합 정리한 
 ### 3.2 The platform usage trap part 2: Choosing meaningful monitoring metrics
 
 {%- include news-card.html
-  title="[클라우드] The platform usage trap part 2: Choosing meaningful monitoring metrics"
+  title="[클라우드] 플랫폼 사용량의 함정 2부: 의미 있는 모니터링 지표 선택하기"
   url="https://cloud.google.com/blog/products/application-development/how-john-lewis-partnership-chose-its-monitoring-metrics/"
   image="https://storage.googleapis.com/gweb-cloudblog-publish/images/03_-_Application_Development_SWHuGHU.max-2600x2600.jpg"
   summary="이 시리즈의 1부에서 John Lewis Partnership의 Alex Moss가 개발자 플랫폼 가치 측정에 사용하는 메트릭을 다루었습니다. 이번 2부에서는 측정 전략의 핵심 요소인 &quot;올바른 측정 대상 선택&quot;에 대해 논의합니다."
@@ -680,7 +680,7 @@ AWS가 호스트 서버에 물리적으로 연결된 NVMe 기반 SSD 블록 수�
 ### 4.1 Get Started with the Atlassian Rovo MCP Server Using Docker
 
 {%- include news-card.html
-  title="[DevOps] Get Started with the Atlassian Rovo MCP Server Using Docker"
+  title="[DevOps] Docker로 Atlassian Rovo MCP Server 시작하기"
   url="https://www.docker.com/blog/atlassian-remote-mcp-server-getting-started-with-docker/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
   summary="원격 Atlassian Rovo MCP 서버가 Docker의 MCP Catalog 및 Toolkit에서 사용 가능하게 되었습니다."
@@ -705,7 +705,7 @@ AWS가 호스트 서버에 물리적으로 연결된 NVMe 기반 SSD 블록 수�
 ### 4.2 Conversing with Large Language Models using Dapr
 
 {%- include news-card.html
-  title="[DevOps] Conversing with Large Language Models using Dapr"
+  title="[DevOps] Dapr를 사용해 대규모 언어 모델과 대화하기"
   url="https://www.cncf.io/blog/2026/02/04/conversing-with-large-language-models-using-dapr/"
   image="https://www.cncf.io/wp-content/uploads/2026/01/Akamia-Cloud-Credits-27.png"
   summary="각자의 경계(Boundary) 내에서 운영되는 다수의 마이크로서비스를 관리할 때 직면하는 과제를 생각해 보겠습니다. 분산 애플리케이션 런타임(Dapr)은 이러한 마이크로서비스 운영의 복잡성을 해결하고 대규모 언어 모델(LLM)과의 통신을 효율적으로 구현하는 방법을 제공합니다."
@@ -730,7 +730,7 @@ AWS가 호스트 서버에 물리적으로 연결된 NVMe 기반 SSD 블록 수�
 ### 4.3 CNCF celebrates successful mentees from LFX Mentorship 2025 Term 3
 
 {%- include news-card.html
-  title="[DevOps] CNCF celebrates successful mentees from LFX Mentorship 2025 Term 3"
+  title="[DevOps] CNCF, LFX Mentorship 2025 Term 3 수료 멘티들을 축하"
   url="https://www.cncf.io/blog/2026/02/04/cncf-celebrates-successful-mentees-from-lfx-mentorship-2025-term-3/"
   image="https://www.cncf.io/wp-content/uploads/2026/02/Akamia-Cloud-Credits-29.png"
   summary="Cloud Native Computing Foundation(CNCF)이 2025년 3기(9월~11월) LFX Mentorship 프로그램을 성공적으로 수료한 멘티들을 축하했습니다. 이번 기수에서 훌륭한 멘티 코호트가 CNCF 프로젝트에 기여하며 클라우드 네이티브 생태계 발전에 참여했습니다."
@@ -759,7 +759,7 @@ Cloud Native Computing Foundation(CNCF)이 2025년 3기(9월~11월) LFX Mentorsh
 ### 5.1 Alleged Bitcoin Ransom Deepens Mystery in Nancy Guthrie Disappearance
 
 {%- include news-card.html
-  title="[블록체인] Alleged Bitcoin Ransom Deepens Mystery in Nancy Guthrie Disappearance"
+  title="[블록체인] Bitcoin 몸값 의혹, Nancy Guthrie 실종 사건의 의문을 키우다"
   url="https://bitcoinmagazine.com/news/alleged-bitcoin-ransom-nancy-guthrie"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/01/Crypto-Crime-Soared-to-154-Billion-in-2025-as-Russia-North-Korea-and-Iran-Exploit-Blockchain-Tech.jpg"
   summary="84세 Nancy Guthrie의 실종 사건에서 TMZ가 Bitcoin으로 수백만 달러를 요구하는 몸값 요구서를 수신했다고 보도하면서 사건이 확대되었습니다. 요구서에는 기한, 위해 위협, 그리고 검증된 지갑 주소가 포함되어 있어 암호화폐를 활용한 범죄 행위의 추적 및 블록체인 포렌식의 중요성을 보여주는 사례입니다."
@@ -784,7 +784,7 @@ Cloud Native Computing Foundation(CNCF)이 2025년 3기(9월~11월) LFX Mentorsh
 ### 5.2 Rutherford Chang Retrospective: Hundreds and Thousands at UCCA Beijing
 
 {%- include news-card.html
-  title="[블록체인] Rutherford Chang Retrospective: Hundreds and Thousands at UCCA Beijing"
+  title="[블록체인] Rutherford Chang 회고전: UCCA Beijing에서 열린 Hundreds and Thousands"
   url="https://bitcoinmagazine.com/culture/rutherford-chang-retrospective-hundreds-and-thousands-at-ucca-beijing"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/02/Rutherford-Chang.png"
   summary="베이징 UCCA에서 Rutherford Chang의 회고전 &quot;Hundreds and Thousands&quot;가 개최되었습니다. Rutherford Chang가 대량 생산된 오브제 내에서 시간, 촉감, 유통의 흔적을 어떻게 시각화했는지를 보여주는 전시로, 디지털 아트와 물리적 오브제의 가치에 대한 논의를 확장합니다."
@@ -812,14 +812,14 @@ Cloud Native Computing Foundation(CNCF)이 2025년 3기(9월~11월) LFX Mentorsh
 
 {% capture spotlight_items %}
 {% include news-spotlight-item.html
-  title="Tesla's new FSD push looks like a gross money grab..."
+  title="Tesla의 새 FSD 밀어붙이기는 노골적인 돈벌이처럼 보인다"
   url="https://electrek.co/2026/02/04/teslas-new-fsd-push-looks-like-a-gross-money-grab-they-have-questions-to-anwser/"
   source="Electrek"
   tag="Operator Signal"
   summary="Tesla의 FSD 확장 전략이 기술 완성도보다 수익화 압박과 규제 리스크를 먼저 키울 수 있다는 비판을 다루며, 자율주행 기능 판매가 신뢰와 책임 구조에 미치는 영향을 점검하게 합니다."
 %}
 {% include news-spotlight-item.html
-  title="Quick Charge checks out the e-bikes at CABDA Chica..."
+  title="Quick Charge, CABDA Chicago의 전기자전거를 살펴보다"
   url="https://electrek.co/2026/02/04/quick-charge-checks-out-the-e-bikes-cabda-chicago-2026/"
   source="Electrek"
   tag="Operator Signal"

--- a/_posts/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.md
+++ b/_posts/2026-02-06-Tech_Security_Weekly_Digest_AI_Botnet_Cloud_Threat.md
@@ -107,7 +107,7 @@ summary_card:
 ### 1.1 AI Usage Control - Buyer's Guide
 
 {%- include news-card.html
-  title="[보안] AI Usage Control - Buyer's Guide"
+  title="[보안] AI 사용 통제 — 구매 가이드"
   url="https://thehackernews.com/2026/02/the-buyers-guide-to-ai-usage-control.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhlpSoX57ALenPL8np8ytWrS5oa8e4k8YIalPfIMcz22AlZ0d6ty1EO1myE6RDnMzhJvexH4pdak5SFgADFsYSqv7yb788Y6wm1aAVuxBQfOzENiAydw6vUhEVpBdI27mA0GVGnCwICW5okRNTyXHthGXdMoOVnrnC-gTqISgISWgRqPmwbgQAFZXpBveo/s1700-e365/main.jpg"
   summary="The Hacker News에서 기업의 AI 사용 통제를 위한 구매 가이드를 발표했습니다. 직원들이 무분별하게 사용하는 생성형 AI 서비스(ChatGPT, Claude, Gemini 등)로 인한 데이터 유출, 지적재산 노출, 규정 준수 위험을 관리하기 위한 솔루션 선택 기준과 평가 프레임워크를 제시합니다."
@@ -132,7 +132,7 @@ The Hacker News에서 기업의 AI 사용 통제를 위한 구매 가이드를 �
 ### 1.2 The Security Implementation Gap
 
 {%- include news-card.html
-  title="[보안] The Security Implementation Gap"
+  title="[보안] 보안 구현의 격차"
   url="https://www.microsoft.com/en-us/security/blog/2026/02/05/the-security-implementation-gap/"
   image="https://www.microsoft.com/en-us/security/blog/wp-content/uploads/2026/02/Operation-Winter-Shield.png"
   summary="Microsoft Security Blog에서 보안 도구 도입과 실제 구현 사이의 간극(Implementation Gap)을 분석했습니다. 많은 조직이 최신 보안 솔루션을 도입하지만, 올바르게 구성하고 운영하지 못해 실질적인 보안 효과를 달성하지 못하는 현상을 다루며, Microsoft의 보안 구현 지원 전략을 소개합니다."
@@ -200,7 +200,7 @@ Claude Opus 4.6의 향상된 에이전트 능력은 OWASP Agentic AI Top 10에�
 ### 3.1 Reduce Vulnerability Noise with VEX: Wiz + Docker Hardened Images
 
 {%- include news-card.html
-  title="[클라우드] Reduce Vulnerability Noise with VEX: Wiz + Docker Hardened Images"
+  title="[클라우드] VEX로 취약점 노이즈 줄이기: Wiz + Docker Hardened Images"
   url="https://www.docker.com/blog/reduce-vulnerability-noise-with-vex-wiz-docker-hardened-images/"
   image="https://www.docker.com/app/uploads/2025/03/image.png"
   summary="Docker와 Wiz가 협력하여 VEX(Vulnerability Exploitability eXchange) 표준을 활용한 취약점 노이즈 감소 방안을 발표했습니다. 하드닝된 컨테이너 이미지를 사용하더라도 취약점 스캐너가 수십~수백 개의 CVE를 보고하지만, 실제로 악용 가능한 취약점은 극소수입니다. VEX는 이러한 우선순위 결정 문제를 해결합니다."
@@ -259,7 +259,7 @@ CNCF 프로젝트 Dragonfly v2.4.0이 출시되었습니다. P2P(Peer-to-Peer) �
 ### 3.3 .NET Framework 3.5 Standalone Deployment
 
 {%- include news-card.html
-  title="[클라우드] .NET Framework 3.5 Standalone Deployment"
+  title="[클라우드] .NET Framework 3.5 독립 실행형 배포"
   url="https://devblogs.microsoft.com/dotnet/dotnet-framework-3-5-moves-to-standalone-deployment-in-new-versions-of-windows/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/02/dotnet-framework-35-standalone-featured.webp"
   summary="Microsoft가 새로운 Windows 버전에서 .NET Framework 3.5의 독립 배포(Standalone Deployment) 방식 전환을 발표했습니다. 기존에는 Windows 구성 요소로 기본 포함되었으나, 향후 새 Windows 버전에서는 별도 설치가 필요합니다."

--- a/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
+++ b/_posts/2026-02-18-Tech_Security_Weekly_Digest_AI_Cloud_Malware_Update.md
@@ -394,14 +394,14 @@ Mandiant와 Google Threat Intelligence Group(GTIG)은 Dell RecoverPoint for Virt
 
 {% capture spotlight_items %}
 {% include news-spotlight-item.html
-  title="Robotaxis wreck 4x more than humans, and at least ..."
+  title="로보택시 사고율이 사람보다 4배 높고, 적어도"
   url="https://electrek.co/2026/02/17/robotaxis-wreck-4x-more-than-humans-and-at-least-one-tesla-wants-to-swim/"
   source="Electrek"
   tag="Operator Signal"
   summary="로보택시 안전성 논쟁이 기술 성능보다 운영 기준, 책임 소재, 규제 수용성의 문제로 이동하고 있음을 드러내는 업데이트입니다."
 %}
 {% include news-spotlight-item.html
-  title="South Dakota just approved its largest wind farm e..."
+  title="South Dakota, 역대 최대 규모 풍력 발전소를 승인"
   url="https://electrek.co/2026/02/17/south-dakota-just-approved-its-largest-wind-farm-ever/"
   source="Electrek"
   tag="Operator Signal"

--- a/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
+++ b/_posts/2026-02-20-Tech_Security_Weekly_Digest_Gemini_AI_Supply_Chain_Kubernetes.md
@@ -671,25 +671,25 @@ UAE 왕실 연계 채굴 업체가 6,782 BTC(약 4억 5,300만 달러)를 보유
 
 {% capture spotlight_items %}
 {% include news-spotlight-item.html
-  title="Spotify Multi-Agent Architecture for Advertising"
+  title="Spotify의 광고용 멀티 에이전트 아키텍처"
   url="https://engineering.atspotify.com/2026/2/our-multi-agent-architecture-for-smarter-advertising/"
   source="Spotify Engineering"
   tag="Operator Signal"
 %}
 {% include news-spotlight-item.html
-  title="Discord Osprey: Open Sourcing our Rule Engine"
+  title="Discord Osprey: 룰 엔진 오픈소스 공개"
   url="https://discord.com/blog/osprey-open-sourcing-our-rule-engine"
   source="Discord Blog"
   tag="Operator Signal"
 %}
 {% include news-spotlight-item.html
-  title="Chrome CSS Zero-Day CVE-2026-2441"
+  title="Chrome CSS 제로데이 CVE-2026-2441"
   url="https://news.hada.io/topic?id=26823"
   source="GeekNews"
   tag="Tech Signals"
 %}
 {% include news-spotlight-item.html
-  title="ThreatsDay Bulletin: OpenSSL RCE, Foxit 0-Days"
+  title="ThreatsDay 브리핑: OpenSSL RCE, Foxit 제로데이"
   url="https://thehackernews.com/2026/02/threatsday-bulletin-openssl-rce-foxit-0.html"
   source="The Hacker News"
   tag="Operator Signal"

--- a/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
+++ b/_posts/2026-02-24-Tech_Security_Weekly_Digest_Malware_AI_Docker_LLM.md
@@ -324,7 +324,7 @@ Google Cloud가 분산 시스템을 위한 Firefly 시계 동기화 프로토콜
 ### 3.2 AWS Weekly Roundup: Claude Sonnet 4.6, Kiro GovCloud
 
 {%- include news-card.html
-  title="[클라우드] AWS Weekly Roundup: Claude Sonnet 4.6, Kiro GovCloud"
+  title="[클라우드] AWS 주간 소식: Claude Sonnet 4.6, Kiro GovCloud"
   url="https://aws.amazon.com/blogs/aws/aws-weekly-roundup-claude-sonnet-4-6-in-amazon-bedrock-kiro-in-govcloud-regions-new-agent-plugins-and-more-february-23-2026/"
   image="https://d2908q01vomqb2.cloudfront.net/da4b9237bacccdf19c0760cab7aec4a8359010b0/2023/08/13/AWS-WIR-default.png"
   summary="AWS 주간 라운드업에서 Amazon Bedrock에 Claude Sonnet 4.6 모델 추가, AWS Kiro의 GovCloud 리전 확장, 새로운 Agent 플러그인 등 주요 업데이트를 발표했습니다."

--- a/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
+++ b/_posts/2026-02-25-Tech_Security_Weekly_Digest_AI_Malware_Ransomware_LLM.md
@@ -333,7 +333,7 @@ Docker의 'Captain's Chair' 시리즈에서 프론트엔드 어드보케이트�
 ### 4.2 WinForms + AI: The Dongle Died at Midnight
 
 {%- include news-card.html
-  title="[DevOps] WinForms + AI: The Dongle Died at Midnight"
+  title="[DevOps] WinForms + AI: 자정에 동글이 죽었다"
   url="https://devblogs.microsoft.com/dotnet/the-dongle-died-at-midnight/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/02/the-dongle-died-at-midnight.webp"
   summary="Klaus Loeffelmann이 고장난 USB 동글로 인해 독일에서 시간 연구를 수행할 수 없게 된 어머니를 돕기 위해, WinForms 전문가 에이전트와 GitHub Copilot을 활용하여 주말 동안 맞춤형 애플리케이션을 개발한 사례입니다."

--- a/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
+++ b/_posts/2026-02-27-Tech_Security_Weekly_Digest_AI_Botnet_Blockchain_Go.md
@@ -502,7 +502,7 @@ Citi 경영진이 Bitcoin을 자사 뱅킹 시스템에 통합하고 수탁(cust
 
 {% capture spotlight_items %}
 {% include news-spotlight-item.html
-  title="Tech Monitor - Real-Time AI & Tech Industry"
+  title="Tech Monitor — 실시간 AI·기술 산업 동향"
   url="https://tech.worldmonitor.app/?lat=20.0000&lon=0.0000&zoom=1.00&view=global&timeRange=7d&layers=cables%2Cweather%2Ceconomic%2Coutages%2Cdatacenters%2Cnatural%2CstartupHubs%2CcloudRegions%2CtechHQs%2CtechEvents"
   source="Tech World Monitor"
   tag="Operator Signal"
@@ -514,7 +514,7 @@ Citi 경영진이 Bitcoin을 자사 뱅킹 시스템에 통합하고 수탁(cust
   tag="Operator Signal"
 %}
 {% include news-spotlight-item.html
-  title="Donut solid-state batteries tested, Tesla"
+  title="도넛형 전고체 배터리 시험, 그리고 Tesla"
   url="https://electrek.co/2026/02/26/donut-solid-state-batteries-tested-tesla-engineer-quits-and-solar-value/"
   source="Electrek"
   tag="Operator Signal"

--- a/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
+++ b/_posts/2026-03-06-Tech_Security_Weekly_Digest_Security_Threat_AI_AWS.md
@@ -547,7 +547,7 @@ Bitcoin Magazine가 BIP 54 소프트포크 제안을 심층 분석했습니다. 
   tag="Operator Signal"
 %}
 {% include news-spotlight-item.html
-  title="Cloudflare Dynamic Path MTU Discovery"
+  title="Cloudflare의 동적 경로 MTU 탐색"
   url="https://blog.cloudflare.com/client-dynamic-path-mtu-discovery/"
   source="Cloudflare Blog"
   tag="Cloud / Platform"

--- a/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
+++ b/_posts/2026-03-15-Tech_Security_Weekly_Digest_AWS_AI_Bitcoin.md
@@ -100,7 +100,7 @@ summary_card:
 ### 1.1 GlassWorm 공급망 공격 - Open VSX 72개 확장 악용
 
 {% include news-card.html
-  title="GlassWorm Supply-Chain Attack Abuses 72 Open VSX Extensions to Target Developers"
+  title="GlassWorm 공급망 공격, Open VSX 확장 72개를 악용해 개발자를 노리다"
   url="https://thehackernews.com/2026/03/glassworm-supply-chain-attack-abuses-72.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg4d-2XpiCS0UYnMWh32sQEJP9LnlN_m7m2hok9CnY_vu05XXwWn4INodYCvrEdweEzpho7XqcuOFvEPnnEWlHCRa_q3HY3V5O_ii35MVWAimRwsgrpNQrvGqeUchhZ48FRUl91zTpYQdLMRxVvRjV_T8GEm-J9mnMesefzlgeaoE_EU7Ba32liTr63SsQq/s1600/open.jpg"
   summary="GlassWorm은 VSCodium, Eclipse Che 등 오픈소스 IDE가 의존하는 Open VSX 레지스트리를 표적으로 삼았습니다. 공격 방식은 인기 있는 정상 확장을 복제한 뒤 이름을 유사하게 변조(typosquatting)하거나, 기존 확장 유지관리자 계정을 탈취해 악성 업데이트를 배포하는 두 가지입니다."
@@ -164,7 +164,7 @@ NOT (Image="code.exe" OR Image="codium" OR Image="node")
 ### 1.2 AI 에이전트 설계 결함 - 프롬프트 인젝션·데이터 탈취
 
 {% include news-card.html
-  title="OpenClaw AI Agent Flaws Could Enable Prompt Injection and Data Exfiltration"
+  title="OpenClaw AI 에이전트 취약점, 프롬프트 인젝션과 데이터 유출로 이어질 수 있다"
   url="https://thehackernews.com/2026/03/openclaw-ai-agent-flaws-could-enable.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEg2mVucJhli25A25joXcap-ewfeMT1Vh-95wQKQfGOue7PwZJ1_55YsG8OQ1DQF7WVOU8tsOy73kGDzgfpTLLeqTYQ1k9LqrFWTNavDmfvCV-9IIER9PfrRsdg1wA5UzpIMrer3xC1mBClBzKkaT6pfczDbppMjZM7afcWu-RURquDGrEfjq3vVBsmlltLm/s1600/open-clawss.jpg"
   summary="이번에 공개된 취약점은 특정 제품의 버그가 아니라 AI 에이전트 설계 패턴 자체의 구조적 문제입니다. 대부분의 LLM 에이전트는 사용자 입력, 도구 호출 결과, 웹 검색 결과를 구분 없이 하나의 컨텍스트로 처리합니다."
@@ -243,7 +243,7 @@ def validate_agent_input(text: str, max_length: int = 4096) -> Optional[str]:
 ### 1.3 AWS IAM Identity Center 멀티리전 배포 - 중앙 집중식 접근 관리
 
 {% include news-card.html
-  title="Deploy AWS applications and access AWS accounts across multiple Regions with IAM Identity Center"
+  title="IAM Identity Center로 여러 리전에 걸쳐 AWS 애플리케이션을 배포하고 계정에 접근하기"
   url="https://aws.amazon.com/blogs/security/deploy-aws-applications-and-access-aws-accounts-across-multiple-regions-with-iam-identity-center/"
   summary="AWS IAM Identity Center(구 AWS SSO)의 멀티리전 지원이 확장됐습니다. 기존에는 특정 리전을 홈 리전으로 설정하고, 그 리전에서만 Identity Center 콘솔을 관리했습니다."
   source="AWS Security Blog"
@@ -335,7 +335,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
 ### 2.1 Basel III 규칙 변경이 BTC 시장 유동성에 미치는 영향
 
 {% include news-card.html
-  title="Changing Basel rules could unlock 'huge' liquidity for BTC"
+  title="Basel 규제 변경이 BTC에 '막대한' 유동성을 열어줄 수 있다"
   url="https://cointelegraph.com/news/changing-basel-rules-huge-liquidity-btc?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDEvMDE5YmU2M2MtNWYyMy03N2MyLWIwNTItODQ3ODEwY2E0MjIwLmpwZw==.jpg"
   summary="현행 Basel III 체계에서 Bitcoin은 Group 2b 자산으로 분류돼 1,250%의 위험 가중치가 적용됩니다. 이는 은행이 BTC 1달러를 보유하려면 자기자본 12.5달러를 적립해야 한다는 의미로, 사실상 은행의 BTC 직접 보유를 금지하는 수준입니다."
@@ -354,7 +354,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
 ### 2.2 Boris Johnson, BTC 폰지 사기 연루 의혹
 
 {% include news-card.html
-  title="Boris Johnson linked to BTC Ponzi scheme allegations"
+  title="Boris Johnson, BTC 폰지 사기 의혹에 연루"
   url="https://cointelegraph.com/news/boris-johnson-btc-ponzi-scheme?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDMvMDE5Y2VkNzAtNzk3ZC03ZWE5LTk5MTItMjAwOGM4YjY1ZTczLmpwZw==.jpg"
   summary="이번 사례는 기술적 취약점이 아닌 사회공학적 신뢰 조작의 전형입니다. 전직 국가 지도자 수준의 유명인을 내세워 투자자들의 경계심을 낮추는 이 수법은 딥페이크 광고와 결합해 더 정교해지고 있습니다."
@@ -373,7 +373,7 @@ resource "aws_ssoadmin_account_assignment" "prod_ap_northeast" {
 ### 2.3 Bitcoin, 주식 수익률 상회 - Strategy $776M BTC 매수 계획
 
 {% include news-card.html
-  title="Bitcoin beats stocks as Strategy eyes $776M BTC buying potential"
+  title="Strategy가 7억 7,600만 달러 규모 BTC 매수 여력을 검토하는 가운데 Bitcoin이 주식을 앞서다"
   url="https://cointelegraph.com/news/bitcoin-beats-stocks-strategy-strc-776m-btc-buying-potential?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://images.cointelegraph.com/images/528_aHR0cHM6Ly9zMy5jb2ludGVsZWdyYXBoLmNvbS91cGxvYWRzLzIwMjYtMDIvMDE5Yzk5ODMtZWRmNS03NjU2LTlmOWQtNjgwM2FlOWI4ZTg0LmpwZw==.jpg"
   summary="Strategy의 Michael Saylor 모델(채권 발행 → BTC 매수)이 기관 투자자들의 레퍼런스 케이스로 자리 잡으면서, 유사 전략을 채택하는 상장사가 늘고 있습니다. 이번 $776M 매수 계획은 STRC라는 수익 공유형 채권 상품을 통해 조달하며, BTC 가격 상승 시 채권 이자를 BTC로 지급하는 구조입니다."

--- a/_posts/2026-05-05-Tech_Security_Weekly_Digest_AI_Patch_AWS.md
+++ b/_posts/2026-05-05-Tech_Security_Weekly_Digest_AI_Patch_AWS.md
@@ -322,7 +322,7 @@ Chrome Enterprise가 의료 분야를 위한 새로운 통합 기능을 도입�
 ### 4.1 Microsoft Agent Framework – Building Blocks for AI Part 3
 
 {% include news-card.html
-  title="Microsoft Agent Framework – Building Blocks for AI Part 3"
+  title="Microsoft Agent Framework — AI를 위한 구성 요소 3부"
   url="https://devblogs.microsoft.com/dotnet/microsoft-agent-framework-building-blocks-for-ai-part-3/"
   image="https://devblogs.microsoft.com/dotnet/wp-content/uploads/sites/10/2026/05/agent-framework.webp"
   summary="Microsoft Agent Framework의 Part 3에서는 .NET에서 도구, 다중 턴 대화, 메모리 및 그래프 기반 워크플로를 활용한 지능형 AI 에이전트를 구축하는 방법을 다룹니다. 이는 Parts 1과 2의 구성 요소를 통합하여 완성된 에이전트를 만드는 데 초점을 맞춥니다."

--- a/_posts/2026-07-10-Tech_Security_Weekly_Digest_AWS.md
+++ b/_posts/2026-07-10-Tech_Security_Weekly_Digest_AWS.md
@@ -285,7 +285,7 @@ Google Cloud에서 AlphaEvolve를 모든 사용자에게 공개했습니다. Alp
 ### 3.3 Autopilot Clusters with GKE managed DRANET: GPUs and TPUs
 
 {% include news-card.html
-  title="Autopilot Clusters with GKE managed DRANET: GPUs and TPUs"
+  title="GKE 관리형 DRANET을 사용하는 Autopilot 클러스터: GPU와 TPU"
   url="https://cloud.google.com/blog/topics/developers-practitioners/autopilot-clusters-with-gke-managed-dranet-gpus-and-tpus/"
   summary="Google Kubernetes Engine (GKE) managed DRANET이 Autopilot 클러스터에서 GPU와 TPU를 모두 지원합니다. 표준 클러스터와 달리 Autopilot은 Google이 구성을 대신 처리해 주는 방식입니다. 이 블로그에서는 Autopilot 클러스터 설정 방법을 다룹니다."
   source="Google Cloud Blog"

--- a/_posts/2026-07-14-Tech_Security_Weekly_Digest_AI_Security_Malware_Go.md
+++ b/_posts/2026-07-14-Tech_Security_Weekly_Digest_AI_Security_Malware_Go.md
@@ -94,7 +94,7 @@ summary_card:
 ### 1.1 AI Security Report 2026
 
 {% include news-card.html
-  title="AI Security Report 2026"
+  title="AI 보안 리포트 2026"
   url="https://research.checkpoint.com/2026/ai-security-report-2026/"
   summary="Check Point Research의 2026년 AI 보안 보고서는 AI가 기존 공격 기술을 가속화하는 도구에서 벗어나 직접 공격을 실행하는 운영자로 전환하고 있음을 지적합니다. AI는 이제 공격자의 보조 역할을 넘어 스스로 공격을 수행하는 단계에 진입했습니다."
   source="Check Point Research"

--- a/_posts/2026-07-28-Tech_Security_Weekly_Digest_AI_Open-Source_Botnet_Blockchain.md
+++ b/_posts/2026-07-28-Tech_Security_Weekly_Digest_AI_Open-Source_Botnet_Blockchain.md
@@ -277,7 +277,7 @@ SAP와 Google Cloud가 SAP Business Data Cloud Connect for BigQuery의 일반 �
 ### 3.2 Cyber Snapshot Report: Go beyond the toolchain and build
 
 {% include news-card.html
-  title="Cyber Snapshot Report: Go beyond the toolchain and build"
+  title="Cyber Snapshot 보고서: 툴체인을 넘어서 구축하라"
   url="https://cloud.google.com/blog/products/identity-security/cyber-snapshot-report-enterprise-resilience-key-to-toolchain-success/"
   summary="Mandiant의 M-Trends 2026 보고서에 따르면, 기계 속도의 공격이 주목받지만 대부분의 성공적인 침입은 여전히 근본적인 인간 및 시스템 결함에서 비롯됩니다. 이는 toolchain을 넘어선 기업 복원력 구축의 필요성을 강조합니다."
   source="Google Cloud Blog"

--- a/_posts/2026-08-23-Tech_Security_Weekly_Digest_AWS_Malware_Botnet_AI.md
+++ b/_posts/2026-08-23-Tech_Security_Weekly_Digest_AWS_Malware_Botnet_AI.md
@@ -87,7 +87,7 @@ summary_card:
 ### 1.1 TikTok Agrees to $400 Million Settlement in U.S. Child Privacy Lawsuit
 
 {% include news-card.html
-  title="TikTok Agrees to $400 Million Settlement in U.S. Child Privacy Lawsuit"
+  title="TikTok, 미국 아동 프라이버시 소송에서 4억 달러 합의에 동의"
   url="https://thehackernews.com/2026/08/tiktok-agrees-to-400-million-settlement.html"
   image="https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEhuigeGBdB6K4zmYLAIVAQ2NR4LskJUGGLo94UiAtL1d89WIdT3ekZUY58J7Em-QxANVODEDSuLoEwVlBKiwEQCBss89hDYzpOuUWcAd8bUphqatYsgIA801ytGpe6c9Pr66CZicJqHx81XREePakS0n3RhYGdD_awrTW5UNGjUdSEmwcKo0K5UOrOIdyGo/s1600/tiktok.jpg"
   summary="Department of Justice(DoJ)는 금요일 ByteDance 소유의 TikTok이 아동 프라이버시법 위반 혐의로 제기된 2024년 소송을 4억 달러에 합의 종결한다고 발표했다. 합의에 따라 이 플랫폼은 3억 달러를 즉시 지불한다."
@@ -113,7 +113,7 @@ Department of Justice(DoJ)는 금요일 ByteDance 소유의 TikTok이 아동 프
 ### 1.2 Hackers infect Android car head units with proxy botnet malware
 
 {% include news-card.html
-  title="Hackers infect Android car head units with proxy botnet malware"
+  title="해커들이 Android 차량 헤드유닛을 프록시 봇넷 악성코드로 감염시키다"
   url="https://www.bleepingcomputer.com/news/security/hackers-infect-android-car-head-units-with-proxy-botnet-malware/"
   image="https://www.bleepstatic.com/content/hl-images/2026/08/21/car.jpg"
   summary="Android 기반 차량 헤드유닛을 노린 공급망 공격이 정상 기기 업데이트 앱을 악용해 악성코드를 배포하고 있다. 감염된 기기는 프록시 봇넷에 편입되거나 광고 사기에 이용된다."
@@ -140,7 +140,7 @@ Android 기반 차량 헤드유닛을 노린 공급망 공격이 정상 기기 �
 ### 1.3 Named Pipes Under Attack: Securing Windows Interprocess Communication
 
 {% include news-card.html
-  title="Named Pipes Under Attack: Securing Windows Interprocess Communication"
+  title="공격받는 Named Pipe: Windows 프로세스 간 통신 보호하기"
   url="https://www.bleepingcomputer.com/news/security/named-pipes-under-attack-securing-windows-interprocess-communication/"
   image="https://www.bleepstatic.com/content/posts/2026/08/18/0_named-pipe-header-image.jpg"
   summary="Windows named pipe는 빠른 프로세스 간 통신을 제공하지만 접근 제어가 느슨하면 권한 있는 서비스가 신뢰할 수 없는 프로세스에 노출될 수 있다. ThreatLocker는 엔드포인트 검증, 명령 인가, 입력 검증, 최소 권한 범위로 named pipe를 보호하는 방법을 설명한다."
@@ -173,7 +173,7 @@ Windows named pipe는 빠른 프로세스 간 통신을 제공하지만, 접근 
 ### 2.1 MiCA is coming for DeFi vaults, but regulation will be
 
 {% include news-card.html
-  title="MiCA is coming for DeFi vaults, but regulation will be"
+  title="MiCA가 DeFi vault를 겨냥하고 있으나, 규제는"
   url="https://cointelegraph.com/magazine/mica-is-coming-for-defi-vaults-but-regulation-will-be-difficult?utm_source=rss_feed&utm_medium=rss&utm_campaign=rss_partner_inbound"
   image="https://s3-images.ctmedia.io/media/article-covers/defi-lending-vaults-live-in-micas-blind-spot-but-brussels-may-be-about-to-close-it.jpg"
   summary="Brussels는 암호화폐 대출을 MiCA 적용 대상에 포함할지 검토하고 있으나, DeFi 대출 vault 구조 때문에 규제 대상을 특정하기 어려워지고 있다. 규제 동향을 법무 및 컴플라이언스 조직과 공유해야 한다."
@@ -191,7 +191,7 @@ Brussels는 암호화폐 대출을 MiCA 적용 대상에 포함할지 검토하�
 ### 2.2 Crypto exchange BitMart weighs partial restart and creditor
 
 {% include news-card.html
-  title="Crypto exchange BitMart weighs partial restart and creditor"
+  title="암호화폐 거래소 BitMart, 부분 재개와 채권자 관련 방안을 검토"
   url="https://www.coindesk.com/business/2026/08/22/crypto-exchange-bitmart-weighs-partial-restart-and-creditor-payouts-weeks-after-announcing-shutdown"
   image="https://cdn.sanity.io/images/s3y3vcno/production/420f2af41b8e84b394d9798060c7ccfa92703ed7-2280x1284.png"
   source="CoinDesk"
@@ -206,7 +206,7 @@ Brussels는 암호화폐 대출을 MiCA 적용 대상에 포함할지 검토하�
 ### 2.3 Tokenized stocks risk repeating Wall Street’s 1960s ‘paper
 
 {% include news-card.html
-  title="Tokenized stocks risk repeating Wall Street's 1960s 'paper"
+  title="토큰화 주식이 1960년대 Wall Street의 '페이퍼' 사태를 반복할 위험"
   url="https://www.coindesk.com/tech/2026/08/22/tokenized-stocks-risk-repeating-wall-street-s-1960s-paper-crisis-fairmint-ceo-says"
   image="https://cdn.sanity.io/images/s3y3vcno/production/155e3ead47a755d673f9182dd4ef2a4d2eaecf98-1500x1001.jpg"
   source="CoinDesk"

--- a/scripts/check_card_title_language.py
+++ b/scripts/check_card_title_language.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Require news-card `title=` values to be Korean, with an explicit allow-list.
+
+This blog is Korean and its card titles are faithful translations of the source
+headline with proper nouns left in English — e.g. "ToxicPanda Android 악성코드,
+VPN 권한 악용해 Google Play 차단". Measured 2026-08-24 before this gate landed:
+2261 Korean titles vs 51 English ones (2.2 %), so the English ones were drift,
+not a citation convention. All 48 translatable ones were translated; the three
+that remain are pure proper-noun strings with nothing to translate.
+
+Why a dedicated gate instead of reusing check_digest_untranslated.py
+-------------------------------------------------------------------
+That script's `is_untranslated()` deliberately exempts cited English titles and
+Title-Cased proper-noun runs, because it inspects *prose summaries* where an
+embedded English article title is legitimate. Run over these 51 titles it
+flagged **1**. It is the right heuristic for its own job and the wrong one here,
+so this gate uses the opposite shape: deny by default, allow by exact string —
+the same pattern check_digest_proper_nouns.py uses for entity spellings.
+
+Every allow-list entry carries its reason. An entry without one is how a
+deny-by-default list quietly becomes a deny-nothing list.
+
+The `[클라우드]`-style bracket prefix is stripped before the check: those labels
+are already Korean and would otherwise satisfy the Hangul test for a fully
+English title.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import unicodedata
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSTS_DIR = REPO_ROOT / "_posts"
+
+_TITLE_RE = re.compile(r'title="([^"]+)"')
+_LABEL_RE = re.compile(r"^\[[^\]]*\]\s*")
+_HANGUL_RE = re.compile(r"[가-힣]")
+
+# Titles allowed to stay English, with the reason. Keep this list short: if it
+# starts absorbing real headlines, the gate has stopped meaning anything.
+ENGLISH_TITLE_ALLOW: Dict[str, str] = {
+    "[클라우드] Google ADK + Datadog LLM Observability":
+        "product names only (Google ADK, Datadog LLM Observability) — nothing to translate",
+    "[DevOps] KubeCon Europe 2026 Open Source SecurityCon":
+        "event names; KubeCon and Open Source SecurityCon are not translated in Korean coverage",
+    "I/O 2026":
+        "Google's conference name",
+}
+
+
+def normalize(text: str) -> str:
+    """Whitespace/Unicode-normalized form used for allow-list lookup.
+
+    RSS feeds deliver U+00A0 (and friends) that render identically to a space.
+    One 2026-02-05 title carried two of them, which silently defeated exact
+    string matching during the translation pass — so the allow-list is keyed on
+    the normalized form rather than the raw bytes.
+    """
+    for ch in (" ", " ", " ", " "):
+        text = text.replace(ch, " ")
+    return re.sub(r"\s+", " ", unicodedata.normalize("NFC", text)).strip()
+
+
+_ALLOW_NORMALIZED = {normalize(k): v for k, v in ENGLISH_TITLE_ALLOW.items()}
+
+
+def offending_titles(text: str) -> List[str]:
+    """Card titles with no Hangul that are not on the allow-list."""
+    out = []
+    for m in _TITLE_RE.finditer(text):
+        raw = m.group(1)
+        if normalize(raw) in _ALLOW_NORMALIZED:
+            continue
+        if not _HANGUL_RE.search(_LABEL_RE.sub("", raw)):
+            out.append(raw)
+    return out
+
+
+def staged_posts() -> List[Path]:
+    res = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM", "--", "_posts"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return [
+        REPO_ROOT / line
+        for line in res.stdout.split("\n")
+        if line.strip().endswith(".md") and (REPO_ROOT / line).exists()
+    ]
+
+
+def scan(paths) -> Tuple[List[str], int]:
+    violations, checked = [], 0
+    for path in paths:
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        titles = _TITLE_RE.findall(text)
+        if not titles:
+            continue
+        checked += len(titles)
+        for bad in offending_titles(text):
+            violations.append(f"{path.name}: {bad}")
+    return violations, checked
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument("--all", action="store_true", help="scan every post (default)")
+    scope.add_argument("--staged", action="store_true", help="scan staged posts only")
+    parser.add_argument("--quiet", action="store_true", help="only print the summary")
+    args = parser.parse_args()
+
+    corpus = sorted(POSTS_DIR.glob("*.md"))
+    if not corpus:
+        print("[card-title-language] no posts found", file=sys.stderr)
+        return 1
+
+    scoped = staged_posts() if args.staged else corpus
+    if args.staged and not scoped:
+        print("[card-title-language] no staged posts — nothing to check.")
+        return 0
+
+    violations, checked = scan(scoped)
+
+    if violations:
+        print(
+            "[card-title-language] FAIL — these card titles have no Korean text.\n"
+            "Card titles are faithful translations of the source headline with\n"
+            "proper nouns left in English. If a title is genuinely untranslatable\n"
+            "(a pure product or event name), add it to ENGLISH_TITLE_ALLOW in\n"
+            "scripts/check_card_title_language.py WITH ITS REASON.\n",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  {v}", file=sys.stderr)
+        print(f"\n{len(violations)} violation(s).", file=sys.stderr)
+        return 1
+
+    if not args.quiet:
+        print(
+            f"[card-title-language] OK — {checked} card title(s) across "
+            f"{len(scoped)} post(s), {len(ENGLISH_TITLE_ALLOW)} allow-listed, "
+            "0 violations."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_card_title_language.py
+++ b/scripts/tests/test_check_card_title_language.py
@@ -1,0 +1,98 @@
+"""Tests for the news-card title language gate.
+
+Context worth keeping: before this gate, 51 of 2312 card titles were English
+(2.2 %). The convention is a faithful Korean translation of the source headline
+with proper nouns left in English, so those 51 were drift. 48 were translated;
+3 pure proper-noun strings are allow-listed.
+
+The gate could not reuse `check_digest_untranslated.is_untranslated()` — that
+heuristic deliberately exempts cited English titles and Title-Cased proper-noun
+runs because it inspects prose summaries, and run over the 51 it flagged 1.
+These tests pin the opposite shape: deny by default, allow by exact string.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scripts import check_card_title_language as gate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+POSTS_DIR = REPO_ROOT / "_posts"
+
+
+def test_korean_title_passes():
+    assert gate.offending_titles('title="Android 악성코드 분석"') == []
+
+
+def test_english_title_is_flagged():
+    """Proof the gate is not vacuously green."""
+    assert gate.offending_titles('title="Hackers exploit a new flaw"') == [
+        "Hackers exploit a new flaw"
+    ]
+
+
+def test_korean_bracket_label_does_not_mask_an_english_title():
+    """`[클라우드]` is Hangul and would satisfy a naive check on the raw value."""
+    assert gate.offending_titles('title="[클라우드] Fully English Headline Here"') == [
+        "[클라우드] Fully English Headline Here"
+    ]
+
+
+def test_allow_listed_title_passes():
+    allowed = next(iter(gate.ENGLISH_TITLE_ALLOW))
+    assert gate.offending_titles(f'title="{allowed}"') == []
+
+
+def test_allow_list_matches_through_non_breaking_spaces():
+    """RSS feeds deliver U+00A0 that renders identically to a space.
+
+    Two of them in a 2026-02-05 title silently defeated exact matching during
+    the translation pass, so the allow-list is keyed on the normalized form.
+    """
+    allowed = next(iter(gate.ENGLISH_TITLE_ALLOW))
+    with_nbsp = allowed.replace(" ", " ")
+    assert with_nbsp != allowed
+    assert gate.offending_titles(f'title="{with_nbsp}"') == []
+
+
+def test_every_allow_list_entry_states_a_reason():
+    """A deny-by-default list without reasons becomes a deny-nothing list."""
+    for title, reason in gate.ENGLISH_TITLE_ALLOW.items():
+        assert reason and len(reason) > 15, f"{title!r} has no usable reason"
+
+
+def test_allow_list_stays_small():
+    """If this starts absorbing real headlines the gate means nothing.
+
+    Three entries as of 2026-08-24. Raising the ceiling is a decision: say why
+    in the PR rather than growing it quietly.
+    """
+    assert len(gate.ENGLISH_TITLE_ALLOW) <= 6, sorted(gate.ENGLISH_TITLE_ALLOW)
+
+
+def test_every_allow_list_entry_is_still_used():
+    """An entry whose title no longer exists is dead permission."""
+    corpus = "\n".join(
+        p.read_text(encoding="utf-8", errors="ignore") for p in POSTS_DIR.glob("*.md")
+    )
+    normalized = gate.normalize(corpus)
+    orphans = [t for t in gate.ENGLISH_TITLE_ALLOW if gate.normalize(t) not in normalized]
+    assert orphans == [], f"allow-listed titles no longer in the corpus: {orphans}"
+
+
+def test_live_corpus_has_no_unallowed_english_titles():
+    violations, checked = gate.scan(sorted(POSTS_DIR.glob("*.md")))
+    assert violations == [], violations
+    assert checked > 2000, f"only {checked} titles scanned — did the regex break?"
+
+
+def test_the_scan_is_actually_looking_at_titles():
+    """Guards against the corpus assertion reducing to an empty scan."""
+    _, checked = gate.scan(sorted(POSTS_DIR.glob("*.md")))
+    raw = sum(
+        len(re.findall(r'title="[^"]+"', p.read_text(encoding="utf-8", errors="ignore")))
+        for p in POSTS_DIR.glob("*.md")
+    )
+    assert checked == raw > 0

--- a/scripts/tests/test_ci_svg_lint_schedule_guard.py
+++ b/scripts/tests/test_ci_svg_lint_schedule_guard.py
@@ -33,6 +33,7 @@ this guard should be updated in the same PR with the reasoning.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -164,3 +165,31 @@ def test_diff_scoped_steps_have_a_non_pull_request_base():
         "fallback(s); a diff-scoped step would fail on the scheduled sweep "
         "instead of checking the latest commit."
     )
+
+
+def test_documented_gate_count_matches_reality():
+    """The header's "N corpus-wide gates" must equal the actual `--all` count.
+
+    That number drifted twice in 2026-08 while gates were moved to --all: it was
+    incremented by hand from a base that was already off. A stale count in the
+    file that documents the gates is the same class of defect as a stale comment
+    justifying a diff-scope — it reads as verified and is not.
+    """
+    raw = WORKFLOW.read_text(encoding="utf-8")
+    m = re.search(r"carries (\d+) corpus-wide gates", raw)
+    assert m, "the header no longer states a corpus-wide gate count"
+    documented = int(m.group(1))
+
+    code = _body()
+    actual = len(re.findall(r"python3 (?:scripts/\S+\.py)[^\n]*?--all", code))
+    assert documented == actual, (
+        f"header says {documented} corpus-wide gates but {actual} `--all` "
+        "invocations exist. Update the header, or the gate you just added is "
+        "undocumented."
+    )
+    # The other two mentions of the same number must agree with the first.
+    for phrase in (rf"these {documented} gates", rf"All {documented} gates"):
+        assert re.search(phrase, raw), (
+            f"the header's other reference to the count disagrees: expected "
+            f"'{phrase}'"
+        )


### PR DESCRIPTION
## 관례 확정이 먼저였습니다

이 블로그는 한국어이고 카드 제목은 **원문 헤드라인의 충실한 번역에 고유명사만 영문**으로 남깁니다. 실제 샘플:

```
title: ToxicPanda Android 악성코드, VPN 권한 악용해 Google Play 차단
  url: .../toxicpanda-android-malware-uses-vpn-permissions-...
```

실측(2026-08-24): **한국어 2261건 vs 영문 51건(2.2%)**. 관례가 한국어이므로 영문 51건은 인용 관례가 아니라 드리프트입니다.

## 48건 번역, 3건 allow-list

남긴 3건은 **번역할 것이 없는 순수 고유명사**입니다:

| 제목 | 사유 |
|---|---|
| `[클라우드] Google ADK + Datadog LLM Observability` | 제품명만 |
| `[DevOps] KubeCon Europe 2026 Open Source SecurityCon` | 행사명 |
| `I/O 2026` | Google 컨퍼런스명 |

## 원문이 손상된 것은 만들어내지 않았습니다

수집기가 잘라놓은 제목이 여럿입니다(`...`, 단어 중간 절단). 진술된 부분만 옮기고 빠진 뒷부분은 발명하지 않았습니다:

```
MiCA is coming for DeFi vaults, but regulation will be
→ MiCA가 DeFi vault를 겨냥하고 있으나, 규제는
```

## 왜 기존 휴리스틱을 재사용하지 않았나 — 측정으로 판정

`check_digest_untranslated`의 `is_untranslated()`를 51건에 돌려보니 **1건만** 플래그했습니다. 그 함수는 산문 요약을 보도록 설계돼 있고 **인용된 영문 제목과 Title-Case 고유명사 연쇄를 의도적으로 면제**합니다. 자기 일에는 맞는 휴리스틱이고 여기엔 틀린 휴리스틱입니다.

그래서 반대 형태를 썼습니다: **deny-by-default + 사유가 붙은 exact-string allow-list**. `check_digest_proper_nouns`가 엔티티 표기에 쓰는 것과 같은 패턴입니다.

## 작업 중 걸린 함정

RSS 피드가 **U+00A0(non-breaking space)** 을 실어보내고 그건 일반 공백과 똑같이 렌더됩니다. 2026-02-05 제목 하나에 두 개가 들어 있어 exact 매칭 배치가 실패했습니다. allow-list 조회를 정규화된 형태로 키잉하고 그 회귀를 `test_allow_list_matches_through_non_breaking_spaces`로 고정했습니다.

게이트는 `[클라우드]` 같은 대괄호 라벨을 먼저 제거합니다 — 그 라벨이 한국어여서 **전부 영문인 제목도 Hangul 검사를 통과**시켜버립니다. 그 회귀도 테스트로 고정했습니다.

allow-list 규율: 사유 필수(사유 없는 deny-by-default는 deny-nothing이 됩니다), 6개 상한, 고아 항목 금지(코퍼스에 없는 제목의 허가는 죽은 권한).

## 부수: 게이트 카운트를 실측값으로 + 드리프트 가드

헤더가 `"N corpus-wide gates (--all)"`을 적는데, 이번 달 게이트를 `--all`로 옮기면서 그 숫자를 손으로 증가시켰고 **두 번 틀렸습니다** — 이미 부정확한 기준에서 더했기 때문입니다. 실측 19개, 헤더 20이었습니다.

19로 정정하고 `test_documented_gate_count_matches_reality`를 넣어 손으로 유지하지 않게 했습니다. **게이트를 문서화하는 파일의 낡은 카운트는 diff-scope를 정당화하는 낡은 주석과 같은 부류**입니다 — 검증된 것처럼 읽히지만 아닙니다. 이 세션에서 그 부류로 이미 세 번 걸렸습니다(`"레거시는 이미 한국어"`, `"135 legacy"`, `"~176 레거시"`).

## 검증

```
pytest scripts/tests/                        4372 passed / 0 failed  (신규 11건)
check_card_title_language.py --all           2312 제목 / 3 allow-listed / 0 violations
check_digest_untranslated / proper-nouns / structure / boilerplate / broken-links   전부 PASS
```

비-공허성 확인: 영문 제목 주입 → 플래그 / 대괄호 라벨만 한국어인 제목 → 플래그 / nbsp 변형 allow-list → 통과 / 헤더 카운트 23으로 변조 → 실패.

배선: pre-commit step 17(`--staged`) + svg-lint CI(`--all`, daily schedule 포함이라 크론 직푸시도 사후 포착). CLAUDE.md enforcing 게이트 표 **13번**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
