### PR TITLE
feat(dev): CLS 하네스 --origin 라이브 모드 — 로컬 floor로는 AdSense 변경을 검증할 수 없다

### DIFF
--- a/scripts/dev/measure_cls_attribution.mjs
+++ b/scripts/dev/measure_cls_attribution.mjs
@@ -40,11 +40,25 @@
  * Use measure_ad_collapse_cls.mjs for that half, and read this one as
  * "first-party floor", not "total".
  *
+ * Measuring an AdSense change requires --origin
+ * ---------------------------------------------
+ * The local mode above cannot validate an AdSense dashboard change (Auto ads
+ * off, or a bottom-of-document placement exclusion). It aborts third party, so
+ * ads never load and the number is 0.0000 whether or not the setting changed.
+ * That is a floor, and a floor cannot show an improvement.
+ *
+ * --origin <url> points the same instrumentation at the deployed site with ALL
+ * third party allowed, which is the only place an Auto ads placement decision
+ * is observable. Costs: the number is stochastic (fill varies per load), so run
+ * it several times and read the distribution, not one value.
+ *
  * Usage:
  *   JEKYLL_ENV=production bundle exec jekyll build -d _site
  *   node scripts/dev/measure_cls_attribution.mjs /posts/2026/08/25/Some_Slug/
  *   node scripts/dev/measure_cls_attribution.mjs /posts/... --allow giscus.app
  *   node scripts/dev/measure_cls_attribution.mjs /posts/... --scroll
+ *   node scripts/dev/measure_cls_attribution.mjs /posts/... --scroll \
+ *       --origin https://tech.2twodragon.com          # live, ads included
  *
  * --scroll walks the page top-to-bottom before settling, because a shift below
  * the fold is only recorded once it is in (or near) the viewport.
@@ -59,15 +73,21 @@ import { fileURLToPath } from 'node:url';
 const argv = process.argv.slice(2);
 const urlPath = argv.find((a) => a.startsWith('/'));
 if (!urlPath) {
-  console.error('usage: measure_cls_attribution.mjs /posts/YYYY/MM/DD/slug/ [--allow host] [--scroll]');
+  console.error('usage: measure_cls_attribution.mjs /posts/YYYY/MM/DD/slug/ [--allow host] [--scroll] [--origin https://host]');
   process.exit(2);
 }
 const allow = argv.reduce((acc, a, i) => (a === '--allow' && argv[i + 1] ? acc.concat(argv[i + 1]) : acc), []);
 const doScroll = argv.includes('--scroll');
+const originIdx = argv.indexOf('--origin');
+const origin = originIdx !== -1 ? argv[originIdx + 1] : null;
+if (originIdx !== -1 && !origin) {
+  console.error('--origin needs a URL, e.g. --origin https://tech.2twodragon.com');
+  process.exit(2);
+}
 
 const SITE = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '_site');
-if (!fs.existsSync(SITE)) {
-  console.error(`No _site at ${SITE} — build first.`);
+if (!origin && !fs.existsSync(SITE)) {
+  console.error(`No _site at ${SITE} — build first, or pass --origin <url>.`);
   process.exit(2);
 }
 
@@ -92,12 +112,21 @@ const server = http.createServer((req, res) => {
   }
   res.writeHead(404).end('nf');
 });
-await new Promise((r) => server.listen(0, '127.0.0.1', r));
-const base = `http://127.0.0.1:${server.address().port}`;
+let base;
+if (origin) {
+  base = origin.replace(/\/$/, '');
+} else {
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  base = `http://127.0.0.1:${server.address().port}`;
+}
 
 const browser = await chromium.launch();
 const ctx = await browser.newContext({ viewport: { width: 1512, height: 827 } });
 await ctx.route('**/*', (route) => {
+  // Live mode measures what a reader actually gets, so nothing is blocked —
+  // blocking the ad script is precisely what would hide the thing being
+  // measured. Local mode stays deny-by-default plus --allow.
+  if (origin) return route.continue();
   const url = route.request().url();
   if (url.startsWith(base)) return route.continue();
   if (allow.some((a) => url.includes(a))) return route.continue();
@@ -151,7 +180,11 @@ const total = await page.evaluate(() => window.__cls);
 const entries = await page.evaluate(() => window.__entries);
 
 console.log(`\nURL      : ${urlPath}`);
-console.log(`third-party allowed: ${allow.length ? allow.join(', ') : '(none — first-party floor)'}`);
+console.log(
+  origin
+    ? `mode     : LIVE ${base} — all third party allowed (stochastic; repeat runs)`
+    : `mode     : LOCAL _site, third-party allowed: ${allow.length ? allow.join(', ') : '(none — first-party floor, cannot show an ads change)'}`
+);
 console.log(`scrolled : ${doScroll}`);
 console.log(`TOTAL CLS: ${total.toFixed(4)}   (${entries.length} shift entries)\n`);
 
@@ -183,4 +216,4 @@ if (top.length) {
 console.log('');
 
 await browser.close();
-server.close();
+if (!origin) server.close();


### PR DESCRIPTION
## 문제: 요청받은 측정으로는 AdSense 변경을 검증할 수 없다

`measure_cls_attribution.mjs` 의 로컬 모드는 서드파티를 **전부 차단**합니다. 광고가 아예 로드되지 않으므로 AdSense 대시보드 변경(Auto ads 끄기 / 하단 게재 제외) **전후로 결과가 0.0000 으로 동일**합니다. floor 는 개선을 보여줄 수 없습니다.

실제로 요청받은 명령을 현재 main 에서 돌린 결과:

```
mode     : LOCAL _site, third-party allowed: (none — first-party floor)
TOTAL CLS: 0.0000   (0 shift entries)
```

#610/#611 머지 후에도 1st-party floor 는 여전히 깨끗합니다(그 자체는 유의미한 회귀 확인). 하지만 광고에 대해서는 아무것도 말해주지 않습니다.

## 변경: `--origin <url>` 라이브 모드

같은 계측을 **배포된 사이트**에 붙이고 서드파티를 전부 허용합니다. Auto ads 배치 결정이 관측 가능한 유일한 지점입니다. 로컬 모드는 기존대로 deny-by-default + `--allow` 를 유지합니다.

```
node scripts/dev/measure_cls_attribution.mjs /posts/... --scroll \
    --origin https://tech.2twodragon.com
```

광고 게재가 확률적이므로 **여러 번 돌려 분포를 읽으라**고 docstring 에 명시했습니다.

## 실측 (08-25 디제스트)

| 모드 | 결과 |
|---|---|
| LOCAL floor | **0.0000** (엔트리 0건) |
| LIVE 5회 | **0.0172 / 0.0046 / 0.0046 / 0.0016 / 0.0031** |
| 최대 기여 | `DIV.post-content` (y/h `[0,0] -> [651,176]`) |

## 그런데 라이브 랩도 리더의 0.1797을 재현하지 못한다

5회 전부 0.02 미만입니다. 이것은 이미 레포에 기록된 랩/필드 divergence 그대로입니다 — `measure_ad_collapse_cls.mjs` 헤더:

> lab runs kept reporting CLS 0.0000 while a real reader saw 0.20

헤드리스에서는 광고가 unfilled 되어(주신 콘솔의 400 들과 동일) 큰 삽입이 일어나지 않습니다.

## 결론: AdSense 변경의 권위 있는 신호는 필드다 — 그리고 그 파이프라인은 죽어 있다

```
$ python3 scripts/check_runtime_env_contract.py --vercel
[runtime-env] FAIL
  GA4_API_SECRET
    api/vitals.js — 절대 시: 모든 web_vitals 비콘이 폐기되고
    엔드포인트는 여전히 204 를 반환해 수집이 동작하는 것처럼 읽힘
```

즉 **현재는 AdSense 변경을 랩으로도 필드로도 검증할 수 없습니다.** 이 PR 은 랩 절반을 가능하게 만들고, 필드 절반이 막혀 있다는 사실을 드러냅니다.

검증 순서 제안:
1. `GA4_API_SECRET` 프로비저닝 (런북: `docs/setup/VERCEL_ENV_SETUP.md`) — 또는 Vercel Speed Insights CLS 사용(10% 샘플링)
2. AdSense 하단 Auto ads 제외 적용
3. 필드 CLS 변화 확인. 라이브 랩(`--origin`)은 보조 지표로만

## 검증

- `pytest scripts/tests/` — 4401 passed, 5 skipped
- 로컬 모드 회귀 없음 (위 A/B 실행 확인), 라이브 모드 5회 실행
- 스크립트 단독 실행 시 usage 정상 출력

## 범위

측정 도구만 추가합니다. 사이트 코드는 건드리지 않았습니다 — Auto ads 배치는 서버 결정이라 레포에서 끌 수 없고, 완화책은 AdSense 대시보드 설정입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
