### PR TITLE
fix(ci): security-audit.yml SC2086 19건 인용 — 래칫 70 → 51

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -55,15 +55,15 @@ jobs:
         id: set-output
         run: |
           if [ "${{ github.event_name }}" == "schedule" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "should-audit=true" >> $GITHUB_OUTPUT
+            echo "should-audit=true" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "pull_request" ]; then
             if [ "${{ steps.filter.outputs.should-audit }}" == "true" ]; then
-              echo "should-audit=true" >> $GITHUB_OUTPUT
+              echo "should-audit=true" >> "$GITHUB_OUTPUT"
             else
-              echo "should-audit=false" >> $GITHUB_OUTPUT
+              echo "should-audit=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "should-audit=true" >> $GITHUB_OUTPUT
+            echo "should-audit=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Output decision
@@ -95,12 +95,12 @@ jobs:
         run: |
           npm audit --audit-level=high --json > npm-audit-report.json 2>&1 || true
           VULNS=$(cat npm-audit-report.json | jq '.metadata.vulnerabilities.high + .metadata.vulnerabilities.critical' 2>/dev/null || echo "0")
-          echo "vulnerabilities=$VULNS" >> $GITHUB_OUTPUT
+          echo "vulnerabilities=$VULNS" >> "$GITHUB_OUTPUT"
           if [ "$VULNS" -gt "0" ]; then
-            echo "## npm Audit: $VULNS high/critical vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-            npm audit --audit-level=high 2>&1 | head -50 >> $GITHUB_STEP_SUMMARY || true
+            echo "## npm Audit: $VULNS high/critical vulnerabilities found" >> "$GITHUB_STEP_SUMMARY"
+            npm audit --audit-level=high 2>&1 | head -50 >> "$GITHUB_STEP_SUMMARY" || true
           else
-            echo "## npm Audit: No high/critical vulnerabilities" >> $GITHUB_STEP_SUMMARY
+            echo "## npm Audit: No high/critical vulnerabilities" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # Self-clearing signal. This step used to run only when VULNS > 0 and did
@@ -233,12 +233,12 @@ jobs:
         run: |
           bundle audit check --update 2>&1 | tee bundle-audit-report.txt || true
           if grep -q "Vulnerabilities found!" bundle-audit-report.txt 2>/dev/null; then
-            echo "vulnerable=true" >> $GITHUB_OUTPUT
-            echo "## Bundle Audit: Vulnerabilities found" >> $GITHUB_STEP_SUMMARY
-            cat bundle-audit-report.txt >> $GITHUB_STEP_SUMMARY
+            echo "vulnerable=true" >> "$GITHUB_OUTPUT"
+            echo "## Bundle Audit: Vulnerabilities found" >> "$GITHUB_STEP_SUMMARY"
+            cat bundle-audit-report.txt >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "vulnerable=false" >> $GITHUB_OUTPUT
-            echo "## Bundle Audit: No vulnerabilities" >> $GITHUB_STEP_SUMMARY
+            echo "vulnerable=false" >> "$GITHUB_OUTPUT"
+            echo "## Bundle Audit: No vulnerabilities" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       # Same self-clearing reconcile as the npm side. #446 was still open from
@@ -363,7 +363,7 @@ jobs:
         run: |
           NPM="${{ needs.npm-audit.result }}"
           BUNDLE="${{ needs.bundle-audit.result }}"
-          echo "## Security Audit Summary" >> $GITHUB_STEP_SUMMARY
+          echo "## Security Audit Summary" >> "$GITHUB_STEP_SUMMARY"
 
           label() {
             case "$1" in
@@ -372,8 +372,8 @@ jobs:
               *)       echo "❌ $1" ;;
             esac
           }
-          echo "- npm audit: $(label "$NPM")" >> $GITHUB_STEP_SUMMARY
-          echo "- bundle audit: $(label "$BUNDLE")" >> $GITHUB_STEP_SUMMARY
+          echo "- npm audit: $(label "$NPM")" >> "$GITHUB_STEP_SUMMARY"
+          echo "- bundle audit: $(label "$BUNDLE")" >> "$GITHUB_STEP_SUMMARY"
 
           bad=""
           for r in "$NPM" "$BUNDLE"; do
@@ -388,9 +388,9 @@ jobs:
           fi
 
           if [ "$NPM" = "skipped" ] && [ "$BUNDLE" = "skipped" ]; then
-            echo "⏭️ Neither audit ran (no dependency manifest changed)." >> $GITHUB_STEP_SUMMARY
-            echo "This check passing does NOT mean dependencies were audited." >> $GITHUB_STEP_SUMMARY
-            echo "Coverage comes from the Monday cron, which audits unconditionally." >> $GITHUB_STEP_SUMMARY
+            echo "⏭️ Neither audit ran (no dependency manifest changed)." >> "$GITHUB_STEP_SUMMARY"
+            echo "This check passing does NOT mean dependencies were audited." >> "$GITHUB_STEP_SUMMARY"
+            echo "Coverage comes from the Monday cron, which audits unconditionally." >> "$GITHUB_STEP_SUMMARY"
             echo "⏭️ Neither audit ran — not a clean bill of health."
             exit 0
           fi

--- a/scripts/actionlint_ratchet_baseline.txt
+++ b/scripts/actionlint_ratchet_baseline.txt
@@ -13,7 +13,7 @@
 # The ratchet is two-sided: a higher count is a regression, a lower count means
 # this file is stale and must be regenerated with --update so the slots you
 # freed cannot be silently refilled.
-# Total grandfathered findings: 70
+# Total grandfathered findings: 51
 .github/workflows/buttondown-notify.yml SC2086 info 6
 .github/workflows/buttondown-notify.yml SC2129 style 1
 .github/workflows/generate-images.yml SC2012 info 3
@@ -27,7 +27,6 @@
 .github/workflows/monitoring.yml SC2016 info 1
 .github/workflows/monthly-quality-report.yml SC2086 info 1
 .github/workflows/monthly-quality-report.yml SC2129 style 1
-.github/workflows/security-audit.yml SC2086 info 19
 .github/workflows/security-audit.yml SC2129 style 1
 .github/workflows/sentry-release.yml SC2086 info 3
 .github/workflows/vercel-deploy.yml SC2086 info 2


### PR DESCRIPTION
래칫(#624)이 생겼으니 실제 감축 착수. 가장 큰 단일 버킷인 `security-audit.yml`의 SC2086 19건.

## 왜 전건 인용이 안전한가

19건 **전부** `>> $GITHUB_OUTPUT` 또는 `>> $GITHUB_STEP_SUMMARY` 리다이렉트 대상이다. 4개 `run:` 블록(56·95·233·363행)을 개별로 읽었고, 워드 분할이 의도된 자리는 하나도 없다. SC2086은 보통 기계적 치환처럼 보이지만 다중 인자 전달 자리를 인용하면 워크플로가 깨지므로 일괄 sed로 처리하지 않았다.

## 변경이 인용뿐임을 증명

인용을 다시 벗겨 정규화하면 원본과 **바이트 동일**하다:

```
인용 정규화 후 동일: True
19줄 추가 / 19줄 삭제
```

## 래칫의 첫 실전 동작

의도대로였다 — 개선을 회귀가 아니라 **베이스라인 낙후**로 잡아 조이라고 요구했다:

```
Baseline is stale — fewer findings than recorded:
  .github/workflows/security-audit.yml  SC2086:info  19 -> 0  (-19)
Run: python3 scripts/check_actionlint_ratchet.py --update
```

양방향 래칫이 아니었다면 19칸이 그대로 열린 채 남아 나중에 조용히 다시 채워질 수 있었다.

베이스라인 **70 → 51**, 그리고 `security-audit.yml SC2086` 항목은 통째로 사라졌다 — 이 파일에 새 미인용 변수가 들어오면 `0 -> 1`로 걸린다.

## 검증

| | |
|---|---|
| 래칫 | `51 findings now, 51 in baseline` exit 0 |
| 차단 게이트 | exit 0 |
| YAML 구조 | 4개 잡 그대로 (`check-changes`/`npm-audit`/`bundle-audit`/`summary`) |
| 전체 | **4985 passed, 5 skipped** |