### PR TITLE
docs(setup): GA4_API_SECRET 미설정 근거를 2026-08-25로 재확인

### DIFF
--- a/docs/setup/VERCEL_ENV_SETUP.md
+++ b/docs/setup/VERCEL_ENV_SETUP.md
@@ -35,7 +35,7 @@ Redis를 쓰는 것은 아니다(위 표의 `USE_UPSTASH_RATELIMIT` 참조).
 
 `web_vitals` 수집은 이 값 없이는 **0건**이다. PR #558·#586이 gtag 배치 유실을
 없애려고 퍼스트파티 비콘으로 옮겼지만, 시크릿이 없어 그 파이프라인은 아직 아무것도
-수집하지 않았다. 근거: `vercel env ls production`에 이름이 없음(2026-08-24).
+수집하지 않았다. 근거: `vercel env ls production`에 이름이 없음(2026-08-24 최초 확인, **2026-08-25 재확인** — production 목록은 `SENTRY_DSN`, `REDIS_URL`, `BLOB_READ_WRITE_TOKEN`, `PRISMA_DATABASE_URL`, `DATABASE_URL`, `POSTGRES_URL`, `DEEPSEEK_API_KEY` 뿐이다). `scripts/check_runtime_env_contract.py --vercel` 도 같은 날 FAIL 을 반환했다.
 
 1. **GA4에서 값 생성**
    Google Analytics → **Admin** → **Data streams** → 웹 스트림 선택 →


### PR DESCRIPTION
## 요청과 실제로 한 일

`GA4_API_SECRET` 프로비저닝을 요청받았습니다. **완료하지 못했습니다** — 1단계가 GA4 Admin → Data streams → Measurement Protocol API secrets → **Create** 이고, 이는 시크릿 값 생성이라 제가 수행할 수 없습니다. 값을 만들 수도, 읽을 수도 없습니다.

대신 런북의 사실 주장이 지금도 유효한지 재검증하고 날짜 근거만 갱신했습니다.

## 재확인 결과 (2026-08-25)

`vercel env ls production` (이름만, 값 미노출):

```
SENTRY_DSN, REDIS_URL, BLOB_READ_WRITE_TOKEN, PRISMA_DATABASE_URL,
DATABASE_URL, POSTGRES_URL, DEEPSEEK_API_KEY
```

`GA4_API_SECRET` 없음. `scripts/check_runtime_env_contract.py --vercel` 도 같은 날 FAIL:

```
[runtime-env] FAIL
  GA4_API_SECRET
    api/vitals.js — 절대 시 모든 web_vitals 비콘 폐기, 엔드포인트는 204 반환
```

즉 `web_vitals` 수집은 여전히 0건이고, 204 때문에 정상처럼 보이는 상태도 그대로입니다.

## 남은 작업 (사용자 액션)

런북 내용은 정확하므로 절차는 손대지 않았습니다. 순서만 옮겨 적으면:

1. GA4 → Admin → Data streams → 웹 스트림 → Measurement Protocol API secrets → **Create**, 값 복사
2. `vercel env add GA4_API_SECRET production` → 프롬프트에 붙여넣기 (Production만; Preview는 데이터 오염)
3. **재배포** — 환경 변수는 빌드 시점 주입이라 기존 배포에는 적용되지 않습니다
4. 검증 3단: `check_runtime_env_contract.py --vercel` → DevTools `/api/vitals` 204 → **GA4 Realtime `web_vitals`**. (b)의 204는 시크릿 유무와 무관하므로 (c)까지 가야 수집이 증명됩니다

## 왜 지금 중요한가

CLS/AdSense 변경을 검증할 유일한 권위 있는 신호가 필드 데이터인데 그 파이프라인이 죽어 있습니다. 랩 측정은 리더가 본 CLS 0.1797을 재현하지 못합니다 (로컬 floor 0.0000, 라이브 5회 0.0016~0.0172 — #611/#613 참조).

🤖 Generated with [Claude Code](https://claude.com/claude-code)