### PR TITLE
fix(ci): Slack sender 4개 전부 배송 실패를 exit code로 — 복사-붙여넣기 결함

### DIFF
--- a/.github/workflows/googlebot-access-monitor.yml
+++ b/.github/workflows/googlebot-access-monitor.yml
@@ -106,15 +106,31 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$payload")
           echo "Slack response: $HTTP_STATUS"
+          # A failed delivery exits non-zero. The step above already refuses to
+          # run with a missing secret on exactly this reasoning — "the alert this
+          # job exists to deliver would have been dropped silently" — but the
+          # delivery itself then warned and returned 0, dropping the alert
+          # silently for every other reason: channel_not_found, not_in_channel,
+          # invalid_auth, a revoked scope, HTTP 429. Half the argument was
+          # implemented.
+          #
+          # This one is a Googlebot-visibility alarm, so a dropped alert means
+          # the site can be serving 429 to Googlebot with nobody told — the
+          # failure mode that first made this workflow necessary.
+          #
+          # Not retried: chat.postMessage is not idempotent and a retry after a
+          # lost response double-posts.
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             ok=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("ok",""))')
             if [ "$ok" = "True" ]; then
               echo "Slack notification sent successfully"
             else
               error=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("error","unknown"))')
-              echo "::warning::Slack API error: $error"
+              echo "::error::Slack accepted the request (HTTP $HTTP_STATUS) but reported ok=false: $error. The Googlebot probe failure above was NOT announced."
+              exit 1
             fi
           else
-            echo "::warning::Slack HTTP error (HTTP $HTTP_STATUS)"
+            echo "::error::Slack HTTP error (HTTP $HTTP_STATUS). The Googlebot probe failure above was NOT announced."
             cat /tmp/slack_resp.txt || true
+            exit 1
           fi

--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -141,17 +141,35 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$payload")
           echo "Slack response: $HTTP_STATUS"
+          # A failed delivery exits non-zero. This step runs under `if: failure()`,
+          # so the job is already red and the exit code does not change that —
+          # what it changes is the step's own check mark. Until 2026-08-26 both
+          # branches below warned and returned 0, so the run showed
+          # "Slack notification on failure ✓" while no alert had been delivered.
+          # That is the same "reports a constant, not the result" defect this
+          # workflow already shipped once: its Slack step used to hang off
+          # SLACK_WEBHOOK, a secret that was never registered, and therefore never
+          # fired for a real outage (fixed in #583).
+          #
+          # This is the highest-stakes instance of the three senders, because the
+          # whole point of the alert is to reach someone who is NOT looking at the
+          # run list.
+          #
+          # Not retried: chat.postMessage is not idempotent and a retry after a
+          # lost response double-posts.
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             ok=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("ok",""))')
             if [ "$ok" = "True" ]; then
               echo "Slack alert sent"
             else
               error=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("error","unknown"))')
-              echo "::warning::Slack API error: $error"
+              echo "::error::Slack accepted the request (HTTP $HTTP_STATUS) but reported ok=false: $error. The monitoring failure above was NOT announced."
+              exit 1
             fi
           else
-            echo "::warning::Slack HTTP error (HTTP $HTTP_STATUS)"
+            echo "::error::Slack HTTP error (HTTP $HTTP_STATUS). The monitoring failure above was NOT announced."
             cat /tmp/slack_resp.txt || true
+            exit 1
           fi
 
   success-notification:

--- a/.github/workflows/slack-category-digest.yml
+++ b/.github/workflows/slack-category-digest.yml
@@ -94,15 +94,31 @@ jobs:
             -H "Content-Type: application/json; charset=utf-8" \
             -d "$payload")
           echo "Slack response: $HTTP_STATUS"
+          # A failed delivery exits non-zero. Until 2026-08-26 both branches below
+          # warned and returned 0, so `channel_not_found`, `not_in_channel`,
+          # `invalid_auth`, a revoked scope or a 429 produced a GREEN scheduled
+          # run with nothing delivered. This workflow fires on a 01:30 UTC timer
+          # and nobody reads its logs, so "green" was the only signal available
+          # and it was wrong.
+          #
+          # All three Slack senders in this repo carried the identical block —
+          # it was copy-pasted — and all three were fixed together. The guard
+          # scripts/tests/test_ci_slack_notify_delivery_guard.py now asserts the
+          # shape across the whole family so a fourth copy cannot reintroduce it.
+          #
+          # Not retried: chat.postMessage is not idempotent and a retry after a
+          # lost response double-posts.
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             ok=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("ok",""))')
             if [ "$ok" = "True" ]; then
               echo "Slack digest sent successfully"
             else
               error=$(python3 -c 'import json; r=json.load(open("/tmp/slack_resp.txt")); print(r.get("error","unknown"))')
-              echo "::warning::Slack API error: $error"
+              echo "::error::Slack accepted the request (HTTP $HTTP_STATUS) but reported ok=false: $error. The category digest was NOT delivered."
+              exit 1
             fi
           else
-            echo "::warning::Slack HTTP error (HTTP $HTTP_STATUS)"
+            echo "::error::Slack HTTP error (HTTP $HTTP_STATUS). The category digest was NOT delivered."
             cat /tmp/slack_resp.txt || true
+            exit 1
           fi

--- a/scripts/tests/test_ci_slack_notify_delivery_guard.py
+++ b/scripts/tests/test_ci_slack_notify_delivery_guard.py
@@ -48,6 +48,38 @@ FAILURE_BRANCHES = (
     ("non-2xx", 'Slack HTTP error'),
 )
 
+# Every chat.postMessage sender in the repo, as (workflow, job, step).
+#
+# The defect this file guards spread by copy-paste: all three carried a
+# byte-identical delivery block, and all three swallowed a failed send as
+# `::warning::` + exit 0. Fixing only the one that prompted the audit would have
+# left two live and invited a fourth copy. So the family is the unit.
+#
+#   slack-post-notify        — announces a new post; called by ai-blogwatcher (#616)
+#   monitoring               — `if: failure()`, the production outage alert
+#   slack-category-digest    — 01:30 UTC scheduled digest
+#   googlebot-access-monitor — `if: failure()`, Googlebot 429/challenge alarm
+#
+# The fourth was found by test_sender_list_is_complete below, not by reading the
+# audit request: it named three workflows and the canary immediately reported a
+# fourth carrying the same block. That is the argument for the canary existing.
+SENDERS = (
+    ("slack-post-notify.yml", "notify", POST_STEP),
+    ("monitoring.yml", "monitor", "Slack notification on failure"),
+    ("slack-category-digest.yml", "post-category-digest", POST_STEP),
+    ("googlebot-access-monitor.yml", "probe", "Notify Slack on failure"),
+)
+
+
+def _sender_body(workflow: str, job: str, step: str) -> str:
+    path = REPO_ROOT / ".github" / "workflows" / workflow
+    assert path.is_file(), f"{path} not found"
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    for s in doc["jobs"][job]["steps"]:
+        if s.get("name") == step:
+            return _uncommented(s["run"])
+    pytest.fail(f"no step {step!r} in {workflow}:{job}")
+
 
 def _doc(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -210,6 +242,79 @@ def test_message_is_derived_not_literal():
     builder = _uncommented(_step("Detect new posts and build message")["run"])
     assert "build_slack_post_message.py" in builder, (
         "the message is no longer built from the post file"
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job", "step"), SENDERS, ids=lambda v: str(v))
+@pytest.mark.parametrize(("label", "marker"), FAILURE_BRANCHES)
+def test_every_slack_sender_exits_on_delivery_failure(
+    label: str, marker: str, workflow: str, job: str, step: str
+):
+    """Family-wide: the same assertion, on every chat.postMessage sender."""
+    body = _sender_body(workflow, job, step)
+    lines = body.splitlines()
+    at = next((i for i, ln in enumerate(lines) if marker in ln), None)
+    assert at is not None, (
+        f"{workflow}: the {label} failure branch is gone (looked for {marker!r})"
+    )
+    assert "::error::" in lines[at], (
+        f"{workflow}: the {label} branch no longer raises ::error:: — {lines[at]!r}"
+    )
+    assert "exit 1" in _block_after(lines, at), (
+        f"{workflow}: the {label} branch does not `exit 1` before its block "
+        "closes, so a failed send leaves the step green. This block was "
+        "copy-pasted into three workflows and was broken in all three until "
+        "2026-08-26."
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job", "step"), SENDERS, ids=lambda v: str(v))
+def test_no_slack_sender_softens_a_failure(workflow: str, job: str, step: str):
+    """No ``::warning::`` in any sender's delivery block."""
+    body = _sender_body(workflow, job, step)
+    assert "::warning::" not in body, (
+        f"{workflow}: a failure path was softened to ::warning::. A warning "
+        "leaves the step green, and for monitoring.yml that means the run shows "
+        "'Slack notification on failure ✓' with no alert delivered."
+    )
+
+
+@pytest.mark.parametrize(("workflow", "job", "step"), SENDERS, ids=lambda v: str(v))
+def test_every_slack_sender_fails_closed_on_missing_secrets(
+    workflow: str, job: str, step: str
+):
+    body = _sender_body(workflow, job, step)
+    lines = body.splitlines()
+    for secret in ("SLACK_BOT_TOKEN", "SLACK_CHANNEL_ID"):
+        at = next(
+            (i for i, ln in enumerate(lines) if f'-z "${{{secret}:-}}"' in ln), None
+        )
+        assert at is not None, f"{workflow}: the {secret} presence check is gone"
+        assert "exit 1" in _block_after(lines, at), (
+            f"{workflow}: {secret} absence no longer fails the step. It IS "
+            "registered in this repo, so absence means removal, rotation or lost "
+            "access — the one regression worth knowing about."
+        )
+
+
+def test_sender_list_is_complete():
+    """A fourth copy of the block must be added to SENDERS, not left unguarded.
+
+    Scans every workflow for a chat.postMessage call and requires it to be one
+    of the senders above. Without this the guard silently covers a shrinking
+    fraction of the family — which is how three copies drifted in the first
+    place.
+    """
+    listed = {w for w, _j, _s in SENDERS}
+    found = {
+        p.name
+        for p in (REPO_ROOT / ".github" / "workflows").glob("*.yml")
+        if "chat.postMessage" in p.read_text(encoding="utf-8")
+    }
+    assert found == listed, (
+        f"chat.postMessage senders on disk {sorted(found)} != guarded "
+        f"{sorted(listed)}. Add the new one to SENDERS (and give it the same "
+        "hard-exit delivery block) or remove the stale entry."
     )
 
 


### PR DESCRIPTION
## 4단계 점검 결과

`notification_reports_constant_not_result`의 체크리스트를 잔여 알림 워크플로에 적용했다. #620이 고친 블록이 레포에 **네 벌** 있었고, 네 벌 모두 같은 결함이었다.

| 워크플로 | 1 파생 | 2 always() | 3 시크릿 | 4 배송→exit | 비고 |
|---|---|---|---|---|---|
| `monitoring.yml` | ✅ | ✅ | ✅ | ❌ | `if: failure()` — 프로덕션 장애 알림 |
| `slack-category-digest.yml` | ✅ | ✅ | ✅ | ❌ | 01:30 UTC schedule |
| `googlebot-access-monitor.yml` | ✅ | ✅ | ✅ | ❌ | **카나리아가 발견** |
| `sentry-healthcheck.yml` | ✅ | ✅ | ✅ | ✅ | 발송 없음 — 손대지 않음 |

세 워크플로 모두 `ok=false`(`channel_not_found`, `not_in_channel`, `invalid_auth`, 스코프 회수)와 HTTP non-2xx(429 포함)를 `::warning::` 후 exit 0으로 넘겼다.

### 지정 범위를 하나 넘었다

점검 대상으로 주신 건 3개(`monitoring`, `slack-category-digest`, `sentry-healthcheck`)였다. 가드에 넣은 완결성 카나리아가 첫 실행에서 **`googlebot-access-monitor.yml`**을 보고했고, 확인해보니 동일 결함이었다. 알고도 남겨두는 것이 더 나쁘다고 판단해 함께 고쳤다.

### `sentry-healthcheck.yml`은 통과 — 고치지 않았다

`chat.postMessage`가 없다(외부 발송이 아니라 `$GITHUB_STEP_SUMMARY` 기록). "Write summary"에 `always()`가 있지만 모든 값이 `steps.X.outputs.*` 파생이고 `|| 'false'` 보수적 기본값이다. #599(`always()` + 하드코딩 `--status SUCCESS`)와 **정반대** 패턴이다.

### `monitoring.yml`이 가장 나쁘다

`if: failure()`라 잡은 이미 red지만 **스텝 자체는 green**이어서 실행 화면에 `Slack notification on failure ✓`가 뜬다 — 알림이 갔다고 주장하면서 안 간 상태다. 이 워크플로는 같은 계열 결함 전적이 있다: 미등록 `SLACK_WEBHOOK`에 걸려 실제 장애에 한 번도 울리지 않았다(#583).

`googlebot` 쪽은 시크릿 부재 검사에 *"the alert this job exists to deliver would have been dropped silently"*라고 써 두고 배송 실패는 조용히 넘겼다 — 논거의 절반만 구현돼 있었다.

재시도는 넣지 않았다: `chat.postMessage`는 멱등이 아니고 응답 유실 후 재시도는 중복 발송이 된다.

## 가드를 계열 단위로 일반화

결함이 복사로 퍼졌으므로 단위는 파일이 아니라 계열이다. `SENDERS` 테이블에 4개를 등록하고 동일 assertion을 파라미터화했다. `test_sender_list_is_complete`가 디스크의 `chat.postMessage` 호출자를 스캔해 `SENDERS`와 집합 일치를 요구하므로 **다섯 번째 복사본은 배선 없이 통과할 수 없다** — 네 번째를 찾은 것이 바로 이 검사다.

## 검증

- `pytest scripts/tests/` **4932 passed, 5 skipped** · `ruff(py311) clean`
- **대조군 17/17 pass + 뮤테이션 9/9 caught** — sender별 `ok=false` exit 제거 / non-2xx warning화 각 4쌍, 그리고 미등록 5번째 sender 출현
- 실제 스텝 본문을 추출해 `curl`만 스텁으로 바꿔 실측:

```
monitoring.yml                 ok=true rc=0 | ok=false rc=1 | HTTP 500 rc=1
googlebot-access-monitor.yml   ok=true rc=0 | ok=false rc=1 | HTTP 500 rc=1
```

## 범위 밖 — 보고만

`actionlint` SC2016(info) 2건(`monitoring.yml`, `googlebot-access-monitor.yml`). main과 **동일한 개수**로 pre-existing이고, `actionlint`는 이 레포 CI/훅에 배선돼 있지 않다.

## 검증 못 한 것

실제 Slack 배송 실패는 재현하지 않았다(채널 권한을 일부러 깨는 일이라 하지 않음). 스텁으로 분기 로직만 검증했다.