### PR TITLE
fix(ci): 이미지 트리거를 스캔 범위에 맞춘다 — 래스터는 필터 밖이었다

### DIFF
--- a/.github/workflows/check-svg.yml
+++ b/.github/workflows/check-svg.yml
@@ -21,12 +21,20 @@ name: SVG Quality Check
 # (diagrams/, mermaid/, _unused_archive/). Those 156 were inside the scan and
 # outside the trigger: the same trigger-narrower-than-scan shape described above,
 # one directory level down. Widened to `**.svg`, matching svg-lint.yml's glob.
+#
+# 2026-08-26 follow-up: `**.svg` was still narrower than the scan, this time by
+# extension rather than by depth. verify_images_unified.py:198 scans
+# {.svg,.png,.webp,.jpg,.jpeg}, so a push that adds or removes only a raster was
+# inside the scan and outside the trigger. Widened to `assets/images/**`: the
+# steps sweep the whole directory anyway, so anything under it is in scope by
+# construction and no future extension can fall back out. Same fix in
+# svg-lint.yml, where the miss was demonstrable — see there.
 on:
   push:
     branches:
       - main
     paths:
-      - 'assets/images/**.svg'
+      - 'assets/images/**'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
       - 'scripts/check_svg_quality.py'
@@ -36,7 +44,7 @@ on:
     branches:
       - main
     paths:
-      - 'assets/images/**.svg'
+      - 'assets/images/**'
       - 'scripts/check_posts.py'
       - 'scripts/check_cover_qr_urls.py'
       - 'scripts/check_svg_quality.py'

--- a/.github/workflows/svg-lint.yml
+++ b/.github/workflows/svg-lint.yml
@@ -24,11 +24,26 @@ name: SVG Compliance Lint
 # The count above is MEASURED, not maintained by hand: it drifted twice while
 # gates were moved to --all in 2026-08. test_ci_svg_lint_schedule_guard.py
 # asserts it equals the actual number of `--all` invocations below.
+#
+# 2026-08-26: the image glob was `assets/images/**.svg`, which is narrower than
+# what these gates read. check_orphan_cover_rasters.py iterates assets/images/
+# for `<slug>_{og,card}.{png,webp,avif}` and fails when one has no base .svg —
+# so its entire input surface is rasters, and rasters did not appear in this
+# filter. The miss is not hypothetical: commit 9bf4c2e5 ("remove 45 orphan cover
+# rasters from renamed covers") changed 45 files, every one of them matching
+# `_(og|card)\.(png|webp|avif)$` and none matching any pattern here. The commit
+# that REMEDIATED the orphan-raster problem could not trigger the gate that
+# exists to catch it. One such commit in the last 400 on main — rare, and
+# precisely the commit where it mattered.
+#
+# Widened to `assets/images/**`. The steps sweep the whole corpus regardless, so
+# the directory is the honest trigger scope and no future raster extension can
+# silently fall outside it. Guarded by test_ci_image_path_filter_guard.py.
 on:
   push:
     paths:
       - '.github/workflows/svg-lint.yml'
-      - 'assets/images/**.svg'
+      - 'assets/images/**'
       - 'scripts/lint_svg_compliance.py'
       - 'scripts/upgrade_digest_cover.py'
       - 'scripts/lib/svg_l22_generator.py'
@@ -87,7 +102,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/svg-lint.yml'
-      - 'assets/images/**.svg'
+      - 'assets/images/**'
       - 'scripts/lint_svg_compliance.py'
       - 'scripts/upgrade_digest_cover.py'
       - 'scripts/lib/svg_l22_generator.py'

--- a/scripts/tests/test_ci_image_path_filter_guard.py
+++ b/scripts/tests/test_ci_image_path_filter_guard.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""CI regression guard: the image trigger must be at least as wide as the scan.
+
+Both image workflows sweep the whole corpus and are triggered by a `paths`
+filter. Whenever that filter is narrower than what the steps actually read, a
+change lands inside the scan and outside the trigger — the workflow stays green
+by never running, which is indistinguishable from passing. This repo has now
+hit that shape three times on the same two files:
+
+- pre-#489: `assets/images/*.svg` (depth-1 only) vs `rglob("*.svg")` — 156 SVGs
+  under diagrams/, mermaid/, _unused_archive/ were scanned but not triggerable.
+- 2026-08-10: widened to `**.svg`, fixing the depth axis.
+- 2026-08-26: still narrow on the EXTENSION axis. check_orphan_cover_rasters.py
+  reads only `<slug>_{og,card}.{png,webp,avif}`, and verify_images_unified.py
+  scans {.svg,.png,.webp,.jpg,.jpeg} — none of which `**.svg` matches. Commit
+  9bf4c2e5, "remove 45 orphan cover rasters from renamed covers", changed 45
+  files that all matched `_(og|card)\\.(png|webp|avif)$` and none of the 51
+  patterns: the commit remediating the orphan-raster problem could not trigger
+  the gate for it.
+
+So this guard does not assert a literal pattern — a literal is what kept getting
+fixed on one axis and left broken on another. It asserts BEHAVIOUR: representative
+paths of every kind these workflows read must match some pattern in the filter.
+Add a new asset type the steps scan, and this fails until the trigger covers it.
+
+Direction: coverage. Narrowing the filter, or broadening a scan without the
+trigger, trips this.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = (
+    REPO_ROOT / ".github" / "workflows" / "svg-lint.yml",
+    REPO_ROOT / ".github" / "workflows" / "check-svg.yml",
+)
+
+# One representative path per asset kind the steps read, with the reader that
+# makes it in-scope. These are the scan surface; the trigger must cover them.
+SCANNED_SAMPLES = (
+    ("assets/images/2026-01-01-Post.svg", "cover SVG — every --all cover gate"),
+    ("assets/images/diagrams/flow.svg", "verify_images_unified.py rglob, depth >= 2"),
+    ("assets/images/2026-01-01-Post_og.png", "check_orphan_cover_rasters.py"),
+    ("assets/images/2026-01-01-Post_og.webp", "check_orphan_cover_rasters.py"),
+    ("assets/images/2026-01-01-Post_og.avif", "check_orphan_cover_rasters.py"),
+    ("assets/images/2026-01-01-Post_card.webp", "check_orphan_cover_rasters.py"),
+    ("assets/images/photo.jpg", "verify_images_unified.py:198 ext set"),
+)
+
+
+def _gh_glob_matches(path: str, pattern: str) -> bool:
+    """GitHub Actions path-filter semantics: `**` crosses `/`, `*` does not."""
+    rx = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+    return re.fullmatch(rx, path) is not None
+
+
+def _filters(workflow: Path) -> dict[str, list[str]]:
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    on = doc.get(True, doc.get("on")) or {}
+    out = {}
+    for event in ("push", "pull_request"):
+        block = on.get(event)
+        if isinstance(block, dict) and block.get("paths"):
+            out[event] = block["paths"]
+    return out
+
+
+def test_workflows_exist():
+    for wf in WORKFLOWS:
+        assert wf.is_file(), f"{wf} not found"
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_both_events_are_path_filtered(workflow: Path):
+    events = _filters(workflow)
+    assert set(events) == {"push", "pull_request"}, (
+        f"{workflow.name}: expected path-filtered push AND pull_request, got "
+        f"{sorted(events)}. If an event lost its filter it now runs always "
+        "(harmless) or lost the event entirely (not harmless) — check which."
+    )
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+@pytest.mark.parametrize(("sample", "reader"), SCANNED_SAMPLES, ids=lambda v: v.split("/")[-1] if "/" in str(v) else v)
+def test_trigger_covers_every_scanned_asset_kind(
+    workflow: Path, sample: str, reader: str
+):
+    for event, patterns in _filters(workflow).items():
+        assert any(_gh_glob_matches(sample, p) for p in patterns), (
+            f"{workflow.name} ({event}): no pattern matches {sample!r}, which "
+            f"{reader} reads. The steps scan it, the trigger cannot see it — so "
+            "a change to that asset leaves the workflow green by not running. "
+            "That is how 9bf4c2e5 (45 orphan rasters) escaped the orphan-raster "
+            "gate. Widen the filter rather than narrowing the scan."
+        )
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_schedule_survives_as_the_backstop(workflow: Path):
+    """The filter is the fast path; the daily sweep is what covers bot pushes.
+
+    A GITHUB_TOKEN push triggers no workflow at all, so for the cron — the
+    dominant producer of these assets — no `paths` value is wide enough. Only
+    the schedule sees those commits.
+    """
+    doc = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    on = doc.get(True, doc.get("on")) or {}
+    assert on.get("schedule"), (
+        f"{workflow.name} lost its schedule. Path filters cannot substitute: the "
+        "blogwatcher pushes with GITHUB_TOKEN and that triggers nothing, so the "
+        "daily sweep is the only thing that ever inspects a bot-published cover."
+    )
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_workflow_file_retriggers_itself(workflow: Path):
+    """Editing the gate must run the gate."""
+    rel = f".github/workflows/{workflow.name}"
+    for event, patterns in _filters(workflow).items():
+        assert any(_gh_glob_matches(rel, p) for p in patterns), (
+            f"{workflow.name} ({event}) no longer lists itself, so a change to "
+            "the gate ships without the gate running once"
+        )

--- a/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
+++ b/scripts/tests/test_ci_svg_gate_no_conceal_guard.py
@@ -70,6 +70,32 @@ def _filtered_paths(body: str) -> set:
     return set(re.findall(r"^\s*-\s*['\"]([^'\"]+)['\"]\s*$", body, re.MULTILINE))
 
 
+def _gh_glob_matches(path: str, pattern: str) -> bool:
+    """GitHub Actions path-filter semantics: `**` crosses `/`, `*` does not."""
+    rx = re.escape(pattern).replace(r"\*\*", ".*").replace(r"\*", "[^/]*")
+    return re.fullmatch(rx, path) is not None
+
+
+def _image_filter_reaches(sample: str, event: str | None = None) -> bool:
+    """Does some pattern under the given event (or any) match `sample`?
+
+    Asserting reachability rather than a literal glob: the literal is what got
+    fixed on the depth axis in 2026-08-10 and stayed broken on the extension
+    axis until 2026-08-26.
+    """
+    import yaml
+
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    on = doc.get(True, doc.get("on")) or {}
+    events = [event] if event else ["push", "pull_request"]
+    for ev in events:
+        block = on.get(ev) or {}
+        patterns = block.get("paths") or []
+        if not any(_gh_glob_matches(sample, p) for p in patterns):
+            return False
+    return True
+
+
 def test_workflow_exists():
     assert WORKFLOW.is_file(), f"{WORKFLOW} not found (moved/renamed?)"
 
@@ -173,31 +199,42 @@ def test_scripts_referenced_by_paths_exist():
 
 
 def test_svg_trigger_glob_is_recursive():
-    """The SVG path filter must cross directories, because the scan does.
+    """The image path filter must cross directories, because the scan does.
 
     ``assets/images/*.svg`` does not match a subdirectory in Actions path filters,
     but ``verify_images_unified.py:267`` scans with ``rglob("*.svg")``. Measured
     2026-08-10: 307 SVGs at depth 1, 156 at depth >= 2 (diagrams/, mermaid/,
     _unused_archive/) — all inside the scan, none reachable by the trigger. That is
     the same hazard this file documents, one directory level down.
+
+    2026-08-26: this test used to require the literal ``'assets/images/**.svg'``,
+    and that literal turned out to be the next iteration of the same bug. It is
+    correct on the depth axis and wrong on the extension axis: the same scan also
+    reads {.png,.webp,.jpg,.jpeg} and check_orphan_cover_rasters.py reads nothing
+    BUT rasters. Pinning the literal actively blocked the fix. So assert the
+    property — depth-1 globs are rejected, and the filter must still reach a
+    nested SVG — and leave the width to
+    ``test_ci_image_path_filter_guard.py``, which drives it from the scan surface
+    rather than from a string.
     """
     body = _body()
     assert "'assets/images/*.svg'" not in body, (
         "check-svg.yml uses the depth-1 glob 'assets/images/*.svg'. Actions path "
         "filters do not cross '/', so every SVG in a subdirectory is scanned but "
-        "cannot trigger the scan. Use 'assets/images/**.svg'."
+        "cannot trigger the scan. Use 'assets/images/**'."
     )
-    assert "'assets/images/**.svg'" in body, (
-        "check-svg.yml must filter on 'assets/images/**.svg'"
+    assert _image_filter_reaches("assets/images/diagrams/flow.svg"), (
+        "check-svg.yml's image filter no longer reaches a nested SVG"
     )
 
 
 def test_svg_trigger_glob_present_on_both_events():
-    """push and pull_request must both carry the recursive glob, not just one."""
-    assert _body().count("'assets/images/**.svg'") >= 2, (
-        "expected the recursive SVG glob under both the push and pull_request "
-        "triggers; a one-sided filter leaves the other event blind."
-    )
+    """push and pull_request must both reach nested images, not just one."""
+    for event in ("push", "pull_request"):
+        assert _image_filter_reaches("assets/images/diagrams/flow.svg", event), (
+            f"the {event} trigger cannot reach a nested SVG; a one-sided filter "
+            "leaves the other event blind."
+        )
 
 
 def test_recursive_glob_would_actually_reach_nested_svgs():


### PR DESCRIPTION
## 왜

`svg-lint`가 PR #616에서 안 돈 것을 계기로 두 이미지 워크플로의 트리거를 감사했다.

먼저 이상 없는 쪽부터: **게이트 스크립트 37개는 전부 자기 자신을 필터에 갖고 있다**(편집하면 재실행된다). 데이터 표면도 `.md`/`.svg`/`.yml`은 `_posts/**.md` · `assets/images/**.svg` · `_data/*_covers/**.yml`로 덮여 있다. #616이 안 돈 것도 정상 — 워크플로와 테스트만 바꿨고 코퍼스 게이트를 깰 수 없다.

문제는 **래스터**다.

`check_orphan_cover_rasters.py`는 `assets/images/`를 훑어 `<slug>_{og,card}.{png,webp,avif}`에 대응 `.svg`가 없으면 실패한다 — 입력 표면 전체가 래스터인데, 필터에는 `assets/images/**.svg`뿐이었다. `verify_images_unified.py:198`도 `{.svg,.png,.webp,.jpg,.jpeg}`를 스캔하면서 `check-svg.yml` 트리거는 같은 `**.svg`였다.

**실증** — main 최근 400커밋(first-parent)을 스캔해 "커버 래스터를 건드리면서 svg-lint를 트리거할 파일은 하나도 없는" 커밋을 찾았다. 정확히 1건:

```
9bf4c2e5  Twodragon  rasters=45 files=45
chore(assets): remove 45 orphan cover rasters from renamed covers
```

45개 전부 `_(og|card)\.(png|webp|avif)$`에 매치하고 51개 패턴 중 어느 것에도 매치하지 않는다. **고아 래스터 문제를 해결한 커밋이, 그것을 잡으라고 만든 게이트를 트리거할 수 없었다.** 드물지만 하필 중요했던 그 한 건이다.

이건 같은 형태의 세 번째 반복이다 — pre-#489 depth-1 → 2026-08-10 `**.svg`(depth 해결) → 지금 확장자 축.

## 무엇을

`assets/images/**.svg` → `assets/images/**` (두 워크플로 × push/PR = 4곳). 스텝이 어차피 디렉토리 전체를 훑으므로 디렉토리가 정직한 트리거 범위이고, 앞으로 어떤 래스터 확장자도 다시 빠질 수 없다.

`schedule`은 그대로다. 봇 push는 어떤 paths 값으로도 못 잡으므로(GITHUB_TOKEN 재귀 방지) 일일 스윕이 여전히 유일한 백스톱이고, 가드로 고정했다.

### 기존 가드가 수정을 막고 있었다

`test_ci_svg_gate_no_conceal_guard.py`가 리터럴 `'assets/images/**.svg'`를 assert하고 있어 이 PR에서 2건 실패했다. 한 축에서 맞고 다른 축에서 틀린 리터럴이 다음 반복을 차단한 것 — 이 파일이 문서화하는 바로 그 함정의 재현이다.

- 기존 테스트: **depth 축 속성 검사**로 변경 (depth-1 glob 거부 + 중첩 SVG 도달 확인). 원래 목적은 유지.
- 신규 `test_ci_image_path_filter_guard.py`: **폭을 스캔 표면에서 유도**한다. 리터럴이 아니라 대표 경로 7종(`.svg` depth1/depth2, `_og.png`, `_og.webp`, `_og.avif`, `_card.webp`, `.jpg`)이 각각 어떤 패턴엔가 매치하는지 본다. 스텝이 새 자산 종류를 읽기 시작하면 트리거가 따라올 때까지 실패한다.

## 검증

- `pytest scripts/tests/` **4898 passed, 5 skipped**
- `actionlint` 두 파일 rc=0 · `ruff --target-version py311` clean
- 뮤테이션:
  - `**.svg` 복귀 → 신규 가드가 7개 샘플 중 **5개**(래스터 4 + jpg) FAIL
  - `*.svg`(depth-1) 복귀 → **6개** FAIL
  - 두 워크플로 `schedule` 제거 → 각각 caught
  - 자기 재트리거 패턴 제거 → caught
  - 기존 테스트는 depth-1 회귀를 여전히 caught
- 첫 schedule 뮤테이션은 MISSED로 나왔는데 가드 구멍이 아니라 **프로브 오류**였다(`schedule:`과 `- cron:` 사이 주석 3줄 때문에 문자열 치환이 no-op). 라인 범위로 다시 잘라 YAML에서 키가 실제로 사라진 것을 확인한 뒤 재측정 → caught.

## 부작용

`_unused_archive/` 같은 하위 디렉토리의 이미지 변경도 이제 두 워크플로를 깨운다(각 ~3.5분). 400커밋에 1건 빈도이고, `verify_images_unified`가 그 디렉토리를 rglob으로 실제 스캔하므로 의도한 동작이다.