### PR TITLE
fix(digest): 08-25 크론 발행분 미번역 영문 요약 2건 — 새 --all 게이트의 첫 실제 포착

### DIFF
--- a/_posts/2026-08-25-Tech_Security_Weekly_Digest_AI_Malware.md
+++ b/_posts/2026-08-25-Tech_Security_Weekly_Digest_AI_Malware.md
@@ -299,14 +299,14 @@ AWS는 학생들을 대상으로 AWS Builder Center에서 보상 프로그램을
 {% include news-card.html
   title="대체 텍스트가 자동 검사를 통과했다고 해서 실제로 좋은 텍스트라는 뜻은 아닙니다."
   url="https://github.blog/engineering/user-experience/your-alt-text-passes-automated-checks-that-doesnt-mean-its-any-good/"
-  summary="We built a plugin for the GitHub Accessibility Scanner to make sure your alt text is actually accessible. Here's how it works. The post Your alt text passes automated checks. 인프라 및 운영 환경 영향을 검토하세요."
+  summary="GitHub Accessibility Scanner용 플러그인을 만들어 대체 텍스트가 실제로 접근성을 갖추는지 검증했습니다. 자동 검사만 통과하는 대체 텍스트로는 충분하지 않다는 점을 짚습니다."
   source="GitHub Engineering Blog"
   severity="Medium"
 %}
 
 #### 요약
 
-We built a plugin for the GitHub Accessibility Scanner to make sure your alt text is actually accessible. Here's how it works. The post Your alt text passes automated checks. 인프라 및 운영 환경 영향을 검토하세요.
+GitHub Accessibility Scanner용 플러그인을 만들어 대체 텍스트가 실제로 접근성을 갖추는지 검증했습니다. 자동 검사만 통과하는 대체 텍스트로는 충분하지 않다는 점을 짚습니다. 인프라 및 운영 환경 영향을 검토하세요.
 
 
 ---
@@ -390,14 +390,14 @@ Strive 주식이 1,110 Bitcoin 매수 이후 급등했으며, 이는 Nasdaq 상�
   title="Strategy, Bitcoin 매입을 다시 건너뛰고 USD 현금 달러 준비금을 설정하다"
   url="https://bitcoinmagazine.com/news/strategy-establishes-new-usd-cash-reserve"
   image="https://bitcoinmagazine.com/wp-content/uploads/2026/06/Strategy-MSTR-Sells-Bitcoin-for-First-Time-in-Years-as-Bitcoin-Price-Tumbles.jpg"
-  summary="Bitcoin Magazine Strategy Again Skips Bitcoin Buy And Establishes USD Cash Dollar Reserve Strategy went another week without buying or selling bitcoin but has a new pool of cash. This post Strategy"
+  summary="Strategy가 또 한 주 동안 Bitcoin을 매수하지도 매도하지도 않은 채 새로운 달러 현금 준비금을 확보했다고 Bitcoin Magazine이 전했습니다."
   source="Bitcoin Magazine"
   severity="Medium"
 %}
 
 #### 요약
 
-Bitcoin Magazine Strategy Again Skips Bitcoin Buy And Establishes USD Cash Dollar Reserve Strategy went another week without buying or selling bitcoin but has a new pool of cash. This post Strategy Again Skips Bitcoin Buy And Establishes USD Cash Dollar Reserve first appeared on Bitcoin Magazine 하드웨어 지갑 키 관리와 출금 서명 흐름을 재점검해 조작된 트랜잭션 승인 리스크를 차단하세요.
+Strategy가 또 한 주 동안 Bitcoin을 매수하지도 매도하지도 않은 채 새로운 달러 현금 준비금을 확보했다고 Bitcoin Magazine이 전했습니다. 하드웨어 지갑 키 관리와 출금 서명 흐름을 재점검해 조작된 트랜잭션 승인 리스크를 차단하세요.
 
 
 ---


### PR DESCRIPTION
**이번 세션 작업의 실전 시험이자 첫 실제 포착입니다.**

크론이 방금 2026-08-25 digest를 main에 직푸시했고(`98a4170d`), 그 푸시는 GitHub recursion prevention 때문에 **어떤 워크플로도 트리거하지 않습니다.** PR #602 이전이라면 `digest-untranslated`가 diff-scoped여서 비교할 base가 없어 아무것도 못 봤을 상황입니다. `--all`로 옮긴 뒤라 즉시 잡혔습니다.

```
$ python3 scripts/check_digest_untranslated.py --all
FAIL _posts/2026-08-25-Tech_Security_Weekly_Digest_AI_Malware.md
  - 영문 요약 블록 #8:  We built a plugin for the GitHub Accessibility Scanner...
  - 영문 요약 블록 #13: Bitcoin Magazine Strategy Again Skips Bitcoin Buy...
  - 영문 summary= 필드 #10 / #15: (동일)
```

알려진 `repository_dispatch` LLM 키 파티션 폴백 패턴입니다. 오늘 밤 daily schedule에서 CI가 red가 됐을 것이고, 이 PR이 그걸 미리 막습니다.

## 번역 원칙

고유명사 영문 유지(`GitHub Accessibility Scanner`, `Bitcoin`, `Strategy`, `Bitcoin Magazine`), 뒤에 붙어 있던 한국어 조치 문장은 보존했습니다.

RSS 피드 상용구(`"The post ... first appeared on Bitcoin Magazine"`)는 **기사 내용이 아니라 피드 산출물**이므로 옮기지 않았습니다.

## 치환 순서 함정 (기록해둡니다)

A 항목은 산문 블록 텍스트가 `summary=` 값의 **상위 문자열**입니다. bare 형태를 먼저 치환하면 `summary=` 속성이 망가집니다 — 실제로 첫 시도가 `expected 1, got 2`로 실패했습니다. 더 구체적인 `summary="..."` 형태를 먼저 치환해야 합니다.

## 검증

```
check_digest_untranslated.py --all        PASS
check_digest_proper_nouns.py --all        PASS
check_card_title_language.py --all        PASS
check_template_echo.py --all --quiet      PASS
check_digest_structure.py --all           PASS
check_post_boilerplate.py --all           PASS
check_broken_links.py --all               PASS

pytest scripts/tests/                     4376 passed / 0 failed
```

## 남는 구조적 문제

이 패턴은 반복됩니다. 게이트가 이제 **사후에** 잡지만, 근본 원인(`repository_dispatch` 경로에서 LLM 번역 키가 파티션돼 영문 RSS 원문으로 폴백)은 그대로입니다. 재번역 워크플로가 자동으로 PR을 열 수 없는 것도 그대로입니다(`Allow GitHub Actions to create and approve pull requests` off). 둘 다 별도 결정 사항입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
