### PR TITLE
fix(ci): visual-regression이 자기 자신을 트리거에 넣는다 + 5개 게이트 불변식 통합

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -1,5 +1,31 @@
 name: L20 Visual Regression Gate
 
+# Trigger scope, audited 2026-08-26 after the svg-lint/check-svg raster widening
+# (#617) and the visual-baseline pass (#618). Recording the result so the
+# depth-1 glob below is not "fixed" for consistency:
+#
+# run.py scans `ASSETS.glob("*.svg")` — depth-1, no rglob — then keeps only the
+# 30 hardcoded dates in ALL_TARGET_DATES plus REFERENCE_NAME. So the trigger
+# glob matches the scan glob exactly; `**` would add nothing to look at. It also
+# reads no raster: covers are rendered fresh through rsvg-convert into a working
+# directory, so the extension axis that mattered in #617 does not apply here
+# either.
+#
+# The sweep is narrow but NOT vestigial, which is the other thing worth writing
+# down. Measured: 49 target covers resolve on disk, several were last modified
+# 2026-07-05 by the topic-tag / topic-line dedup campaigns, and the gate has 22
+# real failures on record — all between 2026-04-25 and 04-30, during the L20
+# hero-system and palette-unify work, with 55 passes since.
+#
+# Added: this file. Editing the gate must run the gate — the invariant
+# svg-lint.yml, check-svg.yml and both visual-baseline workflows already hold.
+# Guarded by test_ci_image_path_filter_guard.py.
+#
+# Not added: the generator entries below are weaker than they look, exactly as
+# in the visual-baseline pair. run.py never imports or executes a generator, so
+# a PR that edits one WITHOUT regenerating covers renders byte-identical PNGs
+# and passes trivially; one that does regenerate is already caught by the SVG
+# glob. Left alone because removing them changes behaviour for no gain.
 on:
   pull_request:
     paths:
@@ -7,6 +33,7 @@ on:
       - 'scripts/lib/svg_l20_hero.py'
       - 'scripts/lib/svg_l22_generator.py'
       - 'reports/l20-visual-regression/run.py'
+      - '.github/workflows/visual-regression.yml'
   workflow_dispatch:
 
 concurrency:

--- a/scripts/tests/test_ci_image_path_filter_guard.py
+++ b/scripts/tests/test_ci_image_path_filter_guard.py
@@ -118,14 +118,33 @@ def test_schedule_survives_as_the_backstop(workflow: Path):
     )
 
 
-@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+# Every image-related gate, for the one invariant they all share: editing the
+# gate must run the gate. Kept as a single list so a new image workflow is one
+# line away from being covered, and so the invariant cannot be satisfied for
+# some of them and quietly dropped for others — which is how
+# visual-baseline-refresh.yml and visual-regression.yml both came to be missing
+# it while the other three had it.
+SELF_TRIGGERING = (
+    *WORKFLOWS,
+    REPO_ROOT / ".github" / "workflows" / "visual-baseline-refresh.yml",
+    REPO_ROOT / ".github" / "workflows" / "visual-baseline-verify.yml",
+    REPO_ROOT / ".github" / "workflows" / "visual-regression.yml",
+)
+
+
+@pytest.mark.parametrize("workflow", SELF_TRIGGERING, ids=lambda p: p.name)
 def test_workflow_file_retriggers_itself(workflow: Path):
     """Editing the gate must run the gate."""
+    assert workflow.is_file(), f"{workflow} not found"
     rel = f".github/workflows/{workflow.name}"
-    for event, patterns in _filters(workflow).items():
+    filters = _filters(workflow)
+    assert filters, f"{workflow.name} has no path-filtered event to assert on"
+    for event, patterns in filters.items():
         assert any(_gh_glob_matches(rel, p) for p in patterns), (
-            f"{workflow.name} ({event}) no longer lists itself, so a change to "
-            "the gate ships without the gate running once"
+            f"{workflow.name} ({event}) does not list itself, so a change to the "
+            "gate ships without the gate having run once under its new form. For "
+            "visual-baseline-refresh that is sharper than usual: --capture "
+            "auto-commits baselines on main."
         )
 
 
@@ -188,12 +207,5 @@ def test_visual_baseline_trigger_reaches_its_own_read_surfaces(workflow: Path):
             )
 
 
-@pytest.mark.parametrize("workflow", VISUAL_BASELINE, ids=lambda p: p.name)
-def test_visual_baseline_workflow_retriggers_itself(workflow: Path):
-    rel = f".github/workflows/{workflow.name}"
-    for event, patterns in _filters(workflow).items():
-        assert any(_gh_glob_matches(rel, p) for p in patterns), (
-            f"{workflow.name} ({event}) does not list itself. refresh/--capture "
-            "auto-commits on main, so an unreviewed change to it would take "
-            "effect without the workflow having run once under its new form."
-        )
+# Self-listing for these two is asserted by test_workflow_file_retriggers_itself
+# above, which covers all five image gates from one list.


### PR DESCRIPTION
## 점검 결과: 트리거 확대는 **불필요**

`run.py`는 `ASSETS.glob("*.svg")` — depth-1, `rglob` 아님 — 로 훑은 뒤 `ALL_TARGET_DATES`(30개 날짜: 01-23~02-22, 03-16~03-31) + `REFERENCE_NAME`(04-08)만 남긴다. **트리거 glob이 스캔 glob과 정확히 일치**하므로 `**`로 넓혀도 볼 것이 늘지 않는다. 래스터도 안 읽는다 — `rsvg-convert`로 작업 디렉토리에 fresh 렌더하므로 #617의 확장자 축은 여기 적용되지 않는다.

## 다만 "동결 스윕이라 무의미"는 실측과 다르다

| 측정 | 값 |
|---|---|
| 디스크에 존재하는 대상 커버 | **49개** |
| 그중 최근 수정 | **2026-07-05** (topic-tag / topic-line dedup 캠페인) |
| 총 실행 | 77회 |
| failure | **22회** — 전부 2026-04-25~30 (L20 hero-system, palette-unify) |
| 이후 | 55회 연속 pass, 마지막 실행 2026-08-11 |

좁지만 살아 있는 게이트다. 코퍼스 커버 캠페인이 이 대상들을 실제로 건드리고, 그때 발화한 이력이 있다.

## 추가한 것: 자기 참조 하나

게이트를 고치면 게이트가 돌아야 한다 — `svg-lint`·`check-svg`·`visual-baseline` 양쪽이 이미 갖고 있고 이 파일만 없었다.

제너레이터 항목은 `visual-baseline`과 같은 이유로 그대로 뒀다: `run.py`는 제너레이터를 import하지도 실행하지도 않으므로 재생성 없는 제너레이터 변경은 동일 PNG를 렌더해 무조건 통과하고, 재생성한 경우는 이미 SVG glob이 잡는다.

## 가드 통합

5개 워크플로(`svg-lint`, `check-svg`, `visual-baseline-refresh`, `visual-baseline-verify`, `visual-regression`)를 하나의 `SELF_TRIGGERING` 목록으로 합쳤다. 일부만 만족하고 나머지가 조용히 빠지는 게 정확히 `refresh`와 `visual-regression` 둘 다 이 불변식을 잃은 경위다.

## 검증 — 그리고 앞선 두 PR의 검증 정정

- `pytest scripts/tests/` **4904 passed, 5 skipped** · `actionlint rc=0` · `ruff(py311) clean`
- 뮤테이션 **5/5 caught**, 이번엔 **대조군을 함께** 돌렸다: 미변형 사본 5/5 pass + 자기 참조 제거 5/5 FAIL.

**정정**: #617과 #618에서 자기 참조 뮤테이션에 쓴 프로브는 `NamedTemporaryFile`을 써서 basename이 `tmpXXXX.yml`로 바뀌었다. 그러면 테스트 안의 `rel = .github/workflows/tmpXXXX.yml`이 어떤 패턴과도 매치하지 않아 **뮤테이션과 무관하게 항상 실패**한다 — 가짜 CAUGHT였다. 실제 파일명을 유지하는 임시 디렉토리로 다시 돌려 확인했다. assertion 자체는 옳았고 검증 방법이 틀렸다. 두 PR의 다른 뮤테이션들은 파일 내용만 보므로 영향 없다.