### PR TITLE
fix(blogwatcher): Gemini CLI shim의 두 번째 하드코딩 모델 + 빈 문자열 트랩 — 실호출로 gemini-2.5-flash 검증

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -106,6 +106,13 @@ jobs:
       CLAUDE_API_KEY: ${{ github.event_name != 'repository_dispatch' && secrets.CLAUDE_API_KEY || '' }}
       OPENAI_API_KEY: ${{ github.event_name != 'repository_dispatch' && secrets.OPENAI_API_KEY || '' }}
       DEEPSEEK_API_KEY: ${{ github.event_name != 'repository_dispatch' && secrets.DEEPSEEK_API_KEY || '' }}
+      # Not a secret — a repo variable, so a retired Gemini model ID can be
+      # swapped without a code change. Google retires these on its own schedule
+      # and the published lifecycle dates do not match runtime, which is how
+      # gemini-2.0-flash came to 404 on every call for weeks unnoticed.
+      # Unset resolves to '' here, so every reader must treat empty as absent
+      # (os.getenv's default does NOT fire on a set-but-empty var).
+      AUTO_PUBLISH_GEMINI_MODEL: ${{ vars.AUTO_PUBLISH_GEMINI_MODEL }}
 
     steps:
       - name: Checkout repository
@@ -201,7 +208,16 @@ jobs:
               sys.exit(1)
 
           genai.configure(api_key=api_key)
-          model = genai.GenerativeModel("gemini-2.0-flash")
+          # Same env override as the REST path (_cfg._GEMINI_MODEL). This shim
+          # had its own hardcoded copy of the retired gemini-2.0-flash, so the
+          # config fix in scripts/news/config.py did not reach it — the CLI is
+          # tried BEFORE the REST call, so a stale ID here fails first on every
+          # use_ai=gemini run.
+          # `or` not os.getenv's default: the workflow always defines this var,
+          # so an unset repo variable arrives as "" and the default never fires.
+          model = genai.GenerativeModel(
+              os.getenv("AUTO_PUBLISH_GEMINI_MODEL", "").strip() or "gemini-2.5-flash"
+          )
 
           if len(sys.argv) > 2 and sys.argv[1] == "-p":
               prompt = sys.argv[2]

--- a/scripts/news/config.py
+++ b/scripts/news/config.py
@@ -256,7 +256,23 @@ _GEMINI_MAX_RETRIES: int = max(1, int(os.getenv("AUTO_PUBLISH_GEMINI_RETRIES", "
 # digest ran on DeepSeek alone. Overriding this must never require a code
 # change again. Retired IDs also keep appearing in ListModels, so verify a swap
 # with a real call against the production key, not against the model list.
-_GEMINI_MODEL: str = os.getenv("AUTO_PUBLISH_GEMINI_MODEL", "gemini-2.5-flash")
+_GEMINI_MODEL_DEFAULT = "gemini-2.5-flash"
+
+
+def resolve_gemini_model() -> str:
+    """Model id from AUTO_PUBLISH_GEMINI_MODEL, else the default.
+
+    `or` rather than os.getenv's default: ai-blogwatcher.yml always defines the
+    var (from a repo variable), so when the variable is unset it arrives as an
+    empty string and os.getenv's default would never fire — leaving no model id
+    at all. A function, not an inline expression, so the empty case is testable
+    without reloading this module (reloading it rebinds state that
+    content_generator captured at import and breaks unrelated tests).
+    """
+    return os.getenv("AUTO_PUBLISH_GEMINI_MODEL", "").strip() or _GEMINI_MODEL_DEFAULT
+
+
+_GEMINI_MODEL: str = resolve_gemini_model()
 _CLAUDE_MODEL: str = os.getenv("AUTO_PUBLISH_CLAUDE_MODEL", "claude-3-5-sonnet-latest")
 _OPENAI_Codex_MODEL: str = os.getenv("AUTO_PUBLISH_OPENAI_CODEX_MODEL", "gpt-5.3-codex")
 _OPENAI_GPT54_MODEL: str = os.getenv("AUTO_PUBLISH_OPENAI_GPT54_MODEL", "gpt-5.4")

--- a/scripts/tests/test_ai_http_retry.py
+++ b/scripts/tests/test_ai_http_retry.py
@@ -153,3 +153,58 @@ class TestGeminiModelIsConfigurable:
         assert "_cfg._GEMINI_MODEL" in src, (
             "the Gemini REST URL no longer reads the configurable model id"
         )
+
+    @pytest.mark.parametrize(
+        ("env_value", "expected"),
+        [
+            (None, "gemini-2.5-flash"),
+            ("", "gemini-2.5-flash"),
+            ("   ", "gemini-2.5-flash"),
+            ("gemini-3.5-flash", "gemini-3.5-flash"),
+        ],
+    )
+    def test_empty_env_falls_back_to_the_default(self, monkeypatch, env_value, expected):
+        """An unset repo variable arrives as "", not as absent.
+
+        ai-blogwatcher.yml always defines AUTO_PUBLISH_GEMINI_MODEL (from
+        ``vars.``), so when the variable is not configured the step still gets
+        the name with an empty value. ``os.getenv(name, default)`` returns ""
+        there — the default never fires — and the URL would be built with no
+        model id at all. Same shape as the GA4_API_SECRET outage: a variable
+        that is present-but-empty is not the same as missing.
+        """
+        from scripts.news import config as cfg
+
+        if env_value is None:
+            monkeypatch.delenv("AUTO_PUBLISH_GEMINI_MODEL", raising=False)
+        else:
+            monkeypatch.setenv("AUTO_PUBLISH_GEMINI_MODEL", env_value)
+        assert cfg.resolve_gemini_model() == expected
+
+    def test_workflow_shim_uses_the_same_override(self):
+        """The CLI shim kept its own hardcoded copy of the retired model.
+
+        `_gemini_call` tries the CLI *before* the REST API, so a stale id in
+        the shim fails first on every ``use_ai=gemini`` run — the config fix
+        alone did not reach it. Found while verifying the model against the
+        production key (run 32811835061).
+        """
+        wf = (
+            REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+        ).read_text("utf-8")
+        shim_raw = wf[wf.index("Install Gemini CLI") :][:2000]
+        # Code lines only — the shim's comment names the retired id deliberately.
+        shim = "\n".join(
+            ln for ln in shim_raw.splitlines() if not ln.lstrip().startswith("#")
+        )
+        assert "gemini-2.0-flash" not in shim, (
+            "the Gemini CLI shim hardcodes the retired gemini-2.0-flash again"
+        )
+        assert "AUTO_PUBLISH_GEMINI_MODEL" in shim, (
+            "the shim no longer honours the AUTO_PUBLISH_GEMINI_MODEL override, "
+            "so swapping the model would need two edits and one would be missed"
+        )
+        assert 'or "' in shim, (
+            "the shim uses os.getenv's default instead of `or`, so an unset repo "
+            "variable (which arrives as an empty string) leaves it with no model id"
+        )


### PR DESCRIPTION
## 배경

#608 의 미검증 항목("교체한 Gemini 모델 ID 가 프로덕션 키에서 동작하는가")을 실호출로 검증하다가 결함 2건을 더 발견했습니다.

## 결함 1 — 하드코딩된 모델이 하나 더 있었다

#608 은 `enhancer.py` 의 **REST 경로**만 고쳤습니다. 그런데 워크플로가 `/usr/local/bin/gemini` 로 설치하는 shim 이 `gemini-2.0-flash` 를 자체 하드코딩하고 있었습니다 (`ai-blogwatcher.yml:204`).

`_gemini_call` 은 CLI 를 REST **보다 먼저** 시도하므로, `use_ai=gemini` 실행에서는 이 낡은 ID 가 먼저 실패합니다. config 수정만으로는 도달하지 못하는 지점이었습니다.

## 결함 2 — 빈 문자열 트랩

워크플로가 `AUTO_PUBLISH_GEMINI_MODEL` 을 repo variable 로 **항상 정의**하므로, 변수 미설정 시 값은 "없음"이 아니라 **빈 문자열**로 도착합니다. `os.getenv(name, default)` 는 이때 default 를 쓰지 않고 `""` 를 반환해 모델 ID 가 통째로 비게 됩니다.

실측으로 확인했습니다 — 검증 런 로그에 `AUTO_PUBLISH_GEMINI_MODEL: ` (빈 값)이 그대로 찍힙니다. `GA4_API_SECRET` 미설정 사건과 같은 형태입니다. 양쪽 리더 모두 `or` 연산으로 교정했습니다.

## 실호출 검증 결과 — `gemini-2.5-flash` 정상 동작

두 경로 모두 실제 프로덕션 키로 확인했습니다 (둘 다 `dry_run=true`, main 에 아무것도 발행되지 않음).

**CLI shim 경로** (run [`32812476167`](https://github.com/Twodragon0/tech-blog/actions/runs/32812476167), `use_ai=gemini`):
```
INFO - Gemini enhanced: Operation QUICSILVER Targets Myanmar Government an...
INFO - Gemini enhanced: Unpatched Calix flaw lets hackers bypass NAT to ex...
[Title QA] score=100 title='Operation QUICSILVER, 패치되지 않은 Calix 취약점'
```

**REST 경로** (run [`32812957692`](https://github.com/Twodragon0/tech-blog/actions/runs/32812957692), `use_ai=auto` — **실제 크론 설정**). 이 경로가 중요합니다: 크론은 `use_ai=auto` 라 shim 설치 스텝이 스킵되고 REST 로만 갑니다.

| 신호 | 고장난 08-25 크론 (32794655444) | 수정 후 (32812957692) |
|---|---|---|
| `Gemini API status 404` | 14 | **0** |
| `circuit breaker OPEN` | 1 | **0** |
| `Template fallback` | 1 | **0** |
| `Gemini enhanced` | **0** | **2** |

남은 "404" 문자열 5건은 `Ubuntu2404` 등 무관한 부분일치입니다.

## 변경 내용

- shim 이 `AUTO_PUBLISH_GEMINI_MODEL` 을 REST 경로와 동일하게 참조
- job env 에 `vars.AUTO_PUBLISH_GEMINI_MODEL` 배선 — 코드 변경 없이 모델 교체 가능
- `config.resolve_gemini_model()` 로 분리. 인라인 표현식이 아니라 **함수**인 이유: 빈 문자열 케이스를 모듈 reload 없이 테스트하기 위함입니다. `importlib.reload(config)` 를 쓰는 버전을 먼저 작성했다가 `test_content_generator_quote_safety` 가 깨졌습니다 — reload 가 `content_generator` 가 import 시점에 캡처한 상태를 재바인딩합니다. 실제로 겪고 나서 접근을 바꿨습니다
- 테스트 6건 추가

## 검증

- `pytest scripts/tests/` — **4401 passed, 5 skipped** (reload 오염 해소 확인)
- 변이 테스트 3종 전부 검출: shim 하드코딩 복귀 / `os.getenv` default 회귀 / shim 의 override 참조 제거
- YAML 파싱 + 전 `run:` 블록 `bash -n` 통과

## 참고

repo variable `AUTO_PUBLISH_GEMINI_MODEL` 은 **설정하지 않은 채로 두었습니다.** 코드 기본값이 동작하는 것을 확인했으므로, 변수를 비워두면 드리프트 지점이 하나 줄어듭니다. 다음에 2.5 가 은퇴하면 그때 변수만 설정하면 됩니다 — 이제 코드 변경은 불필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
