### PR TITLE
fix: 08-27 크론 런에서 나온 결함 2건 — gemini 헛spawn 43회, 절단 조사 목록 불일치

### DIFF
--- a/scripts/news/content_generator.py
+++ b/scripts/news/content_generator.py
@@ -3190,8 +3190,22 @@ def _truncate_korean_sentence(text: str, max_len: int) -> str:
     # Word boundary fallback
     clipped = clipped.rsplit(" ", 1)[0].rstrip(" ,.·:;")
     if re.search(r"[가-힣]", clipped):
+        # Keep in lockstep with _TRUNCATION_PARTICLES in
+        # scripts/digest_quality_report.py — that gate blocks publication when a
+        # table cell ends in one of these, so any particle it knows and this
+        # does not is a cell this function will happily emit and the gate will
+        # then reject. `위한`/`하기`/`대한` were exactly that gap, pinned by
+        # test_truncation_particle_lockstep.py.
+        #
+        # NOTE: not _DANGLING_SUFFIXES_RE, despite the overlap. That one has no
+        # `\s+` anchor, so substituting it here would strip the particle off a
+        # word it is attached to ("복지에" -> "복지") instead of removing a
+        # dangling standalone token. It is safe in _trim_dangling_particles
+        # only because that function cuts whole tokens in a loop.
         clipped = re.sub(
-            r"\s+(에|의|을|를|이|가|은|는|와|과|로|으로|에서|한|된|인|할)$", "", clipped
+            r"\s+(에|의|을|를|이|가|은|는|와|과|로|으로|에서|한|된|인|할|위한|하기|대한)$",
+            "",
+            clipped,
         )
         if not re.search(r"[.다됨임]$", clipped):
             clipped += " 등이 확인되었습니다."

--- a/scripts/news/enhancer.py
+++ b/scripts/news/enhancer.py
@@ -180,11 +180,41 @@ def _gemini_call(prompt: str, timeout: int = 35) -> str:
         except subprocess.TimeoutExpired:
             _cfg._GEMINI_CONSECUTIVE_FAILURES += 1
             logging.warning(f"Gemini CLI timeout ({timeout}s)")
+        except FileNotFoundError as e:
+            # The binary is absent, and that will not change mid-run. Latch it
+            # so the remaining calls skip straight to the API path.
+            #
+            # Nothing else latches it: `_gemini_available()` returns True at the
+            # API-key check *before* it ever probes the CLI, so
+            # `_GEMINI_AVAILABLE` stays None, and the gate above admits None.
+            # Measured on the 2026-08-27 cron run (33043799857): 43 identical
+            # "Gemini CLI error: [Errno 2]" warnings, one per enhancement call,
+            # each paying a doomed spawn. The circuit breaker could not help —
+            # the API fallback below kept succeeding (0 API errors in that run),
+            # which resets the failure counter, so the breaker never opened.
+            # That is correct behaviour for the breaker and exactly why the
+            # absent binary needed its own latch.
+            _cfg._GEMINI_AVAILABLE = False
+            _cfg._GEMINI_CONSECUTIVE_FAILURES += 1
+            logging.warning(
+                "Gemini CLI not installed (%s) - using the API path for the rest "
+                "of this run",
+                mask_sensitive_info(str(e)),
+            )
         except (subprocess.SubprocessError, OSError) as e:
+            # Transient: do NOT latch. A one-off spawn failure should not
+            # disable the CLI for the whole run.
             _cfg._GEMINI_CONSECUTIVE_FAILURES += 1
             logging.warning("Gemini CLI error: %s", mask_sensitive_info(str(e)))
 
-    if _cfg._GEMINI_API_KEY and _cfg._GEMINI_CONSECUTIVE_FAILURES > 0:
+    # The failure counter is the "the CLI just failed, try the API" trigger. It
+    # only ever rises when the CLI is *attempted*, so latching an absent binary
+    # off above would otherwise strand this branch at 0 forever and make
+    # _gemini_call return "" for the rest of the run. `_GEMINI_AVAILABLE is
+    # False` is the second, equivalent trigger: there is no CLI to fail.
+    if _cfg._GEMINI_API_KEY and (
+        _cfg._GEMINI_CONSECUTIVE_FAILURES > 0 or _cfg._GEMINI_AVAILABLE is False
+    ):
         api_timeout = min(timeout, 20)
         result = _gemini_api_call(prompt, timeout=api_timeout)
         if result and len(result) > 20:

--- a/scripts/tests/test_gemini_cli_absence_latch.py
+++ b/scripts/tests/test_gemini_cli_absence_latch.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""An absent `gemini` binary must be latched, not rediscovered on every call.
+
+Measured on the 2026-08-27 scheduled run (33043799857): 43 identical
+``Gemini CLI error: [Errno 2] No such file or directory: 'gemini'`` warnings,
+one per enhancement call, each paying a spawn that could not succeed.
+
+Three things had to line up for that, and the fix only removes the third:
+
+1. ``_gemini_available()`` returns True at the API-key check *before* it probes
+   the CLI, so ``_GEMINI_AVAILABLE`` is left at ``None``.
+2. ``_gemini_call`` gates the CLI attempt on ``is not False`` — ``None`` passes.
+3. Nothing in the failure path ever set the flag.
+
+The circuit breaker was not the missing guard and must not be pressed into the
+role: the API fallback kept succeeding (0 API errors in that run), which resets
+the consecutive-failure counter, so the breaker correctly never opened. A
+missing binary is a permanent condition and needs its own latch; a transient
+spawn error is not, and must NOT latch — that distinction is what
+``test_transient_subprocess_error_does_not_latch`` pins.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from news import enhancer
+
+# Take the config module off `enhancer` rather than importing it here.
+# `enhancer.py` does `import scripts.news.config as _cfg`, so `news.config` and
+# `scripts.news.config` are two distinct objects in sys.modules; patching the
+# wrong one leaves the code reading untouched state and every assertion below
+# measures nothing. The first draft of this file did exactly that and reported
+# "0 spawns" — which reads like a passing latch, not like a broken test.
+_cfg = enhancer._cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolate_gemini_state(monkeypatch):
+    """Give each test a clean, CLI-eligible starting state."""
+    monkeypatch.setattr(_cfg, "_GEMINI_AVAILABLE", None, raising=False)
+    monkeypatch.setattr(_cfg, "_GEMINI_CIRCUIT_OPEN", False, raising=False)
+    monkeypatch.setattr(_cfg, "_GEMINI_CONSECUTIVE_FAILURES", 0, raising=False)
+    monkeypatch.setattr(_cfg, "_GEMINI_API_KEY", "", raising=False)
+
+
+def _count_spawns(monkeypatch, exc):
+    """Run three _gemini_call()s where the spawn raises `exc`; count attempts."""
+    calls = []
+
+    def _fake_run(cmd, *a, **k):
+        calls.append(cmd)
+        raise exc
+
+    monkeypatch.setattr(enhancer.subprocess, "run", _fake_run)
+    for _ in range(3):
+        enhancer._gemini_call("prompt")
+    return calls
+
+
+def test_missing_binary_is_latched_after_the_first_attempt(monkeypatch):
+    calls = _count_spawns(
+        monkeypatch, FileNotFoundError(2, "No such file or directory", "gemini")
+    )
+    assert len(calls) == 1, (
+        f"the absent binary was spawned {len(calls)} times across 3 calls. It "
+        "must be attempted once and then latched, which is the 43-spawn "
+        "regression this test exists for."
+    )
+    assert _cfg._GEMINI_AVAILABLE is False
+
+
+# With no API key the pre-existing circuit breaker opens after the second call
+# (the failure counter is incremented twice per call in that configuration), so
+# the spawn count is 2, not 3. That is untouched behaviour; asserting an exact 3
+# here would be testing a number this change never promised. What matters is
+# that the CLI was retried at all rather than latched off after the first error.
+def test_transient_subprocess_error_does_not_latch(monkeypatch):
+    """A one-off spawn failure must not disable the CLI for the whole run."""
+    calls = _count_spawns(monkeypatch, subprocess.SubprocessError("transient"))
+    assert len(calls) > 1, (
+        "a transient error latched the CLI off after one attempt. Only "
+        "FileNotFoundError means the binary is absent; everything else may "
+        "succeed on the next call."
+    )
+    assert _cfg._GEMINI_AVAILABLE is not False
+
+
+def test_timeout_does_not_latch(monkeypatch):
+    calls = _count_spawns(monkeypatch, subprocess.TimeoutExpired("gemini", 35))
+    assert len(calls) > 1
+    assert _cfg._GEMINI_AVAILABLE is not False
+
+
+def test_latching_does_not_disable_the_api_path(monkeypatch):
+    """The behaviour that must NOT change: Gemini still answers, via the API.
+
+    In the measured run the API path served all 43 calls successfully. Latching
+    the CLI off is a noise/efficiency fix, so the API must still be reached —
+    and reached on the very first call, not only after the latch.
+    """
+    monkeypatch.setattr(_cfg, "_GEMINI_API_KEY", "dummy-key", raising=False)
+
+    def _fake_run(cmd, *a, **k):
+        raise FileNotFoundError(2, "No such file or directory", "gemini")
+
+    api_calls = []
+
+    def _fake_api(prompt, timeout=20):
+        api_calls.append(prompt)
+        return "x" * 50  # >20 chars, so it counts as a success
+
+    monkeypatch.setattr(enhancer.subprocess, "run", _fake_run)
+    monkeypatch.setattr(enhancer, "_gemini_api_call", _fake_api)
+
+    assert enhancer._gemini_call("first") == "x" * 50
+    assert enhancer._gemini_call("second") == "x" * 50
+    assert len(api_calls) == 2, "the API path stopped being used after the latch"
+    assert _cfg._GEMINI_AVAILABLE is False
+
+
+def test_successful_api_keeps_the_breaker_closed(monkeypatch):
+    """Why the breaker was never the guard for this.
+
+    A succeeding API call resets the consecutive-failure counter, so the
+    breaker stays closed however many times the CLI is missing. That is
+    correct, and it is exactly why the absent binary needs a separate latch.
+    """
+    monkeypatch.setattr(_cfg, "_GEMINI_API_KEY", "dummy-key", raising=False)
+    monkeypatch.setattr(
+        enhancer.subprocess,
+        "run",
+        lambda *a, **k: (_ for _ in ()).throw(
+            FileNotFoundError(2, "No such file or directory", "gemini")
+        ),
+    )
+    monkeypatch.setattr(enhancer, "_gemini_api_call", lambda p, timeout=20: "y" * 50)
+
+    for _ in range(5):
+        enhancer._gemini_call("p")
+
+    assert _cfg._GEMINI_CIRCUIT_OPEN is False
+    assert _cfg._GEMINI_CONSECUTIVE_FAILURES == 0

--- a/scripts/tests/test_truncation_particle_lockstep.py
+++ b/scripts/tests/test_truncation_particle_lockstep.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""The truncation detector and the truncation trimmer must know the same particles.
+
+`digest_quality_report.py` blocks publication when a digest table cell ends in a
+dangling Korean particle. `content_generator._truncate_korean_sentence` is what
+produces those cells and strips the particle before emitting. The two carry
+separate hand-written lists, so any particle the gate knows and the trimmer does
+not is a cell the generator will happily emit and the gate will then reject —
+a self-inflicted red cron with no bad input required.
+
+Measured 2026-08-27: the trimmer was missing `위한`, `하기`, `대한`.
+
+Direction: the trimmer's set must be a superset of the detector's. It may strip
+more (harmless — the cell just gets shorter); it must never strip less.
+
+This does NOT claim to explain the 2026-08-27 cron failure. That cell ended in
+`의`, which both lists already carried, so its truncation came from somewhere
+else — most likely the model's own output limit, which no Python truncator here
+would produce. This test pins a latent instance of the same failure mode, not
+that incident's root cause.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DETECTOR = REPO_ROOT / "scripts" / "digest_quality_report.py"
+GENERATOR = REPO_ROOT / "scripts" / "news" / "content_generator.py"
+
+# The trimmer inside _truncate_korean_sentence: `\s+(...)$`, anchored so it only
+# removes a standalone trailing token.
+_TRIMMER_RE = re.compile(r'r"\\s\+\(([^)]+)\)\$"')
+_DETECTOR_RE = re.compile(r'_TRUNCATION_PARTICLES = re\.compile\(\s*r"\\s\+\(([^)]+)\)')
+
+
+def _detector_particles() -> set[str]:
+    text = DETECTOR.read_text(encoding="utf-8")
+    match = _DETECTOR_RE.search(text)
+    assert match, (
+        "_TRUNCATION_PARTICLES not found in digest_quality_report.py. Either the "
+        "gate changed shape or this regex went stale — check which before "
+        "assuming the former, because a lockstep test that extracts nothing "
+        "passes vacuously."
+    )
+    return set(match.group(1).split("|"))
+
+
+def _trimmer_particles() -> set[str]:
+    text = GENERATOR.read_text(encoding="utf-8")
+    matches = _TRIMMER_RE.findall(text)
+    assert len(matches) == 1, (
+        f"expected exactly one `\\s+(...)$` particle list in content_generator.py, "
+        f"found {len(matches)}. A second copy is another place for the two sets to "
+        "drift apart; fold them together or extend this test to cover both."
+    )
+    return set(matches[0].split("|"))
+
+
+def test_both_lists_are_extracted():
+    """Guard the extractors themselves — empty sets would pass everything."""
+    assert len(_detector_particles()) > 10
+    assert len(_trimmer_particles()) > 10
+
+
+def test_trimmer_covers_every_particle_the_gate_rejects():
+    detector = _detector_particles()
+    trimmer = _trimmer_particles()
+    missing = detector - trimmer
+    assert not missing, (
+        f"the publication gate rejects cells ending in {sorted(missing)} but the "
+        "generator never strips them, so it can emit a cell that is guaranteed to "
+        "be rejected. Add them to the `\\s+(...)$` list in "
+        "_truncate_korean_sentence."
+    )


### PR DESCRIPTION
2026-08-27 스케줄 런(`33043799857`)을 읽고 확인된 것 두 가지.

## 1. 없는 `gemini` 바이너리를 매 호출마다 다시 시도 (43회)

로그에 `Gemini CLI error: [Errno 2]`가 **43회**, 호출당 1회. 세 조건이 겹쳤다:

1. `_gemini_available()`이 API 키 검사에서 **CLI를 탐침하기 전에** `True`를 반환 → `_GEMINI_AVAILABLE`이 `None`으로 남음
2. `_gemini_call`의 게이트가 `is not False` → `None`도 통과
3. 실패 경로가 플래그를 내리지 않음

**회로차단기는 이 자리의 가드가 아니다.** API 폴백이 계속 성공해서(그 런의 API 에러 **0건**) 연속실패 카운터가 리셋되므로 차단기는 정당하게 안 열린다. 없는 바이너리는 영구 조건이라 별도 latch가 필요하다.

`FileNotFoundError`만 latch한다. transient한 `SubprocessError`/`Timeout`은 다음 호출에 성공할 수 있으므로 latch하지 않는다.

**같은 커밋에서 API 게이트도 고쳤다.** `CONSECUTIVE_FAILURES > 0`은 CLI를 시도해야만 오르는 트리거라, latch만 넣으면 API 경로가 0에 갇혀 남은 런 내내 빈 문자열을 반환한다. 테스트가 이 회귀를 먼저 잡았다.

> **콘텐츠 동작은 불변.** 이 런의 Gemini는 API 경로로 정상 동작했다 — DeepSeek 폴백이 아니었다. 고친 건 spawn 낭비와 로그 노이즈다.

## 2. 절단 조사 목록이 발행 게이트와 어긋나 있었다

`_truncate_korean_sentence`의 `\s+(...)$` 목록이 `digest_quality_report._TRUNCATION_PARTICLES` 대비 **`위한`·`하기`·`대한` 3개 누락**. 게이트가 거부하는 걸 생성기가 안 걷어내면, 나쁜 입력 없이도 생성기 스스로 반드시 거부당할 셀을 만들어 크론을 red로 만든다.

`_DANGLING_SUFFIXES_RE`로 **대체하지 않았다** — 그쪽은 `\s+` 앵커가 없어 붙어 있는 조사까지 깎는다(`복지에`→`복지`). 그 정규식이 `_trim_dangling_particles`에서 안전한 건 거기가 토큰 단위로 자르기 때문이다.

lockstep 테스트로 고정했고, 추출기 자체가 공허해지지 않도록 "양쪽 목록이 실제로 추출됐는지"도 함께 단언한다.

### ⚠ 이건 08-27 실패의 원인이 아니다

그 셀은 ` 의`로 끝났고 **양쪽 목록에 이미 있었다**. 재구성한 텍스트를 `_table_summary`/`_truncate_korean_sentence`/`_smart_truncate_korean`에 통과시켜도 재현되지 않았다. 파이썬 절단기가 만든 게 아니며 **모델 출력 자체가 잘렸을 가능성이 가장 높지만, 확정하지 못했다** — 실패한 포스트 파일은 게이트가 지웠고 재현하려면 실제 발행 경로를 돌려야 한다. 원인 미확정으로 남긴다.

## 검증

| | |
|---|---|
| gemini latch | 대조군 5 pass / latch 제거 → 2 FAIL / API 게이트 원복 → 1 FAIL |
| 조사 lockstep | 대조군 2 pass / 3개 제거 → CAUGHT |
| 전체 | **4994 passed, 5 skipped** |

첫 테스트 초안은 `news.config`를 patch했는데 `enhancer`는 `scripts.news.config`를 읽는다 — 별개 모듈 객체라 monkeypatch가 헛돌았고 "spawn 0회"로 나왔다. latch가 동작하는 것처럼 읽히는 값이라 대조군 없이는 통과로 오독할 수 있었다.