### PR TITLE
feat(ci): actionlint를 워크플로 위생 잡에 배선 — 지금까지 아무것도 린트하지 않았다

### DIFF
--- a/.github/workflows/action-pin-check.yml
+++ b/.github/workflows/action-pin-check.yml
@@ -1,8 +1,17 @@
 name: Action Pin Check
 
-# Validates that all GitHub Actions `uses:` references across .github/workflows/
-# use consistent 40-char SHA pins. Floating tags (@v1, @v2) generate warnings.
-# On PRs that touch workflow files, existence is verified via the GitHub API.
+# Workflow hygiene. Two checks, same trigger:
+#
+# 1. All GitHub Actions `uses:` references across .github/workflows/ use
+#    consistent 40-char SHA pins. Floating tags (@v1, @v2) generate warnings.
+#    On PRs that touch workflow files, existence is verified via the GitHub API.
+# 2. actionlint over every workflow (added 2026-08-26). Until then NOTHING
+#    linted these files — no CI job and no pre-commit hook ran actionlint or
+#    shellcheck over them, which is a gap worth closing after a session that
+#    edited seven of them.
+#
+# Why it lands here rather than in a new workflow: identical purpose and
+# identical trigger (`.github/workflows/**` on PR + main push).
 
 on:
   pull_request:
@@ -38,3 +47,78 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/check_workflow_action_pins.py --check-existence
+
+      - name: Install actionlint (version-pinned, checksum-verified)
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          # Not the upstream `download-actionlint.bash` one-liner: that curls a
+          # script from the mutable `main` ref and pipes it to bash, which is
+          # the opposite of what this workflow exists to enforce. Not a `uses:`
+          # action either — that would add a pin for check_workflow_action_pins
+          # to track for a single binary fetch. Release tarball + checksum keeps
+          # the supply chain auditable in-file.
+          #
+          # Verified locally 2026-08-26: this URL and checksum match the real
+          # artifact (2353908 bytes, statically linked ELF x86-64).
+          cd "$RUNNER_TEMP"
+          curl -sSL --retry 3 --max-time 120 -o actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+          sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          actionlint --version
+
+      - name: actionlint (blocking — warning and above)
+        run: |
+          set -euo pipefail
+          # NOTE: no comment line in this script may begin with the word
+          # "shellcheck" straight after the `#` — shellcheck parses that as a
+          # directive and reports SC1072/SC1073. This gate caught exactly that
+          # in its own first draft, before merge.
+          #
+          # Threshold: actionlint's own rules (all severities) plus SC findings
+          # at `warning` and above. Measured on the corpus 2026-08-26,
+          # before wiring — the rule this repo learned the hard way is to run a
+          # dormant gate at the scope you intend to enforce and read the output
+          # first, because a gate nobody has run has never been right:
+          #
+          #   actionlint native rules ... 0 findings
+          #   SC info .................. 65  (59x SC2086 quote-to-prevent-splitting)
+          #   SC style .................. 5  (SC2129 prefer `{ } >> file`)
+          #   SC warning ................ 1  (SC2034 unused var in sentry-release)
+          #
+          # The one warning is fixed in this change, so this step starts at zero
+          # rather than being born red. info+style are excluded deliberately:
+          # 70 cosmetic findings across 12 workflows would either force an
+          # unrelated 70-site rewrite or get muted, and muted gates are how this
+          # repo ended up with jobs that had never once been right. They are
+          # surfaced in the summary step below instead of hidden.
+          #
+          # The ignore patterns are anchored to `SC<digits>:` so they can only
+          # ever suppress SC output — a bare ':info:' could match a
+          # native actionlint message and silently widen the hole.
+          actionlint \
+            -ignore 'SC[0-9]+:info:' \
+            -ignore 'SC[0-9]+:style:'
+
+      - name: actionlint informational findings (non-blocking)
+        if: always()
+        run: |
+          set -uo pipefail
+          # Visibility for the excluded tiers, so "we ignore info" does not
+          # decay into "nobody knows how many there are". Counts are derived
+          # from the actual run, never asserted as a constant.
+          out="$(actionlint 2>&1 || true)"
+          info=$(printf '%s\n' "$out" | grep -cE 'SC[0-9]+:info:' || true)
+          style=$(printf '%s\n' "$out" | grep -cE 'SC[0-9]+:style:' || true)
+          {
+            echo "## actionlint — informational (not gating)"
+            echo ""
+            echo "- SC \`info\`: ${info}"
+            echo "- SC \`style\`: ${style}"
+            echo ""
+            echo "Gating tier is \`warning\` and above, plus all native actionlint rules."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -68,7 +68,6 @@ jobs:
             local max_retries=3
             local retry=0
             local http_code=""
-            local body=""
             local response=""
 
             while [ $retry -lt $max_retries ]; do
@@ -80,7 +79,13 @@ jobs:
               local exit_code=$?
 
               http_code=$(echo "$response" | tail -n1)
-              body=$(echo "$response" | sed '$d')
+              # The response body is deliberately not captured: this function
+              # returns only the HTTP code and every caller switches on that.
+              # `body=$(echo "$response" | sed '$d')` used to sit here, assigned
+              # and never read — a subshell per retry for nothing, and the only
+              # SC2034 in the repo. Removed when actionlint was wired into CI
+              # (2026-08-26). Note: a comment line must not start with the word
+              # "shellcheck" right after the `#`, or it is parsed as a directive.
 
               if [ "$exit_code" -eq 0 ] && echo "$http_code" | grep -qE '^[0-9]{3}$'; then
                 echo "$http_code"

--- a/scripts/tests/test_ci_actionlint_gate_guard.py
+++ b/scripts/tests/test_ci_actionlint_gate_guard.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""CI regression guard: the actionlint gate stays pinned, verified and unsoftened.
+
+Nothing linted `.github/workflows/` until 2026-08-26 — no CI job and no
+pre-commit hook ran actionlint or shellcheck over them. That gap mattered
+because the plumbing added in #616 (a `workflow_call` job, `needs:` outputs,
+`secrets: inherit`) is exactly the class actionlint validates and no other gate
+in this repo touches: a typo in `needs.auto-publish.outputs.post_file` is
+invisible to YAML parsing, to pytest, and to the pin checker.
+
+Measured before wiring, at the scope being enforced, per the rule that a gate
+nobody has run has never been right:
+
+    actionlint native rules ...  0
+    SC info .................... 65   (59x SC2086)
+    SC style ....................  5   (SC2129)
+    SC warning ..................  1   (SC2034, fixed in the same change)
+
+So the gate starts at zero rather than being born red, and the excluded info +
+style tiers are printed to the run summary instead of hidden.
+
+Three things here are load-bearing:
+
+1. The binary is version-pinned AND checksum-verified. The upstream install
+   path is `curl | bash` off the mutable `main` ref, which would make a
+   workflow whose whole purpose is pin hygiene depend on an unpinned script.
+2. The ignore patterns are anchored to `SC<digits>:`. A bare `':info:'` can
+   match a native actionlint message, silently widening the exclusion from
+   "cosmetic shell findings" to "anything whose text happens to contain
+   ':info:'".
+3. Neither the gate step nor the job is softened.
+
+Direction: pins are `==` (a bump must be deliberate and re-checksummed),
+exclusions are an exact set, softeners are forbidden.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "action-pin-check.yml"
+
+JOB = "check-pins"
+INSTALL_STEP = "Install actionlint"
+GATE_STEP = "actionlint (blocking"
+INFO_STEP = "actionlint informational"
+
+# Exactly the two tiers excluded from gating. Widening this set is a policy
+# change and must be argued for in the diff, not slipped in.
+EXPECTED_IGNORES = {"SC[0-9]+:info:", "SC[0-9]+:style:"}
+
+
+def _doc() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _steps() -> list[dict]:
+    return _doc()["jobs"][JOB]["steps"]
+
+
+def _step(fragment: str) -> dict:
+    for s in _steps():
+        if fragment in (s.get("name") or ""):
+            return s
+    pytest.fail(f"no step whose name contains {fragment!r} in {WORKFLOW.name}")
+
+
+def _uncommented(shell: str) -> str:
+    return "\n".join(ln for ln in shell.splitlines() if not ln.lstrip().startswith("#"))
+
+
+def _logical_lines(shell: str) -> list[str]:
+    """Shell lines with trailing-backslash continuations joined.
+
+    The actionlint invocation spans four physical lines. Checking physical lines
+    let a `|| true` appended to the last continuation escape entirely: that line
+    does not contain the word "actionlint", so a loop keyed on it never looked.
+    The mutation was confirmed to have landed before this was diagnosed.
+    """
+    out: list[str] = []
+    buf = ""
+    for raw in shell.splitlines():
+        ln = raw.strip()
+        if not ln:
+            continue
+        if ln.endswith("\\"):
+            buf += ln[:-1].rstrip() + " "
+            continue
+        out.append((buf + ln).strip())
+        buf = ""
+    if buf:
+        out.append(buf.strip())
+    return out
+
+
+def test_workflow_exists():
+    assert WORKFLOW.is_file(), f"{WORKFLOW} not found"
+
+
+def test_actionlint_is_version_pinned_and_checksum_verified():
+    step = _step(INSTALL_STEP)
+    env = step.get("env") or {}
+    version = str(env.get("ACTIONLINT_VERSION", ""))
+    digest = str(env.get("ACTIONLINT_SHA256", ""))
+    assert re.fullmatch(r"\d+\.\d+\.\d+", version), (
+        f"ACTIONLINT_VERSION is {version!r}; it must be an exact release, not a "
+        "range or a tag like 'latest'"
+    )
+    assert re.fullmatch(r"[0-9a-f]{64}", digest), (
+        f"ACTIONLINT_SHA256 is {digest!r}; a 64-hex sha256 of the release tarball "
+        "is required. If bumping the version, fetch the new checksum from the "
+        "release's checksums.txt and verify it against the downloaded artifact — "
+        "do not copy a value you have not checked."
+    )
+    body = _uncommented(step["run"])
+    assert "sha256sum -c" in body, (
+        "the checksum is declared but never verified. An unverified pin is "
+        "documentation, not a control."
+    )
+    # The URL must interpolate the env var rather than repeat the literal, so a
+    # version bump cannot leave the download pointing at the old release while
+    # the pin claims the new one. (An earlier draft of this test asserted the
+    # literal appeared in the body and failed on correct code.)
+    url = next(ln for ln in body.splitlines() if "releases/download" in ln)
+    assert "${ACTIONLINT_VERSION}" in url, (
+        f"the download URL does not interpolate ACTIONLINT_VERSION: {url.strip()!r}. "
+        "A hardcoded version there can silently disagree with the pin above."
+    )
+    assert "${ACTIONLINT_SHA256}" in body, (
+        "the checksum comparison does not use ACTIONLINT_SHA256"
+    )
+
+
+def test_install_does_not_pipe_a_remote_script_to_a_shell():
+    """The upstream one-liner curls from the mutable `main` ref."""
+    body = _uncommented(_step(INSTALL_STEP)["run"])
+    assert not re.search(r"curl[^|\n]*\|\s*(ba)?sh", body), (
+        "the install step pipes a remote script into a shell. This workflow "
+        "exists to enforce pin hygiene; it must not depend on an unpinned script."
+    )
+    assert "download-actionlint.bash" not in body, (
+        "download-actionlint.bash is fetched from refs/heads/main — unpinned"
+    )
+
+
+def test_gate_excludes_exactly_the_documented_tiers():
+    body = _uncommented(_step(GATE_STEP)["run"])
+    found = set(re.findall(r"-ignore\s+'([^']+)'", body))
+    assert found == EXPECTED_IGNORES, (
+        f"actionlint exclusions are {sorted(found)}, expected "
+        f"{sorted(EXPECTED_IGNORES)}. Adding one hides a tier that currently "
+        "gates; removing one makes the job red on 70 pre-existing cosmetic "
+        "findings. Either way it is a policy change — say so in the diff."
+    )
+
+
+def test_ignore_patterns_cannot_swallow_native_actionlint_findings():
+    """Anchored to `SC<digits>:`, so only shellcheck output can match."""
+    body = _uncommented(_step(GATE_STEP)["run"])
+    for pattern in re.findall(r"-ignore\s+'([^']+)'", body):
+        assert pattern.startswith("SC[0-9]+"), (
+            f"the exclusion {pattern!r} is not anchored to a shellcheck code. A "
+            "bare severity like ':info:' also matches native actionlint "
+            "messages, turning a narrow cosmetic exclusion into a general one."
+        )
+
+
+def test_gate_is_not_softened():
+    gate = _step(GATE_STEP)
+    assert not gate.get("continue-on-error"), "the actionlint gate is continue-on-error"
+    assert not gate.get("if"), (
+        f"the gate carries a condition ({gate.get('if')!r}); it must run on every "
+        "trigger of this workflow"
+    )
+    lines = _logical_lines(_uncommented(gate["run"]))
+    invocations = [ln for ln in lines if ln.startswith("actionlint")]
+    assert invocations, "the gate no longer invokes actionlint"
+    for ln in invocations:
+        for softener in ("|| true", "|| echo", "continue-on-error", "|| :"):
+            assert softener not in ln, (
+                f"the actionlint invocation is softened with {softener!r}: {ln!r}"
+            )
+    assert not _doc()["jobs"][JOB].get("continue-on-error"), (
+        "the whole job is continue-on-error, which defeats both gates in it"
+    )
+
+
+def test_informational_step_is_reporting_only_and_derives_its_counts():
+    """The excluded tiers must stay visible, and the numbers must be measured."""
+    step = _step(INFO_STEP)
+    assert step.get("if") == "always()", (
+        "the informational step should run even when the gate fails; that is when "
+        "its counts are most useful"
+    )
+    body = _uncommented(step["run"])
+    assert "GITHUB_STEP_SUMMARY" in body, "the counts are not surfaced anywhere"
+    assert "$(actionlint" in body or "actionlint 2>&1" in body, (
+        "the counts are no longer derived from an actual run. A hardcoded number "
+        "here is the same defect as a hardcoded --status: it reports a constant, "
+        "not a result."
+    )
+    assert not re.search(r"info=\s*\d+", body), (
+        "an info count is hardcoded rather than computed"
+    )
+
+
+def test_gate_runs_whenever_any_workflow_changes():
+    on = _doc().get(True, _doc().get("on")) or {}
+    for event in ("push", "pull_request"):
+        block = on.get(event) or {}
+        paths = block.get("paths") or []
+        assert ".github/workflows/**" in paths, (
+            f"the {event} trigger no longer covers .github/workflows/**, so "
+            "editing a workflow would not lint it"
+        )


### PR DESCRIPTION
## 왜

`.github/workflows/` 를 검사하는 것이 **하나도 없었다**. CI 잡도, pre-commit 훅도 actionlint나 shellcheck를 이 파일들에 돌리지 않았다.

이번 세션에 워크플로 7개를 고쳤고, 그중 #616이 추가한 배선(`workflow_call` 잡, `needs` 출력, `secrets: inherit`)은 **정확히 actionlint가 검증하고 이 레포의 다른 게이트는 못 보는 계열**이다 — `needs.auto-publish.outputs.post_file` 의 오타는 YAML 파싱에도, pytest에도, 핀 체커에도 걸리지 않는다.

## 배선 전 실측

휴면 게이트는 배선 전에 의도한 스코프로 돌려 출력을 읽는다:

| 계층 | 건수 |
|---|---|
| actionlint 자체 규칙 | **0** |
| SC `info` | 65 (59× SC2086) |
| SC `style` | 5 (SC2129) |
| SC `warning` | 1 (SC2034) |

**게이팅 임계값 = actionlint 전체 규칙 + SC `warning` 이상.** 유일한 warning 1건을 이 변경에서 함께 고쳤으므로 게이트는 **0에서 시작**한다.

`info`/`style` 70건은 일부러 제외했다 — 12개 워크플로에 걸친 미용 수정 70곳을 강요하거나 게이트를 뮤트하게 되고, 뮤트된 게이트가 이 레포에 "한 번도 옳은 적 없는 잡"을 만든 원인이다. 숨기는 대신 요약 스텝에 개수를 출력한다(값은 실제 실행에서 파생, 상수 아님).

`ignore` 패턴은 `SC[0-9]+:` 로 앵커했다. 맨 `':info:'` 는 actionlint 자체 메시지에도 매치할 수 있어 좁은 미용 제외가 범용 제외로 조용히 넓어진다.

## SC2034 수정 (동작 불변)

`sentry-release.yml` 의 `sentry_api()` 안에서 `body` 가 대입되고 **한 번도 읽히지 않았다** — 함수는 `http_code` 만 반환한다. 재시도마다 서브셸 하나를 낭비한 dead assignment.

제거 후 확인: 실행 라인에 `body` 언급 **0건**, `http_code` 대입 / `response` 캡처 / `echo "$http_code"; return 0` 경로 모두 불변.

## 설치 방식

upstream `download-actionlint.bash` 는 **mutable `main` ref에서 curl해 bash에 파이프**한다 — 핀 위생을 강제하려는 워크플로가 의존할 대상이 아니다. `uses:` 액션도 아니다(단일 바이너리 페치에 `check_workflow_action_pins` 가 추적할 핀을 추가하게 된다).

릴리스 tarball + sha256 검증. 체크섬은 릴리스 `checksums.txt` 에서 받아 **실제 아티팩트로 대조 검증**했다(2353908 bytes, statically linked ELF x86-64).

호스트는 `action-pin-check.yml` — 동일 목적(워크플로 위생), 동일 트리거(`.github/workflows/**` PR + main push).

## 게이트가 자기 자신을 잡았다

첫 초안에서 내 주석 두 곳이 `# shellcheck` 로 시작해 shellcheck **directive** 로 파싱되어 SC1072/SC1073 **error** 가 났다. 머지 전에 잡혔다 — 새 게이트의 즉각적 실증이다. 두 파일 모두 문구를 바꾸고 재발 방지를 위해 그 사실을 주석에 남겼다.

## 검증

- `pytest scripts/tests/` **4941 passed, 5 skipped** · `ruff(py311) clean`
- 게이트 exit 0 · 핀 게이트 exit 0 · 정보 계층 실측 info 65 / style 5 / warning+ **0**
- 가드 `test_ci_actionlint_gate_guard.py`: **대조군 7/7 pass + 뮤테이션 11/11 caught** (version→latest / 체크섬 공백 / `sha256sum -c` 제거 / URL이 버전 하드코딩 / curl\|bash / 세 번째 ignore 추가 / ignore 앵커 해제 / `continue-on-error` / `\|\| true` / `\|\| echo` / info 하드코딩 / path 필터 제거)

뮤테이션 중 1건이 처음 MISSED였고 **가드 결함**이었다 — actionlint 호출이 4줄 line-continuation인데 검사가 물리 라인만 봐서, 마지막 continuation에 붙은 `|| true` 가 "actionlint" 를 포함하지 않아 루프가 보지 못했다. 논리 라인 결합 후 재측정해 caught.

## 정직하게

`sentry_api()` 를 standalone shellcheck로 돌리면 warning+ 2건이 남는데, 이는 **추출 방식의 artifact**다: `${{ github.sha }}` 는 Actions 표현식이라 shellcheck가 파싱하지 못한다(SC2296). actionlint는 이를 치환한 뒤 실행하므로 0이다. 게이트의 숫자는 actionlint의 0이다.

CI에서의 실제 다운로드·설치는 머지 후 첫 실행에서만 확인된다. 로컬에서 동일 URL·체크섬으로 다운로드·검증·압축해제까지 재현했다.