### PR TITLE
fix(ci): lighthouse 게이트가 포스트 대신 홈페이지를 측정하던 문제 — serve --single 제거

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -14,10 +14,25 @@
 #   scripts/dev/resolve_lighthouse_urls.py: the homepage, plus the post page
 #   the PR actually edited (capped, so run time stays flat regardless of how
 #   many posts a corpus-wide PR touches). A post URL is measured only when it
-#   exists in BOTH builds — `serve --single` answers an unknown path with the
-#   homepage at HTTP 200, so measuring a head-only URL would compare a post
-#   page against the homepage. PRs that touch no post keep the representative
-#   post below.
+#   exists in BOTH builds, so a head-only URL cannot be compared against
+#   whatever base answers for it. PRs that touch no post keep the
+#   representative post below.
+#
+#   The servers run WITHOUT `--single`. That flag was here on the theory that
+#   it only substitutes the homepage for *unknown* paths, which the both-sides
+#   existence rule above would then cover. That theory is wrong: `serve
+#   --single` rewrites every extensionless path to /index.html *before* the
+#   filesystem lookup, so it also answers an EXISTING posts/…/index.html with
+#   the homepage at HTTP 200 — no redirect, finalDisplayedUrl unchanged.
+#   Consequence: from the day _posts/** began triggering this gate until
+#   2026-08-25 every post row was homepage-vs-homepage. Run 32795353240
+#   (PR #605) is the worked example — both URLs returned a byte-identical
+#   147905-byte document loading home-posts-filter.js, and the homepage's LCP
+#   is bimodal (~835 ms / ~1255 ms with nothing between), so the two
+#   independent medians landed on opposite modes and the gate reported a
+#   phantom +430 ms "regression" on the post.
+#   Two backstops now: no `--single`, and a per-side page-identity probe that
+#   refuses to measure when a non-homepage URL returns the homepage's bytes.
 #
 #   Head and base get their OWN port (4000 / 4001). Sharing one port is a
 #   correctness hazard, not a detail: `npx serve` silently falls back to a
@@ -189,7 +204,14 @@ jobs:
           mkdir -p lhci-head
           # --no-port-switching: fail loudly instead of drifting to a random
           # port and leaving Lighthouse pointed at the other build on :4000.
-          npx serve _site_head -l 4000 --single --no-port-switching > serve-head.log 2>&1 &
+          # NO --single: this is a static Jekyll tree, not an SPA. `serve
+          # --single` rewrites *every* extensionless path to /index.html before
+          # the filesystem lookup, so it answered an existing
+          # posts/…/index.html with the homepage at HTTP 200 (verified against
+          # serve 14.2.6 with a fixture whose post index.html differed from the
+          # homepage). Every post measurement was therefore homepage-vs-homepage
+          # — see the header note.
+          npx serve _site_head -l 4000 --no-port-switching > serve-head.log 2>&1 &
           SERVER_PID=$!
           SERVING=""
           for _ in $(seq 1 20); do
@@ -203,6 +225,22 @@ jobs:
             kill $SERVER_PID 2>/dev/null || true
             exit 1
           fi
+          # Page-identity probe. The build-id check above proves *which tree* is
+          # served; it cannot prove that a given URL resolves to its own page.
+          # Assert every non-homepage URL differs from the homepage, so a
+          # homepage substitution can never again be measured as a post.
+          HOME_SHA=$(curl -sf http://localhost:4000/ | sha256sum | cut -d' ' -f1)
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            [ "$path" = "/" ] && continue
+            PAGE_SHA=$(curl -sf "http://localhost:4000${path}" | sha256sum | cut -d' ' -f1)
+            if [ "$PAGE_SHA" = "$HOME_SHA" ]; then
+              echo "::error::head :4000 answered ${path} with a document byte-identical to the homepage. The gate would compare the homepage against itself. Refusing to measure."
+              pkill -P $SERVER_PID 2>/dev/null || true
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+          done < lh-urls.txt
           while IFS= read -r path; do
             [ -n "$path" ] || continue
             url="http://localhost:4000${path}"
@@ -239,7 +277,9 @@ jobs:
           mkdir -p lhci-base
           # --no-port-switching: fail loudly instead of drifting to a random
           # port and leaving Lighthouse pointed at the other build on :4000.
-          npx serve _site_base -l 4001 --single --no-port-switching > serve-base.log 2>&1 &
+          # NO --single — see the head step for why it made every post
+          # measurement homepage-vs-homepage.
+          npx serve _site_base -l 4001 --no-port-switching > serve-base.log 2>&1 &
           SERVER_PID=$!
           SERVING=""
           for _ in $(seq 1 20); do
@@ -253,6 +293,19 @@ jobs:
             kill $SERVER_PID 2>/dev/null || true
             exit 1
           fi
+          # Page-identity probe — see the head step.
+          HOME_SHA=$(curl -sf http://localhost:4001/ | sha256sum | cut -d' ' -f1)
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            [ "$path" = "/" ] && continue
+            PAGE_SHA=$(curl -sf "http://localhost:4001${path}" | sha256sum | cut -d' ' -f1)
+            if [ "$PAGE_SHA" = "$HOME_SHA" ]; then
+              echo "::error::base :4001 answered ${path} with a document byte-identical to the homepage. The gate would compare the homepage against itself. Refusing to measure."
+              pkill -P $SERVER_PID 2>/dev/null || true
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+          done < lh-urls.txt
           while IFS= read -r path; do
             [ -n "$path" ] || continue
             url="http://localhost:4001${path}"

--- a/scripts/dev/resolve_lighthouse_urls.py
+++ b/scripts/dev/resolve_lighthouse_urls.py
@@ -15,17 +15,25 @@ PR actually touched.
 
 The both-sides rule (this is a correctness requirement, not an optimisation)
 ---------------------------------------------------------------------------
-The workflow serves each build with ``npx serve … --single``. In ``--single``
-mode a path that does not exist is answered with ``index.html`` — the homepage —
-at HTTP 200, with no redirect. Lighthouse therefore records the *requested* URL
-while measuring the *homepage*. If a URL exists on head but not on base (a newly
-added post), the comparison would silently pit the real post page against the
-homepage and emit a garbage delta in whichever direction the two happen to
+If a URL exists on head but not on base (a newly added post), there is nothing
+like-for-like to compare: base answers with a 404 page, and the delta between a
+real post and an error page is garbage in whichever direction the two happen to
 differ.
 
 Hence: a post URL is measured only when it exists in **every** site directory
 passed via ``--site-dir``. New posts drop out and the gate falls back to
 comparing the homepage, which is honest.
+
+This check is necessary but was never sufficient, and believing otherwise cost
+the gate months of vacuous runs. The workflow used to serve each build with
+``npx serve … --single`` on the theory that ``--single`` only substitutes the
+homepage for *unknown* paths — which this rule would then cover. That theory is
+wrong: ``--single`` rewrites every extensionless path to ``/index.html``
+*before* the filesystem lookup, so it answered an **existing** post page with
+the homepage at HTTP 200 as well. Every post URL this resolver correctly
+admitted was still measured as the homepage. ``--single`` is gone and the
+workflow now probes page identity over HTTP before measuring; see
+``.github/workflows/lighthouse-ci.yml`` and PR #606.
 
 Slug rule
 ---------

--- a/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
+++ b/scripts/tests/test_ci_lighthouse_perf_gate_guard.py
@@ -14,12 +14,16 @@ What can be undone silently here
    measured a fixed 2026-04-29 post. On a ``_posts/**`` PR that post is
    byte-identical on both sides, so the gate reports +0 ms and blocks nothing —
    green, and vacuous. The URL list must come from the resolver.
-3. **Stop requiring the URL to exist in both builds.** The runs are served with
-   ``serve … --single``, which answers an unknown path with the homepage at
-   HTTP 200 and no redirect. Measure a head-only URL and the comparison pits a
-   post page against the homepage; the delta is noise with a plausible sign.
-   The existence check needs ``--site-dir`` for *both* builds and the local
-   measurement steps need both builds to have succeeded.
+3. **Stop requiring the URL to exist in both builds.** Measure a head-only URL
+   and the comparison pits a post page against whatever base answers for it;
+   the delta is noise with a plausible sign. The existence check needs
+   ``--site-dir`` for *both* builds and the local measurement steps need both
+   builds to have succeeded.
+3b. **Re-add ``serve --single``**, which answers an *existing* post page with
+   the homepage at HTTP 200 — see
+   ``test_server_serves_real_pages_not_the_homepage``. This one defeated the
+   existence check in (3) entirely: the URL existed in both builds and was
+   still never measured.
 4. **Raise the 200 ms threshold** or neutralise the compare step.
 5. **Remove the post-URL cap**, turning a 100-post corpus PR into a 101-URL
    sweep — 100× the run time, on a 30-minute job timeout.
@@ -285,6 +289,55 @@ class TestPerfGateConfig:
             assert f"echo {expected} > {site}/build-id.txt" in stamp, (
                 f"{site} is no longer stamped with its build id, so the probe "
                 "above cannot tell the two builds apart."
+            )
+
+    def test_server_serves_real_pages_not_the_homepage(self):
+        """The bug that made this gate vacuous for the *second* time.
+
+        ``serve --single`` was believed to substitute the homepage only for
+        paths that do not exist, which the resolver's both-sides existence rule
+        would then cover. It does not: the flag rewrites every extensionless
+        path to ``/index.html`` *before* the filesystem lookup, so an EXISTING
+        ``posts/…/index.html`` is answered with the homepage at HTTP 200, with
+        no redirect and ``finalDisplayedUrl`` left intact. Verified against
+        serve 14.2.6 with a fixture whose post page differed from the homepage.
+
+        So every post row this gate ever produced was homepage-vs-homepage. In
+        run 32795353240 both URLs returned the same 147905-byte document, and
+        because the homepage's LCP is bimodal (~835 / ~1255 ms) the two medians
+        landed on opposite modes and the gate blocked PR #605 with a phantom
+        +430 ms regression.
+
+        Two independent defences, because the failure is silent and reads as a
+        plausible result: never pass ``--single``, and prove over HTTP that a
+        non-homepage URL does not return the homepage's bytes.
+        """
+        wf = _workflow()
+        for name in (
+            "Run Lighthouse on head (local build)",
+            "Run Lighthouse on base (local build)",
+        ):
+            run = _step(wf, name).get("run", "")
+            # Only the invocation itself — the surrounding comment names the
+            # flag on purpose, to explain why it must stay gone.
+            serve_cmd = re.search(r"^\s*npx serve .*$", run, re.MULTILINE)
+            assert serve_cmd, f"'{name}' no longer invokes npx serve."
+            assert "--single" not in serve_cmd.group(0), (
+                f"'{name}' passes --single to serve. This is a static Jekyll "
+                "tree, not an SPA: --single answers an existing post page with "
+                "the homepage at HTTP 200, so every post row silently becomes "
+                "homepage-vs-homepage and the delta is noise with a plausible "
+                "sign. Re-opens the PR #605 phantom-regression defect."
+            )
+            assert "HOME_SHA=" in run and "PAGE_SHA=" in run, (
+                f"'{name}' no longer runs the page-identity probe. build-id.txt "
+                "proves which *tree* is served; it cannot prove a URL resolves "
+                "to its own page. Without this probe a homepage substitution is "
+                "measured as if it were the post."
+            )
+            assert 'PAGE_SHA" = "$HOME_SHA' in run, (
+                f"'{name}' computes the page hashes but no longer compares them "
+                "against the homepage, so the probe cannot fail."
             )
 
     def test_default_post_url_is_a_single_source(self):

--- a/scripts/tests/test_resolve_lighthouse_urls.py
+++ b/scripts/tests/test_resolve_lighthouse_urls.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """Tests for scripts/dev/resolve_lighthouse_urls.py.
 
-The property that matters most here is the both-sides intersection. The perf
-gate serves each build with ``serve --single``, which answers an unknown path
-with the homepage at HTTP 200 and no redirect, so a URL that exists on head but
-not on base would be compared against the homepage and produce a meaningless
-delta. Several tests below pin that behaviour specifically.
+The property that matters most here is the both-sides intersection: a URL that
+exists on head but not on base has nothing like-for-like to be compared
+against, so the delta would be meaningless. Several tests below pin that
+behaviour specifically.
+
+Note this is necessary but not sufficient. The gate also used to serve with
+``serve --single``, which substitutes the homepage for *existing* post pages
+too — so URLs this resolver correctly admitted were still measured as the
+homepage. That is fixed in the workflow, not here; see PR #606 and
+``test_ci_lighthouse_perf_gate_guard.test_server_serves_real_pages_not_the_homepage``.
 """
 
 from __future__ import annotations
@@ -112,7 +117,7 @@ class TestResolve:
         ]
 
     def test_new_post_absent_from_base_is_dropped(self, tmp_path):
-        """The --single hazard: measuring it would compare post vs homepage."""
+        """Measuring it would compare a real post against base's 404 page."""
         head, base = tmp_path / "head", tmp_path / "base"
         _make_post(head, "/posts/2026/08/08/BrandNew/")
         base.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## 요약

`lighthouse-perf-gate` 는 포스트 페이지를 **한 번도 측정한 적이 없다.** 두 URL 모두 홈페이지를 측정하고 있었다.

원인은 `npx serve … --single` 이다. 이 플래그는 확장자 없는 모든 경로를 파일시스템 조회 *이전에* `/index.html` 로 재작성한다. 워크플로가 전제하던 "존재하지 않는 경로만 홈페이지로 대체된다"(→ 리졸버의 양측 존재 검사로 커버 가능)는 틀렸다. 실제로 **존재하는** `posts/…/index.html` 도 홈페이지를 HTTP 200 으로 응답하며, 리다이렉트가 없어 `finalDisplayedUrl` 도 그대로 남는다. 그래서 리졸버의 존재 검사를 통과한 URL이 그대로 홈페이지로 측정됐다.

## 근거

**1. serve 동작 재현** (serve 14.2.6, 홈페이지와 다른 포스트 `index.html` 픽스처)

```
--single 있음:  GET /posts/2026/08/25/Foo_Bar/ → "HOMEPAGE"  (200)
--single 없음:  GET /posts/2026/08/25/Foo_Bar/ → "POSTPAGE"  (200)
                GET /nonexistent/path/         → 404
```

**2. 실제 CI 산출물** — run `32795353240` (PR #605) 아티팩트의 LHR JSON:

- 홈페이지와 포스트 측정이 **동일 문서**: 147905 바이트, 30개 요청, 동일한 `div.container > div.home > section.hero > p.hero-description` LCP 셀렉터
- 두 측정의 유일한 차이는 문서 URL 자체. 나머지 29개 서브리소스가 동일하며 그중 **`/assets/js/home-posts-filter.js`** 는 홈페이지 전용 스크립트다

**3. 유령 회귀의 정체** — 홈페이지 LCP 는 이봉분포다. 40개 샘플 전부 ~835ms 또는 ~1255ms 이고 중간값이 없다:

```
head /     [ 834,  840,  837,  834, 1243]
head POST  [ 835, 1261, 1263, 1280, 1267]
base /     [1269, 1265,  833, 1245, 1268]
base POST  [1239,  838,  831,  833,  813]
```

같은 페이지를 두 번 측정하니 두 중앙값이 서로 다른 모드에 떨어지고, 그 차이가 ±430ms 로 200ms 임계를 넘는다. 재실행 3회에서 판정이 실제로 뒤집혔다:

| 시도 | `/` | 포스트 |
|---|---|---|
| 1 | PASS (−416ms) | **FAIL (+411ms)** |
| 2 | PASS (−428ms) | **FAIL (+430ms)** |
| 3 | **FAIL (+401ms)** | PASS (−410ms) |

3회차는 홈페이지 행이 FAIL 이다 — 홈페이지 행은 정의상 "포스트 회귀"일 수 없으므로, 두 행이 같은 페이지였다는 직접 증거다.

## 변경 내용

- 양측 `npx serve` 호출에서 `--single` 제거
- **페이지 동일성 프로브** 추가: 홈페이지가 아닌 URL 이 홈페이지와 동일한 바이트를 반환하면 측정을 거부하고 실패. 기존 `build-id.txt` 프로브는 "어느 트리를 서빙 중인가"만 증명하고 "URL 이 제 페이지로 해석되는가"는 증명하지 못한다
- 회귀 가드 `test_server_serves_real_pages_not_the_homepage` 추가
- 반증된 전제를 서술하던 워크플로 헤더 주석과 가드 docstring 정정

## 검증

- `pytest scripts/tests/` — 4377 passed, 5 skipped
- 변이 테스트 2건으로 새 가드가 실제로 실패하는지 확인: `--single` 재도입 → FAIL, 프로브 비교문 무력화 → FAIL, 원복 → PASS
- 워크플로 YAML 파싱 + 전 `run:` 블록 `bash -n` 통과

## 영향

이 게이트가 무의미해진 것은 이번이 **두 번째**다 (1차: PR #326 의 serve 포트 폴백, 2026-08-08 수정). 이번 건은 1차 수정의 방어책(리졸버 양측 존재 검사)이 잘못된 실패 모드를 겨냥하고 있었기 때문에 남아 있었다 — URL 은 양쪽에 존재했고, 그럼에도 측정되지 않았다.

`--single` 제거로 존재하지 않는 경로는 이제 404 가 되므로, 리졸버의 존재 검사도 비로소 의미를 갖는다.

머지 후 #605 를 리베이스하면 실제 포스트 페이지를 측정하게 된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
