### PR TITLE
fix(security): Gemini 키를 URL→헤더 + 예외 로그 마스킹 (2층)

### DIFF
--- a/scripts/ai_improve_posts.py
+++ b/scripts/ai_improve_posts.py
@@ -419,8 +419,11 @@ def improve_with_gemini(post_info: Dict) -> Optional[str]:
 원본 포스트: {original_url}
 """
 
-        # URL에 API 키가 포함되므로 로그에 기록 시 마스킹 필요
-        url = f"{GEMINI_API_URL}?key={GEMINI_API_KEY}"
+        # 키는 헤더로 보낸다 — URL 에 실으면 requests 예외 문자열이 URL 을
+        # 그대로 담아 공개 Actions 로그로 새어나간다. 마스킹은 로그 호출마다
+        # 기억해야 하는 규율이고, 헤더는 그 경로 자체를 없앤다.
+        url = GEMINI_API_URL
+        headers = {"x-goog-api-key": GEMINI_API_KEY}
 
         data = {
             "contents": [{"parts": [{"text": prompt}]}],
@@ -432,7 +435,7 @@ def improve_with_gemini(post_info: Dict) -> Optional[str]:
             },
         }
 
-        response = requests.post(url, json=data, timeout=60)
+        response = requests.post(url, headers=headers, json=data, timeout=60)
 
         if response.status_code == 200:
             result = response.json()

--- a/scripts/generate_missing_diagrams.py
+++ b/scripts/generate_missing_diagrams.py
@@ -166,7 +166,11 @@ def generate_image_with_gemini(
             api_url = (
                 GEMINI_IMAGE_PRO_API_URL if USE_PRO_MODEL else GEMINI_IMAGE_API_URL
             )
-            url = f"{api_url}?key={GEMINI_API_KEY}"
+            # 키는 헤더로. URL 에 실으면 requests 예외 문자열이 URL 을 그대로
+            # 담아 공개 Actions 로그로 새어나간다 — "URL 을 로그에 찍지 말 것"
+            # 이라는 규율에만 의존하지 않고 경로 자체를 없앤다.
+            url = api_url
+            headers = {"x-goog-api-key": GEMINI_API_KEY}
 
             # Security: Don't log URL with API key
             log_message("🎨 Gemini API로 이미지 생성 시도 중...")
@@ -180,7 +184,7 @@ def generate_image_with_gemini(
                 },
             }
 
-            response = requests.post(url, json=data, timeout=120)
+            response = requests.post(url, headers=headers, json=data, timeout=120)
 
             if response.status_code == 200:
                 result = response.json()

--- a/scripts/generate_post_images.py
+++ b/scripts/generate_post_images.py
@@ -607,7 +607,11 @@ def generate_image_with_gemini(
             api_url = (
                 GEMINI_IMAGE_PRO_API_URL if USE_PRO_MODEL else GEMINI_IMAGE_API_URL
             )
-            url = f"{api_url}?key={GEMINI_API_KEY}"
+            # 키는 헤더로. URL 에 실으면 requests 예외 문자열이 URL 을 그대로
+            # 담아 공개 Actions 로그로 새어나간다 — "URL 을 로그에 찍지 말 것"
+            # 이라는 규율에만 의존하지 않고 경로 자체를 없앤다.
+            url = api_url
+            headers = {"x-goog-api-key": GEMINI_API_KEY}
 
             log_message("🎨 Gemini API로 이미지 생성 시도 중...")
             log_message(
@@ -624,7 +628,7 @@ def generate_image_with_gemini(
                 },
             }
 
-            response = requests.post(url, json=data, timeout=120)
+            response = requests.post(url, headers=headers, json=data, timeout=120)
 
             if response.status_code == 200:
                 result = response.json()

--- a/scripts/news/enhancer.py
+++ b/scripts/news/enhancer.py
@@ -97,9 +97,17 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
     try:
         import requests
 
+        # 키는 헤더로 보낸다(x-goog-api-key). 쿼리스트링에 실으면 URL 자체가
+        # 비밀이 되어, requests 예외 문자열이 그 URL 을 그대로 담는다 —
+        # 아래 `except Exception as e: logging.warning(f"... {e}")` 가 공개
+        # 리포의 Actions 로그에 키를 찍는다는 뜻이다(실측 확인).
+        # 헤더로 옮기면 그 경로가 통째로 사라진다.
+        # 검증: fake 키를 헤더로 보내면 400 "API key not valid",
+        # 키 없이 보내면 403 "unregistered callers" — 헤더가 읽힌다는 대조군.
         response = requests.post(
             f"https://generativelanguage.googleapis.com/v1beta/models/"
-            f"{_cfg._GEMINI_MODEL}:generateContent?key={_cfg._GEMINI_API_KEY}",
+            f"{_cfg._GEMINI_MODEL}:generateContent",
+            headers={"x-goog-api-key": _cfg._GEMINI_API_KEY},
             json={"contents": [{"parts": [{"text": prompt}]}]},
             timeout=timeout,
         )
@@ -117,11 +125,13 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
             # WARNING while gemini-2.0-flash 404'd on every single call for
             # weeks, so the primary translator's death never surfaced. Name the
             # override so the fix is obvious from the log alone.
-            # The response body is deliberately NOT logged. The request URL
-            # carries ?key=<API key>, so an error body that echoes the request
-            # would put the key in a public Actions log — CodeQL
-            # py/clear-text-logging-sensitive-data flags exactly that path. The
-            # model id and the remediation are the whole diagnosis anyway.
+            # The response body is still not logged, but the reason has
+            # changed: the key now travels in the x-goog-api-key header, so the
+            # URL is no longer a secret and an echoed request could not leak it.
+            # It stays out because the model id and the remediation are the
+            # whole diagnosis — the body adds noise, not information. Measured:
+            # a bad key answers "API key not valid. Please pass a valid API
+            # key." and never echoes the key itself.
             logging.error(
                 "Gemini model '%s' returned 404 (retired, or not enabled for this "
                 "key) - the Gemini path is dead for this whole run. Set "

--- a/scripts/news/enhancer.py
+++ b/scripts/news/enhancer.py
@@ -7,6 +7,7 @@ import time
 from typing import Dict, Optional
 
 import scripts.news.config as _cfg
+from scripts.lib.security import mask_sensitive_info
 
 # A transport fault on the runner -> DeepSeek path costs the item its Korean
 # text: the call returns "" and the caller falls through to the English
@@ -59,7 +60,16 @@ def post_with_retry(
                 attempt + 1,
                 _TRANSIENT_RETRIES,
             )
-    logging.warning("%s failed after %d attempts: %s", label, _TRANSIENT_RETRIES + 1, last_error)
+    # Masked: last_error may be a requests exception, and urllib3 embeds the
+    # full request URL in the MaxRetryError family. This helper is generic — a
+    # future caller may pass an endpoint that still carries a credential in its
+    # query string, so mask at the sink rather than trusting every call site.
+    logging.warning(
+        "%s failed after %d attempts: %s",
+        label,
+        _TRANSIENT_RETRIES + 1,
+        mask_sensitive_info(str(last_error)),
+    )
     return None
 
 
@@ -145,7 +155,7 @@ def _gemini_api_call(prompt: str, timeout: int = 20) -> str:
     except ImportError:
         logging.debug("requests library not available for Gemini API")
     except Exception as e:
-        logging.warning(f"Gemini API error: {e}")
+        logging.warning("Gemini API error: %s", mask_sensitive_info(str(e)))
 
     return ""
 
@@ -172,7 +182,7 @@ def _gemini_call(prompt: str, timeout: int = 35) -> str:
             logging.warning(f"Gemini CLI timeout ({timeout}s)")
         except (subprocess.SubprocessError, OSError) as e:
             _cfg._GEMINI_CONSECUTIVE_FAILURES += 1
-            logging.warning(f"Gemini CLI error: {e}")
+            logging.warning("Gemini CLI error: %s", mask_sensitive_info(str(e)))
 
     if _cfg._GEMINI_API_KEY and _cfg._GEMINI_CONSECUTIVE_FAILURES > 0:
         api_timeout = min(timeout, 20)
@@ -295,7 +305,7 @@ def enhance_with_deepseek(item: Dict) -> str:
     except Exception as e:
         # Transport faults are handled (and retried) inside post_with_retry;
         # anything reaching here is a response-shaping bug, not a flaky network.
-        logging.warning(f"DeepSeek API error: {e}")
+        logging.warning("DeepSeek API error: %s", mask_sensitive_info(str(e)))
 
     return ""
 
@@ -359,7 +369,7 @@ def enhance_with_claude(item: Dict) -> str:
     except ImportError:
         logging.warning("requests library not available for Claude API")
     except Exception as e:
-        logging.warning(f"Claude API error: {e}")
+        logging.warning("Claude API error: %s", mask_sensitive_info(str(e)))
 
     return ""
 
@@ -422,7 +432,7 @@ def enhance_with_openai_codex_medium(item: Dict) -> str:
     except ImportError:
         logging.warning("requests library not available for OpenAI API")
     except Exception as e:
-        logging.warning(f"OpenAI API error: {e}")
+        logging.warning("OpenAI API error: %s", mask_sensitive_info(str(e)))
 
     return ""
 
@@ -487,7 +497,7 @@ def enhance_with_openai_gpt54(item: Dict) -> str:
     except ImportError:
         logging.warning("requests library not available for OpenAI API")
     except Exception as e:
-        logging.warning(f"OpenAI GPT-5.4 API error: {e}")
+        logging.warning("OpenAI GPT-5.4 API error: %s", mask_sensitive_info(str(e)))
 
     return ""
 

--- a/scripts/tests/test_api_key_not_in_url.py
+++ b/scripts/tests/test_api_key_not_in_url.py
@@ -124,3 +124,62 @@ class TestTheFixedCallSitesUseHeaders:
             "removed entirely, drop it from this list in the same commit and say "
             "why; otherwise the key is back in the URL."
         )
+
+class TestExceptionLogsAreMasked:
+    """Second layer, added after review: mask at the sink too.
+
+    Keeping the key out of the URL (above) closes the Gemini path. This closes
+    the *class*, because the leak is a property of ``requests``, not of one
+    endpoint: urllib3 embeds the full request URL in the MaxRetryError family.
+    Measured which failures actually carry it —
+
+        DNS failure / connection refused / invalid schema -> URL in str(e)
+        read timeout / connection reset                   -> no URL
+
+    — which is why this never surfaced: every exception logged across the last
+    20 blogwatcher runs was a read timeout or ConnectionResetError(104). The
+    leak path is latent, not realized. A runner DNS flake is enough to realize
+    it.
+
+    ``post_with_retry`` is the reason to mask rather than rely on call sites: it
+    is generic, and a future caller may pass an endpoint that does carry a
+    credential in its query string.
+
+    The image generators already did this — they log through ``log_message``,
+    which applies ``mask_sensitive_info`` unconditionally
+    (scripts/lib/logging_utils.py). ``enhancer.py`` was the one module touching
+    a key-bearing URL that logged raw.
+    """
+
+    def test_masker_neutralises_the_exact_urllib3_leak_string(self):
+        from scripts.lib.security import mask_sensitive_info
+
+        key = "AIza" + "S" * 35  # real Google keys are AIza + 35 chars
+        leak = (
+            "HTTPSConnectionPool(host='generativelanguage.googleapis.com', "
+            "port=443): Max retries exceeded with url: "
+            f"/v1beta/models/gemini-2.5-flash:generateContent?key={key} "
+            "(Caused by NewConnectionError(...))"
+        )
+        out = mask_sensitive_info(leak)
+        assert key not in out, f"masker left the key in: {out}"
+        assert "MASKED" in out
+
+    def test_enhancer_masks_every_exception_it_logs(self):
+        """A raw f-string of an exception is the shape that leaked."""
+        src = (REPO_ROOT / "scripts" / "news" / "enhancer.py").read_text("utf-8")
+        code = [
+            ln for ln in src.splitlines() if not ln.lstrip().startswith("#")
+        ]
+        raw = [
+            ln.strip()
+            for ln in code
+            if "logging." in ln and ("{e}" in ln or "{last_error}" in ln)
+        ]
+        assert not raw, (
+            "enhancer.py logs an exception without mask_sensitive_info: "
+            f"{raw}. requests exceptions can embed the full request URL."
+        )
+        assert "mask_sensitive_info" in src, (
+            "enhancer.py no longer imports the masker"
+        )

--- a/scripts/tests/test_api_key_not_in_url.py
+++ b/scripts/tests/test_api_key_not_in_url.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Regression guard: an API key must never be built into a request URL.
+
+Why this exists
+---------------
+`scripts/news/enhancer.py` used to call the Gemini REST API as
+``…:generateContent?key={_GEMINI_API_KEY}``. That makes the URL itself a secret,
+and a URL is far leakier than a header:
+
+- ``requests`` stringifies the full URL into its exception messages. Measured:
+
+      >>> requests.post("https://127.0.0.1:9/...?key=<KEY>", timeout=2)
+      ConnectionError: HTTPSConnectionPool(host='127.0.0.1', port=9):
+        Max retries exceeded with url: /...?key=<KEY> (Caused by ...)
+
+  and `enhancer.py` logged exactly that object (``logging.warning(f"… {e}")``).
+  This repo is PUBLIC, so Actions logs are public.
+- CodeQL's `py/clear-text-logging-sensitive-data` flagged the neighbouring
+  *response body* log and it was dismissed as a false positive. That dismissal
+  was correct about the body — a bad key answers "API key not valid. Please
+  pass a valid API key." and never echoes the key. What nobody checked was the
+  exception line two lines below, which is the real exposure.
+
+The lesson, and why this is a path-shaped guard rather than a log-shaped one:
+masking at each log call is a discipline you must remember every time. Keeping
+the key out of the URL removes the whole class — exceptions, redirects, proxy
+logs, Referer, retry traces.
+
+Google accepts the header form; verified against the live endpoint with a
+control:
+
+    header x-goog-api-key + fake key -> 400 "API key not valid"      (header read)
+    no key at all                    -> 403 "unregistered callers"   (control)
+
+Direction: ABSENCE assertion. Adding a key back into a URL trips it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# `key=` immediately after ? or & followed by an interpolation of something
+# key-shaped. Deliberately narrow: a literal `?key=` in a docstring or a test
+# fixture is not a finding, an f-string splicing a credential is.
+_KEY_IN_URL = re.compile(
+    r"""[?&]key=\{[^}]*(?:KEY|TOKEN|SECRET|_key|_token)[^}]*\}""",
+    re.IGNORECASE,
+)
+
+# The masking helper and its own tests legitimately contain the pattern as data.
+_EXEMPT = {
+    "scripts/lib/security.py",
+    "scripts/tests/test_lib_security.py",
+    "scripts/tests/test_api_key_not_in_url.py",
+}
+
+
+def _python_sources() -> list[Path]:
+    """Every Python source that must not embed a credential in a URL.
+
+    Exempt files are filtered out HERE rather than skipped inside the test. A
+    skip whose reason is a static fact about the repo reports nothing and is
+    rejected by test_skip_path_policy.py — correctly: if the exemption list
+    goes stale, an absent parametrize case is honest whereas a green skip is
+    not.
+    """
+    out: list[Path] = []
+    for d in ("scripts", "api"):
+        root = REPO_ROOT / d
+        if root.is_dir():
+            out.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+    return sorted(
+        p for p in out if p.relative_to(REPO_ROOT).as_posix() not in _EXEMPT
+    )
+
+
+def _code_lines(path: Path) -> list[tuple[int, str]]:
+    """Line number + text, comment-only lines dropped.
+
+    The fixed call sites explain the hazard in prose and name the old
+    `?key=<API key>` shape on purpose. Matching raw text would flag the
+    explanation and, worse, would keep passing if someone deleted the comment
+    while reintroducing the bug.
+    """
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return [
+        (i + 1, ln) for i, ln in enumerate(lines) if not ln.lstrip().startswith("#")
+    ]
+
+
+@pytest.mark.parametrize("path", _python_sources(), ids=lambda p: str(p.name))
+def test_no_credential_interpolated_into_a_url(path: Path):
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    hits = [(n, ln.strip()) for n, ln in _code_lines(path) if _KEY_IN_URL.search(ln)]
+    assert not hits, (
+        f"{rel} builds a credential into a request URL: {hits}\n"
+        "A URL carrying a key leaks through requests' exception strings (which "
+        "this repo logs, publicly). Send it as a header instead — Gemini "
+        "accepts x-goog-api-key."
+    )
+
+
+class TestTheFixedCallSitesUseHeaders:
+    """Pin the four sites that were converted, so none silently reverts."""
+
+    @pytest.mark.parametrize(
+        "rel",
+        [
+            "scripts/news/enhancer.py",
+            "scripts/ai_improve_posts.py",
+            "scripts/generate_post_images.py",
+            "scripts/generate_missing_diagrams.py",
+        ],
+    )
+    def test_site_sends_the_key_as_a_header(self, rel: str):
+        src = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "x-goog-api-key" in src, (
+            f"{rel} no longer sends the Gemini key as a header. If the call was "
+            "removed entirely, drop it from this list in the same commit and say "
+            "why; otherwise the key is back in the URL."
+        )


### PR DESCRIPTION
## 재triage 결론: dismiss 판정은 **본문에 대해서는 옳았다**

CodeQL `py/clear-text-logging-sensitive-data` (high) 가 잡고 dismiss 된 라인:

```python
logging.warning(f"Gemini API status {response.status_code}: {response.text[:100]}")
```

**이 판정은 유지합니다 — 실측으로 확인했습니다.** 잘못된 키는 `{"error":{code,message,status,details}}` 엔벌로프만 반환하며 키·URL·`key=` 파라미터를 에코하지 않습니다. `details[].fieldViolations` 는 요청 **payload** 를 되울리는데 키는 payload 에 없습니다. 이 라인은 건드리지 않았습니다 — 본문을 지우면 `gemini-2.0-flash` 404 가 몇 주간 묻혔던 실패를 반복합니다.

**아무도 확인하지 않은 것은 두 줄 아래의 예외 로그입니다.**

## 실제 노출: 잠재적이지만 실재

`urllib3` 은 **MaxRetryError 계열**에 요청 URL 전체를 담습니다. 어떤 실패가 실제로 URL 을 싣는지 실측했습니다:

| 실패 유형 | `str(e)` 에 URL·키 포함 |
|---|---|
| DNS 해석 실패 | **YES** |
| 연결 거부 | **YES** |
| invalid schema | **YES** |
| read timeout | no |
| connection reset (08-25 실제 장애) | no |

그리고 `enhancer.py` 가 바로 그 객체를 `logging.warning(f"Gemini API error: {e}")` 로 찍었습니다. 리포는 **PUBLIC** 이라 Actions 로그가 공개입니다.

**정정:** 최근 20회 blogwatcher 실행에서 기록된 예외는 **전부** read timeout 또는 `ConnectionResetError(104)` — MaxRetryError 는 0건입니다. 즉 이 경로는 **잠재적이고 실현된 적이 없습니다.** 초기 PR 본문의 "the real leak" 표현은 과했습니다. 러너 DNS 순간장애 한 번으로 실현되므로 고칠 값은 있지만, 지금 새고 있다는 뜻은 아닙니다.

GitHub 시크릿 마스킹도 완화에 기여합니다 — 6개 대입 전부 `secrets.GEMINI_API_KEY` 출처라 값이 등록돼 있고, 마스킹은 substring 기반이므로 URL 안의 키도 가려집니다. (이 마지막 항목은 GitHub 문서 기반이며 **테스트하지 못했습니다** — 검증하려면 실제 키를 의도적으로 유출해야 합니다.)

## 두 번째 정정: 이미지 생성기는 원래 누출이 아니었다

`generate_post_images.py` / `generate_missing_diagrams.py` 는 예외를 `log_message` 로 찍고, 그 함수는 `mask_sensitive_info` 를 **무조건** 적용합니다 (`scripts/lib/logging_utils.py`, 코드 확인). 즉 이 두 곳은 이미 보호되고 있었습니다.

**`enhancer.py` 만이 키를 실은 URL 을 만지면서 raw 로 로깅한 유일한 모듈입니다.** 초기 커밋이 4개 지점 전부를 노출로 함의한 것은 과장이었습니다.

## 변경 (2층)

**1층 — 키를 URL 에서 제거** (`x-goog-api-key` 헤더, 4개 지점). 두 엔드포인트 모두 **대조군과 함께 실측**:

| 엔드포인트 | 헤더+fake키 | 키 없음 (대조군) |
|---|---|---|
| `gemini-2.5-flash:generateContent` | `400 "API key not valid"` | `403 "unregistered callers"` |
| `gemini-2.5-flash-image:generateContent` | `400 "API key not valid"` | `403 "unregistered callers"` |

이미지 엔드포인트도 확인했으므로 그 3개 지점 변경은 이제 **추론이 아니라 검증된** 상태입니다(누출을 막는 것은 아니고 다층 방어).

**2층 — sink 에서 마스킹** (리뷰 반영). `enhancer.py` 의 예외 로그 6곳 + `post_with_retry` 의 `last_error` 를 `mask_sensitive_info` 경유로. 이유: 누출은 엔드포인트가 아니라 `requests` 의 속성이고, `post_with_retry` 는 범용 헬퍼라 앞으로 쿼리스트링에 자격증명을 싣는 엔드포인트에 쓰일 수 있습니다. 호출자를 믿지 말고 sink 에서 막습니다. 이미지 생성기가 이미 쓰던 레포 관례입니다.

## 회귀 가드

`scripts/tests/test_api_key_not_in_url.py`
- URL 에 자격증명을 f-string 으로 끼워넣는 패턴 금지 (`scripts/`·`api/` 전체)
- 4개 지점이 `x-goog-api-key` 를 계속 쓰는지
- `enhancer.py` 가 예외를 raw f-string 으로 찍지 않는지
- 마스커가 **실제 누출 문자열**을 무력화하는지 (AIza+35자 키 → `***MASKED***`)

면제 파일은 `pytest.skip` 이 아니라 parametrize 목록에서 제외합니다. 처음엔 skip 으로 썼다가 레포의 `test_skip_path_policy.py` 가 정확히 거부했습니다 — 정적 사실에 대한 skip 은 아무것도 보고하지 않습니다.

## 검증

- `pytest scripts/tests/` — **4830 passed, 5 skipped**
- 변이 3종 검출: 키를 URL 로 되돌림 / 예외 로그를 raw f-string 으로 복귀 / (가드 자체)
- `ruff` — 변경 파일 clean

## 미조치 (보고만)

`scripts/monitor_vercel_builds.sh:154` 는 `PAGESPEED_API_KEY` 를 URL 에 싣고 `monitoring.yml:51` 로 CI 배선돼 있으나 **바꾸지 않았습니다**: 해당 시크릿이 리포에 미등록이라 `[ -n "$PAGESPEED_API_KEY" ]` 분기가 죽어 있고, `curl -s ... 2>/dev/null` 이라 URL 이 찍히지 않습니다. PageSpeed API 의 헤더 수용을 검증하지 않았고, 휴면 경로를 눈감고 바꾸는 것은 이 레포가 반복적으로 대가를 치른 실수입니다.

## 사람 검토 필요 (§5B)

시크릿 취급 코드 변경입니다. 테스트 통과와 무관하게 **사람 검토 대기**로 보고합니다. 실제 키로 end-to-end 호출은 검증하지 못했습니다(로컬에 키 없음) — 확인한 것은 두 엔드포인트가 헤더를 키로 **읽는다**는 사실까지입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 실제 키 end-to-end 검증 완료 (2026-08-25, 머지 직전 추가)

이전 본문의 "실제 키로 end-to-end 호출은 검증하지 못했습니다" 항목을 해소했습니다. 두 엔드포인트 모두 **유효한 키**로 성공 응답을 확인했습니다.

**텍스트 엔드포인트** — run [`32823685680`](https://github.com/Twodragon0/tech-blog/actions/runs/32823685680) (`ai-blogwatcher`, `use_ai=auto`, `dry_run=true`, 이 브랜치 기준):

| 신호 | 건수 |
|---|---|
| `Gemini enhanced` (REST 성공) | **2** |
| `Gemini API status` (non-200) | 0 |
| `API key not valid` | 0 |
| `circuit breaker` / `Template fallback` | 0 |

`use_ai=auto` 라 CLI shim 이 설치되지 않고(`Gemini CLI error: No such file`) REST 로만 갑니다. 즉 이 2건은 `_gemini_api_call` — 헤더를 쓰는 바로 그 코드 경로입니다.

**이미지 엔드포인트** — run [`32823270550`](https://github.com/Twodragon0/tech-blog/actions/runs/32823270550) (`generate-images`, `use_api=true`, `force=true`, 이 브랜치 기준):

```
📡 Mode: Gemini API (with SVG fallback)
🎨 Gemini API로 이미지 생성 시도 중...  모델: Gemini 2.5 Flash Image (Nano Banana)
✅ 이미지 생성 완료: ....png (1173245 bytes)
```

1.17 MB PNG 가 실제로 반환됐습니다. 해당 워크플로의 커밋 스텝은 `github.event_name == 'push'` 로 게이트돼 있어 dispatch 실행은 아무것도 커밋하지 않습니다.

**직접 실행되지 않은 2개 지점**: `ai_improve_posts.py` 는 위에서 검증된 것과 **동일한 텍스트 엔드포인트**를, `generate_missing_diagrams.py` 는 **동일한 이미지 엔드포인트 상수**를 같은 헤더 형태로 씁니다. 개별 실행은 아니지만 형제 지점이 검증된 추론입니다.

**부수 관찰**: 이미지 런 로그에 포스트 파일명이 `2026-08-***MASKED***.md` 로 찍힙니다. `mask_sensitive_info` 가 파일명을 과도하게 마스킹하는 기존 동작이며(이 PR 이 만든 것이 아님) 로그 가독성을 떨어뜨립니다. 동시에 리뷰가 지적한 "이미지 생성기는 `log_message` 로 이미 마스킹된다"는 주장을 실측으로 확인해 줍니다.
