### PR TITLE
fix(ci): visual-baseline-refresh가 자기 자신과 베이스라인을 트리거에 넣는다

### DIFF
--- a/.github/workflows/visual-baseline-refresh.yml
+++ b/.github/workflows/visual-baseline-refresh.yml
@@ -15,15 +15,42 @@
 
 name: SVG Visual Baseline Refresh
 
+# Trigger scope, audited 2026-08-26 alongside the svg-lint/check-svg raster fix
+# (#617). The extension-axis problem found there does NOT apply here, and the
+# reason is worth recording so nobody "fixes" this file to match:
+# svg_visual_baseline.py reads exactly two things — the 32 hardcoded paths in
+# TARGET_SVGS (all `.svg`) and tests/visual-baselines/ (baseline PNGs +
+# manifest.json). It reads no raster under assets/images/, so widening the SVG
+# glob to `assets/images/**` here would only add runs that compare 32 unchanged
+# files.
+#
+# Two entries added here, both invariants this repo enforces elsewhere and this
+# file was missing:
+#   - itself, so editing the gate runs the gate (visual-baseline-verify.yml,
+#     svg-lint.yml and check-svg.yml all already list themselves)
+#   - tests/visual-baselines/**, its own second read surface. Without it a
+#     hand-edited or corrupted baseline is not re-captured until some unrelated
+#     SVG happens to change.
+#
+# The generator entries below are kept but are weaker than they look, and the
+# same is true in visual-baseline-verify.yml: this script never imports or
+# executes a generator — it shells out to rsvg-convert and rasterises whatever
+# SVG is already on disk. A PR that edits a generator WITHOUT regenerating
+# covers therefore renders byte-identical PNGs and passes trivially; one that
+# does regenerate is already caught by the `assets/images/**.svg` entry. So they
+# are belt-and-braces, not the detection mechanism. Left in place because
+# removing them changes behaviour for no gain.
 on:
   push:
     branches:
       - main
     paths:
       - "assets/images/**.svg"
+      - "tests/visual-baselines/**"
       - "scripts/lib/svg_l20_hero.py"
       - "scripts/lib/svg_l22_generator.py"
       - "scripts/svg_visual_baseline.py"
+      - ".github/workflows/visual-baseline-refresh.yml"
   workflow_dispatch:
 
 concurrency:

--- a/scripts/tests/test_ci_image_path_filter_guard.py
+++ b/scripts/tests/test_ci_image_path_filter_guard.py
@@ -127,3 +127,73 @@ def test_workflow_file_retriggers_itself(workflow: Path):
             f"{workflow.name} ({event}) no longer lists itself, so a change to "
             "the gate ships without the gate running once"
         )
+
+
+# ---------------------------------------------------------------------------
+# visual-baseline pair
+#
+# Deliberately NOT subject to the extension-axis assertions above. Audited
+# 2026-08-26: svg_visual_baseline.py reads exactly two surfaces — the 32
+# hardcoded `.svg` paths in TARGET_SVGS and tests/visual-baselines/ — and
+# rasterises them via rsvg-convert. It reads no raster under assets/images/, so
+# `assets/images/**` would be wider than the scan rather than narrower. What
+# these two DO need is that their own read surfaces stay reachable.
+# ---------------------------------------------------------------------------
+
+VISUAL_BASELINE = (
+    REPO_ROOT / ".github" / "workflows" / "visual-baseline-refresh.yml",
+    REPO_ROOT / ".github" / "workflows" / "visual-baseline-verify.yml",
+)
+BASELINE_SCRIPT = REPO_ROOT / "scripts" / "svg_visual_baseline.py"
+
+
+def _target_svgs() -> list[str]:
+    """Every quoted path in TARGET_SVGS, parsed from source (PIL may be absent).
+
+    Matches any quoted path, NOT just `*.svg`. An earlier version filtered on
+    `\\.svg"` here, which made ``test_target_svgs_is_still_a_hardcoded_svg_only
+    _sample`` vacuous: a `.png` added to the list was dropped by this extractor
+    before the assertion could see it, so the mutation that the assertion exists
+    to catch passed. The extractor is the assertion's haystack — it must not
+    pre-filter on the property being asserted.
+    """
+    src = BASELINE_SCRIPT.read_text(encoding="utf-8")
+    block = src.split("TARGET_SVGS", 1)[1].split("\n]", 1)[0]
+    return re.findall(r'"([^"]+/[^"]+)"', block)
+
+
+def test_target_svgs_is_still_a_hardcoded_svg_only_sample():
+    """The premise behind exempting these two from the extension axis."""
+    targets = _target_svgs()
+    assert targets, "TARGET_SVGS could not be parsed; re-derive this exemption"
+    assert all(t.endswith(".svg") for t in targets), (
+        "TARGET_SVGS now contains a non-SVG entry. The visual-baseline workflows "
+        "are exempt from the raster assertions above ONLY because this sample is "
+        "SVG-only — re-check their filters before extending the sample."
+    )
+
+
+@pytest.mark.parametrize("workflow", VISUAL_BASELINE, ids=lambda p: p.name)
+def test_visual_baseline_trigger_reaches_its_own_read_surfaces(workflow: Path):
+    """Both TARGET_SVGS and the baseline directory must be reachable."""
+    sample_target = _target_svgs()[0]
+    for event, patterns in _filters(workflow).items():
+        for surface, why in (
+            (sample_target, "a TARGET_SVGS entry"),
+            ("tests/visual-baselines/manifest.json", "the baseline store"),
+        ):
+            assert any(_gh_glob_matches(surface, p) for p in patterns), (
+                f"{workflow.name} ({event}): nothing matches {surface!r}, which is "
+                f"{why} this workflow reads. A change there would not run it."
+            )
+
+
+@pytest.mark.parametrize("workflow", VISUAL_BASELINE, ids=lambda p: p.name)
+def test_visual_baseline_workflow_retriggers_itself(workflow: Path):
+    rel = f".github/workflows/{workflow.name}"
+    for event, patterns in _filters(workflow).items():
+        assert any(_gh_glob_matches(rel, p) for p in patterns), (
+            f"{workflow.name} ({event}) does not list itself. refresh/--capture "
+            "auto-commits on main, so an unreviewed change to it would take "
+            "effect without the workflow having run once under its new form."
+        )


### PR DESCRIPTION
## 점검 결과: 확장자 축 문제는 여기 **없다**

#617에서 고친 "트리거가 스캔보다 좁다"가 `visual-baseline-{refresh,verify}.yml`에도 있는지 봤다. 결론은 없음이고, 근거를 워크플로 주석에 남겼다 — 나중에 누가 일관성을 이유로 넓히지 않도록.

`svg_visual_baseline.py`가 읽는 것은 정확히 둘뿐이다:

| 읽기 표면 | 커버 여부 |
|---|---|
| `TARGET_SVGS` 하드코딩 32경로 (전부 `.svg`) | `assets/images/**.svg` ✅ |
| `tests/visual-baselines/` (베이스라인 PNG + `manifest.json`) | verify ✅ / **refresh ❌** |

`assets/images/` 아래 래스터는 하나도 읽지 않는다. subprocess 호출은 `rsvg-convert`와 `qlmanage`뿐. 그래서 여기서 `assets/images/**`로 넓히면 변경 없는 32개를 비교하는 실행만 늘어난다.

샘플 구성 실측 — **28 L20 + 1 digest(L22 spec) + 2 rollup + 1 미표기 = 32**. (앞선 측정에서 "rollup spec 0개"가 나왔는데 제 조회 오류였다. rollup spec은 slug가 아니라 날짜로 명명돼 있다: `_data/rollup_covers/2026-04-05.yml`. `upgrade_digest_cover.py --all --check` → `33 specs OK`로 03-07 타깃이 digest spec 관리 대상임을 확인했다.)

## 실제로 있던 것 — 이 파일에만 빠진 불변식 2개

`verify`·`svg-lint`·`check-svg`는 셋 다 갖고 있는데 `refresh`만 없었다.

- **자기 자신**: 게이트를 고치면 게이트가 돌아야 한다. refresh는 `--capture`가 main에서 **자동 커밋**하므로 특히 중요하다 — 새 형태로 한 번도 안 돌아본 채 효력이 생긴다.
- **`tests/visual-baselines/**`**: 두 번째 읽기 표면. 없으면 손상·수정된 베이스라인이 무관한 SVG가 바뀔 때까지 재캡처되지 않는다.

## 제너레이터 항목은 생각보다 약하다 (주석으로 명시, 제거는 안 함)

이 스크립트는 제너레이터를 **import하지도 실행하지도 않는다**. 온디스크 SVG를 rsvg-convert로 래스터화할 뿐이다. 따라서:

- 제너레이터만 고치고 커버를 재생성하지 않은 PR → 동일한 PNG → **무조건 통과**
- 재생성한 PR → 이미 `assets/images/**.svg`가 잡음

즉 탐지 수단이 아니라 이중 안전장치다. 두 워크플로가 서로 다른 제너레이터를 나열하는 비대칭(refresh=l22, verify=rollup)도 같은 이유로 무해하다. 제거는 동작 변경이고 이득이 없어 하지 않았다.

## 가드 자체 결함 1건

확장 과정에서 제 가드가 공허하게 통과하는 것을 발견해 고쳤다. `_target_svgs()`가 `"([^"]+\.svg)"`로 추출해서, "TARGET_SVGS에 `.png`가 추가됨" 뮤테이션이 **추출 단계에서 걸러져** assertion이 볼 수조차 없었다. 추출기가 assertion의 건초더미이므로 검사 대상 속성으로 미리 거르면 안 된다. 임의 경로를 뽑도록 고쳤다.

## 검증

- `pytest scripts/tests/` **4903 passed, 5 skipped** · `actionlint rc=0` · `ruff(py311) clean`
- 뮤테이션 **4/4 caught**: 자기 참조 제거 / `tests/visual-baselines/**` 제거 / SVG glob 축소로 TARGET_SVGS 도달 불가 / TARGET_SVGS에 래스터·베이스라인 PNG 추가
- 공유 프리미티브(`_target_svgs`) 수정 후 기존 뮤테이션 3종 재실행 → 전부 caught 유지, svg-lint 쪽 5/7도 그대로