### PR TITLE
feat(dev): per-element CLS 귀속 하네스 — 0.18은 댓글이 아니라 그 위 Auto ads

### DIFF
--- a/scripts/dev/measure_cls_attribution.mjs
+++ b/scripts/dev/measure_cls_attribution.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+/**
+ * Per-element CLS attribution harness.
+ *
+ * Why this exists alongside measure_ad_collapse_cls.mjs
+ * -----------------------------------------------------
+ * That script answers one specific question — "is reserving ad height and then
+ * collapsing it worse than not reserving?" — by driving that one transition and
+ * reporting a single total. It cannot say WHICH element moved, so it cannot be
+ * used to check a field report.
+ *
+ * The field report this was written for (2026-08-25, a reader's console on the
+ * live 08-25 digest):
+ *
+ *   [Performance] CLS is high: 0.179668
+ *   Cause: SECTION#comments.comments-section, NAV.post-navigation
+ *
+ * Those are first-party elements, so the reflex reading is "the comments block
+ * is unreserved". But .giscus-wrapper already reserves min-height:400px, and the
+ * same console showed AdSense slots at ady=19148 / ady=20938 — directly above
+ * navigation and comments — all returning 400 (unfilled). A shift ATTRIBUTED to
+ * an element is not the same as a shift CAUSED by it: everything below a
+ * collapsing ad is reported as the source, because those are the nodes that
+ * actually moved.
+ *
+ * So this harness reports, per layout-shift entry: the score, and the
+ * `sources[]` element selectors with their before/after rects. That is what
+ * distinguishes "comments grew" from "comments got pushed".
+ *
+ * Third-party handling
+ * --------------------
+ * `--allow <substr>` may be repeated to let specific third-party origins load.
+ * Everything else is aborted. Default is first-party only, which means ads never
+ * render and giscus never mounts — that run measures the FLOOR (what shifts with
+ * no third party at all). Compare it against a run that allows giscus.app to
+ * isolate the comments iframe's own contribution.
+ *
+ * Ads cannot be reproduced this way: Auto ads placement is server-decided and
+ * stochastic, so an ad-collapse contribution measured locally would be fiction.
+ * Use measure_ad_collapse_cls.mjs for that half, and read this one as
+ * "first-party floor", not "total".
+ *
+ * Usage:
+ *   JEKYLL_ENV=production bundle exec jekyll build -d _site
+ *   node scripts/dev/measure_cls_attribution.mjs /posts/2026/08/25/Some_Slug/
+ *   node scripts/dev/measure_cls_attribution.mjs /posts/... --allow giscus.app
+ *   node scripts/dev/measure_cls_attribution.mjs /posts/... --scroll
+ *
+ * --scroll walks the page top-to-bottom before settling, because a shift below
+ * the fold is only recorded once it is in (or near) the viewport.
+ */
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const argv = process.argv.slice(2);
+const urlPath = argv.find((a) => a.startsWith('/'));
+if (!urlPath) {
+  console.error('usage: measure_cls_attribution.mjs /posts/YYYY/MM/DD/slug/ [--allow host] [--scroll]');
+  process.exit(2);
+}
+const allow = argv.reduce((acc, a, i) => (a === '--allow' && argv[i + 1] ? acc.concat(argv[i + 1]) : acc), []);
+const doScroll = argv.includes('--scroll');
+
+const SITE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '_site');
+if (!fs.existsSync(SITE)) {
+  console.error(`No _site at ${SITE} — build first.`);
+  process.exit(2);
+}
+
+const MIME = {
+  '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
+  '.woff2': 'font/woff2', '.svg': 'image/svg+xml', '.json': 'application/json',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.webp': 'image/webp', '.avif': 'image/avif',
+};
+
+const server = http.createServer((req, res) => {
+  const u = decodeURIComponent((req.url || '/').split('?')[0]);
+  const candidates = u.endsWith('/')
+    ? [path.join(SITE, u, 'index.html')]
+    : [path.join(SITE, u), path.join(SITE, u, 'index.html')];
+  for (const c of candidates) {
+    const r = path.resolve(c);
+    if (!r.startsWith(SITE)) continue;
+    if (fs.existsSync(r) && fs.statSync(r).isFile()) {
+      res.writeHead(200, { 'Content-Type': MIME[path.extname(r)] || 'application/octet-stream' });
+      return fs.createReadStream(r).pipe(res);
+    }
+  }
+  res.writeHead(404).end('nf');
+});
+await new Promise((r) => server.listen(0, '127.0.0.1', r));
+const base = `http://127.0.0.1:${server.address().port}`;
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({ viewport: { width: 1512, height: 827 } });
+await ctx.route('**/*', (route) => {
+  const url = route.request().url();
+  if (url.startsWith(base)) return route.continue();
+  if (allow.some((a) => url.includes(a))) return route.continue();
+  return route.abort();
+});
+const page = await ctx.newPage();
+
+// Record every shift with its sources. `sources` carries the nodes that MOVED,
+// which is exactly the distinction the field report could not make.
+await page.addInitScript(() => {
+  window.__cls = 0;
+  window.__entries = [];
+  const describe = (node) => {
+    if (!node || node.nodeType !== 1) return '(no node)';
+    const id = node.id ? `#${node.id}` : '';
+    const cls = node.className && typeof node.className === 'string'
+      ? '.' + node.className.trim().split(/\s+/).slice(0, 3).join('.')
+      : '';
+    return `${node.tagName}${id}${cls}`;
+  };
+  new PerformanceObserver((list) => {
+    for (const e of list.getEntries()) {
+      if (e.hadRecentInput) continue;
+      window.__cls += e.value;
+      window.__entries.push({
+        value: e.value,
+        t: Math.round(e.startTime),
+        sources: (e.sources || []).map((s) => ({
+          el: describe(s.node),
+          from: s.previousRect ? [Math.round(s.previousRect.y), Math.round(s.previousRect.height)] : null,
+          to: s.currentRect ? [Math.round(s.currentRect.y), Math.round(s.currentRect.height)] : null,
+        })),
+      });
+    }
+  }).observe({ type: 'layout-shift', buffered: true });
+});
+
+await page.goto(base + urlPath, { waitUntil: 'load', timeout: 60000 });
+await page.waitForTimeout(4000);
+
+if (doScroll) {
+  const h = await page.evaluate(() => document.documentElement.scrollHeight);
+  for (let y = 0; y < h; y += 700) {
+    await page.evaluate((yy) => window.scrollTo(0, yy), y);
+    await page.waitForTimeout(220);
+  }
+  await page.waitForTimeout(2500);
+}
+
+const total = await page.evaluate(() => window.__cls);
+const entries = await page.evaluate(() => window.__entries);
+
+console.log(`\nURL      : ${urlPath}`);
+console.log(`third-party allowed: ${allow.length ? allow.join(', ') : '(none — first-party floor)'}`);
+console.log(`scrolled : ${doScroll}`);
+console.log(`TOTAL CLS: ${total.toFixed(4)}   (${entries.length} shift entries)\n`);
+
+// Aggregate by element so the headline answer is "what moved, and how much".
+const byEl = new Map();
+for (const e of entries) {
+  for (const s of e.sources) {
+    byEl.set(s.el, (byEl.get(s.el) || 0) + e.value / Math.max(1, e.sources.length));
+  }
+}
+if (byEl.size) {
+  console.log('per-element share (a source is a node that MOVED, not necessarily the cause):');
+  [...byEl.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12)
+    .forEach(([el, v]) => console.log(`  ${v.toFixed(4)}  ${el}`));
+} else {
+  console.log('no shift sources recorded.');
+}
+
+const top = entries.slice().sort((a, b) => b.value - a.value).slice(0, 6);
+if (top.length) {
+  console.log('\nlargest individual shifts:');
+  for (const e of top) {
+    console.log(`  ${e.value.toFixed(4)} @ ${e.t}ms`);
+    for (const s of e.sources.slice(0, 4)) {
+      console.log(`      ${s.el}  y/h ${JSON.stringify(s.from)} -> ${JSON.stringify(s.to)}`);
+    }
+  }
+}
+console.log('');
+
+await browser.close();
+server.close();


### PR DESCRIPTION
## 결론: CLS 0.18의 원인은 댓글이 아니다. 댓글은 **밀린** 쪽이다.

필드 리포트:
```
[Performance] CLS is high: 0.179668
Cause: SECTION#comments.comments-section, NAV.post-navigation
```

`layout-shift` 엔트리의 `sources[]` 는 **움직인 노드**이고 **원인 노드가 아닙니다.** 무언가가 위에서 커지거나 접히면, 그 아래 전부가 source 로 보고됩니다.

## 측정 (로컬 프로덕션 빌드, 08-25 디제스트 포스트)

| # | 측정 | 결과 |
|---|---|---|
| 1 | 1st-party floor (서드파티 전면 차단, `--scroll`) | **CLS 0.0000**, shift 엔트리 **0건** |
| 2 | giscus.app 허용 | **CLS 0.0000**, 0건 |
| 3 | 수동 슬롯 예약→붕괴 (`measure_ad_collapse_cls.mjs`) | **0.0039**, 컨테이너 이미 `[0,0,0]` |
| 4 | **하네스 자체 검증** — 댓글 *위* 스페이서 100px→400px | **CLS 0.1744**, source = `SECTION#comments.comments-section` |

**4번이 결정적입니다.** 필드 리포트와 수치(0.1744 vs 0.179668)와 귀속 대상이 모두 일치하는데, 제가 한 것은 댓글을 건드린 게 아니라 **그 위를 300px 키운 것**입니다.

1·2번은 우리 마크업·CSS·`.giscus-wrapper` 의 `min-height:400px` 예약이 모두 정상임을 뜻합니다. 3번은 예약→붕괴 경로가 이미 해소돼 있음을 확인합니다(2026-08-14 수정이 유효).

## 그래서 원인은

주신 콘솔의 Auto ads 슬롯이 `ady=19148` (770×462) 와 `ady=20938` (770×90) — **네비게이션·댓글 바로 위**이고, 합계 552px 입니다. 4번에서 300px 성장이 0.1744 를 만들었으니 크기 규모가 맞습니다. 늦게 삽입되는 Auto ads 가 아래를 밀어내는 것이 남는 유일한 후보입니다.

## 왜 이 PR 은 코드를 고치지 않는가

Auto ads 배치는 **서버 결정 + 확률적**이라 로컬에서 재현할 수 없고, 레포에서 끌 수도 없습니다. 실제 완화책은 둘 다 **AdSense 대시보드 설정**입니다:

- Auto ads 를 끄고 예약 공간이 있는 수동 슬롯만 사용
- 또는 AdSense UI 의 "광고 게재 위치 제외"로 문서 하단 영역 제외

레포 변경으로 해결되지 않으므로 코드를 건드리지 않았습니다. 이 PR 은 **진단 도구 + 측정 근거**만 추가합니다.

## 기존 스크립트로는 왜 안 됐나

`measure_ad_collapse_cls.mjs` 는 단일 총합만 보고합니다 — "예약이 붕괴보다 나쁜가"라는 한 가지 질문에는 답하지만 **어느 요소가 움직였는지**는 말해주지 못하므로 필드 리포트를 검증할 수 없습니다. 이 하네스는 엔트리별 `sources[]` 와 before/after rect 를 출력합니다.

`--allow <substr>` 로 특정 서드파티만 통과시킬 수 있어(1번 vs 2번) giscus 기여분을 분리할 수 있습니다. 기본값은 1st-party 만이며, docstring 에 **"총합이 아니라 floor 로 읽어야 한다"** 를 명시했습니다.

## 검증

- `pytest scripts/tests/` — 4401 passed, 5 skipped
- **하네스가 0 이 아닌 값을 낼 수 있음을 먼저 증명했습니다** (4번). 0.0000 만 출력해 본 측정기는 검증된 적 없는 측정기입니다

## 함께 밝히는 우려 (#610 관련)

방금 머지한 #610 은 표 안 Auto ads 를 **제거**합니다. Google 이 삽입 → 페인트 → 우리가 제거 순서가 되면 그 제거 자체가 시프트입니다. 관찰자 경로는 삽입 시 microtask 로 즉시 처리하므로 대개 페인트 전이지만 **0 이라고 보장할 수는 없습니다.** 표가 광고로 쪼개지는 것보다는 낫다는 판단이었고, 다음 실측 때 확인할 항목으로 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
