### PR TITLE
fix(ci): Slack 배송 실패가 exit code에 반영된다 — 4번째 "상수 알림"

### DIFF
--- a/.github/workflows/slack-post-notify.yml
+++ b/.github/workflows/slack-post-notify.yml
@@ -144,15 +144,41 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$payload")
           echo "Slack response: $HTTP_STATUS"
+          # A failed delivery exits non-zero. Until 2026-08-26 both failure
+          # branches below printed `::warning::` and fell through to exit 0, so
+          # `channel_not_found`, `not_in_channel`, `invalid_auth`, a revoked
+          # scope or a 429 all produced a GREEN job with no message delivered.
+          #
+          # That was survivable while this workflow only ran on human pushes —
+          # someone had just merged and was looking at the run. It stopped being
+          # survivable when ai-blogwatcher.yml started calling it (#616): that
+          # path fires at 00:00 UTC and nobody reads cron logs, so a silent
+          # delivery failure is indistinguishable from the bug #616 fixed, which
+          # is exactly the failure mode this repo has shipped three times
+          # (run-blog-autonomous-cron.sh's fixed "100% Passed", monitoring.yml's
+          # never-firing Slack step, monthly-quality-report.yml's hardcoded
+          # --status SUCCESS). An alert is only worth anything when it fails.
+          #
+          # Deliberately NOT retried: chat.postMessage is not idempotent, and a
+          # retry after a lost response double-posts. Fail loudly instead.
+          #
+          # The digest is already committed and pushed by the time this runs, so
+          # a red job here means "published, not announced" — it does not
+          # unpublish anything and does not need to.
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+            # A non-JSON body fails this substitution under `set -e`, which is
+            # the correct direction — stated explicitly so it is not "tidied"
+            # into a warning later.
             ok=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("ok",""))')
             if [ "$ok" = "True" ]; then
               echo "Slack notification sent successfully"
             else
               error=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("error","unknown"))')
-              echo "::warning::Slack API error: $error"
+              echo "::error::Slack accepted the request (HTTP $HTTP_STATUS) but reported ok=false: $error. The post is live; the announcement was NOT delivered."
+              exit 1
             fi
           else
-            echo "::warning::Slack HTTP error (HTTP $HTTP_STATUS)"
+            echo "::error::Slack HTTP error (HTTP $HTTP_STATUS). The post is live; the announcement was NOT delivered."
             cat /tmp/slack_resp.txt || true
+            exit 1
           fi

--- a/scripts/tests/test_ci_slack_notify_delivery_guard.py
+++ b/scripts/tests/test_ci_slack_notify_delivery_guard.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""CI regression guard: a Slack delivery failure must reach the exit code.
+
+This repo has shipped "the notification reports a constant, not the result"
+three times:
+
+- ``run-blog-autonomous-cron.sh`` put a fixed ``Zero-Regression Gate: 100%
+  Passed`` in the webhook body, so a failing gate still announced success.
+- ``monitoring.yml``'s Slack step hung off ``SLACK_WEBHOOK``, a secret that was
+  never registered, so it never fired for a real outage (fixed in #583).
+- ``monthly-quality-report.yml`` combined ``if: always()`` with a hardcoded
+  ``--status "SUCCESS"``, announcing a published issue even when ``gh issue
+  create`` failed or was skipped (fixed in #599).
+
+``slack-post-notify.yml`` was the fourth, in a subtler shape: the status was
+correctly derived, but both **delivery**-failure branches printed
+``::warning::`` and fell through to exit 0. ``channel_not_found``,
+``not_in_channel``, ``invalid_auth``, a revoked scope and HTTP 429 all produced
+a green job with nothing delivered.
+
+That was survivable while the workflow only ran on human pushes — someone had
+just merged and was watching the run. It stopped being survivable when
+ai-blogwatcher.yml began calling it (#616): that path fires at 00:00 UTC, nobody
+reads cron logs, and a silent delivery failure looks exactly like the bug #616
+fixed. An alert is only worth anything at the moment it fails.
+
+Direction: the failure branches must stay hard. Softening one back to a warning,
+adding ``continue-on-error``, or introducing ``always()`` trips this.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "slack-post-notify.yml"
+CALLER = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+
+POST_STEP = "Post to Slack via Bot API"
+
+# (branch marker, what makes it a failure) — both must end in a hard exit.
+FAILURE_BRANCHES = (
+    ("ok=false", 'reported ok=false'),
+    ("non-2xx", 'Slack HTTP error'),
+)
+
+
+def _doc(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _step(name: str) -> dict:
+    for s in _doc(WORKFLOW)["jobs"]["notify"]["steps"]:
+        if s.get("name") == name:
+            return s
+    pytest.fail(f"no step named {name!r} in slack-post-notify.yml")
+
+
+def _uncommented(shell: str) -> str:
+    """Comment-only lines removed.
+
+    The step explains the anti-pattern it avoids and names ``::warning::`` in
+    prose. Matching raw text would hit the explanation and stay green after the
+    real ``exit 1`` was deleted.
+    """
+    return "\n".join(ln for ln in shell.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def test_workflow_exists():
+    assert WORKFLOW.is_file(), f"{WORKFLOW} not found"
+
+
+def _block_after(lines: list[str], at: int) -> list[str]:
+    """Lines belonging to the same shell block as ``lines[at]``.
+
+    Scoped by indentation: scanning stops at the first line indented LESS than
+    the anchor, which is the `fi`/`else` that closes the branch.
+
+    An earlier version of this guard used a flat ``lines[at+1:at+6]`` window.
+    That window ran past the closing `fi` and the `else`, and found the OTHER
+    branch's ``exit 1`` — so deleting the ok=false branch's exit left the guard
+    green. The mutation was verified to have landed before this was diagnosed;
+    the window, not the mutation, was the defect.
+    """
+    indent = len(lines[at]) - len(lines[at].lstrip())
+    out = []
+    for ln in lines[at + 1 :]:
+        if not ln.strip():
+            continue
+        if len(ln) - len(ln.lstrip()) < indent:
+            break
+        out.append(ln.strip())
+    return out
+
+
+@pytest.mark.parametrize(("label", "marker"), FAILURE_BRANCHES)
+def test_delivery_failure_exits_nonzero(label: str, marker: str):
+    body = _uncommented(_step(POST_STEP)["run"])
+    lines = body.splitlines()
+    at = next((i for i, ln in enumerate(lines) if marker in ln), None)
+    assert at is not None, (
+        f"the {label} failure branch is gone (looked for {marker!r}); re-read the "
+        "step before trusting this guard"
+    )
+    assert "::error::" in lines[at], (
+        f"the {label} branch no longer raises ::error:: — it reads {lines[at]!r}"
+    )
+    block = _block_after(lines, at)
+    assert "exit 1" in block, (
+        f"the {label} branch does not `exit 1` before its block closes (saw "
+        f"{block}). Without it the job stays green and a digest publishes with no "
+        "announcement — indistinguishable from the pre-#616 bug."
+    )
+
+
+def test_step_never_softens_a_failure():
+    """No ``::warning::`` anywhere in this step, at all.
+
+    Asserted over the whole step body rather than per-branch on purpose. The
+    per-branch version keyed on the branch's own message text, so a mutation
+    that REPLACED that text with a `::warning::` removed the very string the
+    loop searched for and the test passed having examined nothing. An assertion
+    must not depend on a string its target mutation can delete.
+
+    There is no legitimate warning in this step: every path here is either a
+    successful delivery or something a human needs to act on.
+    """
+    body = _uncommented(_step(POST_STEP)["run"])
+    assert "::warning::" not in body, (
+        "a failure path in the Slack post step was softened to ::warning::. A "
+        "warning leaves the job green, and nobody reads a green cron run — which "
+        "is how this exact step announced nothing for four straight digests."
+    )
+
+
+def test_error_paths_and_exits_stay_balanced():
+    """Canary: 4 error paths, 4 exits — two secret checks, two delivery branches.
+
+    Coarse on purpose. If the step is restructured, this fails and forces a
+    re-read rather than letting the per-branch assertions drift into vacuity.
+    """
+    body = _uncommented(_step(POST_STEP)["run"])
+    errors = body.count("::error::")
+    exits = sum(1 for ln in body.splitlines() if ln.strip() == "exit 1")
+    assert errors == exits == 4, (
+        f"expected 4 ::error:: paths each ending in `exit 1`, found "
+        f"{errors} errors / {exits} exits. If the step was intentionally "
+        "restructured, re-derive the per-branch assertions above and update this "
+        "count in the same change."
+    )
+
+
+def test_missing_secret_still_fails_closed():
+    body = _uncommented(_step(POST_STEP)["run"])
+    for secret in ("SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID"):
+        # the emptiness test, then an exit within the same block
+        at = next(
+            (
+                i
+                for i, ln in enumerate(body.splitlines())
+                if f'-z "${{{secret}:-}}"' in ln
+            ),
+            None,
+        )
+        assert at is not None, f"the {secret} presence check is gone"
+        window = [ln.strip() for ln in body.splitlines()[at : at + 4]]
+        assert any(ln == "exit 1" for ln in window), (
+            f"{secret} absence no longer fails the step. It IS registered in this "
+            "repo, so absence means removal, rotation or lost access — the one "
+            "regression worth knowing about."
+        )
+
+
+def test_no_always_on_the_notification_path():
+    """`always()` without derived status is how #599 announced a non-event."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    body = "\n".join(
+        ln for ln in text.splitlines() if not ln.lstrip().startswith("#")
+    )
+    assert "always()" not in body, (
+        "always() appeared in slack-post-notify.yml. It defeats the default "
+        "skip-on-failure, so without a derived status it guarantees a false "
+        "report — monthly-quality-report.yml's exact defect."
+    )
+
+
+def test_nothing_on_the_path_is_continue_on_error():
+    doc = _doc(WORKFLOW)
+    job = doc["jobs"]["notify"]
+    assert not job.get("continue-on-error"), "continue-on-error on the notify job"
+    for step in job["steps"]:
+        assert not step.get("continue-on-error"), (
+            f"continue-on-error on step {step.get('name')!r} defeats the exit code "
+            "this guard exists to protect"
+        )
+
+
+def test_message_is_derived_not_literal():
+    """Step 1 of the checklist: the announcement must be a function of the post."""
+    step = _step(POST_STEP)
+    message = str((step.get("env") or {}).get("MESSAGE", ""))
+    assert "steps.posts.outputs.message" in message, (
+        f"MESSAGE is {message!r}, not derived from the detection step. A literal "
+        "announcement is the run-blog-autonomous-cron.sh defect."
+    )
+    builder = _uncommented(_step("Detect new posts and build message")["run"])
+    assert "build_slack_post_message.py" in builder, (
+        "the message is no longer built from the post file"
+    )
+
+
+def test_caller_still_gates_on_a_real_publish():
+    """A red notify job must not be reachable for an unpublished digest."""
+    job = _doc(CALLER)["jobs"]["notify-slack"]
+    assert "published_to_main == 'true'" in job.get("if", ""), (
+        "ai-blogwatcher.yml's notify-slack lost its published_to_main gate. Now "
+        "that delivery failure is a hard error, an ungated call would turn the "
+        "quarantined repository_dispatch path red as well as announcing it."
+    )


### PR DESCRIPTION
## 4단계 점검 결과

`notification_reports_constant_not_result`의 체크리스트를 #616이 추가한 Slack 배선에 적용했다.

| 단계 | 결과 | 근거 |
|---|---|---|
| 1. 상태가 파생값인가 | ✅ PASS | `MESSAGE`=`steps.posts.outputs.message`, `has_posts`/`count`는 실제 탐지에서 파생, 게이팅 `published_to_main`은 `git push` 성공에서 파생. 리터럴 상태 문자열 없음 |
| 2. `if: always()` | ✅ PASS | `slack-post-notify.yml`에 `always()` 없음 |
| 3. 요구 시크릿 등록 | ✅ PASS | `SLACK_BOT_TOKEN`·`SLACK_CHANNEL_ID` 둘 다 `gh secret list`에 존재 |
| 4. 배송 실패가 exit code로 전파 | ❌ **FAIL** | 실패 브랜치 2개의 `exit 1` 개수 = **0** |

`ok=false`(`channel_not_found`, `not_in_channel`, `invalid_auth`, 스코프 회수)와 HTTP non-2xx(429 포함)가 전부 `::warning::` 후 exit 0이었다. **green job + 미배송.**

사람 push 전용일 때는 견딜 수 있었다 — 방금 머지한 사람이 실행을 보고 있다. #616으로 크론이 이 워크플로를 호출하기 시작한 순간 성립하지 않는다. 00:00 UTC에 돌고 크론 로그는 아무도 안 읽으므로, **조용한 배송 실패는 #616이 고친 버그와 구분되지 않는다.**

이 레포가 같은 형태를 세 번 냈다: `run-blog-autonomous-cron.sh`의 고정 `100% Passed` · `monitoring.yml`의 미등록 시크릿 · `monthly-quality-report.yml`의 하드코딩 `--status SUCCESS`. 이번이 네 번째이고, 상태 파생은 맞았으나 **배송**이 빠진 더 미묘한 형태였다.

## 무엇을

두 실패 브랜치를 `::error::` + `exit 1`로. 4경로 모두 실측했다 — 실제 스텝 본문을 YAML에서 추출해 `curl`만 스텁으로 바꿔 실행:

```
ok=true         rc=0  "Slack notification sent successfully"
ok=false        rc=1  ::error::...reported ok=false: channel_not_found
HTTP 429        rc=1  ::error::Slack HTTP error (HTTP 429)
non-JSON body   rc=1  (set -e가 command substitution에서 종료)
```

**재시도는 일부러 넣지 않았다**: `chat.postMessage`는 멱등이 아니고 응답 유실 후 재시도는 중복 발송이 된다. 디제스트는 이 시점에 이미 커밋·push됐으므로 red job은 "발행됐고 알리지 못했다"를 뜻하며 아무것도 되돌리지 않는다.

## 가드 작성 중 가드 자체 결함 2건

대조군을 먼저 돌리는 규칙 덕에 잡혔다. 둘 다 처음엔 MISSED였고, **뮤테이션이 실제로 반영됐는지 먼저 확인**한 뒤 진단했다.

1. **`exit 1` 탐색 창이 브랜치를 넘었다.** flat `lines[at+1:at+6]`이 닫는 `fi`와 `else`를 지나 **다른 브랜치의** `exit 1`을 찾았다 → `ok=false`에서 exit를 지워도 green. 들여쓰기 기준 블록 스코핑으로 교체.
2. **warning 검사가 삭제 가능한 문자열을 키로 삼았다.** 브랜치 자체 메시지 텍스트로 라인을 찾았는데, 그 텍스트를 `::warning::`으로 치환하는 뮤테이션이 검색 대상을 함께 지워 루프가 아무것도 검사하지 않고 통과했다 → 스텝 본문 전체에 `::warning::` 부재를 assert(이 스텝에 정당한 warning은 없다).

## 검증

- `pytest scripts/tests/` **4915 passed, 5 skipped** · `actionlint rc=0` · `ruff(py311) clean`
- **대조군 9/9 pass + 뮤테이션 9/9 caught**: ok=false→warning / ok=false exit 제거 / non-2xx exit 제거 / balance canary / 시크릿 exit 제거 / `always()` 도입 / `continue-on-error` 추가 / MESSAGE 하드코딩 / 호출자 publish 게이트 제거

## 검증 못 한 것

실제 Slack 배송 실패는 재현하지 않았다(채널 권한을 일부러 깨는 일이라 하지 않음). 스텁으로 분기 로직만 검증했다.