### PR TITLE
fix(blogwatcher): 미번역 영문 요약 재발 3중 차단 — 죽은 Gemini 모델·재시도 부재·발행 전 미검사

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -432,6 +432,38 @@ jobs:
           fi
           python3 scripts/check_digest_proper_nouns.py "$POST_FILE"
 
+      - name: Untranslated-summary pre-flight (self-heal, then block)
+        if: env.RUN_CHECKS == 'true' && steps.check_post.outputs.post_created == 'true'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          # An English 요약/summary= is a dropped HTTP call, not a style issue:
+          # when every translation backend returns "" the generator emits the
+          # source English verbatim. Until now nothing looked before the commit,
+          # so it shipped to main and was caught hours later — by the svg-lint
+          # --all gate on some unrelated PR (that is how #605 found the two
+          # 2026-08-25 items) or by the 01:30 UTC backfill, which fixes it via a
+          # PR someone still has to merge.
+          #
+          # Same shape as the three self-heals above: heal, re-verify, block.
+          # The one difference is that this heal needs a network backend, so the
+          # block is conditional on having had one. On repository_dispatch the
+          # LLM keys are deliberately zeroed (MED-1), retranslate_digest is a
+          # graceful no-op, and that path opens a review PR rather than pushing
+          # to main — blocking there would kill the PR that carries the very
+          # post a human is meant to look at. So: warn there, block here.
+          POST_FILE="${{ steps.check_post.outputs.post_file }}"
+          if ! python3 scripts/check_digest_untranslated.py "$POST_FILE"; then
+            echo "::warning::Untranslated English in ${POST_FILE} — attempting retranslate_digest self-heal."
+            python3 scripts/retranslate_digest.py "$POST_FILE" || true
+          fi
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            python3 scripts/check_digest_untranslated.py "$POST_FILE" \
+              || echo "::warning::Untranslated English survives in ${POST_FILE}. This is the untrusted dispatch path, which holds no LLM keys, so no translation was possible. The review PR this run opens carries the untranslated text — translate it before merging."
+            exit 0
+          fi
+          python3 scripts/check_digest_untranslated.py "$POST_FILE"
+
       - name: Commit and publish
         if: steps.check_post.outputs.post_created == 'true' && env.DRY_RUN != 'true'
         env:

--- a/scripts/news/config.py
+++ b/scripts/news/config.py
@@ -248,6 +248,15 @@ _GEMINI_CIRCUIT_OPEN: bool = False
 _AI_MODE: str = os.getenv("AUTO_PUBLISH_USE_AI", "auto").lower()
 _GEMINI_CALL_TIMEOUT: int = max(8, int(os.getenv("AUTO_PUBLISH_GEMINI_TIMEOUT", "15")))
 _GEMINI_MAX_RETRIES: int = max(1, int(os.getenv("AUTO_PUBLISH_GEMINI_RETRIES", "1")))
+# Gemini text model. Env-overridable like the Claude/OpenAI models below,
+# because Google retires these IDs on its own schedule and the published
+# lifecycle dates do not match runtime: gemini-2.0-flash was hardcoded here and
+# had been answering every call with HTTP 404 "no longer available" — silently,
+# as a WARNING — so the primary translator was dead on every cron run and the
+# digest ran on DeepSeek alone. Overriding this must never require a code
+# change again. Retired IDs also keep appearing in ListModels, so verify a swap
+# with a real call against the production key, not against the model list.
+_GEMINI_MODEL: str = os.getenv("AUTO_PUBLISH_GEMINI_MODEL", "gemini-2.5-flash")
 _CLAUDE_MODEL: str = os.getenv("AUTO_PUBLISH_CLAUDE_MODEL", "claude-3-5-sonnet-latest")
 _OPENAI_Codex_MODEL: str = os.getenv("AUTO_PUBLISH_OPENAI_CODEX_MODEL", "gpt-5.3-codex")
 _OPENAI_GPT54_MODEL: str = os.getenv("AUTO_PUBLISH_OPENAI_GPT54_MODEL", "gpt-5.4")

--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -28,6 +28,7 @@ from scripts.news.enhancer import (
     _gemini_call,
     check_gemini_available,
     enhance_content_with_fallback,
+    post_with_retry,
 )
 from scripts.news.svg_generator import (
     _escape_svg_text,
@@ -2680,8 +2681,6 @@ def _translate_to_korean_deepseek(
         return ""
 
     try:
-        import requests
-
         if mode == "title":
             prompt = (
                 f"다음 {context} 제목을 한국어로 자연스럽게 번역해 주세요. "
@@ -2709,13 +2708,16 @@ def _translate_to_korean_deepseek(
             "max_tokens": 300,
         }
 
-        response = requests.post(
+        response = post_with_retry(
             "https://api.deepseek.com/v1/chat/completions",
             headers=headers,
             json=payload,
             timeout=20,
+            label="DeepSeek translate",
         )
 
+        if response is None:
+            return ""
         if response.status_code == 200:
             result = response.json()
             content = (
@@ -2727,9 +2729,9 @@ def _translate_to_korean_deepseek(
                 return translated
         else:
             logging.warning(f"DeepSeek translate API status {response.status_code}")
-    except ImportError:
-        logging.debug("requests library not available for DeepSeek translation")
     except Exception as e:
+        # Transport faults are retried inside post_with_retry; reaching here
+        # means the response could not be shaped, not that the network blipped.
         logging.warning(f"DeepSeek translate error: {e}")
 
     return ""

--- a/scripts/news/enhancer.py
+++ b/scripts/news/enhancer.py
@@ -117,12 +117,16 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
             # WARNING while gemini-2.0-flash 404'd on every single call for
             # weeks, so the primary translator's death never surfaced. Name the
             # override so the fix is obvious from the log alone.
+            # The response body is deliberately NOT logged. The request URL
+            # carries ?key=<API key>, so an error body that echoes the request
+            # would put the key in a public Actions log — CodeQL
+            # py/clear-text-logging-sensitive-data flags exactly that path. The
+            # model id and the remediation are the whole diagnosis anyway.
             logging.error(
-                "Gemini model '%s' returned 404 (retired or not enabled for this "
+                "Gemini model '%s' returned 404 (retired, or not enabled for this "
                 "key) - the Gemini path is dead for this whole run. Set "
-                "AUTO_PUBLISH_GEMINI_MODEL to a live model ID. Response: %s",
+                "AUTO_PUBLISH_GEMINI_MODEL to a live model ID.",
                 _cfg._GEMINI_MODEL,
-                response.text[:100],
             )
         else:
             logging.warning(

--- a/scripts/news/enhancer.py
+++ b/scripts/news/enhancer.py
@@ -3,9 +3,64 @@
 import logging
 import os
 import subprocess
+import time
 from typing import Dict, Optional
 
 import scripts.news.config as _cfg
+
+# A transport fault on the runner -> DeepSeek path costs the item its Korean
+# text: the call returns "" and the caller falls through to the English
+# template. Run 32794655444 hit ConnectionResetError(104) three times inside a
+# single digest, which is how two English summaries reached main on 2026-08-25.
+# One immediate retry plus one backed-off retry covers a reset without turning
+# a genuine outage into a long stall.
+_TRANSIENT_RETRIES: int = max(0, int(os.getenv("AUTO_PUBLISH_HTTP_RETRIES", "2")))
+_TRANSIENT_BACKOFF_S: float = 1.5
+
+
+def post_with_retry(
+    url: str,
+    *,
+    headers: Optional[Dict] = None,
+    json: Optional[Dict] = None,
+    timeout: int = 20,
+    label: str = "AI API",
+):
+    """POST that retries transport faults and 429/5xx. ``None`` when exhausted.
+
+    A 4xx other than 429 is a real answer — bad key, retired model, malformed
+    request — so it is returned to the caller rather than retried. Retrying it
+    would only burn the job's wall clock and bury the reason.
+    """
+    try:
+        import requests
+    except ImportError:
+        logging.debug("requests library not available for %s", label)
+        return None
+
+    last_error = None
+    for attempt in range(_TRANSIENT_RETRIES + 1):
+        try:
+            response = requests.post(
+                url, headers=headers, json=json, timeout=timeout
+            )
+            if response.status_code == 429 or response.status_code >= 500:
+                last_error = f"status {response.status_code}"
+            else:
+                return response
+        except Exception as e:  # connection reset, read timeout, DNS, ...
+            last_error = e
+        if attempt < _TRANSIENT_RETRIES:
+            time.sleep(_TRANSIENT_BACKOFF_S * (attempt + 1))
+            logging.info(
+                "%s transient failure (%s) - retry %d/%d",
+                label,
+                last_error,
+                attempt + 1,
+                _TRANSIENT_RETRIES,
+            )
+    logging.warning("%s failed after %d attempts: %s", label, _TRANSIENT_RETRIES + 1, last_error)
+    return None
 
 
 def _allow_gemini() -> bool:
@@ -43,7 +98,8 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
         import requests
 
         response = requests.post(
-            f"https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key={_cfg._GEMINI_API_KEY}",
+            f"https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{_cfg._GEMINI_MODEL}:generateContent?key={_cfg._GEMINI_API_KEY}",
             json={"contents": [{"parts": [{"text": prompt}]}]},
             timeout=timeout,
         )
@@ -56,6 +112,18 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
                 .get("text", "")
             )
             return text.strip()
+        elif response.status_code == 404:
+            # A retired model ID, not a transient fault. This was a plain
+            # WARNING while gemini-2.0-flash 404'd on every single call for
+            # weeks, so the primary translator's death never surfaced. Name the
+            # override so the fix is obvious from the log alone.
+            logging.error(
+                "Gemini model '%s' returned 404 (retired or not enabled for this "
+                "key) - the Gemini path is dead for this whole run. Set "
+                "AUTO_PUBLISH_GEMINI_MODEL to a live model ID. Response: %s",
+                _cfg._GEMINI_MODEL,
+                response.text[:100],
+            )
         else:
             logging.warning(
                 f"Gemini API status {response.status_code}: {response.text[:100]}"
@@ -165,8 +233,6 @@ def enhance_with_deepseek(item: Dict) -> str:
         return ""
 
     try:
-        import requests
-
         prompt = f"""\ub2e4\uc74c \ubcf4\uc548/\uae30\uc220 \ub274\uc2a4\ub97c DevSecOps \uc2e4\ubb34\uc790 \uad00\uc810\uc5d0\uc11c \ubd84\uc11d:
 \uc81c\ubaa9: {title}
 \uc694\uc57d: {summary}
@@ -191,13 +257,16 @@ def enhance_with_deepseek(item: Dict) -> str:
             "max_tokens": 1000,
         }
 
-        response = requests.post(
+        response = post_with_retry(
             "https://api.deepseek.com/v1/chat/completions",
             headers=headers,
             json=payload,
             timeout=30,
+            label="DeepSeek enhance",
         )
 
+        if response is None:
+            return ""
         if response.status_code == 200:
             result = response.json()
             content = (
@@ -209,9 +278,9 @@ def enhance_with_deepseek(item: Dict) -> str:
         else:
             logging.warning(f"DeepSeek API returned status {response.status_code}")
 
-    except ImportError:
-        logging.warning("requests library not available for DeepSeek API")
     except Exception as e:
+        # Transport faults are handled (and retried) inside post_with_retry;
+        # anything reaching here is a response-shaping bug, not a flaky network.
         logging.warning(f"DeepSeek API error: {e}")
 
     return ""

--- a/scripts/tests/test_ai_http_retry.py
+++ b/scripts/tests/test_ai_http_retry.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for scripts/news/enhancer.post_with_retry.
+
+Why this exists
+---------------
+An untranslated English summary reaching main is not a translation-quality
+problem — it is a dropped HTTP call. In blogwatcher run 32794655444 the DeepSeek
+endpoint raised ``ConnectionResetError(104)`` three times inside one digest, and
+because a failed call returned ``""`` the caller fell straight through to the
+English template. Two of those became the English summaries fixed by hand in
+commit 8dc5dd2e.
+
+The distinction that matters, and the one these tests pin: a transport fault or
+a 429/5xx is worth retrying, a plain 4xx is not. Retrying a retired model or a
+bad key just burns the job's wall clock and buries the reason in the log.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.news import enhancer  # noqa: E402
+
+
+class _Response:
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+        self.text = f"body-{status_code}"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """Keep the backoff logic exercised but the suite fast."""
+    monkeypatch.setattr(enhancer.time, "sleep", lambda _s: None)
+
+
+@pytest.fixture
+def fake_requests(monkeypatch):
+    """Install a stub ``requests`` module that records every POST."""
+    calls: list[dict] = []
+    module = types.SimpleNamespace()
+
+    def _install(outcomes):
+        """``outcomes``: list of Response or Exception, consumed per attempt."""
+        seq = list(outcomes)
+
+        def _post(url, headers=None, json=None, timeout=None):
+            calls.append({"url": url, "timeout": timeout})
+            outcome = seq.pop(0) if seq else _Response(200)
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
+
+        module.post = _post
+        monkeypatch.setitem(sys.modules, "requests", module)
+        return calls
+
+    return _install
+
+
+class TestTransientFaults:
+    def test_connection_reset_is_retried_and_recovers(self, fake_requests):
+        """The exact fault that cost 2026-08-25 two Korean summaries."""
+        calls = fake_requests(
+            [ConnectionResetError(104, "Connection reset by peer"), _Response(200)]
+        )
+        resp = enhancer.post_with_retry("https://api.example/x", label="t")
+        assert resp is not None and resp.status_code == 200
+        assert len(calls) == 2, "a reset must be retried, not surfaced as failure"
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503])
+    def test_rate_limit_and_server_errors_are_retried(self, fake_requests, status):
+        calls = fake_requests([_Response(status), _Response(200)])
+        resp = enhancer.post_with_retry("https://api.example/x", label="t")
+        assert resp is not None and resp.status_code == 200
+        assert len(calls) == 2
+
+    def test_returns_none_when_retries_are_exhausted(self, fake_requests):
+        calls = fake_requests([ConnectionResetError(104, "reset")] * 9)
+        resp = enhancer.post_with_retry("https://api.example/x", label="t")
+        assert resp is None, (
+            "an exhausted call must return None so the caller can fall back "
+            "deliberately rather than dereference a phantom response"
+        )
+        assert len(calls) == enhancer._TRANSIENT_RETRIES + 1
+
+
+class TestRealAnswersAreNotRetried:
+    @pytest.mark.parametrize("status", [400, 401, 403, 404])
+    def test_client_errors_return_immediately(self, fake_requests, status):
+        """A retired model ID (404) is an answer, not a blip.
+
+        gemini-2.0-flash 404'd on every call for weeks. Retrying that would
+        have tripled the wasted wall clock while telling the reader nothing.
+        """
+        calls = fake_requests([_Response(status), _Response(200)])
+        resp = enhancer.post_with_retry("https://api.example/x", label="t")
+        assert resp is not None and resp.status_code == status
+        assert len(calls) == 1, f"{status} must not be retried"
+
+    def test_success_makes_exactly_one_call(self, fake_requests):
+        calls = fake_requests([_Response(200)])
+        resp = enhancer.post_with_retry("https://api.example/x", label="t")
+        assert resp is not None and resp.status_code == 200
+        assert len(calls) == 1
+
+
+class TestMissingDependency:
+    def test_absent_requests_yields_none(self, monkeypatch):
+        """Callers used to guard this with their own try/except ImportError.
+
+        Those guards were removed when they became unreachable, so the helper
+        now owns the case and must still return None rather than raise.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fail(name, *a, **kw):
+            if name == "requests":
+                raise ImportError("no requests")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.delitem(sys.modules, "requests", raising=False)
+        monkeypatch.setattr(builtins, "__import__", _fail)
+        assert enhancer.post_with_retry("https://api.example/x", label="t") is None
+
+
+class TestGeminiModelIsConfigurable:
+    def test_model_id_comes_from_config_not_a_literal(self):
+        """gemini-2.0-flash was hardcoded in the URL and silently 404'd.
+
+        The whole point of the fix is that swapping the model never again
+        requires a code change, so the literal must be gone from the source.
+        """
+        src = (REPO_ROOT / "scripts" / "news" / "enhancer.py").read_text("utf-8")
+        # Code lines only — the comments name the retired ID on purpose, to
+        # explain why it must not come back.
+        code = "\n".join(
+            ln for ln in src.splitlines() if not ln.lstrip().startswith("#")
+        )
+        assert "gemini-2.0-flash" not in code, (
+            "a retired Gemini model ID is hardcoded again; use "
+            "AUTO_PUBLISH_GEMINI_MODEL via _cfg._GEMINI_MODEL"
+        )
+        assert "_cfg._GEMINI_MODEL" in src, (
+            "the Gemini REST URL no longer reads the configurable model id"
+        )

--- a/scripts/tests/test_ci_blogwatcher_selfheal_reverify_guard.py
+++ b/scripts/tests/test_ci_blogwatcher_selfheal_reverify_guard.py
@@ -57,6 +57,11 @@ SELF_HEALS = (
         "scripts/check_digest_proper_nouns.py",
         "scripts/check_digest_proper_nouns.py --fix",
     ),
+    (
+        "Untranslated-summary pre-flight",
+        "scripts/check_digest_untranslated.py",
+        "scripts/retranslate_digest.py",
+    ),
 )
 
 
@@ -147,6 +152,43 @@ def test_preflight_order_puts_all_gates_before_publish():
     for fragment, _checker, _fixer in SELF_HEALS:
         at = next(i for i, n in enumerate(names) if fragment in n)
         assert at < publish_at, f"{fragment} runs after 'Commit and publish'"
+
+
+@pytest.mark.parametrize(("fragment", "checker", "fixer"), SELF_HEALS)
+def test_last_executable_line_is_the_blocking_reverify(
+    fragment: str, checker: str, fixer: str
+):
+    """The re-verify must be the step's *final* word, bare and unguarded.
+
+    ``test_self_heal_reverifies_after_fixing`` only asks that the checker appear
+    again somewhere after the fixer on a line not starting with ``if``. That is
+    satisfiable without gating anything: the untranslated step runs the checker
+    a second time inside its ``repository_dispatch`` branch, piped into
+    ``|| echo ::warning::`` and followed by ``exit 0``. With only the weaker
+    assertion in place, deleting that step's real blocking line — or softening
+    it to ``|| true`` — left the suite green. Both mutations were run; both
+    passed. So pin the position too, not just the presence.
+
+    Under ``bash -e`` a bare non-zero command ends the step, which is what
+    turns "we re-checked" into "we refused to publish".
+    """
+    run = _uncommented(_find_step(fragment)["run"])
+    lines = [ln.rstrip() for ln in run.splitlines() if ln.strip()]
+    assert lines, f"{fragment}: step body is empty"
+    last = lines[-1].strip()
+    assert checker in last, (
+        f"{fragment}: the step's last executable line is {last!r}, not a bare "
+        f"{checker} re-verify. Anything after the re-verify can swallow its exit "
+        "code, and a re-verify that cannot end the step is decoration."
+    )
+    for softener in ("|| true", "|| echo", "continue-on-error"):
+        assert softener not in last, (
+            f"{fragment}: the final re-verify is softened with {softener!r}, so a "
+            "surviving violation publishes anyway."
+        )
+    assert not last.startswith(("if ", "elif ", "#")), (
+        f"{fragment}: the final re-verify is a condition, not a gate: {last!r}"
+    )
 
 
 def test_lone_adjective_stays_a_warning():


### PR DESCRIPTION
## 전제 정정

**미번역 원인은 `repository_dispatch` 키 파티션이 아닙니다.**

2026-08-25 미번역 포스트는 run [`32794655444`](https://github.com/Twodragon0/tech-blog/actions/runs/32794655444), event = **`schedule`** 로 발행됐고 (00:41:44Z 시작 → 00:45:44Z 커밋 `98a4170d`), 로그상 `GEMINI_API_KEY` / `DEEPSEEK_API_KEY` 모두 정상 주입됐습니다. 최근 20회 실행 중 `repository_dispatch` 는 **한 건도 없습니다** (18회 schedule + 1회 workflow_dispatch). MED-1 파티션(`ai-blogwatcher.yml:105-108`)은 설계대로 동작 중이며 이 증상과 무관합니다.

실제 원인은 3단계로 쌓여 있었습니다.

## 원인 1 — 1차 번역기가 상시 사망 (조용히)

`scripts/news/enhancer.py:46` 이 `gemini-2.0-flash` 를 URL 에 하드코딩. 이 모델은 은퇴했고 매 호출 404 를 반환합니다. 러너에 `gemini` CLI 도 없습니다:

```
WARNING - Gemini CLI error: [Errno 2] No such file or directory: 'gemini'
WARNING - Gemini API status 404: "This model models/gemini-2.0-flash is no longer avai…
WARNING - Gemini circuit breaker OPEN after 4 consecutive failures - switching to DeepSeek/template
```

404 가 `WARNING` 이었기 때문에 1차 번역기의 죽음이 한 번도 드러나지 않았고, 파이프라인은 사실상 **DeepSeek 단일 제공자**로 돌고 있었습니다.

- `_GEMINI_MODEL` (`AUTO_PUBLISH_GEMINI_MODEL`) 로 env 오버라이드 — `_CLAUDE_MODEL` / `_OPENAI_*_MODEL` 이 이미 쓰는 방식과 동일한 컨벤션이며 새 추상화가 아닙니다
- 404 는 `logging.error` 로 승격하고 오버라이드 변수명을 로그에 명시

> ⚠️ **검증되지 않음**: 기본값을 `gemini-2.5-flash` 로 두었으나 이 키에서 실제로 동작하는지는 확인하지 못했습니다(로컬에 키 없음). Google 은 2.5 계열도 신규 키에 404 를 반환하는 사례가 보고돼 있고 `ListModels` 에는 은퇴 모델이 계속 노출됩니다. **실제 키로 1회 호출해 확인**하고, 필요하면 리포 변수 `AUTO_PUBLISH_GEMINI_MODEL` 만 바꾸면 됩니다 — 이제 코드 변경은 불필요합니다.

## 원인 2 — 그 단일 제공자에 재시도가 없음

같은 런에서 DeepSeek 가 `ConnectionResetError(104, 'Connection reset by peer')` 를 **3회** 냈습니다. 실패 호출이 `""` 를 반환하면 호출자는 곧장 영문 템플릿으로 떨어집니다:

```
WARNING - DeepSeek API error: ('Connection aborted.', ConnectionResetError(104, ...))
INFO - Template fallback: ⚡ Weekly Recap: AI-Powered PLC Attacks, GitLab Att
```

이것이 `8dc5dd2e` 로 손수 고친 영문 요약 2건의 정체입니다.

`post_with_retry` 추가 — **전송 오류와 429/5xx 만** 재시도합니다. 그 외 4xx 는 실제 응답(은퇴 모델·잘못된 키)이므로 즉시 반환합니다. 은퇴 모델을 재시도해봐야 wall clock 만 태우고 이유를 로그에 파묻습니다.

## 원인 3 — 발행 전에 아무도 보지 않음

게이트는 `svg-lint --all` 에만 있어서 무관한 PR 에서 뒤늦게 잡히거나(#605 가 바로 그 경로), 01:30 UTC 백필이 PR 을 열어 사람이 머지해야 했습니다.

커밋 **직전** 자가치유 pre-flight 를 추가했습니다. 기존 3종(체크리스트 heading / 템플릿 에코 / 고유명사)과 동일한 `heal → re-verify → block` 형태입니다. `repository_dispatch` 는 키가 없어 번역이 불가능하고 어차피 리뷰 PR 을 여는 경로이므로 거기서만 warn 합니다 — 블록하면 사람이 봐야 할 그 PR 자체를 죽입니다.

## 검증

- `pytest scripts/tests/` — **4395 passed, 5 skipped**
- **이 pre-flight 였다면 08-25 발행이 막혔음을 실증**: pre-fix 포스트(`98a4170d`)에 게이트 실행 → 손으로 고친 4개 스팬을 정확히 검출, post-fix(`8dc5dd2e`) → 0건

  ```
  FAIL  - 영문 요약 블록 #8:  We built a plugin for the GitHub Accessibility Scanner…
        - 영문 요약 블록 #13: Bitcoin Magazine Strategy Again Skips Bitcoin Buy…
        - 영문 summary= 필드 #10 / #15  (동일 2건)
  ```
- **변이 테스트 4종 전부 검출**: 재시도 비활성화 / 4xx 과잉 재시도 / 최종 re-verify `|| true` 소프트닝 / 최종 re-verify 삭제
- `ai-blogwatcher.yml` YAML 파싱 + 전 `run:` 블록 `bash -n` 통과

## 부수 발견 — 기존 셀프힐 가드의 구멍

`test_ci_blogwatcher_selfheal_reverify_guard` 는 "fixer 이후에 checker 가 `if` 로 시작하지 않는 줄에 다시 등장"만 요구합니다. 제 신규 스텝의 **dispatch 분기 검사줄**이 이 조건을 만족해버려서, 최종 차단줄을 `|| true` 로 바꾸거나 통째로 지워도 **두 변이 모두 green 이었습니다**.

마지막 실행줄이 맨 checker 여야 한다는 위치 단언(`test_last_executable_line_is_the_blocking_reverify`)을 추가해 4종 전체에 적용했습니다. 다시 정확히 이 리포의 반복 패턴입니다 — 존재만 보는 게이트는 변형에 눈이 멉니다.

## 범위 밖 (수정하지 않음)

`ruff check scripts/` 는 7건 F541/기타를 보고하지만 전부 `check_cron_status.py`, `generate_quality_report.py`, `notify_webhook.py` 와 그 테스트 — 이 PR 이 건드리지 않은 파일이고 main 에 이미 존재합니다(08-23 커밋 유입). 이 PR 이 만진 파일은 ruff clean 입니다.

## 미검증 사항

- 교체한 Gemini 모델 ID 가 프로덕션 키에서 동작하는지 (위 경고 참조)
- pre-flight 의 실제 크론 동작은 다음 발행(내일 00:40 UTC)에서 확인됩니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)
