### PR TITLE
feat(cron): 품질 게이트가 거부한 초안을 아티팩트로 보존 — 08-27이 재현 불가였던 이유

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -282,6 +282,25 @@ jobs:
           echo "Running: python3 scripts/auto_publish_news.py ${args[*]}"
           python3 scripts/auto_publish_news.py "${args[@]}"
 
+      # The digest quality gate deletes the draft it rejects — correct, but it
+      # also destroyed the only evidence. The 2026-08-27 run reported one
+      # 60-character fragment ("...정부 복지에 의") and the file was already
+      # gone, so whether our truncation helpers or the model produced the cut
+      # could not be determined. auto_publish_news.py now copies the draft aside
+      # before unlinking; this uploads it.
+      #
+      # `failure()` and not `always()`: on success the directory does not exist
+      # and an unconditional upload would log a "no files found" warning on
+      # every healthy run, which is how real warnings stop being read.
+      - name: Upload rejected draft (quality gate diagnostics)
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: digest-gate-failure-${{ github.run_id }}
+          path: .digest-gate-failure/
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Check for new post
         id: check_post
         if: steps.check_news.outputs.has_enough_news == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ _site_test/
 # Build/lint report artifacts
 reports/
 _data/source_articles_cache.json
+
+# Digest quality gate diagnostics (uploaded as a CI artifact, never committed)
+.digest-gate-failure/

--- a/scripts/auto_publish_news.py
+++ b/scripts/auto_publish_news.py
@@ -487,6 +487,38 @@ def _generate_and_commit_raster_variants(
 # ---------------------------------------------------------------------------
 
 
+def _preserve_rejected_post(post_path: Path, issues: List[str]) -> Optional[Path]:
+    """Copy a gate-rejected draft aside so the failure can be reproduced.
+
+    The digest quality gate deletes the post it rejects, which is correct — a
+    truncated draft must not reach the corpus. But it also destroyed the only
+    evidence: on 2026-08-27 the run reported
+
+        L410 TRUNCATED: ...정부 복지에 의
+
+    and nothing else. 60 characters of one cell is not enough to tell whether
+    our own truncation helpers produced it or the model's output was already
+    cut, and by the time anyone looked the file was gone.
+
+    Best-effort by design: this runs on the failure path, and a problem saving
+    diagnostics must not replace the real error with its own. Returns the
+    written path, or None when nothing could be written.
+    """
+    dest_dir = Path(os.getenv("DIGEST_GATE_FAILURE_DIR", ".digest-gate-failure"))
+    try:
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        saved = dest_dir / post_path.name
+        saved.write_text(post_path.read_text(encoding="utf-8"), encoding="utf-8")
+        (dest_dir / f"{post_path.stem}.issues.txt").write_text(
+            "\n".join(str(i) for i in issues) + "\n", encoding="utf-8"
+        )
+        print(f"🗄  Rejected draft preserved at {saved}", file=sys.stderr)
+        return saved
+    except OSError as exc:
+        print(f"   (could not preserve the rejected draft: {exc})", file=sys.stderr)
+        return None
+
+
 def main():
     parser = argparse.ArgumentParser(description="Auto publish news to _posts")
     parser.add_argument(
@@ -763,6 +795,13 @@ def main():
         quality_issues = []
 
     if quality_issues:
+        # Preserve the rejected draft BEFORE deleting it. Without this the only
+        # trace of a gate failure is the issue list, which quotes at most the
+        # last 60 characters of an offending cell \u2014 the 2026-08-27 cron failure
+        # could not be reproduced afterwards because the file was already gone,
+        # so "was this truncated by our own code or by the model?" stayed
+        # unanswerable. The workflow uploads this directory on failure.
+        _preserve_rejected_post(post_path, quality_issues)
         post_path.unlink(missing_ok=True)
         print(
             f"\u274c Digest quality gate FAILED for {post_path.name}:",

--- a/scripts/tests/test_digest_gate_failure_artifact.py
+++ b/scripts/tests/test_digest_gate_failure_artifact.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""The digest quality gate must preserve the draft it rejects.
+
+Deleting a rejected draft is correct — a truncated post must not reach the
+corpus. Deleting it *and* keeping no copy is what made the 2026-08-27 cron
+failure unreproducible: the run reported a single 60-character fragment,
+
+    L410 TRUNCATED: ...정부 복지에 의
+
+and by the time anyone looked the file was gone, so "did our truncation helpers
+produce this, or was the model's output already cut?" could not be answered.
+
+Two invariants here, and the second is the one that rots silently:
+
+1. The draft and the issue list are written before the unlink.
+2. The directory the script writes to is the directory the workflow uploads.
+   Change one and the artifact is quietly empty on the one run that needed it —
+   `if-no-files-found: ignore` means the job will not complain either.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+import auto_publish_news
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+GITIGNORE = REPO_ROOT / ".gitignore"
+
+STEP_NAME = "Upload rejected draft"
+DEFAULT_DIR = ".digest-gate-failure"
+
+
+# --------------------------------------------------------------------------
+# The preservation helper
+# --------------------------------------------------------------------------
+def test_draft_and_issues_are_written(tmp_path, monkeypatch):
+    post = tmp_path / "2026-08-27-Tech_Security_Weekly_Digest.md"
+    post.write_text("---\ntitle: x\n---\n| a | 정부 복지에 의 |\n", encoding="utf-8")
+    dest = tmp_path / "diag"
+    monkeypatch.setenv("DIGEST_GATE_FAILURE_DIR", str(dest))
+
+    saved = auto_publish_news._preserve_rejected_post(post, ["L410 TRUNCATED: ...의"])
+
+    assert saved is not None and saved.is_file()
+    assert saved.read_text(encoding="utf-8") == post.read_text(encoding="utf-8"), (
+        "the preserved copy differs from the rejected draft"
+    )
+    issues = dest / "2026-08-27-Tech_Security_Weekly_Digest.issues.txt"
+    assert issues.is_file()
+    assert "L410 TRUNCATED" in issues.read_text(encoding="utf-8")
+
+
+def test_preservation_happens_before_the_unlink(tmp_path, monkeypatch):
+    """Order matters: reading a deleted file yields nothing to preserve."""
+    post = tmp_path / "2026-08-27-Digest.md"
+    post.write_text("body\n", encoding="utf-8")
+    dest = tmp_path / "diag"
+    monkeypatch.setenv("DIGEST_GATE_FAILURE_DIR", str(dest))
+
+    saved = auto_publish_news._preserve_rejected_post(post, ["issue"])
+    post.unlink()  # what the caller does next
+
+    assert saved.is_file() and saved.read_text(encoding="utf-8") == "body\n"
+
+
+def test_failure_to_preserve_does_not_raise(tmp_path, monkeypatch):
+    """Best-effort: a diagnostics problem must not replace the real error."""
+    missing = tmp_path / "gone.md"  # never created -> read_text raises OSError
+    monkeypatch.setenv("DIGEST_GATE_FAILURE_DIR", str(tmp_path / "diag"))
+    assert auto_publish_news._preserve_rejected_post(missing, ["issue"]) is None
+
+
+def test_default_directory_is_used_when_env_is_unset(tmp_path, monkeypatch):
+    post = tmp_path / "p.md"
+    post.write_text("x\n", encoding="utf-8")
+    monkeypatch.delenv("DIGEST_GATE_FAILURE_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    saved = auto_publish_news._preserve_rejected_post(post, [])
+    assert saved.parent.name == DEFAULT_DIR, (
+        f"default directory is {saved.parent.name!r}; the workflow's `path:` is "
+        f"pinned to {DEFAULT_DIR!r} by test_workflow_uploads_the_directory_the_script_writes"
+    )
+
+
+def test_call_site_preserves_before_it_unlinks():
+    """Order in the source, not just in the helper.
+
+    The two tests above exercise `_preserve_rejected_post` directly, so they
+    stay green even if the call is moved below `post_path.unlink(...)` — at
+    which point it preserves nothing and the artifact is an empty file. Only
+    reading the call site catches that.
+    """
+    source = (REPO_ROOT / "scripts" / "auto_publish_news.py").read_text(encoding="utf-8")
+    # Indent-anchored so the `def _preserve_rejected_post(post_path...)` line —
+    # which sits at column 0 and always precedes the unlink — cannot be mistaken
+    # for the call. A plain `.find()` matched the definition instead, and this
+    # test passed with the call moved below the unlink: vacuous, and it reported
+    # as a healthy guard until a mutation probe said otherwise.
+    calls = [
+        m.start()
+        for m in re.finditer(r"^[ \t]+_preserve_rejected_post\(post_path", source, re.M)
+    ]
+    unlinks = [
+        m.start()
+        for m in re.finditer(r"^[ \t]+post_path\.unlink\(missing_ok=True\)", source, re.M)
+    ]
+    assert len(calls) == 1, (
+        f"expected exactly one call to _preserve_rejected_post, found {len(calls)}; "
+        "an extra call site would make the ordering check ambiguous"
+    )
+    assert len(unlinks) == 1, (
+        f"expected exactly one post_path.unlink(missing_ok=True), found {len(unlinks)}"
+    )
+    preserve, unlink = calls[0], unlinks[0]
+    assert preserve < unlink, (
+        "_preserve_rejected_post is called after post_path.unlink(), so it "
+        "copies a file that no longer exists and the artifact is empty."
+    )
+
+
+# --------------------------------------------------------------------------
+# CI wiring
+# --------------------------------------------------------------------------
+def _upload_step() -> dict:
+    doc = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["auto-publish"]["steps"]
+    matches = [s for s in steps if STEP_NAME in (s.get("name") or "")]
+    if len(matches) != 1:
+        pytest.fail(f"expected exactly one {STEP_NAME!r} step, found {len(matches)}")
+    return matches[0]
+
+
+def test_workflow_uploads_the_directory_the_script_writes():
+    """The lockstep that decides whether the artifact has anything in it."""
+    path = str(_upload_step()["with"]["path"]).rstrip("/")
+    assert path == DEFAULT_DIR, (
+        f"the workflow uploads {path!r} but the script writes to {DEFAULT_DIR!r}. "
+        "With `if-no-files-found: ignore` this mismatch produces an empty "
+        "artifact and a green step on exactly the run that needed the evidence."
+    )
+
+
+def test_upload_runs_on_failure():
+    step = _upload_step()
+    assert step.get("if") == "failure()", (
+        f"the upload condition is {step.get('if')!r}. It must be failure(): the "
+        "gate only rejects on a failing run, and always() would warn about a "
+        "missing directory on every healthy one."
+    )
+
+
+def test_upload_action_is_sha_pinned():
+    uses = _upload_step()["uses"]
+    assert re.fullmatch(r"actions/upload-artifact@[0-9a-f]{40}", uses), (
+        f"upload-artifact is not 40-char SHA pinned: {uses!r}"
+    )
+
+
+def test_diagnostics_directory_is_gitignored():
+    """The rejected draft is a build artifact, not corpus content."""
+    ignored = GITIGNORE.read_text(encoding="utf-8").splitlines()
+    assert any(line.strip().rstrip("/") == DEFAULT_DIR for line in ignored), (
+        f"{DEFAULT_DIR} is not in .gitignore, so a rejected draft could be "
+        "picked up by the auto-commit step and land in the corpus — which is "
+        "precisely what the gate deleted it to prevent."
+    )


### PR DESCRIPTION
## 왜

게이트가 거부한 초안을 지우는 건 **옳다** — 잘린 포스트가 코퍼스에 들어가면 안 된다. 문제는 지우기만 하고 사본을 안 남긴 것이었다.

08-27 크론 실패가 그래서 재현 불가였다. 리포트가 남긴 증거는 셀 하나의 **마지막 60자**뿐이고

```
L410 TRUNCATED: ...정부 복지에 의
```

파일은 이미 사라진 뒤였다. 그래서 "우리 절단 헬퍼가 만든 건가, 모델 출력이 이미 잘린 건가"에 답할 수 없었고, #625에서도 **원인 미확정**으로 남길 수밖에 없었다.

## 무엇

`unlink` **직전에** 초안과 이슈 목록을 `DIGEST_GATE_FAILURE_DIR`(기본 `.digest-gate-failure`)로 복사하고, 워크플로가 `failure()`에서 업로드한다.

- `always()`가 **아닌** 이유: 성공 런에는 디렉터리가 없어 매 healthy 런마다 "no files found" 경고가 찍힌다. 그게 진짜 경고를 안 읽게 만드는 경로다.
- 보존은 **best-effort**: 진단 저장이 실패해도 진짜 에러를 덮지 않는다.
- `.gitignore` 등록: 거부된 초안이 auto-commit에 딸려 들어가면 게이트가 지운 이유가 무의미해진다.

## 가장 중요한 불변식

**스크립트가 쓰는 디렉터리 == 워크플로가 올리는 디렉터리.** 어긋나면 `if-no-files-found: ignore` 때문에 증거가 필요한 바로 그 런에서 *빈 아티팩트 + green 스텝*이 된다 — 조용히 실패하는 종류라 테스트로 고정했다.

## 검증

| 뮤테이션 | 결과 |
|---|---|
| 워크플로 `path:` 불일치 | CAUGHT |
| `if: failure()` → `always()` | CAUGHT |
| `preserve`를 `unlink` 뒤로 이동 | **처음 MISSED** → 수정 후 CAUGHT |
| `.gitignore` 항목 제거 | CAUGHT |

M3가 MISSED였던 건 게이트가 아니라 **테스트가 공허**했기 때문이다. `source.find("_preserve_rejected_post(post_path")`가 호출부가 아니라 **함수 정의**를 잡았고, 정의는 항상 `unlink`보다 앞이라 순서를 뒤집어도 통과했다. 들여쓰기 앵커(`^[ \t]+`)로 정의를 배제하고, 호출/unlink가 각각 정확히 1개인지도 함께 단언한다.

대조군 9 pass, 전체 **5004 passed, 5 skipped**. 래칫 51/51 · 차단 게이트 exit 0 · 핀 일관성 정상.