### PR TITLE
fix(ads): 표 내부 광고 제거 + 늦은 Auto ads 미탐지·분리 노드 크래시 2건

### DIFF
--- a/assets/js/ad-optimizer.js
+++ b/assets/js/ad-optimizer.js
@@ -4,11 +4,33 @@
 (function() {
   'use strict';
 
-  // 광고 컨테이너로 감싸기
+  // 표 안은 광고 자리가 아니다.
+  // Auto ads(slotname=auto)는 본문 어디에나 슬롯을 꽂으며, 디제스트 포스트는
+  // 표가 많아 <table> 내부에 들어가는 일이 생긴다. 그러면 열 폭이 틀어지고
+  // 본문 표가 광고로 쪼개진다. 감싸봐야 표 안이라는 사실은 달라지지 않으므로
+  // 제거한다. 표 밖 슬롯은 그대로 둔다.
+  function isInsideTable(el) {
+    return !!(el && el.closest && el.closest('table'));
+  }
+
+  // 광고 컨테이너로 감싸기. 표 안이라 제거했으면 false.
   function wrapAdInContainer(adElement) {
+    if (isInsideTable(adElement)) {
+      adElement.remove();
+      return false;
+    }
+
     // 이미 컨테이너로 감싸져 있으면 스킵
     if (adElement.closest('.ad-container')) {
-      return;
+      return true;
+    }
+
+    // 이미 문서에서 떨어진 노드. 관찰자 콜백은 변경이 일어난 뒤에 실행되므로
+    // 그 사이 Google 이 자기 슬롯을 치웠을 수 있다. 여기서 parentNode 를 그냥
+    // 참조하면 TypeError 가 나고, 그 예외가 관찰자 콜백 전체를 죽여 이후의
+    // 광고 처리가 통째로 멈춘다 (테스트에서 실제로 재현됨).
+    if (!adElement.parentNode) {
+      return false;
     }
 
     // 컨테이너 생성
@@ -51,6 +73,8 @@
     setTimeout(function() {
       observer.disconnect();
     }, 10000);
+
+    return true;
   }
 
   // 모든 광고 요소 찾기 및 래핑
@@ -61,7 +85,7 @@
     );
     
     ads.forEach(function(ad) {
-      wrapAdInContainer(ad);
+      if (!wrapAdInContainer(ad)) return;
       // minHeight 예약 없음 — 접힐 높이를 잡아두지 않는다. contain 은 시프트가
       // 생기더라도 전파 범위를 제한하므로 유지.
       if (!ad.style.contain) {
@@ -76,7 +100,7 @@
     autoPlacedAds.forEach(function(ad) {
       // 이미 처리된 경우 스킵
       if (!ad.closest('.ad-container')) {
-        wrapAdInContainer(ad);
+        if (!wrapAdInContainer(ad)) return;
         // aspect-ratio 설정으로 CLS 방지
         if (!ad.style.aspectRatio) {
           ad.style.aspectRatio = 'auto';
@@ -93,15 +117,19 @@
           mutation.addedNodes.forEach(function(node) {
             if (node.nodeType === 1) { // Element node
               // 직접 추가된 광고 (adsbygoogle-noablate 포함)
+              // google-auto-placed 를 포함시킨다. 이것이 빠져 있어서, 마지막
+              // 예약 스윕 이후에 Auto ads 가 꽂은 슬롯은 아무도 보지 못했다.
+              // Auto ads 는 계속해서 늦게 삽입하므로 실제로 그런 슬롯이 생긴다.
               if (node.classList && (
                   node.classList.contains('adsbygoogle') || 
                   node.classList.contains('adsbygoogle-noablate') ||
+                  node.classList.contains('google-auto-placed') ||
                   node.tagName === 'INS' && (
                     node.classList.contains('adsbygoogle') || 
                     node.classList.contains('adsbygoogle-noablate')
                   )
                 )) {
-                wrapAdInContainer(node);
+                if (!wrapAdInContainer(node)) return;
                 // 즉시 스타일 적용
                 node.style.display = 'block';
                 node.style.contain = 'layout style';
@@ -109,12 +137,16 @@
               }
               
               // 하위에 있는 광고
+              // .google-auto-placed 를 포함시킨다. 표 안에 꽂히는 것은 수동
+              // 슬롯이 아니라 Auto ads 이고, Auto ads 는 초기 스윕 이후에
+              // 삽입되므로 이 관찰자만이 실제로 그것을 본다.
               const ads = node.querySelectorAll && node.querySelectorAll(
-                'ins.adsbygoogle, .adsbygoogle, ins.adsbygoogle-noablate, .adsbygoogle-noablate'
+                'ins.adsbygoogle, .adsbygoogle, ins.adsbygoogle-noablate, ' +
+                '.adsbygoogle-noablate, .google-auto-placed'
               );
               if (ads) {
                 ads.forEach(function(ad) {
-                  wrapAdInContainer(ad);
+                  if (!wrapAdInContainer(ad)) return;
                   ad.style.display = 'block';
                   ad.style.contain = 'layout style';
                   ad.style.width = '100%';

--- a/tests/js/ad-optimizer-observer.test.js
+++ b/tests/js/ad-optimizer-observer.test.js
@@ -1,0 +1,80 @@
+// Regression tests for the MutationObserver half of assets/js/ad-optimizer.js.
+//
+// These live in their OWN file on purpose. ad-optimizer never disconnects its
+// document.body observer (it must keep watching for late Auto ads), and jsdom
+// reuses one document.body across tests in a file — so every runScript() in a
+// file leaves another live observer behind. With them accumulated, deleting the
+// `google-auto-placed` branch from the observer STILL left the suite green:
+// some other instance swept the node. Verified by probe — in isolation the node
+// survives that mutation, in the shared file it does not. Vitest isolates per
+// file, so one file per observer test keeps the mutation detectable.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = resolve(__dirname, '../../assets/js/ad-optimizer.js');
+const SCRIPT_SOURCE = readFileSync(SCRIPT_PATH, 'utf8') + `\n//# sourceURL=${pathToFileURL(SCRIPT_PATH).href}`;
+
+function runScript() {
+  // eslint-disable-next-line no-new-func
+  new Function('window', 'document', SCRIPT_SOURCE)(window, document);
+  vi.runOnlyPendingTimers();
+}
+
+describe('ad-optimizer.js MutationObserver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  // Auto ads 는 예약된 스윕이 모두 끝난 뒤에도 계속 슬롯을 꽂는다. 그 시점에
+  // 남은 방어선은 MutationObserver 뿐이다.
+  //
+  // 이 테스트의 초안은 주입 후 runOnlyPendingTimers() 를 한 번 더 불렀는데,
+  // 그러면 뒤늦은 스윕이 노드를 지워버려 관찰자를 전혀 검증하지 못했다.
+  // 실제로 관찰자에서 google-auto-placed 선택자를 빼는 변이를 넣어도 초안은
+  // 통과했다. 그래서 타이머를 모두 소진시킨 뒤 microtask 만 흘린다.
+  it('removes a table-nested auto-placed ad injected after every sweep has run', async () => {
+    document.body.innerHTML =
+      '<table><tbody><tr><td id="cell"></td></tr></tbody></table>';
+    runScript();
+    // 남은 예약 스윕까지 모두 소진 — 이후 제거는 관찰자만이 할 수 있다.
+    vi.runAllTimers();
+
+    const injected = document.createElement('div');
+    injected.className = 'google-auto-placed';
+    document.getElementById('cell').appendChild(injected);
+
+    // MutationObserver 콜백은 microtask 로 전달된다.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(document.querySelector('.google-auto-placed')).toBeNull();
+    expect(document.querySelector('table')).not.toBeNull();
+  });
+
+  it('still wraps a non-table auto-placed ad injected after every sweep', async () => {
+    document.body.innerHTML = '<div id="host"></div>';
+    runScript();
+    vi.runAllTimers();
+
+    const injected = document.createElement('div');
+    injected.className = 'google-auto-placed';
+    document.getElementById('host').appendChild(injected);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const ad = document.querySelector('.google-auto-placed');
+    expect(ad).not.toBeNull();
+    expect(ad.closest('.ad-container')).not.toBeNull();
+  });
+
+});

--- a/tests/js/ad-optimizer.test.js
+++ b/tests/js/ad-optimizer.test.js
@@ -85,6 +85,47 @@ describe('ad-optimizer.js', () => {
     expect(ad.style.minHeight).toBe('');
   });
 
+  // 표 안 광고 제거 (2026-08-25). Auto ads(slotname=auto)는 본문 어디에나
+  // 슬롯을 꽂아서 <table> 내부에 들어가는 일이 있고, 디제스트 포스트는 표가
+  // 많다. 그러면 열 폭이 틀어지고 본문 표가 광고로 쪼개진다.
+  it('removes an ad injected inside a table instead of wrapping it', () => {
+    document.body.innerHTML =
+      '<table><tbody><tr><td>' +
+      '<ins class="adsbygoogle"></ins>' +
+      '</td></tr></tbody></table>';
+    runScript();
+
+    expect(document.querySelector('ins.adsbygoogle')).toBeNull();
+    expect(document.querySelectorAll('.ad-container')).toHaveLength(0);
+    // 표 자체는 그대로 남아야 한다 — 광고만 걷어낸다.
+    expect(document.querySelector('table')).not.toBeNull();
+    expect(document.querySelector('td')).not.toBeNull();
+  });
+
+  it('removes a google-auto-placed slot nested deep inside a table', () => {
+    document.body.innerHTML =
+      '<table><tbody><tr><td><div class="wrap">' +
+      '<div class="google-auto-placed"><ins class="adsbygoogle"></ins></div>' +
+      '</div></td></tr></tbody></table>';
+    runScript();
+
+    expect(document.querySelector('.google-auto-placed')).toBeNull();
+    expect(document.querySelectorAll('.ad-container')).toHaveLength(0);
+    expect(document.querySelector('table')).not.toBeNull();
+  });
+
+  it('leaves ads OUTSIDE a table untouched even when a table is present', () => {
+    document.body.innerHTML =
+      '<table><tbody><tr><td>cell</td></tr></tbody></table>' +
+      '<ins class="adsbygoogle"></ins>';
+    runScript();
+
+    const ad = document.querySelector('ins.adsbygoogle');
+    expect(ad).not.toBeNull();
+    expect(ad.parentElement.classList.contains('ad-container')).toBe(true);
+    expect(document.querySelector('table')).not.toBeNull();
+  });
+
   it('handles multiple ad slots on the same page', () => {
     document.body.innerHTML =
       '<ins class="adsbygoogle" data-ad-format="rectangle"></ins>' +


### PR DESCRIPTION
## 요청

> 표 안에 광고 들어가는 것은 아니다.

Auto ads(`slotname=auto`)는 본문 어디에나 슬롯을 꽂습니다. 디제스트 포스트는 표가 많아 `<table>` 내부에 들어가고, 그러면 열 폭이 틀어지고 본문 표가 광고로 쪼개집니다. 감싸봐야 표 안이라는 사실은 달라지지 않으므로 **제거**합니다. 표 밖 슬롯은 그대로 둡니다.

## 수정 중 발견한 결함 2건

**1) 관찰자가 `google-auto-placed` 를 못 봤다.** `MutationObserver` 의 직접-노드 분기가 `adsbygoogle` 계열만 검사해서, 마지막 예약 스윕(`scheduleOptimize`) 이후에 Auto ads 가 꽂은 슬롯은 **아무도 보지 못했습니다.** Auto ads 는 계속 늦게 삽입하므로 실제로 그런 슬롯이 생깁니다. 하위-노드 스캔 선택자에도 함께 추가했습니다.

**2) 분리된 노드에서 `parentNode` 역참조 크래시.** 관찰자 콜백은 변경 *이후에* 실행되므로 그 사이 Google 이 자기 슬롯을 치울 수 있습니다. 그때 `adElement.parentNode.insertBefore` 가 TypeError 를 던지고, **그 예외가 콜백 전체를 죽여 이후 광고 처리가 통째로 멈춥니다.** 추측이 아니라 테스트에서 실제 스택트레이스로 10건 재현됐습니다:

```
TypeError: Cannot read properties of null (reading 'insertBefore')
 ❯ wrapAdInContainer assets/js/ad-optimizer.js:41:26
 ❯ MutationObserver.eval assets/js/ad-optimizer.js:110:19
```

## 테스트를 별도 파일로 분리한 이유

`ad-optimizer` 는 `document.body` 관찰자를 **의도적으로 끊지 않고**(늦은 Auto ads 를 계속 봐야 함), jsdom 은 한 파일 안에서 `document.body` 를 재사용합니다. 그래서 같은 파일에 두면 이전 테스트가 남긴 관찰자 인스턴스가 노드를 대신 쓸어가 변이를 가립니다.

실제로 겪었습니다 — 관찰자에서 `google-auto-placed` 선택자를 빼는 변이가 **한 파일에서는 11/11 통과**했고, 프로브로 격리해 보니 그 변이에서 노드가 살아남았습니다. vitest 는 파일 단위로 격리하므로 분리 후에는 정상적으로 실패합니다.

## 검증

- `npx vitest run` — **30 files / 738 tests 통과**, 0 errors
- `pytest scripts/tests/` — 4396 passed, 5 skipped
- **변이 3종 전부 검출**:

  | 변이 | 결과 |
  |---|---|
  | 표 가드 무력화 (`isInsideTable` → false) | 3 failed |
  | 관찰자 `google-auto-placed` 선택자 제거 | 1 failed (분리 전에는 통과했음) |
  | `parentNode` 가드 제거 | unhandled error 10건 → exit 1 |

## 콘솔 로그 나머지 항목 (조치 없음)

같이 주신 콘솔 덤프 대부분은 우리 사이트가 아닙니다:

| 증상 | 판정 |
|---|---|
| `contentScripts.bundle.js` WebAssembly / unsafe-eval CSP 위반 | **브라우저 확장**. `ObjectMultiplex`, `app-init-liveness` 는 지갑 확장 시그니처. 정책은 Report-Only 라 차단 없음 |
| `MaxListenersExceededWarning`, `orphaned data for stream` | 동일 확장 |
| AdSense `400 Bad Request` | 기존 실측 결론과 동일 — Auto ads unfilled, `ads.txt` 정상. 레포에서 고칠 것 없음 |
| `appier.net` 403 | Google 광고 iframe 내부의 서드파티 광고망. 우리 정책 밖 |
| giscus `/api/discussions` 404 | 정상 — 아직 댓글이 없다는 뜻 |

## 미해결로 남긴 것

`[Performance] CLS is high: 0.179668 | Cause: SECTION#comments.comments-section, NAV.post-navigation`

이 PR 로 고치지 않았습니다. 확인한 사실만 적으면:

- `.giscus-wrapper` 는 이미 `min-height: 400px` 를 예약하고 있어 댓글 영역 자체는 미예약이 아닙니다
- 주신 로그의 광고 슬롯은 `ady=19148`, `ady=20938` — 페이지 하단, 즉 **네비게이션·댓글 바로 위**이고 전부 400(unfilled)입니다. 기존 실측 결론(`CLS 원인은 게재가 아니라 예약→붕괴`)과 일치하는 위치입니다

즉 원인은 댓글 영역이 아니라 그 **위에서 접히는 광고**일 가능성이 높지만, 추측으로 고치지 않았습니다. 레포에 `scripts/dev/measure_ad_collapse_cls.mjs` 가 있으니 별도로 측정 후 다루는 편이 맞습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
