### PR TITLE
feat(ci): GH Pages 백업을 이벤트 구동으로 — 크론 단일 의존 제거

### DIFF
--- a/.github/workflows/ai-blogwatcher.yml
+++ b/.github/workflows/ai-blogwatcher.yml
@@ -734,3 +734,32 @@ jobs:
       post_path: ${{ needs.auto-publish.outputs.post_file }}
       ref: ${{ needs.auto-publish.outputs.published_sha }}
     secrets: inherit
+
+  # Rebuild the GH Pages backup as soon as the digest is live, instead of
+  # waiting for deploy-pages' own 00:30Z cron to notice.
+  #
+  # The bot's GITHUB_TOKEN push cannot fire that workflow's `push:` trigger
+  # (GitHub recursion prevention), so the cron was the ONLY thing keeping the
+  # backup in sync — and on 2026-08-27 the scheduler dropped ~10 hours of
+  # events repo-wide. Missed cycles are not backfilled, so trigger and safety
+  # net were both out on the same day and the backup served 404 for that
+  # digest while production served 200.
+  #
+  # The cron stays. This is the event-driven path; that is the backstop for the
+  # cases this job cannot see (a failed call, or a stale backup from any other
+  # cause). Two independent paths, no shared point of failure.
+  deploy-backup:
+    needs: auto-publish
+    if: needs.auto-publish.outputs.published_to_main == 'true'
+    # Same deny-by-default re-grant as notify-slack above, but this callee
+    # deploys, so it needs the Pages trio. A called workflow cannot hold more
+    # than its caller grants.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/deploy-pages.yml
+    with:
+      # auto-publish ran on the pre-publish SHA. Without this the backup would
+      # rebuild the corpus WITHOUT the post that just triggered it.
+      ref: ${{ needs.auto-publish.outputs.published_sha }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -31,6 +31,25 @@ on:
       - 'llms-full.txt'
       - 'sw.js'
   workflow_dispatch:
+  # Event-driven backup deploy, called by ai-blogwatcher.yml the moment it
+  # publishes. This is the primary path; the cron below is the backstop.
+  #
+  # Both exist because on 2026-08-27 they failed together. GitHub's Actions
+  # scheduler produced no schedule events repo-wide between 08-26T19:43Z and
+  # 08-27T05:50Z, and missed cycles are NOT backfilled — so the 00:30Z cron
+  # never ran. The bot published at 07:11Z, its GITHUB_TOKEN push could not fire
+  # the `push:` trigger, and the backup served 404 for that day's digest while
+  # production served 200. Trigger and safety net, out on the same day.
+  workflow_call:
+    inputs:
+      ref:
+        description: >-
+          Commit to build. Required from ai-blogwatcher: its publish job runs on
+          the PRE-publish SHA, so a default checkout would rebuild the corpus
+          WITHOUT the post that triggered this deploy — and report success. Same
+          reason slack-post-notify.yml takes a `ref`.
+        required: false
+        type: string
   # Self-healing backup deploy: the AI BlogWatcher publishes the daily digest via
   # a github-actions[bot] `git push` at 00:00 UTC (ai-blogwatcher.yml schedule).
   # A GITHUB_TOKEN push does NOT trigger other workflows (GitHub recursion
@@ -61,6 +80,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6
+        with:
+          # `inputs.ref` is empty for push/schedule/workflow_dispatch, where
+          # github.sha is already the right commit. It is load-bearing only for
+          # the workflow_call path — without it that path would deploy the
+          # caller's pre-publish SHA and look like it worked.
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b  # v1

--- a/scripts/tests/test_ci_pages_backup_schedule_guard.py
+++ b/scripts/tests/test_ci_pages_backup_schedule_guard.py
@@ -18,14 +18,32 @@ self-healing property disappears *silently* if someone drops the ``schedule:``
 trigger or its ``cron`` entry. This guard makes that removal fail loudly.
 
 Maps to OWASP CICD-SEC-1 (Insufficient Flow Control). Direction: presence
-assertion — any removal of the scheduled trigger trips this. If the schedule is
-intentionally reworked (e.g. moved into a reusable ``workflow_call`` invoked by
-blogwatcher, Option A), update this guard in the same PR and say why.
+assertion — any removal of the scheduled trigger trips this.
+
+2026-08-27: Option A was added **alongside** the cron rather than replacing it.
+The cron alone turned out to be a single point of failure in a way this guard's
+original text did not anticipate: GitHub's Actions scheduler emitted no schedule
+events repo-wide between 08-26T19:43Z and 08-27T05:50Z, and **missed cycles are
+not backfilled**. So on the day the bot published at 07:11Z, the `push:` trigger
+was suppressed (bot token) *and* the 00:30Z cron never ran — the backup served
+404 for that digest while production served 200.
+
+Two independent paths now, and this guard pins both:
+
+- event-driven: ``ai-blogwatcher.yml`` calls ``deploy-pages.yml`` via
+  ``workflow_call`` the moment it publishes;
+- backstop: the existing cron, for anything the publish job cannot see.
+
+The subtle part is ``ref``. blogwatcher's publish job runs on the PRE-publish
+SHA, so a ``workflow_call`` without ``ref`` rebuilds the corpus *without* the
+post that triggered it — and reports success. That failure is invisible in the
+Actions tab, which is why it gets its own assertions below.
 """
 
 from __future__ import annotations
 
 import re
+import yaml
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -77,4 +95,107 @@ class TestPagesBackupScheduleGuard:
         assert re.search(r"^\s*workflow_dispatch:\s*$", body, re.MULTILINE), (
             "deploy-pages.yml lost workflow_dispatch; the manual backup-deploy "
             "escape hatch is gone. If intentional, update this guard."
+        )
+
+
+class TestPagesBackupEventDrivenPath:
+    """The workflow_call path added 2026-08-27, and the `ref` that makes it real."""
+
+    CALLER = REPO_ROOT / ".github" / "workflows" / "ai-blogwatcher.yml"
+    CALLEE_REL = "./.github/workflows/deploy-pages.yml"
+
+    @classmethod
+    def _callee(cls) -> dict:
+        return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+    @classmethod
+    def _caller_job(cls) -> dict:
+        doc = yaml.safe_load(cls.CALLER.read_text(encoding="utf-8"))
+        jobs = {
+            n: j
+            for n, j in doc["jobs"].items()
+            if str(j.get("uses", "")).strip() == cls.CALLEE_REL
+        }
+        assert jobs, (
+            f"no job in ai-blogwatcher.yml calls {cls.CALLEE_REL}. The GH Pages "
+            "backup is then back to depending on the cron alone — the exact "
+            "single point of failure that produced a 404 backup on 2026-08-27."
+        )
+        assert len(jobs) == 1, f"expected one caller job, found {sorted(jobs)}"
+        return next(iter(jobs.values()))
+
+    def test_callee_exposes_workflow_call_with_ref(self):
+        on = self._callee().get(True) or self._callee().get("on") or {}
+        call = on.get("workflow_call")
+        assert call is not None, (
+            "deploy-pages.yml no longer accepts workflow_call, so blogwatcher "
+            "cannot deploy the backup at publish time."
+        )
+        assert "ref" in (call.get("inputs") or {}), (
+            "the workflow_call interface lost its `ref` input. The caller runs on "
+            "the pre-publish SHA, so without it the backup rebuilds WITHOUT the "
+            "new post and the job still goes green."
+        )
+
+    def test_checkout_honours_the_ref_input(self):
+        """The one line that decides whether the deploy is real or theatre."""
+        doc = self._callee()
+        steps = doc["jobs"]["build"]["steps"]
+        checkout = next(
+            (s for s in steps if "checkout" in str(s.get("uses", "")).lower()), None
+        )
+        assert checkout is not None, "the build job no longer checks out the repo"
+        ref = str((checkout.get("with") or {}).get("ref", ""))
+        assert "inputs.ref" in ref, (
+            f"the checkout ref is {ref!r}. It must consult `inputs.ref`, or the "
+            "workflow_call path silently deploys the caller's pre-publish commit "
+            "— a green run that leaves the backup exactly as stale as before."
+        )
+
+    def test_caller_passes_the_published_sha(self):
+        job = self._caller_job()
+        ref = str((job.get("with") or {}).get("ref", ""))
+        assert "published_sha" in ref, (
+            f"the caller passes ref={ref!r}. It must be the publish job's "
+            "`published_sha` output; anything else points at a commit that "
+            "predates the post being deployed."
+        )
+
+    def test_caller_runs_only_after_a_real_publish(self):
+        job = self._caller_job()
+        cond = str(job.get("if", ""))
+        assert "published_to_main" in cond, (
+            f"the deploy job's condition is {cond!r}. Without the "
+            "published_to_main gate it would redeploy on runs that published "
+            "nothing, including dry runs."
+        )
+        assert job.get("needs") == "auto-publish" or "auto-publish" in (
+            job.get("needs") or []
+        ), "the deploy job does not depend on auto-publish"
+
+    def test_caller_grants_the_permissions_the_callee_needs(self):
+        """ai-blogwatcher.yml is `permissions: {}` deny-by-default at the top.
+
+        A called workflow cannot hold more than its caller grants, so an
+        under-granted job fails at deploy time — after the digest is already
+        live, which is the worst place to find out.
+        """
+        perms = self._caller_job().get("permissions") or {}
+        for scope, level in (("pages", "write"), ("id-token", "write"), ("contents", "read")):
+            assert perms.get(scope) == level, (
+                f"the deploy job grants {scope}={perms.get(scope)!r}, needs {level!r}. "
+                "GitHub Pages deployment requires pages:write + id-token:write."
+            )
+
+    def test_both_paths_coexist(self):
+        """Neither path may quietly replace the other.
+
+        They failed together once because there was only one. The cron covers
+        what the publish job cannot see; the call covers the ~10-hour scheduler
+        outages the cron cannot survive.
+        """
+        body = _noncomment_lines(WORKFLOW.read_text(encoding="utf-8"))
+        assert re.search(r"^\s*schedule:\s*$", body, re.MULTILINE), "cron backstop gone"
+        assert re.search(r"^\s*workflow_call:\s*$", body, re.MULTILINE), (
+            "event-driven path gone"
         )


### PR DESCRIPTION
## 왜 지금

어제 회고 노트(#623)에 "schedule로 고친 안전망들은 스케줄러 가용성에 공통 의존한다 — 함께 죽는다"고 적었는데, **하루 만에 그대로 발생했다.**

- 봇의 `GITHUB_TOKEN` push는 재귀 방지로 `deploy-pages`의 `push:` 트리거를 못 깨운다 → 크론이 **유일한** 동기화 수단
- 08-26T19:43Z ~ 08-27T05:50Z GitHub Actions 스케줄러가 레포 전체 schedule 이벤트를 **0건** 발행 (대조군 08-26은 13건)
- **놓친 주기는 백필되지 않는다** → 08-27의 00:30Z 크론은 영구 유실
- 봇이 07:11Z에 발행 → 트리거(억제)와 안전망(유실)이 **같은 날 동시에** 사망
- 실측: 백업 **404** / 프로덕션 **200**

## 무엇

blogwatcher가 발행 즉시 `deploy-pages`를 `workflow_call`로 호출한다. **크론은 그대로 둔다.**

| 경로 | 담당 |
|---|---|
| 이벤트 구동 (신규) | 다이제스트 발행 시점 — 스케줄러 무관 |
| 크론 (기존) | 이 잡이 볼 수 없는 경우 — 호출 실패, 다른 원인의 낙후 |

하나로 합치지 않은 이유는 위 사건이 "단일 경로"의 결과이기 때문이다. 두 경로가 공유하는 실패 지점이 없어야 한다.

## 조용히 틀릴 수 있는 지점: `ref`

`auto-publish` 잡은 **발행 이전 SHA**에서 돈다. `ref` 없이 호출하면 방금 발행한 포스트가 **빠진** 코퍼스를 빌드하고 **success를 반환한다** — Actions 탭에서는 정상으로 보이고 백업은 그대로 낡아 있다. `slack-post-notify.yml`이 `ref`를 받는 이유와 같다.

그래서 이 부분에 전용 단언 두 개를 붙였다: callee의 checkout이 `inputs.ref`를 참조하는지, caller가 `published_sha`를 넘기는지.

## 권한

caller가 `pages: write` + `id-token: write`를 재부여한다. blogwatcher는 최상위가 `permissions: {}` 라 callee는 caller가 준 것 이상을 가질 수 없고, 부족하면 **다이제스트가 이미 라이브가 된 뒤** 배포 단계에서 실패한다.

## 검증

| 뮤테이션 | 결과 |
|---|---|
| checkout의 `ref` 제거 | CAUGHT |
| `workflow_call` 제거 | CAUGHT |
| caller ref를 `github.sha`로 | **처음 landed=False** → 정확히 겨냥 후 CAUGHT |
| `pages: write` 제거 | CAUGHT |
| `schedule` 제거 | CAUGHT |

대조군 5건 pass. M3의 첫 MISSED는 게이트가 아니라 **프로브가 `uses:`/`ref:` 순서를 반대로 가정**해 아예 적용되지 않은 것이었다. 겨냥을 고친 뒤 CAUGHT였고, `notify-slack`의 동일한 `ref` 라인은 건드리지 않았음도 함께 확인했다.

전체 **5014 passed**, actionlint OK, 래칫 11/11, 핀 일관성 정상.

### ⚠ 한계

`workflow_call` 경로의 **end-to-end 검증은 다음 다이제스트 발행이 처음**이다. PR CI는 이 경로를 실행하지 않고(blogwatcher 트리거에서만 도달), `dry_run`은 `published_to_main`이 서지 않아 이 잡을 건너뛴다. 정적 검증까지만 마친 상태로 보고한다.