### PR TITLE
fix(ci): SC2086 전건 해소 — 인용 35건 + 의도적 분할 5건 명시, 래칫 51 → 11

### DIFF
--- a/.github/workflows/buttondown-notify.yml
+++ b/.github/workflows/buttondown-notify.yml
@@ -55,18 +55,18 @@ jobs:
           
           if [ -z "$NEW_POSTS" ]; then
             echo "No new posts found"
-            echo "has_new_posts=false" >> $GITHUB_OUTPUT
-            echo "posts_json=[]" >> $GITHUB_OUTPUT
-            echo "post_count=0" >> $GITHUB_OUTPUT
+            echo "has_new_posts=false" >> "$GITHUB_OUTPUT"
+            echo "posts_json=[]" >> "$GITHUB_OUTPUT"
+            echo "post_count=0" >> "$GITHUB_OUTPUT"
           else
             echo "New posts found:"
             echo "$NEW_POSTS"
-            echo "has_new_posts=true" >> $GITHUB_OUTPUT
+            echo "has_new_posts=true" >> "$GITHUB_OUTPUT"
             
             # Count posts (grep -c emits "0" + exit 1 on no-match, so chaining
             # `|| echo 0` writes two lines and breaks GITHUB_OUTPUT parsing)
             POST_COUNT=$(echo "$NEW_POSTS" | grep -c '^' || true)
-            echo "post_count=${POST_COUNT:-0}" >> $GITHUB_OUTPUT
+            echo "post_count=${POST_COUNT:-0}" >> "$GITHUB_OUTPUT"
             
             # Encode all posts as JSON array (more reliable than multiline)
             # Convert each post path to base64 and store as JSON array
@@ -86,7 +86,7 @@ jobs:
             POSTS_JSON="$POSTS_JSON]"
             
             # Store as single-line JSON (GitHub Actions output is more reliable this way)
-            echo "posts_json=$POSTS_JSON" >> $GITHUB_OUTPUT
+            echo "posts_json=$POSTS_JSON" >> "$GITHUB_OUTPUT"
             
             echo "Found $POST_COUNT new post(s) to process"
           fi

--- a/.github/workflows/generate-images.yml
+++ b/.github/workflows/generate-images.yml
@@ -80,10 +80,10 @@ jobs:
           USE_API: ${{ github.event.inputs.use_api || 'false' }}
         run: |
           if [ "$USE_API" = "true" ] && [ -n "$GEMINI_API_KEY" ] && [ ${#GEMINI_API_KEY} -ge 20 ]; then
-            echo "api_available=true" >> $GITHUB_OUTPUT
+            echo "api_available=true" >> "$GITHUB_OUTPUT"
             echo "✅ Gemini API key available - will use API for image generation"
           else
-            echo "api_available=false" >> $GITHUB_OUTPUT
+            echo "api_available=false" >> "$GITHUB_OUTPUT"
             echo "📝 Using SVG fallback generator (no API cost)"
             if [ "$USE_API" = "true" ] && [ -z "$GEMINI_API_KEY" ]; then
               echo "⚠️ API requested but GEMINI_API_KEY not set"
@@ -110,11 +110,11 @@ jobs:
           done
           
           if [ -n "$MISSING_IMAGES" ]; then
-            echo "posts_need_images=true" >> $GITHUB_OUTPUT
-            echo "posts=$MISSING_IMAGES" >> $GITHUB_OUTPUT
+            echo "posts_need_images=true" >> "$GITHUB_OUTPUT"
+            echo "posts=$MISSING_IMAGES" >> "$GITHUB_OUTPUT"
             echo "Found posts needing images:$MISSING_IMAGES"
           else
-            echo "posts_need_images=false" >> $GITHUB_OUTPUT
+            echo "posts_need_images=false" >> "$GITHUB_OUTPUT"
             echo "All posts have images"
           fi
 
@@ -248,20 +248,20 @@ jobs:
           # 인젝션 방지: dispatch 입력은 env 경유로만 (test_ci_no_run_input_interpolation_guard).
           IMAGE_TYPE_INPUT: ${{ github.event.inputs.image_type || 'post' }}
         run: |
-          echo "## 📊 Image Generation Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Generation Mode" >> $GITHUB_STEP_SUMMARY
+          echo "## 📊 Image Generation Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Generation Mode" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ steps.api_check.outputs.api_available }}" = "true" ]; then
-            echo "- **Mode**: Gemini API (with SVG fallback)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Mode**: Gemini API (with SVG fallback)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **Mode**: SVG Fallback Only (no API cost)" >> $GITHUB_STEP_SUMMARY
+            echo "- **Mode**: SVG Fallback Only (no API cost)" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- **Type**: $IMAGE_TYPE_INPUT" >> $GITHUB_STEP_SUMMARY
-          echo "- **Trigger**: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Type**: $IMAGE_TYPE_INPUT" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Trigger**: ${{ github.event_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -d "assets/images" ]; then
-            echo "### Generated Files" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            ls -lh assets/images/*.svg assets/images/*.png assets/images/*.jpg 2>/dev/null | tail -n 20 >> $GITHUB_STEP_SUMMARY || echo "No image files found" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "### Generated Files" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+            ls -lh assets/images/*.svg assets/images/*.png assets/images/*.jpg 2>/dev/null | tail -n 20 >> "$GITHUB_STEP_SUMMARY" || echo "No image files found" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/gsc-queue-refresh.yml
+++ b/.github/workflows/gsc-queue-refresh.yml
@@ -86,6 +86,12 @@ jobs:
             LIMIT_FLAG="--limit $LIMIT_INPUT"
           fi
           # Capture the 1-line summary printed to stdout for the job summary
+          # $LIMIT_FLAG is either empty or the two words "--limit N", and both
+          # cases need word splitting: quoted, an empty value becomes one empty
+          # argument and a set value becomes a single unrecognised "--limit N"
+          # token. The regex above already bounds it to digits, which is what
+          # makes the unquoted expansion safe here.
+          # shellcheck disable=SC2086
           SUMMARY=$(python3 scripts/gsc_inspect.py $LIMIT_FLAG | tail -n 1)
           echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
           echo "$SUMMARY"

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -61,16 +61,16 @@ jobs:
         id: set-output
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" == "push" ] || [ "${{ github.event_name }}" == "pull_request" ]; then
             # dorny/paths-filter는 'true' 또는 'false'를 반환
             if [ "${{ steps.filter.outputs.should-build }}" == "true" ]; then
-              echo "should-build=true" >> $GITHUB_OUTPUT
+              echo "should-build=true" >> "$GITHUB_OUTPUT"
             else
-              echo "should-build=false" >> $GITHUB_OUTPUT
+              echo "should-build=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "should-build=true" >> $GITHUB_OUTPUT
+            echo "should-build=true" >> "$GITHUB_OUTPUT"
           fi
       
       - name: Output decision
@@ -158,6 +158,11 @@ jobs:
               exit 1
             fi
             if [ -n "$CHANGED" ]; then
+              # $CHANGED is a space-separated file list that must expand to one
+              # argv entry per file. Quoting it passes a single argument whose
+              # name is every path joined together, and the gate then reports
+              # "file not found" instead of checking anything.
+              # shellcheck disable=SC2086
               python3 scripts/digest_quality_report.py --files $CHANGED --ci
             else
               echo "No Digest posts changed, skipping"
@@ -282,6 +287,9 @@ jobs:
           echo ""
           # Exits 1 below --fail-below (default 60). No `|| true`: a score under the
           # floor, or a crash in the scorer, must both surface.
+          #
+          # $CHANGED_POSTS must word-split into one argv entry per post.
+          # shellcheck disable=SC2086
           python3 scripts/validate_post_quality.py $CHANGED_POSTS
           echo ""
           echo "✅ Post quality at or above the 60-point floor"
@@ -315,12 +323,16 @@ jobs:
           fi
 
           # Generate full dashboard
+          # $ALL_POSTS must word-split into one argv entry per post.
+          # shellcheck disable=SC2086
           DASHBOARD=$(python3 scripts/validate_post_quality.py --summary $ALL_POSTS 2>&1 || true)
 
           # Get changed post scores
           CHANGED_POSTS=$(git diff --name-only origin/main...HEAD -- '_posts/*.md' 2>/dev/null || echo "")
           CHANGED_SCORES=""
           if [ -n "$CHANGED_POSTS" ]; then
+            # $CHANGED_POSTS must word-split into one argv entry per post.
+            # shellcheck disable=SC2086
             CHANGED_SCORES=$(python3 scripts/validate_post_quality.py $CHANGED_POSTS 2>&1 || true)
           fi
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Start local HTTP server
         run: |
           npx --yes serve@14 _site --listen 4000 &
-          echo "SERVER_PID=$!" >> $GITHUB_ENV
+          echo "SERVER_PID=$!" >> "$GITHUB_ENV"
           # Wait for server to be ready
           for i in $(seq 1 15); do
             if curl -sf http://localhost:4000/ > /dev/null 2>&1; then

--- a/.github/workflows/monthly-quality-report.yml
+++ b/.github/workflows/monthly-quality-report.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           echo "Generating monthly quality report..."
           python3 scripts/generate_quality_report.py
-          echo "report_generated=true" >> $GITHUB_OUTPUT
+          echo "report_generated=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update issue
         id: issue

--- a/.github/workflows/sentry-release.yml
+++ b/.github/workflows/sentry-release.yml
@@ -183,7 +183,7 @@ jobs:
               ;;
           esac
 
-          echo "verified=true" >> $GITHUB_OUTPUT
+          echo "verified=true" >> "$GITHUB_OUTPUT"
 
           # Dry run summary
           if [ "$DRY_RUN" = "true" ]; then
@@ -231,10 +231,10 @@ jobs:
 
           if [ "$HTTP_CODE" = "200" ]; then
             echo "ℹ️  Release already exists"
-            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "✅ Release does not exist, will create"
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create Sentry Release

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -44,9 +44,9 @@ jobs:
           GITHUB_SHA_VAL: ${{ github.sha }}
         run: |
           if [ -n "$INPUT_COMMIT_SHA" ]; then
-            echo "sha=$INPUT_COMMIT_SHA" >> $GITHUB_OUTPUT
+            echo "sha=$INPUT_COMMIT_SHA" >> "$GITHUB_OUTPUT"
           else
-            echo "sha=$GITHUB_SHA_VAL" >> $GITHUB_OUTPUT
+            echo "sha=$GITHUB_SHA_VAL" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check Sentry token availability

--- a/scripts/actionlint_ratchet_baseline.txt
+++ b/scripts/actionlint_ratchet_baseline.txt
@@ -13,20 +13,12 @@
 # The ratchet is two-sided: a higher count is a regression, a lower count means
 # this file is stale and must be regenerated with --update so the slots you
 # freed cannot be silently refilled.
-# Total grandfathered findings: 51
-.github/workflows/buttondown-notify.yml SC2086 info 6
+# Total grandfathered findings: 11
 .github/workflows/buttondown-notify.yml SC2129 style 1
 .github/workflows/generate-images.yml SC2012 info 3
-.github/workflows/generate-images.yml SC2086 info 18
 .github/workflows/generate-images.yml SC2129 style 2
 .github/workflows/googlebot-access-monitor.yml SC2016 info 1
-.github/workflows/gsc-queue-refresh.yml SC2086 info 1
-.github/workflows/jekyll.yml SC2086 info 8
 .github/workflows/lighthouse-ci.yml SC2016 info 1
-.github/workflows/lighthouse.yml SC2086 info 1
 .github/workflows/monitoring.yml SC2016 info 1
-.github/workflows/monthly-quality-report.yml SC2086 info 1
 .github/workflows/monthly-quality-report.yml SC2129 style 1
 .github/workflows/security-audit.yml SC2129 style 1
-.github/workflows/sentry-release.yml SC2086 info 3
-.github/workflows/vercel-deploy.yml SC2086 info 2


### PR DESCRIPTION
## 두 부류를 구분한 것이 핵심

SC2086은 기계적 치환처럼 보이지만 아니다. 40건을 분류했더니 **5건은 워드 분할이 의도된 자리**였고, 구분 없이 일괄 치환했다면 워크플로 5곳이 깨졌다.

분류는 추측이 아니라 판정으로 했다 — 파일별로 `리다이렉트형 개수`와 `SC2086 총계`를 비교해서, 일치하지 않는 파일만 개별 확인 대상으로 올렸다:

```
jekyll.yml              SC2086= 8  리다이렉트형= 4  ★ 4건 개별 확인 필요
gsc-queue-refresh.yml   SC2086= 1  리다이렉트형= 0  ★ 1건 개별 확인 필요
buttondown-notify.yml   SC2086= 6  리다이렉트형= 6  전부 안전
...
```

## 인용한 35건

전부 `>> $GITHUB_OUTPUT` / `>> $GITHUB_STEP_SUMMARY` 리다이렉트 대상.

**변경이 인용뿐임을 증명**: 양쪽을 인용 정규화해서 비교하면 전 파일이 원본과 동일하다. (첫 검증 시도는 한쪽만 정규화해서 이미 인용돼 있던 파일까지 불일치로 잡았다 — 검증기가 틀린 것이었고 고쳤다.)

## 인용하지 **않은** 5건

| 위치 | 표현 | 인용하면 |
|---|---|---|
| `jekyll.yml` ×3 | `--files $CHANGED`, `$CHANGED_POSTS` ×2 | 파일 목록이 통째로 **한 개 인자**가 되어 "file not found" |
| `jekyll.yml` ×1 | `--summary $ALL_POSTS` | 동일 |
| `gsc-queue-refresh.yml` | `$LIMIT_FLAG` | 빈 값이 **빈 인자 1개**가 되고, 설정 시 `--limit N`이 한 토큰이 됨 |

베이스라인에 그냥 남기지 않고 현장에 `# shellcheck disable=SC2086`과 이유를 달았다. **래칫만으로는 이걸 못 막기 때문이다** — 다음 사람이 SC2086을 보고 인용하면 래칫은 감소를 "베이스라인 낙후"로만 읽고 그 수정이 틀렸다는 건 잡지 못한다.

## 결과

**SC2086 레포 전체 0건.** 래칫 베이스라인 **51 → 11**, 남은 11건은 SC2129(style) 5 · SC2016 3 · SC2012 3.

| 검증 | |
|---|---|
| 차단 게이트 | exit 0 — 새 지시자가 SC1072/1073을 유발하지 않음 |
| 워크플로 YAML | 전 파일 파싱 정상 |
| 래칫 | `11 findings now, 11 in baseline` exit 0 |
| 테스트 | **4994 passed, 5 skipped** |